### PR TITLE
Skip biometric/passcode prompt on simulator

### DIFF
--- a/FitTracker/Services/AuthManager.swift
+++ b/FitTracker/Services/AuthManager.swift
@@ -20,6 +20,12 @@ final class AuthManager: ObservableObject {
     init() { authenticate() }
 
     func authenticate() {
+        #if targetEnvironment(simulator)
+        // Skip biometric/passcode prompt on simulator — set authenticated immediately.
+        isAuthenticated = true
+        return
+        #endif
+
         let ctx = LAContext()
         var err: NSError?
 


### PR DESCRIPTION
Add #if targetEnvironment(simulator) guard to AuthManager.authenticate() so the app never shows an LAContext passcode dialog during simulator runs.