### PR TITLE
Apply second-pass review fixes: concurrency, safety, and correctness

### DIFF
--- a/FitTracker/Models/TrainingProgramData.swift
+++ b/FitTracker/Models/TrainingProgramData.swift
@@ -87,7 +87,13 @@ struct TrainingProgramData {
     ]
 
     static func exercises(for day: DayType) -> [ExerciseDefinition] {
-        allExercises.filter { $0.dayType == day }.sorted { $0.order < $1.order }
+        #if DEBUG
+        assert(
+            Set(allExercises.map(\.id)).count == allExercises.count,
+            "Duplicate exercise IDs detected in TrainingProgramData.allExercises"
+        )
+        #endif
+        return allExercises.filter { $0.dayType == day }.sorted { $0.order < $1.order }
     }
 
     static let stage1Criteria = [

--- a/FitTracker/Services/Auth/SignInService.swift
+++ b/FitTracker/Services/Auth/SignInService.swift
@@ -343,7 +343,8 @@ final class SignInService: NSObject, ObservableObject {
     }
 
     private func simulateSignIn(provider: AuthProvider, name: String, email: String) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+        Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(800))
             let session = UserSession(
                 provider: provider,
                 userID: UUID().uuidString,
@@ -351,7 +352,7 @@ final class SignInService: NSObject, ObservableObject {
                 email: email,
                 sessionToken: UUID().uuidString
             )
-            self.finishSignIn(session)
+            self?.finishSignIn(session)
         }
     }
 
@@ -486,13 +487,10 @@ extension SignInService: ASAuthorizationControllerDelegate {
 // ─────────────────────────────────────────────────────────
 
 extension SignInService: ASAuthorizationControllerPresentationContextProviding {
+    // cachedWindow is always populated before performRequests() is called (on the main actor),
+    // so this nonisolated callback can safely return it without any cross-thread dispatch.
     nonisolated func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        if Thread.isMainThread {
-            return MainActor.assumeIsolated { presentationAnchorOnMainActor() }
-        }
-        return DispatchQueue.main.sync {
-            MainActor.assumeIsolated { presentationAnchorOnMainActor() }
-        }
+        MainActor.assumeIsolated { presentationAnchorOnMainActor() }
     }
 
     @MainActor

--- a/FitTracker/Services/AuthManager.swift
+++ b/FitTracker/Services/AuthManager.swift
@@ -100,22 +100,29 @@ struct LockScreenView: View {
         }
     }
 
-    private var biometricLabel: String {
+    private var biometricType: LABiometryType? {
         let ctx = LAContext()
         var error: NSError?
         guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
-            return "Unlock"
+            return nil
         }
-        return ctx.biometryType == .faceID ? "Unlock with Face ID" : "Unlock with Touch ID"
+        return ctx.biometryType
+    }
+
+    private var biometricLabel: String {
+        switch biometricType {
+        case .faceID:  "Unlock with Face ID"
+        case .touchID: "Unlock with Touch ID"
+        default:       "Unlock"
+        }
     }
 
     private var biometricIcon: String {
-        let ctx = LAContext()
-        var error: NSError?
-        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
-            return "lock.open.fill"
+        switch biometricType {
+        case .faceID:  "faceid"
+        case .touchID: "touchid"
+        default:       "lock.open.fill"
         }
-        return ctx.biometryType == .faceID ? "faceid" : "touchid"
     }
 }
 

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -504,7 +504,8 @@ struct SyncStatusIndicator: View {
 // ─────────────────────────────────────────────────────────
 
 struct ManualBiometricEntry: View {
-    @EnvironmentObject var dataStore: EncryptedDataStore
+    @EnvironmentObject var dataStore:     EncryptedDataStore
+    @EnvironmentObject var programStore:  TrainingProgramStore
     @Environment(\.dismiss) var dismiss
 
     @State private var weightText  = ""
@@ -578,6 +579,6 @@ struct ManualBiometricEntry: View {
 
     private func makeBlankLog() -> DailyLog {
         DailyLog(date: Date(), phase: dataStore.userProfile.currentPhase,
-                 dayType: .restDay, recoveryDay: dataStore.userProfile.daysSinceStart)
+                 dayType: programStore.todayDayType, recoveryDay: dataStore.userProfile.daysSinceStart)
     }
 }

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -171,9 +171,13 @@ struct SettingsView: View {
         }
     }
 
-    private func lastSyncFormatted(_ date: Date) -> String {
+    private static let lastSyncFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateStyle = .short; f.timeStyle = .short
-        return f.string(from: date)
+        return f
+    }()
+
+    private func lastSyncFormatted(_ date: Date) -> String {
+        Self.lastSyncFormatter.string(from: date)
     }
 }


### PR DESCRIPTION
- Remove DispatchQueue.main.sync from presentationAnchor; cachedWindow is always populated before performRequests() so no cross-thread dispatch needed
- Replace DispatchQueue.main.asyncAfter in simulateSignIn with structured concurrency (Task + weak self + Task.sleep)
- Add #if DEBUG assertion for duplicate exercise IDs in TrainingProgramData
- Cache DateFormatter as static let in SettingsView.lastSyncFormatted
- Use programStore.todayDayType in ManualBiometricEntry.makeBlankLog() instead of hardcoded .restDay
- Consolidate two LAContext evaluations into one biometricType computed property shared by biometricLabel and biometricIcon in LockScreenView