### PR TITLE
Codex/your next feature

### DIFF
--- a/FitTracker/Info.plist
+++ b/FitTracker/Info.plist
@@ -40,10 +40,6 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>FitTracker can save or access cardio session summary photos from your photo library.</string>
 
-	<!-- Microphone (not used — deny access) -->
-	<key>NSMicrophoneUsageDescription</key>
-	<string>FitTracker does not use the microphone.</string>
-
 	<!-- Background modes -->
 	<key>UIBackgroundModes</key>
 	<array>

--- a/FitTracker/Models/DomainModels.swift
+++ b/FitTracker/Models/DomainModels.swift
@@ -213,6 +213,15 @@ struct MealEntry: Identifiable, Codable, Sendable {
     var status:    TaskStatus = .pending
 }
 
+struct MealTemplate: Identifiable, Codable, Sendable {
+    var id:        UUID   = UUID()
+    var name:      String = ""
+    var calories:  Double?
+    var proteinG:  Double?
+    var carbsG:    Double?
+    var fatG:      Double?
+}
+
 // ─────────────────────────────────────────────────────────
 // MARK: – Daily Biometrics
 // ─────────────────────────────────────────────────────────

--- a/FitTracker/Services/AppTheme.swift
+++ b/FitTracker/Services/AppTheme.swift
@@ -9,4 +9,27 @@ extension Color {
     static let appOrange2 = Color(red: 1.0,  green: 0.78, blue: 0.54)
     static let appBlue1   = Color(red: 0.73, green: 0.89, blue: 1.0)
     static let appBlue2   = Color(red: 0.54, green: 0.78, blue: 1.0)
+
+    // Status colour tokens
+    enum status {
+        static let success = Color(red: 0.204, green: 0.780, blue: 0.349)
+        static let warning = Color(red: 1.0,   green: 0.584, blue: 0.0)
+        static let error   = Color(red: 1.0,   green: 0.231, blue: 0.188)
+    }
+
+    // Accent colour tokens
+    enum accent {
+        static let cyan   = Color(red: 0.353, green: 0.784, blue: 0.980)
+        static let purple = Color(red: 0.749, green: 0.353, blue: 0.949)
+        static let gold   = Color(red: 1.0,   green: 0.839, blue: 0.039)
+    }
+}
+
+// Type scale definition
+enum AppType {
+    static let display    = Font.system(size: 34, weight: .bold)
+    static let headline   = Font.system(size: 20, weight: .semibold)
+    static let body       = Font.system(size: 15, weight: .medium)
+    static let subheading = Font.system(size: 13, weight: .regular)
+    static let caption    = Font.system(size: 11, weight: .regular)
 }

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -388,6 +388,49 @@ final class EncryptedDataStore: ObservableObject {
         return streak
     }
 
+    /// Computes a 0–100 readiness score for the given date.
+    /// Returns `nil` if there is insufficient data (fewer than 3 logs with HRV,
+    /// no 30-day baseline, or today's HRV / resting HR not available).
+    func readinessScore(for date: Date, fallbackMetrics: LiveMetrics?) -> Int? {
+        // Need at least 3 biometric logs to establish baseline
+        let logsWithHRV = dailyLogs.filter { $0.biometrics.effectiveHRV != nil }
+        guard logsWithHRV.count >= 3 else { return nil }
+
+        // Get today's biometrics — either from stored log or fallback metrics
+        let todayLog = self.log(for: date)
+        let todayHRV   = todayLog?.biometrics.effectiveHRV      ?? fallbackMetrics?.hrv
+        let todayHR    = todayLog?.biometrics.effectiveRestingHR ?? fallbackMetrics?.restingHR
+        let todaySleep = todayLog?.biometrics.effectiveSleep     ?? fallbackMetrics?.sleepHours
+
+        guard let hrv = todayHRV, let hr = todayHR else { return nil }
+        let sleep = todaySleep ?? 7.0   // default if no sleep data
+
+        // 30-day baseline from stored logs (excluding today)
+        let cal = Calendar.current
+        let thirtyDaysAgo = cal.date(byAdding: .day, value: -30, to: date) ?? date
+        let baseline = dailyLogs.filter {
+            $0.date >= thirtyDaysAgo &&
+            !cal.isDate($0.date, inSameDayAs: date)
+        }
+
+        let baselineHRV = baseline.compactMap { $0.biometrics.effectiveHRV }
+        let baselineHR  = baseline.compactMap { $0.biometrics.effectiveRestingHR }
+
+        guard !baselineHRV.isEmpty, !baselineHR.isEmpty else { return nil }
+
+        let avgBaselineHRV = baselineHRV.reduce(0, +) / Double(baselineHRV.count)
+        let avgBaselineHR  = baselineHR.reduce(0, +)  / Double(baselineHR.count)
+
+        // Score components (each 0–100):
+        let hrvSignal   = min(100, max(0, (hrv / avgBaselineHRV) * 50))
+        let hrSignal    = min(100, max(0, 50 + (avgBaselineHR - hr) * 10))
+        let sleepSignal = min(100, max(0, (sleep / 8.0) * 100))
+
+        // Weighted average:
+        let score = Int(hrvSignal * 0.40 + hrSignal * 0.30 + sleepSignal * 0.30)
+        return score
+    }
+
     func saveProfile(_ p: UserProfile) {
         userProfile = p
         Task { await persistToDisk() }

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -335,6 +335,7 @@ final class EncryptedDataStore: ObservableObject {
     @Published var dailyLogs:       [DailyLog]        = []
     @Published var weeklySnapshots: [WeeklySnapshot]  = []
     @Published var userProfile:     UserProfile       = UserProfile()
+    @Published var mealTemplates:   [MealTemplate]    = []
     @Published var isLoading:       Bool              = false
     @Published var lastError:       String?
     /// Set when `loadFromDisk` fails; observed by the UI to show an alert.
@@ -368,6 +369,25 @@ final class EncryptedDataStore: ObservableObject {
 
     func todayLog() -> DailyLog? { log(for: Date()) }
 
+    var supplementStreak: Int {
+        let sorted = dailyLogs.sorted { $0.date > $1.date }
+        var streak = 0
+        let today = Calendar.current.startOfDay(for: Date())
+        for log in sorted {
+            let logDay = Calendar.current.startOfDay(for: log.date)
+            // Today counts only if fully complete
+            if logDay > today { continue }
+            let complete = log.supplementLog.morningStatus == .completed
+                        && log.supplementLog.eveningStatus == .completed
+            if complete {
+                streak += 1
+            } else {
+                break
+            }
+        }
+        return streak
+    }
+
     func saveProfile(_ p: UserProfile) {
         userProfile = p
         Task { await persistToDisk() }
@@ -377,19 +397,22 @@ final class EncryptedDataStore: ObservableObject {
 
     func persistToDisk() async {
         do {
-            let logsEnc  = try await EncryptionService.shared.encrypt(dailyLogs)
-            let snapsEnc = try await EncryptionService.shared.encrypt(weeklySnapshots)
-            let profEnc  = try await EncryptionService.shared.encrypt(userProfile)
+            let logsEnc      = try await EncryptionService.shared.encrypt(dailyLogs)
+            let snapsEnc     = try await EncryptionService.shared.encrypt(weeklySnapshots)
+            let profEnc      = try await EncryptionService.shared.encrypt(userProfile)
+            let templatesEnc = try await EncryptionService.shared.encrypt(mealTemplates)
 
             // .completeFileProtectionUnlessOpen = encrypted at rest, even when locked (iOS only)
             #if os(iOS)
-            try logsEnc.write(to:  url("logs"),    options: .completeFileProtectionUnlessOpen)
-            try snapsEnc.write(to: url("snaps"),   options: .completeFileProtectionUnlessOpen)
-            try profEnc.write(to:  url("profile"), options: .completeFileProtectionUnlessOpen)
+            try logsEnc.write(to:      url("logs"),          options: .completeFileProtectionUnlessOpen)
+            try snapsEnc.write(to:     url("snaps"),         options: .completeFileProtectionUnlessOpen)
+            try profEnc.write(to:      url("profile"),       options: .completeFileProtectionUnlessOpen)
+            try templatesEnc.write(to: url("mealTemplates"), options: .completeFileProtectionUnlessOpen)
             #else
-            try logsEnc.write(to:  url("logs"))
-            try snapsEnc.write(to: url("snaps"))
-            try profEnc.write(to:  url("profile"))
+            try logsEnc.write(to:      url("logs"))
+            try snapsEnc.write(to:     url("snaps"))
+            try profEnc.write(to:      url("profile"))
+            try templatesEnc.write(to: url("mealTemplates"))
             #endif
         } catch {
             await MainActor.run { lastError = error.localizedDescription }
@@ -410,6 +433,10 @@ final class EncryptedDataStore: ObservableObject {
             if let d = try? Data(contentsOf: url("profile")), !d.isEmpty {
                 let v = try await EncryptionService.shared.decrypt(d, as: UserProfile.self)
                 await MainActor.run { userProfile = v }
+            }
+            if let d = try? Data(contentsOf: url("mealTemplates")), !d.isEmpty {
+                let v = try await EncryptionService.shared.decrypt(d, as: [MealTemplate].self)
+                await MainActor.run { mealTemplates = v }
             }
         } catch {
             await MainActor.run {

--- a/FitTracker/Services/TrainingProgramStore.swift
+++ b/FitTracker/Services/TrainingProgramStore.swift
@@ -14,6 +14,9 @@ final class TrainingProgramStore: ObservableObject {
 
     @Published var todayDayType: DayType = .restDay
 
+    /// Calendar weekday indices (1=Sunday, 4=Wednesday) that are rest days by default.
+    static let restWeekdays: Set<Int> = [1, 4]
+
     init() { detectToday() }
 
     func detectToday() {

--- a/FitTracker/Views/Auth/SignInView.swift
+++ b/FitTracker/Views/Auth/SignInView.swift
@@ -74,39 +74,6 @@ struct SignInView: View {
                                 signIn.signInWithApple()
                             }
 
-                            // Google
-                            SocialSignInButton(
-                                provider: .google,
-                                isLoading: signIn.isLoading
-                            ) {
-                                #if os(iOS)
-                                let root = UIApplication.shared.connectedScenes
-                                    .compactMap { $0 as? UIWindowScene }
-                                    .flatMap { $0.windows }
-                                    .first { $0.isKeyWindow }?
-                                    .rootViewController
-                                signIn.signInWithGoogle(presenting: root)
-                                #else
-                                signIn.signInWithGoogle(presenting: nil)
-                                #endif
-                            }
-
-                            // Facebook
-                            SocialSignInButton(
-                                provider: .facebook,
-                                isLoading: signIn.isLoading
-                            ) {
-                                #if os(iOS)
-                                let root = UIApplication.shared.connectedScenes
-                                    .compactMap { $0 as? UIWindowScene }
-                                    .flatMap { $0.windows }
-                                    .first { $0.isKeyWindow }?
-                                    .rootViewController
-                                signIn.signInWithFacebook(presenting: root)
-                                #else
-                                signIn.signInWithFacebook(presenting: nil)
-                                #endif
-                            }
                         }
 
                         // ── Divider ───────────────────────────────────
@@ -171,16 +138,6 @@ struct SignInView: View {
                                         signIn.registerPasskey()
                                     }
 
-                                    // Info chip about YubiKey
-                                    HStack(spacing: 8) {
-                                        Image(systemName: "info.circle")
-                                            .font(.caption).foregroundStyle(.secondary)
-                                        Text("Physical keys (YubiKey 5 NFC, Security Key NFC) are detected automatically via NFC or USB-C when prompted.")
-                                            .font(.caption2).foregroundStyle(.secondary)
-                                    }
-                                    .padding(10)
-                                    .background(Color.secondary.opacity(0.05),
-                                                in: RoundedRectangle(cornerRadius: 8))
                                 }
                                 .padding(.top, 8)
                                 .transition(.opacity.combined(with: .move(edge: .top)))

--- a/FitTracker/Views/Auth/WelcomeView.swift
+++ b/FitTracker/Views/Auth/WelcomeView.swift
@@ -11,7 +11,6 @@ struct WelcomeView: View {
     @EnvironmentObject var signIn: SignInService
 
     @State private var showSignIn       = false
-    @State private var showRegisterNote = false
     @State private var logoScale: CGFloat = 0.6
     @State private var logoOpacity: CGFloat = 0
     @State private var textOffset: CGFloat = 30
@@ -156,32 +155,6 @@ struct WelcomeView: View {
                     }
                     .buttonStyle(.plain)
 
-                    // REGISTER — cosmetic (visual only)
-                    Button {
-                        showRegisterNote = true
-                    } label: {
-                        HStack(spacing: 10) {
-                            Image(systemName: "person.badge.plus")
-                                .font(.title3)
-                                .opacity(0.5)
-                            Text("Create Account")
-                                .font(.headline)
-                                .opacity(0.5)
-                            Spacer()
-                            Text("Coming soon")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 8).padding(.vertical, 3)
-                                .background(Color.secondary.opacity(0.1), in: Capsule())
-                        }
-                        .padding(.horizontal, 22)
-                        .padding(.vertical, 17)
-                        .foregroundStyle(.white)
-                        .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 16))
-                        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.white.opacity(0.1)))
-                    }
-                    .buttonStyle(.plain)
-
                     // Privacy footnote
                     Text("Your health data never leaves your Apple ecosystem.\nAll data is double-encrypted end-to-end.")
                         .font(.caption2)
@@ -215,12 +188,6 @@ struct WelcomeView: View {
                 .presentationDetents([.large])
                 .presentationCornerRadius(28)
                 .presentationBackground(.ultraThinMaterial)
-        }
-        // ── Register toast ────────────────────────────────
-        .alert("Coming Soon", isPresented: $showRegisterNote) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Account registration will be available in the next update. Use Log In with Apple, Google, or Facebook to get started now.")
         }
     }
 }

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -53,16 +53,16 @@ struct MainScreenView: View {
             VStack(spacing: 0) {
                 greetingHeader
                 Spacer()
-                sectionHeader("Status")
+                SectionHeader(title: "Status")
                 metricPair
                 Spacer()
-                sectionHeader("Goal")
+                SectionHeader(title: "Goal")
                 goalSection
                 Spacer()
-                sectionHeader("Start Training")
+                SectionHeader(title: "Start Training")
                 trainingButton
                 Spacer()
-                sectionHeader("Metrics")
+                SectionHeader(title: "Metrics")
                 quickStats
             }
             .padding(.horizontal, 20)
@@ -158,13 +158,9 @@ struct MainScreenView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            VStack(alignment: .trailing, spacing: 2) {
-                Text("Day \(profile.daysSinceStart)")
-                    .font(.system(.subheadline, design: .monospaced, weight: .bold))
-                Text(profile.currentPhase.rawValue)
-                    .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .padding(.horizontal, 6).padding(.vertical, 2)
-                    .background(Color.white.opacity(0.35), in: Capsule())
+            VStack(alignment: .trailing, spacing: 4) {
+                StatusBadge(text: "Day \(profile.daysSinceStart)", color: .appOrange2)
+                StatusBadge(text: profile.currentPhase.rawValue, color: .appBlue1)
             }
         }
     }
@@ -212,7 +208,7 @@ struct MainScreenView: View {
                 }
                 Text(weightDelta)
                     .font(.system(size: 10))
-                    .foregroundStyle(weightDelta.hasPrefix("+") ? .red : .green)
+                    .foregroundStyle(weightDelta.hasPrefix("+") ? Color.status.error : Color.status.success)
                 Text("Target: \(settings.unitSystem.displayWeightValue(profile.targetWeightMin))–\(settings.unitSystem.displayWeightValue(profile.targetWeightMax)) \(settings.unitSystem.weightLabel())")
                     .font(.system(size: 9))
                     .foregroundStyle(.secondary)
@@ -241,7 +237,7 @@ struct MainScreenView: View {
                 }
                 Text(bfDelta)
                     .font(.system(size: 10))
-                    .foregroundStyle(bfDelta.hasPrefix("+") ? .red : .green)
+                    .foregroundStyle(bfDelta.hasPrefix("+") ? Color.status.error : Color.status.success)
                 Text("Target: \(Int(profile.targetBFMin))–\(Int(profile.targetBFMax))%")
                     .font(.system(size: 9))
                     .foregroundStyle(.secondary)
@@ -387,19 +383,39 @@ struct MainScreenView: View {
     // ─────────────────────────────────────────────────────
 
     private var quickStats: some View {
-        HStack(spacing: 0) {
-            QuickStatPill(icon: "waveform.path.ecg",
-                          value: metrics.hrv.map        { String(format: "%.0f ms", $0) } ?? "—",
-                          label: "HRV",     color: metrics.hrvStatus.color)
-            QuickStatPill(icon: "heart.fill",
-                          value: metrics.restingHR.map  { String(format: "%.0f",    $0) } ?? "—",
-                          label: "Rest HR", color: metrics.restingHRStatus.color)
-            QuickStatPill(icon: "moon.fill",
-                          value: metrics.sleepHours.map { String(format: "%.1f h",  $0) } ?? "—",
-                          label: "Sleep",   color: .purple)
-            QuickStatPill(icon: "figure.walk",
-                          value: metrics.stepCount.map  { "\($0)" } ?? "—",
-                          label: "Steps",   color: .blue)
+        HStack(spacing: 8) {
+            MetricCard(
+                icon: "waveform.path.ecg",
+                label: "HRV",
+                value: metrics.hrv.map { String(format: "%.0f", $0) } ?? "—",
+                unit: "ms",
+                trendDelta: nil,
+                statusColor: metrics.hrvStatus.color
+            )
+            MetricCard(
+                icon: "heart.fill",
+                label: "Rest HR",
+                value: metrics.restingHR.map { String(format: "%.0f", $0) } ?? "—",
+                unit: "bpm",
+                trendDelta: nil,
+                statusColor: metrics.restingHRStatus.color
+            )
+            MetricCard(
+                icon: "moon.fill",
+                label: "Sleep",
+                value: metrics.sleepHours.map { String(format: "%.1f", $0) } ?? "—",
+                unit: "h",
+                trendDelta: nil,
+                statusColor: Color.accent.purple
+            )
+            MetricCard(
+                icon: "figure.walk",
+                label: "Steps",
+                value: metrics.stepCount.map { "\($0)" } ?? "—",
+                unit: nil,
+                trendDelta: nil,
+                statusColor: Color.accent.cyan
+            )
         }
     }
 
@@ -414,15 +430,6 @@ struct MainScreenView: View {
         }
     }
 
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(.system(size: 13, weight: .black, design: .rounded))
-            .foregroundStyle(.black.opacity(0.75))
-            .tracking(1.5)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 4)
-            .padding(.bottom, 6)
-    }
 }
 
 // ─────────────────────────────────────────────────────────

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -62,7 +62,7 @@ struct MainScreenView: View {
                 SectionHeader(title: "Start Training")
                 trainingButton
                 Spacer()
-                SectionHeader(title: "Metrics")
+                SectionHeader(title: "Readiness")
                 quickStats
             }
             .padding(.horizontal, 20)
@@ -135,6 +135,7 @@ struct MainScreenView: View {
             Circle()
                 .fill(Color.white)
                 .frame(width: 13, height: 13)
+                .shadow(color: .white.opacity(0.6), radius: 4)
                 .shadow(color: goalProgress > 0.5 ? .blue.opacity(0.55) : .orange.opacity(0.55), radius: 5)
                 .position(x: x, y: orbY)
                 .animation(.spring(response: 1.2), value: goalProgress)
@@ -194,10 +195,15 @@ struct MainScreenView: View {
 
             // Weight (left)
             VStack(alignment: .leading, spacing: 4) {
-                Label("WEIGHT", systemImage: "scalemass.fill")
-                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(.blue)
-                    .tracking(1)
+                HStack(spacing: 4) {
+                    Label("WEIGHT", systemImage: "scalemass.fill")
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.blue)
+                        .tracking(1)
+                    Circle()
+                        .fill(weightTrendColor)
+                        .frame(width: 8, height: 8)
+                }
                 HStack(alignment: .lastTextBaseline, spacing: 3) {
                     Text(currentWeight.map { settings.unitSystem.displayWeightValue($0) } ?? "—")
                         .font(.system(size: 36, weight: .bold, design: .monospaced))
@@ -223,10 +229,15 @@ struct MainScreenView: View {
 
             // Body Fat (right)
             VStack(alignment: .leading, spacing: 4) {
-                Label("BODY FAT", systemImage: "drop.fill")
-                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(.orange)
-                    .tracking(1)
+                HStack(spacing: 4) {
+                    Label("BODY FAT", systemImage: "drop.fill")
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.orange)
+                        .tracking(1)
+                    Circle()
+                        .fill(bfTrendColor)
+                        .frame(width: 8, height: 8)
+                }
                 HStack(alignment: .lastTextBaseline, spacing: 3) {
                     Text(currentBF.map { String(format: "%.1f", $0) } ?? "—")
                         .font(.system(size: 36, weight: .bold, design: .monospaced))
@@ -267,6 +278,33 @@ struct MainScreenView: View {
         return String(format: "%+.1f%% since start", d)
     }
 
+    // Returns a colour dot for weight trend over 7 days
+    private var weightTrendColor: Color {
+        let logs = dataStore.dailyLogs
+            .filter { !Calendar.current.isDateInToday($0.date) }
+            .sorted { $0.date > $1.date }
+            .prefix(7)
+        let vals = logs.compactMap { $0.biometrics.weightKg }
+        guard vals.count >= 2 else { return Color.secondary }
+        let delta = vals.first! - vals.last!  // sorted newest-first, so first=recent, last=older
+        if delta < -0.2 { return Color.status.success }    // weight decreasing = good
+        if delta > 0.2  { return Color.status.error }      // weight increasing = bad
+        return Color.status.warning                         // flat
+    }
+
+    private var bfTrendColor: Color {
+        let logs = dataStore.dailyLogs
+            .filter { !Calendar.current.isDateInToday($0.date) }
+            .sorted { $0.date > $1.date }
+            .prefix(7)
+        let vals = logs.compactMap { $0.biometrics.bodyFatPercent }
+        guard vals.count >= 2 else { return Color.secondary }
+        let delta = vals.first! - vals.last!
+        if delta < -0.3 { return Color.status.success }
+        if delta > 0.3  { return Color.status.error }
+        return Color.status.warning
+    }
+
     // ─────────────────────────────────────────────────────
     // MARK: – Goal section
     // ─────────────────────────────────────────────────────
@@ -280,7 +318,7 @@ struct MainScreenView: View {
                 Circle()
                     .trim(from: 0, to: goalProgress)
                     .stroke(
-                        AngularGradient(colors: [.orange, .blue, .orange], center: .center),
+                        AngularGradient(colors: [Color.appOrange1, Color.accent.cyan, Color.appOrange1], center: .center),
                         style: StrokeStyle(lineWidth: 8, lineCap: .round)
                     )
                     .frame(width: 74, height: 74)
@@ -365,7 +403,7 @@ struct MainScreenView: View {
                     Image(systemName: activeDayType.icon)
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(.secondary)
-                    Text(activeDayType.rawValue)
+                    Text("💪 \(activeDayType.rawValue) · \(TrainingProgramData.exercises(for: activeDayType).count) ex")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Image(systemName: "chevron.down")
@@ -383,40 +421,7 @@ struct MainScreenView: View {
     // ─────────────────────────────────────────────────────
 
     private var quickStats: some View {
-        HStack(spacing: 8) {
-            MetricCard(
-                icon: "waveform.path.ecg",
-                label: "HRV",
-                value: metrics.hrv.map { String(format: "%.0f", $0) } ?? "—",
-                unit: "ms",
-                trendDelta: nil,
-                statusColor: metrics.hrvStatus.color
-            )
-            MetricCard(
-                icon: "heart.fill",
-                label: "Rest HR",
-                value: metrics.restingHR.map { String(format: "%.0f", $0) } ?? "—",
-                unit: "bpm",
-                trendDelta: nil,
-                statusColor: metrics.restingHRStatus.color
-            )
-            MetricCard(
-                icon: "moon.fill",
-                label: "Sleep",
-                value: metrics.sleepHours.map { String(format: "%.1f", $0) } ?? "—",
-                unit: "h",
-                trendDelta: nil,
-                statusColor: Color.accent.purple
-            )
-            MetricCard(
-                icon: "figure.walk",
-                label: "Steps",
-                value: metrics.stepCount.map { "\($0)" } ?? "—",
-                unit: nil,
-                trendDelta: nil,
-                statusColor: Color.accent.cyan
-            )
-        }
+        ReadinessCard()
     }
 
     // ─────────────────────────────────────────────────────
@@ -454,7 +459,7 @@ struct GoalProgressRow: View {
                         .fill(Color.white.opacity(0.4))
                         .frame(height: 4)
                     RoundedRectangle(cornerRadius: 2)
-                        .fill(color)
+                        .fill(LinearGradient(colors: [Color.appOrange1, Color.accent.cyan], startPoint: .leading, endPoint: .trailing))
                         .frame(width: geo.size.width * progress, height: 4)
                         .animation(.spring(response: 1.0), value: progress)
                 }

--- a/FitTracker/Views/Nutrition/MacroTargetBar.swift
+++ b/FitTracker/Views/Nutrition/MacroTargetBar.swift
@@ -1,0 +1,96 @@
+// Views/Nutrition/MacroTargetBar.swift
+import SwiftUI
+
+/// Stacked horizontal macro progress bar shown at the top of NutritionView.
+struct MacroTargetBar: View {
+
+    /// Consumed macros for the day
+    let protein:   Double   // grams consumed
+    let carbs:     Double   // grams consumed
+    let fat:       Double   // grams consumed
+
+    /// Targets
+    let targetCalories: Int     // kcal target for the day
+    let targetProteinG: Double  // grams target
+
+    // kcal per gram
+    private let proteinKcal = 4.0
+    private let carbsKcal   = 4.0
+    private let fatKcal     = 9.0
+
+    private var consumedCalories: Double {
+        protein * proteinKcal + carbs * carbsKcal + fat * fatKcal
+    }
+    private var remainingCalories: Double {
+        max(0, Double(targetCalories) - consumedCalories)
+    }
+    private var totalForBar: Double {
+        max(Double(targetCalories), consumedCalories)
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            // Stacked bar
+            GeometryReader { geo in
+                HStack(spacing: 2) {
+                    // Protein segment
+                    let proteinWidth = geo.size.width * (protein * proteinKcal / max(totalForBar, 1))
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.accent.cyan)
+                        .frame(width: max(proteinWidth, 2))
+
+                    // Carbs segment
+                    let carbsWidth = geo.size.width * (carbs * carbsKcal / max(totalForBar, 1))
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.appOrange1)
+                        .frame(width: max(carbsWidth, 2))
+
+                    // Fat segment
+                    let fatWidth = geo.size.width * (fat * fatKcal / max(totalForBar, 1))
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.accent.purple)
+                        .frame(width: max(fatWidth, 2))
+
+                    // Remaining (grey)
+                    let remaining = geo.size.width * (remainingCalories / max(totalForBar, 1))
+                    if remaining > 2 {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.white.opacity(0.2))
+                            .frame(width: remaining)
+                    }
+                }
+            }
+            .frame(height: 14)
+
+            // Legend row
+            HStack(spacing: 12) {
+                macroLabel("P", value: protein, unit: "g", color: Color.accent.cyan)
+                macroLabel("C", value: carbs,   unit: "g", color: Color.appOrange1)
+                macroLabel("F", value: fat,     unit: "g", color: Color.accent.purple)
+                Spacer()
+                // Total vs target
+                Text("\(Int(consumedCalories)) / \(targetCalories) kcal")
+                    .font(AppType.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color.white.opacity(0.1), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func macroLabel(_ letter: String, value: Double, unit: String, color: Color) -> some View {
+        HStack(spacing: 3) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text("\(letter) \(Int(value))\(unit)")
+                .font(AppType.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    MacroTargetBar(protein: 120, carbs: 180, fat: 55, targetCalories: 1900, targetProteinG: 130)
+        .padding()
+        .background(Color.appOrange2)
+}

--- a/FitTracker/Views/Nutrition/MealEntrySheet.swift
+++ b/FitTracker/Views/Nutrition/MealEntrySheet.swift
@@ -1,0 +1,665 @@
+// Views/Nutrition/MealEntrySheet.swift
+// Sheet presented when the user taps a meal slot.
+// Three tabs: Manual entry, Template picker, Food search (text + barcode).
+
+import SwiftUI
+import AVFoundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Tab enum
+// ─────────────────────────────────────────────────────────
+
+enum MealEntryTab: String, CaseIterable {
+    case manual   = "Manual"
+    case template = "Template"
+    case search   = "Search"
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Main Sheet
+// ─────────────────────────────────────────────────────────
+
+struct MealEntrySheet: View {
+    @EnvironmentObject var dataStore: EncryptedDataStore
+    @Binding var entry: MealEntry
+    let onSave: (MealEntry) -> Void
+    @Environment(\.dismiss) var dismiss
+
+    @State private var activeTab: MealEntryTab = .manual
+
+    // Manual tab fields
+    @State private var name:     String = ""
+    @State private var calories: String = ""
+    @State private var proteinG: String = ""
+    @State private var carbsG:   String = ""
+    @State private var fatG:     String = ""
+
+    // Template save confirmation
+    @State private var savedTemplate = false
+
+    // Search tab
+    @State private var searchQuery: String = ""
+    @State private var searchResults: [FoodProduct] = []
+    @State private var isSearching: Bool = false
+    @State private var searchError: String? = nil
+
+    // Barcode scanner
+    @State private var showScanner: Bool = false
+
+    // ── Initialise fields from the binding on appear ──────
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Tab picker
+                Picker("Tab", selection: $activeTab) {
+                    ForEach(MealEntryTab.allCases, id: \.self) { tab in
+                        Text(tab.rawValue).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+
+                Divider()
+
+                // Tab content
+                Group {
+                    switch activeTab {
+                    case .manual:   manualTab
+                    case .template: templateTab
+                    case .search:   searchTab
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .navigationTitle("Log Meal \(entry.mealNumber)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .onAppear {
+                name     = entry.name
+                calories = entry.calories.map { String($0) } ?? ""
+                proteinG = entry.proteinG.map  { String($0) } ?? ""
+                carbsG   = entry.carbsG.map    { String($0) } ?? ""
+                fatG     = entry.fatG.map      { String($0) } ?? ""
+            }
+        }
+        #if os(iOS)
+        .sheet(isPresented: $showScanner) {
+            BarcodeScannerSheet { barcode in
+                showScanner = false
+                fetchProduct(barcode: barcode)
+            }
+        }
+        #endif
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Manual Tab
+    // ─────────────────────────────────────────────────────
+
+    private var manualTab: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Group {
+                    manualField(label: "Meal name",       placeholder: "e.g. Chicken & Rice", text: $name)
+                    manualField(label: "Calories (kcal)", placeholder: "e.g. 500",            text: $calories, isNumeric: true)
+                    manualField(label: "Protein (g)",     placeholder: "e.g. 40",             text: $proteinG, isNumeric: true)
+                    manualField(label: "Carbs (g)",       placeholder: "e.g. 60",             text: $carbsG,   isNumeric: true)
+                    manualField(label: "Fat (g)",         placeholder: "e.g. 15",             text: $fatG,     isNumeric: true)
+                }
+                .padding(.horizontal, 16)
+
+                // Buttons
+                VStack(spacing: 12) {
+                    // Save as Template
+                    Button {
+                        saveAsTemplate()
+                    } label: {
+                        HStack {
+                            if savedTemplate {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(Color.status.success)
+                                Text("Saved!")
+                                    .foregroundColor(Color.status.success)
+                            } else {
+                                Image(systemName: "square.and.arrow.down")
+                                Text("Save as Template")
+                            }
+                        }
+                        .font(AppType.body)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 12))
+                    }
+                    .disabled(name.isEmpty)
+
+                    // Log button
+                    Button {
+                        logMeal()
+                    } label: {
+                        Text("Log")
+                            .font(AppType.body)
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(name.isEmpty ? Color.secondary.opacity(0.2) : Color.accent.cyan, in: RoundedRectangle(cornerRadius: 12))
+                            .foregroundColor(name.isEmpty ? .secondary : .white)
+                    }
+                    .disabled(name.isEmpty)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
+            .padding(.top, 16)
+            .padding(.bottom, 32)
+        }
+    }
+
+    @ViewBuilder
+    private func manualField(label: String, placeholder: String, text: Binding<String>, isNumeric: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(AppType.caption)
+                .foregroundColor(.secondary)
+            TextField(placeholder, text: text)
+                .font(AppType.body)
+                #if canImport(UIKit)
+                .keyboardType(isNumeric ? .decimalPad : .default)
+                #endif
+                .padding(10)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Template Tab
+    // ─────────────────────────────────────────────────────
+
+    private var templateTab: some View {
+        Group {
+            if dataStore.mealTemplates.isEmpty {
+                EmptyStateView(
+                    icon: "doc.text",
+                    title: "No Templates Yet",
+                    subtitle: "Save a meal from the Manual tab to reuse it here."
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(dataStore.mealTemplates) { template in
+                    Button {
+                        fillFromTemplate(template)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(template.name)
+                                .font(AppType.body)
+                                .foregroundColor(.primary)
+                            HStack(spacing: 8) {
+                                if let cal = template.calories {
+                                    Text("\(Int(cal)) kcal")
+                                        .font(AppType.caption)
+                                        .foregroundColor(Color.accent.gold)
+                                }
+                                if let pro = template.proteinG {
+                                    Text("\(Int(pro))g protein")
+                                        .font(AppType.caption)
+                                        .foregroundColor(Color.accent.cyan)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Search Tab
+    // ─────────────────────────────────────────────────────
+
+    private var searchTab: some View {
+        VStack(spacing: 0) {
+            // Search bar
+            VStack(spacing: 8) {
+                HStack(spacing: 8) {
+                    TextField("Search food…", text: $searchQuery)
+                        .font(AppType.body)
+                        .padding(10)
+                        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+                        .submitLabel(.search)
+                        .onSubmit { runTextSearch() }
+
+                    Button {
+                        runTextSearch()
+                    } label: {
+                        Image(systemName: isSearching ? "clock" : "magnifyingglass")
+                            .foregroundColor(.white)
+                            .padding(10)
+                            .background(Color.accent.cyan, in: RoundedRectangle(cornerRadius: 10))
+                    }
+                    .disabled(searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || isSearching)
+                }
+
+                #if os(iOS)
+                Button {
+                    showScanner = true
+                } label: {
+                    HStack {
+                        Image(systemName: "barcode.viewfinder")
+                        Text("Scan Barcode")
+                    }
+                    .font(AppType.body)
+                    .foregroundColor(Color.accent.purple)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(Color.accent.purple.opacity(0.1), in: RoundedRectangle(cornerRadius: 10))
+                }
+                #endif
+
+                if let error = searchError {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(Color.status.error)
+                        Text(error)
+                            .font(AppType.caption)
+                            .foregroundColor(Color.status.error)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // Results
+            if searchResults.isEmpty && !isSearching {
+                Spacer()
+                EmptyStateView(
+                    icon: "magnifyingglass",
+                    title: "Search for food",
+                    subtitle: "Type a food name above or scan a barcode to find nutrition data."
+                )
+                Spacer()
+            } else if isSearching {
+                Spacer()
+                ProgressView("Searching…")
+                    .font(AppType.subheading)
+                Spacer()
+            } else {
+                List(searchResults) { product in
+                    Button {
+                        fillFromProduct(product)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(product.name.isEmpty ? "Unknown product" : product.name)
+                                .font(AppType.body)
+                                .foregroundColor(.primary)
+                            HStack(spacing: 8) {
+                                if let cal = product.caloriesPer100g {
+                                    Text("\(Int(cal)) kcal/100g")
+                                        .font(AppType.caption)
+                                        .foregroundColor(Color.accent.gold)
+                                }
+                                if let pro = product.proteinPer100g {
+                                    Text("\(Int(pro))g prot")
+                                        .font(AppType.caption)
+                                        .foregroundColor(Color.accent.cyan)
+                                }
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Actions
+    // ─────────────────────────────────────────────────────
+
+    private func saveAsTemplate() {
+        let template = MealTemplate(
+            name:     name,
+            calories: Double(calories),
+            proteinG: Double(proteinG),
+            carbsG:   Double(carbsG),
+            fatG:     Double(fatG)
+        )
+        dataStore.mealTemplates.append(template)
+        Task { await dataStore.persistToDisk() }
+
+        savedTemplate = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            await MainActor.run { savedTemplate = false }
+        }
+    }
+
+    private func logMeal() {
+        entry.name     = name
+        entry.calories = Double(calories)
+        entry.proteinG = Double(proteinG)
+        entry.carbsG   = Double(carbsG)
+        entry.fatG     = Double(fatG)
+        entry.eatenAt  = Date()
+        entry.status   = .completed
+        onSave(entry)
+        dismiss()
+    }
+
+    private func fillFromTemplate(_ template: MealTemplate) {
+        name     = template.name
+        calories = template.calories.map { formatNum($0) } ?? ""
+        proteinG = template.proteinG.map  { formatNum($0) } ?? ""
+        carbsG   = template.carbsG.map    { formatNum($0) } ?? ""
+        fatG     = template.fatG.map      { formatNum($0) } ?? ""
+        activeTab = .manual
+    }
+
+    private func fillFromProduct(_ product: FoodProduct) {
+        name     = product.name.isEmpty ? searchQuery : product.name
+        calories = product.caloriesPer100g.map { formatNum($0) } ?? ""
+        proteinG = product.proteinPer100g.map   { formatNum($0) } ?? ""
+        carbsG   = product.carbsPer100g.map     { formatNum($0) } ?? ""
+        fatG     = product.fatPer100g.map       { formatNum($0) } ?? ""
+        activeTab = .manual
+    }
+
+    private func formatNum(_ v: Double) -> String {
+        v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Networking
+    // ─────────────────────────────────────────────────────
+
+    private func runTextSearch() {
+        let query = searchQuery.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return }
+        searchError = nil
+        isSearching = true
+        searchResults = []
+
+        Task {
+            defer { isSearching = false }
+            guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                  let url = URL(string: "https://world.openfoodfacts.org/cgi/search.pl?search_terms=\(encoded)&search_simple=1&action=process&json=1&page_size=10")
+            else {
+                searchError = "Invalid search query."
+                return
+            }
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                let decoded = try JSONDecoder().decode(OFFSearchResponse.self, from: data)
+                searchResults = decoded.products.compactMap { FoodProduct(from: $0) }
+                if searchResults.isEmpty {
+                    searchError = "No results found."
+                }
+            } catch {
+                searchError = "Search failed: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func fetchProduct(barcode: String) {
+        searchError = nil
+        isSearching = true
+        activeTab = .search
+
+        Task {
+            defer { isSearching = false }
+            guard let url = URL(string: "https://world.openfoodfacts.org/api/v0/product/\(barcode).json") else {
+                searchError = "Invalid barcode."
+                return
+            }
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                let decoded = try JSONDecoder().decode(OFFProductResponse.self, from: data)
+                if let raw = decoded.product, let product = FoodProduct(from: raw) {
+                    fillFromProduct(product)
+                } else {
+                    searchError = "Product not found for barcode \(barcode)."
+                }
+            } catch {
+                searchError = "Barcode lookup failed: \(error.localizedDescription)"
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – OpenFoodFacts response models
+// ─────────────────────────────────────────────────────────
+
+private struct OFFSearchResponse: Decodable {
+    var products: [OFFProduct]
+}
+
+private struct OFFProductResponse: Decodable {
+    var product: OFFProduct?
+}
+
+private struct OFFProduct: Decodable {
+    var product_name: String?
+
+    struct Nutriments: Decodable {
+        var energyKcal100g: Double?
+        var proteins100g:   Double?
+        var carbohydrates100g: Double?
+        var fat100g:        Double?
+
+        enum CodingKeys: String, CodingKey {
+            case energyKcal100g    = "energy-kcal_100g"
+            case proteins100g      = "proteins_100g"
+            case carbohydrates100g = "carbohydrates_100g"
+            case fat100g           = "fat_100g"
+        }
+    }
+    var nutriments: Nutriments?
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Parsed food product (view model)
+// ─────────────────────────────────────────────────────────
+
+private struct FoodProduct: Identifiable {
+    let id = UUID()
+    var name:             String
+    var caloriesPer100g:  Double?
+    var proteinPer100g:   Double?
+    var carbsPer100g:     Double?
+    var fatPer100g:       Double?
+
+    init?(from raw: OFFProduct) {
+        name             = raw.product_name ?? ""
+        caloriesPer100g  = raw.nutriments?.energyKcal100g.flatMap    { $0 > 0 ? $0 : nil }
+        proteinPer100g   = raw.nutriments?.proteins100g.flatMap       { $0 > 0 ? $0 : nil }
+        carbsPer100g     = raw.nutriments?.carbohydrates100g.flatMap  { $0 > 0 ? $0 : nil }
+        fatPer100g       = raw.nutriments?.fat100g.flatMap            { $0 > 0 ? $0 : nil }
+        return  // always succeed — caller filters empty names in UI
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Barcode Scanner (iOS only)
+// ─────────────────────────────────────────────────────────
+
+#if os(iOS)
+struct BarcodeScannerSheet: View {
+    let onScan: (String) -> Void
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationStack {
+            BarcodeScannerView(onScan: { barcode in
+                onScan(barcode)
+            })
+            .ignoresSafeArea()
+            .navigationTitle("Scan Barcode")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct BarcodeScannerView: UIViewControllerRepresentable {
+    let onScan: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScan: onScan)
+    }
+
+    func makeUIViewController(context: Context) -> BarcodeScannerVC {
+        let vc = BarcodeScannerVC()
+        vc.delegate = context.coordinator
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: BarcodeScannerVC, context: Context) {}
+
+    // ── Coordinator ──────────────────────────────────────
+
+    final class Coordinator: NSObject, BarcodeScannerVCDelegate {
+        let onScan: (String) -> Void
+        private var didScan = false
+
+        init(onScan: @escaping (String) -> Void) { self.onScan = onScan }
+
+        func barcodeScannerVC(_ vc: BarcodeScannerVC, didScanBarcode barcode: String) {
+            guard !didScan else { return }
+            didScan = true
+            DispatchQueue.main.async { self.onScan(barcode) }
+        }
+    }
+}
+
+// ── Protocol ─────────────────────────────────────────────
+
+protocol BarcodeScannerVCDelegate: AnyObject {
+    func barcodeScannerVC(_ vc: BarcodeScannerVC, didScanBarcode barcode: String)
+}
+
+// ── UIViewController wrapping AVCaptureSession ────────────
+
+final class BarcodeScannerVC: UIViewController {
+    weak var delegate: BarcodeScannerVCDelegate?
+
+    private let session        = AVCaptureSession()
+    private var previewLayer:    AVCaptureVideoPreviewLayer?
+    private let metadataQueue  = DispatchQueue(label: "com.fittracker.barcode")
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        setupSession()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        metadataQueue.async {
+            if !self.session.isRunning { self.session.startRunning() }
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        metadataQueue.async {
+            if self.session.isRunning { self.session.stopRunning() }
+        }
+    }
+
+    private func setupSession() {
+        guard AVCaptureDevice.authorizationStatus(for: .video) != .denied else {
+            showPermissionDenied()
+            return
+        }
+
+        session.beginConfiguration()
+        defer { session.commitConfiguration() }
+
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input  = try? AVCaptureDeviceInput(device: device) else { return }
+
+        if session.canAddInput(input) { session.addInput(input) }
+
+        let output = AVCaptureMetadataOutput()
+        if session.canAddOutput(output) {
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(self, queue: metadataQueue)
+            let supported: [AVMetadataObject.ObjectType] = [.ean8, .ean13, .upce, .code128, .qr]
+            output.metadataObjectTypes = supported.filter { output.availableMetadataObjectTypes.contains($0) }
+        }
+
+        let preview = AVCaptureVideoPreviewLayer(session: session)
+        preview.videoGravity = .resizeAspectFill
+        preview.frame = view.bounds
+        view.layer.insertSublayer(preview, at: 0)
+        previewLayer = preview
+
+        // Scanning guide overlay
+        let guide = UIView()
+        guide.layer.borderColor = UIColor.white.withAlphaComponent(0.8).cgColor
+        guide.layer.borderWidth = 2
+        guide.layer.cornerRadius = 8
+        guide.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(guide)
+        NSLayoutConstraint.activate([
+            guide.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            guide.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            guide.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7),
+            guide.heightAnchor.constraint(equalToConstant: 120)
+        ])
+    }
+
+    private func showPermissionDenied() {
+        DispatchQueue.main.async {
+            let label = UILabel()
+            label.text = "Camera access is required to scan barcodes.\nPlease enable it in Settings."
+            label.textColor = .white
+            label.numberOfLines = 0
+            label.textAlignment = .center
+            label.translatesAutoresizingMaskIntoConstraints = false
+            self.view.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+                label.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+                label.widthAnchor.constraint(equalTo: self.view.widthAnchor, constant: -40)
+            ])
+        }
+    }
+}
+
+extension BarcodeScannerVC: AVCaptureMetadataOutputObjectsDelegate {
+    func metadataOutput(_ output: AVCaptureMetadataOutput,
+                        didOutput metadataObjects: [AVMetadataObject],
+                        from connection: AVCaptureConnection) {
+        guard let obj = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              let value = obj.stringValue else { return }
+        session.stopRunning()
+        delegate?.barcodeScannerVC(self, didScanBarcode: value)
+    }
+}
+#endif

--- a/FitTracker/Views/Nutrition/MealSectionView.swift
+++ b/FitTracker/Views/Nutrition/MealSectionView.swift
@@ -1,0 +1,157 @@
+// Views/Nutrition/MealSectionView.swift
+
+import SwiftUI
+
+struct MealSectionView: View {
+    @Binding var nutritionLog: NutritionLog
+    let onTapMeal: (Int) -> Void  // called with mealNumber (1-4) when meal card is tapped
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ForEach(1...4, id: \.self) { mealNumber in
+                let entry = nutritionLog.meals.first(where: { $0.mealNumber == mealNumber })
+                MealCard(mealNumber: mealNumber, entry: entry) {
+                    onTapMeal(mealNumber)
+                }
+            }
+
+            // "+ Add Meal" footer button
+            Button {
+                onTapMeal(0)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(AppType.body)
+                        .foregroundStyle(Color.accent.cyan)
+                    Text("Add Meal")
+                        .font(AppType.body)
+                        .foregroundStyle(Color.accent.cyan)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.accent.cyan.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(Color.accent.cyan.opacity(0.3), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+// MARK: - MealCard
+
+private struct MealCard: View {
+    let mealNumber: Int
+    let entry: MealEntry?
+    let onTap: () -> Void
+
+    private var defaultName: String {
+        switch mealNumber {
+        case 1: return "Breakfast"
+        case 2: return "Lunch"
+        case 3: return "Dinner"
+        case 4: return "Snacks"
+        default: return "Meal \(mealNumber)"
+        }
+    }
+
+    private var displayName: String {
+        if let entry, !entry.name.isEmpty {
+            return entry.name
+        }
+        return defaultName
+    }
+
+    private var borderColor: Color {
+        if entry?.status == .completed {
+            return Color.status.success
+        }
+        return Color.secondary.opacity(0.15)
+    }
+
+    private var borderWidth: CGFloat {
+        entry?.status == .completed ? 1.5 : 1.0
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                // Meal number indicator
+                ZStack {
+                    Circle()
+                        .fill(entry != nil ? Color.appOrange1.opacity(0.25) : Color.secondary.opacity(0.1))
+                        .frame(width: 36, height: 36)
+                    Text("\(mealNumber)")
+                        .font(AppType.body)
+                        .foregroundStyle(entry != nil ? Color.appOrange2 : Color.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(displayName)
+                        .font(AppType.body)
+                        .foregroundStyle(entry != nil ? Color.primary : Color.secondary)
+
+                    if let entry {
+                        HStack(spacing: 8) {
+                            if let calories = entry.calories {
+                                Text("\(Int(calories)) kcal")
+                                    .font(AppType.subheading)
+                                    .foregroundStyle(Color.appOrange2)
+                            }
+                            if let protein = entry.proteinG {
+                                Text("\(Int(protein))g protein")
+                                    .font(AppType.subheading)
+                                    .foregroundStyle(Color.accent.cyan)
+                            }
+                            if let time = entry.eatenAt {
+                                Text(Self.timeFormatter.string(from: time))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(Color.secondary)
+                            }
+                        }
+                    } else {
+                        Text("Tap to log")
+                            .font(AppType.subheading)
+                            .foregroundStyle(Color.secondary.opacity(0.6))
+                    }
+                }
+
+                Spacer()
+
+                // Status indicator / chevron
+                if entry?.status == .completed {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(Color.status.success)
+                        .font(AppType.body)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(AppType.caption)
+                        .foregroundStyle(Color.secondary.opacity(0.5))
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(UIColor.secondarySystemBackground))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(borderColor, lineWidth: borderWidth)
+            )
+            .opacity(entry == nil ? 0.75 : 1.0)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/FitTracker/Views/Nutrition/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/NutritionView.swift
@@ -9,6 +9,8 @@ struct NutritionView: View {
 
     @EnvironmentObject var dataStore: EncryptedDataStore
     @State private var log: DailyLog?
+    @State private var supplementsExpanded = false
+    @State private var editingMealEntry: MealEntry?
 
     private var morning: [SupplementDefinition] { TrainingProgramData.morningSupplements }
     private var evening: [SupplementDefinition] { TrainingProgramData.eveningSupplements }
@@ -25,47 +27,10 @@ struct NutritionView: View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
                 dateHeader
+                macroBar
                 adherenceRow
-                SupplementStackCard(
-                    stackTitle: "🌅  Morning Stack",
-                    stackSubtitle: "Take with breakfast",
-                    supplements: morning,
-                    stackStatus: morningStatus,
-                    individualStatus: individualStatus,
-                    accentColor: Color(red: 1.0, green: 0.75, blue: 0.0)
-                ) { newStatus in
-                    log?.supplementLog.morningStatus = newStatus
-                    if newStatus == .completed {
-                        log?.supplementLog.morningTime = Date()
-                        // Auto-mark all morning supplements as taken
-                        for s in morning { log?.supplementLog.individualOverrides[s.id] = true }
-                    }
-                    saveLog()
-                } onToggle: { suppID, taken in
-                    log?.supplementLog.individualOverrides[suppID] = taken
-                    recomputeStackStatus(isEvening: false)
-                    saveLog()
-                }
-
-                SupplementStackCard(
-                    stackTitle: "🌙  Evening Stack",
-                    stackSubtitle: "30 min before bed",
-                    supplements: evening,
-                    stackStatus: eveningStatus,
-                    individualStatus: individualStatus,
-                    accentColor: Color.accent.purple
-                ) { newStatus in
-                    log?.supplementLog.eveningStatus = newStatus
-                    if newStatus == .completed {
-                        log?.supplementLog.eveningTime = Date()
-                        for s in evening { log?.supplementLog.individualOverrides[s.id] = true }
-                    }
-                    saveLog()
-                } onToggle: { suppID, taken in
-                    log?.supplementLog.individualOverrides[suppID] = taken
-                    recomputeStackStatus(isEvening: true)
-                    saveLog()
-                }
+                mealSection
+                supplementRow
 
                 disclaimerNote
             }
@@ -76,6 +41,30 @@ struct NutritionView: View {
         .navigationTitle("Nutrition")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { loadLog() }
+        .sheet(item: $editingMealEntry) { entry in
+            let entryBinding = Binding<MealEntry>(
+                get: { log?.nutritionLog.meals.first(where: { $0.mealNumber == entry.mealNumber }) ?? entry },
+                set: { newEntry in
+                    if let i = log?.nutritionLog.meals.firstIndex(where: { $0.mealNumber == entry.mealNumber }) {
+                        log?.nutritionLog.meals[i] = newEntry
+                    } else {
+                        log?.nutritionLog.meals.append(newEntry)
+                    }
+                }
+            )
+            MealEntrySheet(entry: entryBinding) { saved in
+                if let i = log?.nutritionLog.meals.firstIndex(where: { $0.mealNumber == saved.mealNumber }) {
+                    log?.nutritionLog.meals[i] = saved
+                } else {
+                    log?.nutritionLog.meals.append(saved)
+                }
+                saveLog()
+                editingMealEntry = nil
+            }
+            .environmentObject(dataStore)
+            .presentationDetents([.large])
+            .presentationCornerRadius(24)
+        }
     }
 
     // ─────────────────────────────────────────────────────
@@ -96,7 +85,7 @@ struct NutritionView: View {
     private var dateHeader: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Supplements")
+                Text("Nutrition")
                     .font(.title2.bold())
                 Text(formattedToday)
                     .font(.subheadline).foregroundStyle(.secondary)
@@ -148,6 +137,234 @@ struct NutritionView: View {
         }
         .padding(14)
         .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var macroBar: some View {
+        let nutrition = log?.nutritionLog ?? NutritionLog()
+        let protein   = nutrition.totalProteinG ?? nutrition.meals.compactMap(\.proteinG).reduce(0, +)
+        let carbs     = nutrition.totalCarbsG   ?? nutrition.meals.compactMap(\.carbsG).reduce(0, +)
+        let fat       = nutrition.totalFatG     ?? nutrition.meals.compactMap(\.fatG).reduce(0, +)
+        let phase     = dataStore.userProfile.currentPhase
+        let isTraining = log?.dayType.isTrainingDay ?? false
+        let targetCal = isTraining ? phase.trainingCalories : phase.restCalories
+        let leanMass  = log?.biometrics.leanBodyMassKg
+        let targetPro = leanMass.map { $0 * 2 } ?? 135.0
+
+        return MacroTargetBar(
+            protein: protein,
+            carbs: carbs,
+            fat: fat,
+            targetCalories: targetCal,
+            targetProteinG: targetPro
+        )
+    }
+
+    private var mealSection: some View {
+        let nutritionBinding = Binding<NutritionLog>(
+            get: { log?.nutritionLog ?? NutritionLog() },
+            set: { log?.nutritionLog = $0 }
+        )
+        return MealSectionView(nutritionLog: nutritionBinding) { mealNumber in
+            let existing = log?.nutritionLog.meals.first(where: { $0.mealNumber == mealNumber })
+            editingMealEntry = existing ?? MealEntry(mealNumber: max(mealNumber, 1))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // Compact supplement row (collapsed) / full cards (expanded)
+    // ─────────────────────────────────────────────────────
+
+    private var supplementRow: some View {
+        Group {
+            if supplementsExpanded {
+                // ── Expanded: show full stack cards with a collapse button ──
+                VStack(spacing: 12) {
+                    HStack {
+                        Spacer()
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                supplementsExpanded = false
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text("Hide")
+                                    .font(.caption.weight(.semibold))
+                                Image(systemName: "chevron.up")
+                                    .font(.caption.weight(.semibold))
+                            }
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(Color.secondary.opacity(0.1), in: Capsule())
+                        }
+                    }
+
+                    SupplementStackCard(
+                        stackTitle: "🌅  Morning Stack",
+                        stackSubtitle: "Take with breakfast",
+                        supplements: morning,
+                        stackStatus: morningStatus,
+                        individualStatus: individualStatus,
+                        accentColor: Color(red: 1.0, green: 0.75, blue: 0.0)
+                    ) { newStatus in
+                        log?.supplementLog.morningStatus = newStatus
+                        if newStatus == .completed {
+                            log?.supplementLog.morningTime = Date()
+                            for s in morning { log?.supplementLog.individualOverrides[s.id] = true }
+                        }
+                        saveLog()
+                    } onToggle: { suppID, taken in
+                        log?.supplementLog.individualOverrides[suppID] = taken
+                        recomputeStackStatus(isEvening: false)
+                        saveLog()
+                    }
+
+                    SupplementStackCard(
+                        stackTitle: "🌙  Evening Stack",
+                        stackSubtitle: "30 min before bed",
+                        supplements: evening,
+                        stackStatus: eveningStatus,
+                        individualStatus: individualStatus,
+                        accentColor: Color.accent.purple
+                    ) { newStatus in
+                        log?.supplementLog.eveningStatus = newStatus
+                        if newStatus == .completed {
+                            log?.supplementLog.eveningTime = Date()
+                            for s in evening { log?.supplementLog.individualOverrides[s.id] = true }
+                        }
+                        saveLog()
+                    } onToggle: { suppID, taken in
+                        log?.supplementLog.individualOverrides[suppID] = taken
+                        recomputeStackStatus(isEvening: true)
+                        saveLog()
+                    }
+                }
+            } else {
+                // ── Collapsed: single compact row ──
+                HStack(spacing: 12) {
+
+                    // Pills icon
+                    Image(systemName: "pills.fill")
+                        .font(.title3)
+                        .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.0))
+
+                    // Morning + Evening pill status buttons
+                    HStack(spacing: 8) {
+                        // Morning pill
+                        Button {
+                            HapticFeedback.impact()
+                            let newStatus: TaskStatus = morningStatus == .completed ? .pending : .completed
+                            log?.supplementLog.morningStatus = newStatus
+                            if newStatus == .completed {
+                                log?.supplementLog.morningTime = Date()
+                                for s in morning { log?.supplementLog.individualOverrides[s.id] = true }
+                            } else {
+                                for s in morning { log?.supplementLog.individualOverrides[s.id] = false }
+                            }
+                            recomputeStackStatus(isEvening: false)
+                            saveLog()
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text("Morning")
+                                    .font(.caption.weight(.semibold))
+                                if morningStatus == .completed {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption2.weight(.bold))
+                                }
+                            }
+                            .foregroundStyle(morningStatus == .completed ? Color.status.success : .secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(
+                                morningStatus == .completed
+                                    ? Color.status.success.opacity(0.15)
+                                    : Color.secondary.opacity(0.08)
+                            )
+                            .overlay(
+                                Capsule()
+                                    .stroke(
+                                        morningStatus == .completed
+                                            ? Color.status.success
+                                            : Color.secondary.opacity(0.3),
+                                        lineWidth: 1
+                                    )
+                            )
+                            .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+
+                        // Evening pill
+                        Button {
+                            HapticFeedback.impact()
+                            let newStatus: TaskStatus = eveningStatus == .completed ? .pending : .completed
+                            log?.supplementLog.eveningStatus = newStatus
+                            if newStatus == .completed {
+                                log?.supplementLog.eveningTime = Date()
+                                for s in evening { log?.supplementLog.individualOverrides[s.id] = true }
+                            } else {
+                                for s in evening { log?.supplementLog.individualOverrides[s.id] = false }
+                            }
+                            recomputeStackStatus(isEvening: true)
+                            saveLog()
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text("Evening")
+                                    .font(.caption.weight(.semibold))
+                                if eveningStatus == .completed {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption2.weight(.bold))
+                                }
+                            }
+                            .foregroundStyle(eveningStatus == .completed ? Color.status.success : .secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(
+                                eveningStatus == .completed
+                                    ? Color.status.success.opacity(0.15)
+                                    : Color.secondary.opacity(0.08)
+                            )
+                            .overlay(
+                                Capsule()
+                                    .stroke(
+                                        eveningStatus == .completed
+                                            ? Color.status.success
+                                            : Color.secondary.opacity(0.3),
+                                        lineWidth: 1
+                                    )
+                            )
+                            .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Spacer()
+
+                    // Streak badge
+                    Text("🔥 \(dataStore.supplementStreak)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.orange)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.orange.opacity(0.12), in: Capsule())
+
+                    // Expand chevron
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            supplementsExpanded = true
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .background(.background.secondary, in: RoundedRectangle(cornerRadius: 14))
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: supplementsExpanded)
     }
 
     private var disclaimerNote: some View {

--- a/FitTracker/Views/Nutrition/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/NutritionView.swift
@@ -53,7 +53,7 @@ struct NutritionView: View {
                     supplements: evening,
                     stackStatus: eveningStatus,
                     individualStatus: individualStatus,
-                    accentColor: .purple
+                    accentColor: Color.accent.purple
                 ) { newStatus in
                     log?.supplementLog.eveningStatus = newStatus
                     if newStatus == .completed {
@@ -114,7 +114,7 @@ struct NutritionView: View {
         return VStack(spacing: 2) {
             Text("\(pct)%")
                 .font(.system(.title3, design: .monospaced, weight: .bold))
-                .foregroundStyle(.green)
+                .foregroundStyle(Color.status.success)
             Text("today")
                 .font(.caption2).foregroundStyle(.secondary)
         }
@@ -139,7 +139,7 @@ struct NutritionView: View {
                     RoundedRectangle(cornerRadius: 3)
                         .fill(Color.secondary.opacity(0.15)).frame(height: 6)
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(LinearGradient(colors: [.green, .mint], startPoint: .leading, endPoint: .trailing))
+                        .fill(LinearGradient(colors: [Color.status.success, Color.status.success], startPoint: .leading, endPoint: .trailing))
                         .frame(width: geo.size.width * frac, height: 6)
                         .animation(.spring(response: 0.6), value: frac)
                 }

--- a/FitTracker/Views/Shared/ChartCard.swift
+++ b/FitTracker/Views/Shared/ChartCard.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// A container card that wraps a Swift Charts chart with a consistent header.
+struct ChartCard<Content: View>: View {
+    let title: String
+    let periodLabel: String        // e.g. "Last 7 days"
+    var trendDelta: Double? = nil  // if non-nil, shows a TrendIndicator
+    var positiveIsGood: Bool = true
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(title)
+                    .font(AppType.headline)
+
+                Spacer()
+
+                if let trendDelta = trendDelta {
+                    TrendIndicator(delta: trendDelta, positiveIsGood: positiveIsGood)
+                }
+            }
+            .padding(.bottom, 8)
+
+            Text(periodLabel)
+                .font(AppType.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 12)
+
+            content()
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color.white.opacity(0.12))
+        )
+    }
+}
+
+#Preview {
+    ChartCard(
+        title: "Weekly Activity",
+        periodLabel: "Last 7 days",
+        trendDelta: 12.5,
+        positiveIsGood: true
+    ) {
+        Text("Chart content goes here")
+            .frame(height: 200)
+    }
+}

--- a/FitTracker/Views/Shared/EmptyStateView.swift
+++ b/FitTracker/Views/Shared/EmptyStateView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Shown when a section has no data. Consistent no-data placeholder.
+struct EmptyStateView: View {
+    let icon: String         // SF Symbol, e.g. "chart.line.uptrend.xyaxis"
+    let title: String        // e.g. "No data yet"
+    let subtitle: String     // e.g. "Log a workout to see your stats here"
+    var ctaLabel: String? = nil
+    var ctaAction: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 44))
+                .foregroundColor(.secondary)
+
+            Text(title)
+                .font(AppType.headline)
+                .foregroundColor(.primary)
+
+            Text(subtitle)
+                .font(AppType.subheading)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let ctaLabel = ctaLabel, ctaAction != nil {
+                Button(action: ctaAction ?? {}) {
+                    Text(ctaLabel)
+                        .font(AppType.body)
+                }
+                .foregroundColor(.orange)
+            }
+        }
+        .padding(.horizontal, 32)
+    }
+}
+
+#Preview {
+    EmptyStateView(
+        icon: "chart.line.uptrend.xyaxis",
+        title: "No data yet",
+        subtitle: "Log a workout to see your stats here"
+    )
+}

--- a/FitTracker/Views/Shared/MetricCard.swift
+++ b/FitTracker/Views/Shared/MetricCard.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+/// Displays a single metric with icon, value, unit, optional trend delta, and status dot.
+struct MetricCard: View {
+    let icon: String          // SF Symbol name, e.g. "scalemass.fill"
+    let label: String         // e.g. "Weight"
+    let value: String         // e.g. "67.3"
+    let unit: String?         // e.g. "kg" — optional
+    let trendDelta: String?   // e.g. "↓ 0.5" — optional
+    let statusColor: Color    // dot colour: Color.status.success / warning / error
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(alignment: .leading, spacing: 8) {
+                // Top row: icon + label
+                HStack(spacing: 6) {
+                    Image(systemName: icon)
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(label)
+                        .font(AppType.caption)
+                        .textCase(.uppercase)
+                }
+                .foregroundColor(.secondary)
+
+                // Middle: value + unit
+                HStack(alignment: .baseline, spacing: 4) {
+                    Text(value)
+                        .font(AppType.display)
+                        .lineLimit(1)
+
+                    if let unit = unit {
+                        Text(unit)
+                            .font(AppType.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                // Bottom: trend delta (if present)
+                if let trendDelta = trendDelta {
+                    Text(trendDelta)
+                        .font(AppType.caption)
+                        .foregroundColor(statusColor)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Status dot at top-right
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+                .padding(12)
+        }
+        .background(Color.white.opacity(0.15))
+        .cornerRadius(14)
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        MetricCard(
+            icon: "scalemass.fill",
+            label: "Weight",
+            value: "67.3",
+            unit: "kg",
+            trendDelta: "↓ 0.5",
+            statusColor: .status.success
+        )
+
+        MetricCard(
+            icon: "heart.fill",
+            label: "Resting HR",
+            value: "58",
+            unit: "bpm",
+            trendDelta: nil,
+            statusColor: .status.warning
+        )
+
+        MetricCard(
+            icon: "flame.fill",
+            label: "Calories",
+            value: "2400",
+            unit: nil,
+            trendDelta: "↑ 120",
+            statusColor: .status.error
+        )
+    }
+    .padding()
+    .background(Color.black.opacity(0.05))
+}

--- a/FitTracker/Views/Shared/ReadinessCard.swift
+++ b/FitTracker/Views/Shared/ReadinessCard.swift
@@ -1,0 +1,439 @@
+// Views/Shared/ReadinessCard.swift
+// Multi-page auto-cycling readiness/health summary card.
+// iOS, iPadOS, macOS
+
+import SwiftUI
+
+struct ReadinessCard: View {
+    @EnvironmentObject var dataStore: EncryptedDataStore
+    @EnvironmentObject var healthKit: HealthKitService
+
+    @State private var currentPage = 0
+    @State private var timer: Timer?
+
+    // ── Timer helpers ─────────────────────────────────────
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { _ in
+            withAnimation(.easeInOut) {
+                currentPage = (currentPage + 1) % 5
+            }
+        }
+    }
+
+    // ── Body ──────────────────────────────────────────────
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            TabView(selection: $currentPage) {
+                scorePage.tag(0)
+                weeklyTrainingPage.tag(1)
+                nutritionPage.tag(2)
+                trendsPage.tag(3)
+                achievementsPage.tag(4)
+            }
+            #if os(iOS)
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            #else
+            .tabViewStyle(.automatic)
+            #endif
+            .frame(height: 180)
+
+            // Custom page dots
+            pageDots
+                .padding(.bottom, 6)
+        }
+        .frame(height: 180)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.white.opacity(0.12))
+        )
+        .onAppear { startTimer() }
+        .onDisappear {
+            timer?.invalidate()
+            timer = nil
+        }
+        .onChange(of: currentPage) { _, _ in
+            startTimer()
+        }
+    }
+
+    // ── Page dots ─────────────────────────────────────────
+
+    private var pageDots: some View {
+        HStack(spacing: 5) {
+            ForEach(0..<5, id: \.self) { i in
+                Circle()
+                    .fill(i == currentPage ? Color.white : Color.white.opacity(0.35))
+                    .frame(width: i == currentPage ? 7 : 5, height: i == currentPage ? 7 : 5)
+                    .animation(.easeInOut(duration: 0.2), value: currentPage)
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Page 0: Readiness Score
+    // ─────────────────────────────────────────────────────
+
+    private var scorePage: some View {
+        let score = dataStore.readinessScore(for: Date(), fallbackMetrics: healthKit.latest)
+        let today = dataStore.todayLog()
+        let live  = healthKit.latest
+
+        let hrv    = live.hrv          ?? today?.biometrics.effectiveHRV
+        let rhr    = live.restingHR    ?? today?.biometrics.effectiveRestingHR
+        let sleep  = live.sleepHours   ?? today?.biometrics.effectiveSleep
+
+        return VStack(spacing: 4) {
+            HStack(alignment: .lastTextBaseline, spacing: 4) {
+                Text(score.map { "\($0)" } ?? "–")
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundStyle(.white)
+                if score != nil {
+                    Text("/ 100")
+                        .font(AppType.subheading)
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+            }
+
+            if score == nil {
+                Text("Add 3+ days of data")
+                    .font(AppType.caption)
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+
+            Text(contextLabel(for: score))
+                .font(AppType.subheading)
+                .foregroundStyle(.white.opacity(0.8))
+                .multilineTextAlignment(.center)
+
+            Spacer(minLength: 4)
+
+            HStack(spacing: 16) {
+                biometricRow(icon: "waveform.path.ecg", label: hrv.map { String(format: "%.0f ms", $0) } ?? "–", title: "HRV")
+                biometricRow(icon: "heart.fill", label: rhr.map { String(format: "%.0f bpm", $0) } ?? "–", title: "RHR")
+                biometricRow(icon: "moon.fill", label: sleep.map { String(format: "%.1f hrs", $0) } ?? "–", title: "Sleep")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func contextLabel(for score: Int?) -> String {
+        guard let s = score else { return "Building your baseline..." }
+        switch s {
+        case 80...: return "HRV looks great today 💪"
+        case 60..<80: return "Good to go today"
+        case 40..<60: return "Sleep was short — train lighter"
+        default: return "Body needs rest today"
+        }
+    }
+
+    private func biometricRow(icon: String, label: String, title: String) -> some View {
+        VStack(spacing: 2) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(.white.opacity(0.7))
+            Text(label)
+                .font(AppType.caption)
+                .foregroundStyle(.white)
+                .lineLimit(1)
+            Text(title)
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.5))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Page 1: Weekly Training
+    // ─────────────────────────────────────────────────────
+
+    private var weeklyTrainingPage: some View {
+        let cal = Calendar.current
+        // Build Mon–Sun for the current week
+        let today = Date()
+        let weekday = cal.component(.weekday, from: today) // 1=Sun..7=Sat
+        // Days offset so Monday = index 0
+        let mondayOffset = (weekday == 1) ? -6 : -(weekday - 2)
+        let monday = cal.date(byAdding: .day, value: mondayOffset, to: cal.startOfDay(for: today)) ?? today
+
+        let weekDays: [Date] = (0..<7).compactMap { cal.date(byAdding: .day, value: $0, to: monday) }
+        let dayLabels = ["M", "T", "W", "T", "F", "S", "S"]
+
+        // Map logs to the week
+        let logsMap: [Date: DailyLog] = Dictionary(
+            uniqueKeysWithValues: dataStore.dailyLogs.compactMap { log in
+                guard let day = weekDays.first(where: { cal.isDate(log.date, inSameDayAs: $0) }) else { return nil }
+                return (day, log)
+            }
+        )
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("This Week")
+                .font(AppType.subheading)
+                .foregroundStyle(.white.opacity(0.7))
+                .padding(.horizontal, 16)
+
+            HStack(alignment: .bottom, spacing: 6) {
+                ForEach(Array(weekDays.enumerated()), id: \.offset) { idx, day in
+                    let log = logsMap[day]
+                    let pct = log?.completionPct ?? 0
+                    let barColor: Color = {
+                        guard log != nil else { return Color.secondary.opacity(0.2) }
+                        if pct >= 100 { return Color.status.success }
+                        if pct > 0    { return Color.accent.cyan }
+                        return Color.secondary.opacity(0.2)
+                    }()
+                    let maxBarHeight: CGFloat = 60
+                    let barHeight: CGFloat = log != nil ? max(4, CGFloat(pct / 100.0) * maxBarHeight) : 4
+
+                    VStack(spacing: 3) {
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(barColor)
+                            .frame(height: barHeight)
+                            .frame(maxWidth: .infinity)
+
+                        Text(dayLabels[idx])
+                            .font(.system(size: 9))
+                            .foregroundStyle(.white.opacity(0.5))
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: maxBarHeight + 16, alignment: .bottom)
+                }
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 76)
+
+            // Next day label
+            let tomorrowType = logsMap[weekDays.first(where: { cal.isDateInTomorrow($0) }) ?? today]?.dayType
+            Text("Next: \(tomorrowType?.rawValue ?? "–")")
+                .font(AppType.caption)
+                .foregroundStyle(.white.opacity(0.6))
+                .padding(.horizontal, 16)
+        }
+        .padding(.vertical, 10)
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Page 2: Nutrition Snapshot
+    // ─────────────────────────────────────────────────────
+
+    private var nutritionPage: some View {
+        let todayLog = dataStore.todayLog()
+        let nutrition = todayLog?.nutritionLog
+        let protein = nutrition?.totalProteinG ?? 0
+        let lbm = todayLog?.biometrics.leanBodyMassKg
+        let proteinTarget = lbm.map { $0 * 2.0 } ?? 135.0
+        let waterML = nutrition?.waterML ?? 0
+
+        let morningDone = todayLog?.supplementLog.morningStatus == .completed
+        let eveningDone = todayLog?.supplementLog.eveningStatus == .completed
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Nutrition")
+                .font(AppType.subheading)
+                .foregroundStyle(.white.opacity(0.7))
+
+            // Protein progress
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text("Protein")
+                        .font(AppType.caption)
+                        .foregroundStyle(.white.opacity(0.6))
+                    Spacer()
+                    Text(String(format: "%.0fg / %.0fg", protein, proteinTarget))
+                        .font(AppType.caption)
+                        .foregroundStyle(.white)
+                }
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color.white.opacity(0.15))
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color.accent.cyan)
+                            .frame(width: geo.size.width * min(1, CGFloat(protein / max(proteinTarget, 1))))
+                    }
+                }
+                .frame(height: 6)
+            }
+
+            // Supplements
+            HStack(spacing: 10) {
+                Image(systemName: "pill.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.6))
+                Text("Supplements")
+                    .font(AppType.caption)
+                    .foregroundStyle(.white.opacity(0.6))
+                supplementDot(label: "AM", done: morningDone)
+                supplementDot(label: "PM", done: eveningDone)
+            }
+
+            // Water
+            if waterML > 0 {
+                HStack(spacing: 6) {
+                    Image(systemName: "drop.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Color.accent.cyan.opacity(0.8))
+                    Text(String(format: "%.0f mL water", waterML))
+                        .font(AppType.caption)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func supplementDot(label: String, done: Bool) -> some View {
+        HStack(spacing: 3) {
+            Circle()
+                .fill(done ? Color.status.success : Color.white.opacity(0.25))
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.6))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Page 3: 7-Day Trends
+    // ─────────────────────────────────────────────────────
+
+    private var trendsPage: some View {
+        let logs = dataStore.dailyLogs
+            .sorted { $0.date < $1.date }
+
+        let latest = logs.last
+        let sevenAgo = logs.count >= 2 ? logs[max(0, logs.count - 7)] : nil
+
+        let weightDelta   = delta(latest: latest?.biometrics.weightKg,          ago: sevenAgo?.biometrics.weightKg)
+        let bfDelta       = delta(latest: latest?.biometrics.bodyFatPercent,     ago: sevenAgo?.biometrics.bodyFatPercent)
+        let hrvDelta      = delta(latest: latest?.biometrics.effectiveHRV,       ago: sevenAgo?.biometrics.effectiveHRV)
+        let sleepDelta    = delta(latest: latest?.biometrics.effectiveSleep,     ago: sevenAgo?.biometrics.effectiveSleep)
+
+        // Training volume: total across last 7 logs vs previous 7
+        let last7  = Array(logs.suffix(7))
+        let prev7  = logs.count >= 14 ? Array(logs.dropLast(7).suffix(7)) : []
+        let volNow  = last7.reduce(0.0) { $0 + $1.exerciseLogs.values.reduce(0.0) { $0 + $1.totalVolume } }
+        let volPrev = prev7.reduce(0.0) { $0 + $1.exerciseLogs.values.reduce(0.0) { $0 + $1.totalVolume } }
+        let volDelta = volPrev > 0 ? volNow - volPrev : nil
+
+        // Steps: use biometrics.stepCount
+        let stepsNow  = last7.compactMap { $0.biometrics.stepCount }.last
+        let stepsPrev = prev7.compactMap { $0.biometrics.stepCount }.last
+        let stepsDelta: Double? = (stepsNow != nil && stepsPrev != nil) ? Double(stepsNow! - stepsPrev!) : nil
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("7-Day Trends")
+                .font(AppType.subheading)
+                .foregroundStyle(.white.opacity(0.7))
+
+            let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
+            LazyVGrid(columns: columns, spacing: 8) {
+                trendCell(label: "Weight",  delta: weightDelta,  positiveIsGood: false)
+                trendCell(label: "Body Fat",delta: bfDelta,      positiveIsGood: false)
+                trendCell(label: "HRV",     delta: hrvDelta,     positiveIsGood: true)
+                trendCell(label: "Sleep",   delta: sleepDelta,   positiveIsGood: true)
+                trendCell(label: "Volume",  delta: volDelta,     positiveIsGood: true)
+                trendCell(label: "Steps",   delta: stepsDelta,   positiveIsGood: true)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func delta(latest: Double?, ago: Double?) -> Double? {
+        guard let a = latest, let b = ago else { return nil }
+        return a - b
+    }
+
+    private func trendCell(label: String, delta: Double?, positiveIsGood: Bool) -> some View {
+        VStack(spacing: 2) {
+            if let d = delta {
+                TrendIndicator(delta: d, positiveIsGood: positiveIsGood, isPercent: false)
+            } else {
+                Text("–")
+                    .font(AppType.caption)
+                    .foregroundStyle(.white.opacity(0.4))
+            }
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.5))
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Page 4: Achievements
+    // ─────────────────────────────────────────────────────
+
+    private var achievementsPage: some View {
+        let streak     = dataStore.supplementStreak
+        let dayOnProgram = dataStore.userProfile.daysSinceStart
+        let prsThisWeek = countPRsThisWeek()
+
+        return VStack(spacing: 6) {
+            Text("Achievements")
+                .font(AppType.subheading)
+                .foregroundStyle(.white.opacity(0.7))
+
+            HStack(spacing: 0) {
+                achievementCell(emoji: "🔥", value: streak,       label: "Supp Streak")
+                Divider().background(Color.white.opacity(0.2)).frame(height: 50)
+                achievementCell(emoji: "🏆", value: prsThisWeek,  label: "PRs This Week")
+                Divider().background(Color.white.opacity(0.2)).frame(height: 50)
+                achievementCell(emoji: "📅", value: dayOnProgram, label: "Program Day")
+            }
+            .padding(.horizontal, 8)
+        }
+        .padding(.vertical, 12)
+    }
+
+    private func achievementCell(emoji: String, value: Int, label: String) -> some View {
+        VStack(spacing: 4) {
+            Text(emoji)
+                .font(.system(size: 20))
+            Text("\(value)")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.white)
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.55))
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func countPRsThisWeek() -> Int {
+        let cal = Calendar.current
+        let today = Date()
+        let weekday = cal.component(.weekday, from: today)
+        let mondayOffset = (weekday == 1) ? -6 : -(weekday - 2)
+        guard let weekStart = cal.date(byAdding: .day, value: mondayOffset, to: cal.startOfDay(for: today)) else { return 0 }
+
+        let thisWeekLogs = dataStore.dailyLogs.filter { $0.date >= weekStart }
+        let priorLogs    = dataStore.dailyLogs.filter { $0.date < weekStart }
+
+        // Build all-time best per exercise from prior logs
+        var allTimeBest: [String: Double] = [:]
+        for log in priorLogs {
+            for (exerciseID, exLog) in log.exerciseLogs {
+                let best = exLog.bestSet?.weightKg ?? 0
+                allTimeBest[exerciseID] = max(allTimeBest[exerciseID] ?? 0, best)
+            }
+        }
+
+        // Count exercises this week that beat all-time prior best
+        var prExercises = Set<String>()
+        for log in thisWeekLogs {
+            for (exerciseID, exLog) in log.exerciseLogs {
+                guard let best = exLog.bestSet?.weightKg else { continue }
+                let prior = allTimeBest[exerciseID] ?? 0
+                if best > prior {
+                    prExercises.insert(exerciseID)
+                }
+            }
+        }
+        return prExercises.count
+    }
+}

--- a/FitTracker/Views/Shared/SectionHeader.swift
+++ b/FitTracker/Views/Shared/SectionHeader.swift
@@ -12,8 +12,7 @@ struct SectionHeader: View {
                 .font(AppType.caption)
                 .textCase(.uppercase)
                 .tracking(1.5)
-                .smallCaps()
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
 
             Spacer()
 

--- a/FitTracker/Views/Shared/SectionHeader.swift
+++ b/FitTracker/Views/Shared/SectionHeader.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Consistent section title header with optional action.
+struct SectionHeader: View {
+    let title: String
+    var actionLabel: String? = nil
+    var action: (() -> Void)? = nil
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(AppType.caption)
+                .textCase(.uppercase)
+                .tracking(1.5)
+                .smallCaps()
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            if let actionLabel = actionLabel {
+                Button(action: { action?() }) {
+                    Text(actionLabel)
+                        .font(AppType.caption)
+                        .foregroundColor(.blue)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        SectionHeader(title: "Today's Metrics")
+
+        SectionHeader(
+            title: "Recent Workouts",
+            actionLabel: "View All",
+            action: { print("View All tapped") }
+        )
+
+        SectionHeader(title: "Health Data")
+    }
+    .padding()
+    .background(Color.black.opacity(0.05))
+}

--- a/FitTracker/Views/Shared/StatusBadge.swift
+++ b/FitTracker/Views/Shared/StatusBadge.swift
@@ -12,7 +12,7 @@ struct StatusBadge: View {
             .padding(.vertical, 4)
             .padding(.horizontal, 10)
             .background(color.opacity(0.2))
-            .capsule()
+            .clipShape(Capsule())
     }
 }
 

--- a/FitTracker/Views/Shared/StatusBadge.swift
+++ b/FitTracker/Views/Shared/StatusBadge.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// A simple pill badge displaying text with a coloured background.
+struct StatusBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(AppType.caption)
+            .foregroundColor(color)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 10)
+            .background(color.opacity(0.2))
+            .capsule()
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        HStack(spacing: 8) {
+            StatusBadge(text: "Active", color: .status.success)
+            StatusBadge(text: "Pending", color: .status.warning)
+            StatusBadge(text: "Error", color: .status.error)
+        }
+
+        HStack(spacing: 8) {
+            StatusBadge(text: "Completed", color: .accent.cyan)
+            StatusBadge(text: "Premium", color: .accent.gold)
+            StatusBadge(text: "Featured", color: .accent.purple)
+        }
+    }
+    .padding()
+    .background(Color.black.opacity(0.05))
+}

--- a/FitTracker/Views/Shared/TrendIndicator.swift
+++ b/FitTracker/Views/Shared/TrendIndicator.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// A coloured pill showing a numeric delta.
+struct TrendIndicator: View {
+    let delta: Double        // e.g. 0.12 = 12%
+    let positiveIsGood: Bool // true for HRV (up=good), false for weight/BF (down=good)
+    var isPercent: Bool = true
+
+    var statusColor: Color {
+        if delta > 0 && positiveIsGood {
+            return .status.success
+        } else if delta < 0 && !positiveIsGood {
+            return .status.success
+        } else if delta == 0 {
+            return .status.warning
+        } else {
+            return .status.error
+        }
+    }
+
+    var displayText: String {
+        let arrow = delta >= 0 ? "↑" : "↓"
+        let absoluteValue = abs(delta)
+
+        if isPercent {
+            return String(format: "%@ %.0f%%", arrow, absoluteValue * 100)
+        } else {
+            return String(format: "%@ %.2f", arrow, absoluteValue)
+        }
+    }
+
+    var body: some View {
+        Text(displayText)
+            .font(AppType.caption)
+            .foregroundColor(statusColor)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(statusColor.opacity(0.2))
+            .capsule()
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        HStack(spacing: 12) {
+            TrendIndicator(delta: 0.12, positiveIsGood: true)
+            TrendIndicator(delta: -0.04, positiveIsGood: false)
+            TrendIndicator(delta: 0.0, positiveIsGood: true)
+        }
+
+        HStack(spacing: 12) {
+            TrendIndicator(delta: -0.08, positiveIsGood: true)
+            TrendIndicator(delta: 0.05, positiveIsGood: false)
+        }
+
+        HStack(spacing: 12) {
+            TrendIndicator(delta: 0.15, positiveIsGood: false, isPercent: false)
+            TrendIndicator(delta: -2.5, positiveIsGood: false, isPercent: false)
+        }
+    }
+    .padding()
+    .background(Color.black.opacity(0.05))
+}

--- a/FitTracker/Views/Shared/TrendIndicator.swift
+++ b/FitTracker/Views/Shared/TrendIndicator.swift
@@ -36,7 +36,7 @@ struct TrendIndicator: View {
             .padding(.vertical, 4)
             .padding(.horizontal, 8)
             .background(statusColor.opacity(0.2))
-            .capsule()
+            .clipShape(Capsule())
     }
 }
 

--- a/FitTracker/Views/Stats/StatsDataHelpers.swift
+++ b/FitTracker/Views/Stats/StatsDataHelpers.swift
@@ -1,0 +1,146 @@
+// Views/Stats/StatsDataHelpers.swift
+import Foundation
+
+extension EncryptedDataStore {
+
+    // MARK: – Body Composition
+
+    /// Returns one entry per DailyLog in [from, to] that has at least one biometric value.
+    func bodyCompositionPoints(from: Date, to: Date)
+        -> [(date: Date, weightKg: Double?, bodyFatPercent: Double?, leanBodyMassKg: Double?)]
+    {
+        dailyLogs
+            .filter { log in
+                log.date >= from && log.date <= to
+            }
+            .sorted { $0.date < $1.date }
+            .compactMap { log in
+                let b = log.biometrics
+                guard b.weightKg != nil || b.bodyFatPercent != nil || b.leanBodyMassKg != nil else {
+                    return nil
+                }
+                return (
+                    date: log.date,
+                    weightKg: b.weightKg,
+                    bodyFatPercent: b.bodyFatPercent,
+                    leanBodyMassKg: b.leanBodyMassKg
+                )
+            }
+    }
+
+    // MARK: – Training Volume
+
+    /// Sum of (weightKg × repsCompleted) across all non-warmup sets per DailyLog in range.
+    func trainingVolumePoints(from: Date, to: Date) -> [(date: Date, volumeKg: Double)] {
+        dailyLogs
+            .filter { log in
+                log.date >= from && log.date <= to && log.dayType.isTrainingDay
+            }
+            .sorted { $0.date < $1.date }
+            .compactMap { log in
+                let volume = log.exerciseLogs.values.flatMap { exerciseLog in
+                    exerciseLog.sets.compactMap { set -> Double? in
+                        guard !set.isWarmup,
+                              let weight = set.weightKg,
+                              let reps = set.repsCompleted
+                        else { return nil }
+                        return weight * Double(reps)
+                    }
+                }.reduce(0, +)
+                guard volume > 0 else { return nil }
+                return (date: log.date, volumeKg: volume)
+            }
+    }
+
+    // MARK: – Zone 2 Cardio
+
+    /// Total cardio duration (minutes) per DailyLog where avgHeartRate is in 106–124 bpm.
+    func zone2Minutes(from: Date, to: Date) -> [(date: Date, minutes: Double)] {
+        dailyLogs
+            .filter { log in
+                log.date >= from && log.date <= to
+            }
+            .sorted { $0.date < $1.date }
+            .compactMap { log in
+                let minutes = log.cardioLogs.values.compactMap { cardioLog -> Double? in
+                    guard let hr = cardioLog.avgHeartRate,
+                          hr >= 106 && hr <= 124,
+                          let duration = cardioLog.durationMinutes
+                    else { return nil }
+                    return duration
+                }.reduce(0, +)
+                guard minutes > 0 else { return nil }
+                return (date: log.date, minutes: minutes)
+            }
+    }
+
+    // MARK: – Recovery
+
+    func recoveryPoints(from: Date, to: Date)
+        -> [(date: Date, hrv: Double?, restingHR: Double?, sleepHours: Double?)]
+    {
+        dailyLogs
+            .filter { log in
+                log.date >= from && log.date <= to
+            }
+            .sorted { $0.date < $1.date }
+            .map { log in
+                let b = log.biometrics
+                return (
+                    date: log.date,
+                    hrv: b.effectiveHRV,
+                    restingHR: b.effectiveRestingHR,
+                    sleepHours: b.effectiveSleep
+                )
+            }
+    }
+
+    // MARK: – Nutrition Adherence
+
+    func nutritionAdherencePoints(from: Date, to: Date)
+        -> [(date: Date, calories: Double?, proteinG: Double?, supplementPct: Double)]
+    {
+        dailyLogs
+            .filter { log in
+                log.date >= from && log.date <= to
+            }
+            .sorted { $0.date < $1.date }
+            .map { log in
+                let nutrition = log.nutritionLog
+                let supp = log.supplementLog
+                let supplementPct =
+                    (supp.morningStatus == .completed ? 0.5 : 0.0) +
+                    (supp.eveningStatus == .completed ? 0.5 : 0.0)
+                return (
+                    date: log.date,
+                    calories: nutrition.totalCalories,
+                    proteinG: nutrition.totalProteinG,
+                    supplementPct: supplementPct
+                )
+            }
+    }
+
+    // MARK: – Personal Records
+
+    /// All-time max SetLog.weightKg per exerciseID, excluding warmup sets.
+    /// Returns dict: [exerciseID: (weightKg: Double, date: Date)]
+    func prRecords() -> [String: (weightKg: Double, date: Date)] {
+        var records: [String: (weightKg: Double, date: Date)] = [:]
+        for log in dailyLogs {
+            for exerciseLog in log.exerciseLogs.values {
+                for set in exerciseLog.sets {
+                    guard !set.isWarmup, let weight = set.weightKg else { continue }
+                    let exerciseID = exerciseLog.exerciseID
+                    if let existing = records[exerciseID] {
+                        if weight > existing.weightKg {
+                            records[exerciseID] = (weightKg: weight, date: log.date)
+                        }
+                    } else {
+                        records[exerciseID] = (weightKg: weight, date: log.date)
+                    }
+                }
+            }
+        }
+        return records
+    }
+}

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -1,78 +1,146 @@
 // Views/Stats/StatsView.swift
-// Tab 4: Stats — placeholder for now, scaffolded for future charts
 
 import SwiftUI
+import Charts
+
+// MARK: – Supporting enums
+
+enum StatsPeriod: String, CaseIterable {
+    case sevenDays    = "7D"
+    case thirtyDays   = "30D"
+    case ninetyDays   = "90D"
+    case allTime      = "All"
+
+    var dateRange: (from: Date, to: Date) {
+        let to = Date()
+        switch self {
+        case .sevenDays:   return (Calendar.current.date(byAdding: .day, value: -7, to: to)!, to)
+        case .thirtyDays:  return (Calendar.current.date(byAdding: .day, value: -30, to: to)!, to)
+        case .ninetyDays:  return (Calendar.current.date(byAdding: .day, value: -90, to: to)!, to)
+        case .allTime:     return (Date.distantPast, to)
+        }
+    }
+}
+
+enum StatsCategory: String, CaseIterable {
+    case body      = "Body"
+    case training  = "Training"
+    case recovery  = "Recovery"
+    case nutrition = "Nutrition"
+}
+
+// MARK: – StatsView
 
 struct StatsView: View {
-
     @EnvironmentObject var dataStore:     EncryptedDataStore
     @EnvironmentObject var healthService: HealthKitService
 
-    private let bgOrange1 = Color.appOrange1
-    private let bgOrange2 = Color.appOrange2
+    @State private var period:   StatsPeriod   = .thirtyDays
+    @State private var category: StatsCategory = .body
+
+    private var dateRange: (from: Date, to: Date) { period.dateRange }
 
     var body: some View {
         ZStack {
-        LinearGradient(colors: [bgOrange1, bgOrange2],
-                       startPoint: .topLeading, endPoint: .bottomTrailing)
+            // Background gradient (same warm orange palette as rest of app)
+            LinearGradient(
+                colors: [Color.appOrange1, Color.appOrange2],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
             .ignoresSafeArea()
 
-        VStack(spacing: 0) {
-            // ── Coming soon state ────────────────────────
-            Spacer()
-            VStack(spacing: 20) {
-                Image(systemName: "chart.bar.fill")
-                    .font(.system(size: 56))
-                    .foregroundStyle(Color.blue)
-
-                VStack(spacing: 8) {
-                    Text("Stats coming soon")
-                        .font(.title3.bold())
-                        .foregroundStyle(.secondary)
-                    Text("Keep logging your training, supplements,\nand biometrics. Charts and trends will\nappear here as data builds up.")
-                        .font(.subheadline)
-                        .foregroundStyle(.tertiary)
-                        .multilineTextAlignment(.center)
+            VStack(spacing: 0) {
+                // Period picker
+                Picker("Period", selection: $period) {
+                    ForEach(StatsPeriod.allCases, id: \.self) { p in
+                        Text(p.rawValue).tag(p)
+                    }
                 }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
 
-                // Show a tiny summary if there's any data
-                if !dataStore.dailyLogs.isEmpty {
-                    dataPreviewCard
+                // Category tab buttons
+                HStack(spacing: 0) {
+                    ForEach(StatsCategory.allCases, id: \.self) { cat in
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.2)) { category = cat }
+                        } label: {
+                            Text(cat.rawValue)
+                                .font(AppType.body)
+                                .foregroundStyle(category == cat ? Color.primary : Color.secondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .background(
+                                    category == cat
+                                        ? Color.white.opacity(0.25)
+                                        : Color.clear
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .background(Color.white.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .padding(.horizontal, 16)
+                .padding(.bottom, 8)
+
+                // Chart content area
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        switch category {
+                        case .body:
+                            bodySection
+                        case .training:
+                            trainingSection
+                        case .recovery:
+                            recoverySection
+                        case .nutrition:
+                            nutritionSection
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 24)
                 }
             }
-            .padding(40)
-            Spacer()
         }
-        } // ZStack
         .navigationTitle("Stats")
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private var dataPreviewCard: some View {
-        VStack(spacing: 12) {
-            Text("DATA COLLECTED SO FAR")
-                .font(.caption2.monospaced())
-                .foregroundStyle(.secondary)
-                .tracking(1.5)
+    // MARK: – Stub sections (filled in subsequent steps)
 
-            HStack(spacing: 0) {
-                StatPreviewPill(value: "\(dataStore.dailyLogs.count)", label: "Days logged")
-                Divider().frame(height: 30)
-                StatPreviewPill(value: "\(totalSets)", label: "Sets logged")
-                Divider().frame(height: 30)
-                StatPreviewPill(value: "\(totalCardioSessions)", label: "Cardio sessions")
-            }
-        }
-        .padding(16)
-        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 14))
+    private var bodySection: some View {
+        EmptyStateView(
+            icon: "chart.line.uptrend.xyaxis",
+            title: "Body Composition",
+            subtitle: "Charts coming in the next build step"
+        )
     }
 
-    private var totalSets: Int {
-        dataStore.dailyLogs.flatMap { $0.exerciseLogs.values }.map { $0.sets.count }.reduce(0, +)
+    private var trainingSection: some View {
+        EmptyStateView(
+            icon: "dumbbell.fill",
+            title: "Training Performance",
+            subtitle: "Charts coming in the next build step"
+        )
     }
 
-    private var totalCardioSessions: Int {
-        dataStore.dailyLogs.map { $0.cardioLogs.count }.reduce(0, +)
+    private var recoverySection: some View {
+        EmptyStateView(
+            icon: "waveform.path.ecg",
+            title: "Recovery Metrics",
+            subtitle: "Charts coming in the next build step"
+        )
+    }
+
+    private var nutritionSection: some View {
+        EmptyStateView(
+            icon: "fork.knife",
+            title: "Nutrition Adherence",
+            subtitle: "Charts coming in the next build step"
+        )
     }
 }
 

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -38,6 +38,20 @@ struct StatsView: View {
     @State private var period:   StatsPeriod   = .thirtyDays
     @State private var category: StatsCategory = .body
 
+    // Body section data
+    @State private var bodyData: [(date: Date, weightKg: Double?, bodyFatPercent: Double?, leanBodyMassKg: Double?)] = []
+
+    // Training section data
+    @State private var volumeData:        [(date: Date, volumeKg: Double)] = []
+    @State private var zone2Data:         [(date: Date, minutes: Double)]  = []
+    @State private var selectedExercise:  String? = nil
+
+    // Recovery section data
+    @State private var recoveryData: [(date: Date, hrv: Double?, restingHR: Double?, sleepHours: Double?)] = []
+
+    // Nutrition section data
+    @State private var nutritionData: [(date: Date, calories: Double?, proteinG: Double?, supplementPct: Double)] = []
+
     private var dateRange: (from: Date, to: Date) { period.dateRange }
 
     var body: some View {
@@ -109,38 +123,451 @@ struct StatsView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    // MARK: – Stub sections (filled in subsequent steps)
+    // MARK: – Body Section
 
     private var bodySection: some View {
-        EmptyStateView(
-            icon: "chart.line.uptrend.xyaxis",
-            title: "Body Composition",
-            subtitle: "Charts coming in the next build step"
-        )
+        VStack(spacing: 16) {
+            // Weight chart
+            ChartCard(title: "Weight", periodLabel: period.rawValue) {
+                if bodyData.compactMap(\.weightKg).isEmpty {
+                    EmptyStateView(icon: "scalemass", title: "No weight data", subtitle: "Log your weight to see the chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(bodyData.filter { $0.weightKg != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("kg", p.weightKg!))
+                                .foregroundStyle(Color.appOrange1.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("kg", p.weightKg!))
+                                .foregroundStyle(Color.appOrange1)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                        RuleMark(y: .value("Target", dataStore.userProfile.targetWeightMax))
+                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                            .foregroundStyle(Color.appOrange1.opacity(0.5))
+                            .annotation(position: .trailing) {
+                                Text("Goal").font(AppType.caption).foregroundStyle(Color.appOrange1)
+                            }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Body Fat chart
+            ChartCard(title: "Body Fat %", periodLabel: period.rawValue) {
+                if bodyData.compactMap(\.bodyFatPercent).isEmpty {
+                    EmptyStateView(icon: "drop", title: "No body fat data", subtitle: "Log your body fat to see the chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(bodyData.filter { $0.bodyFatPercent != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("%", p.bodyFatPercent!))
+                                .foregroundStyle(Color.status.warning.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("%", p.bodyFatPercent!))
+                                .foregroundStyle(Color.status.warning)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                        RuleMark(y: .value("Target", dataStore.userProfile.targetBFMax))
+                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                            .foregroundStyle(Color.status.warning.opacity(0.5))
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Lean Mass chart
+            ChartCard(title: "Lean Mass", periodLabel: period.rawValue) {
+                if bodyData.compactMap(\.leanBodyMassKg).isEmpty {
+                    EmptyStateView(icon: "figure.arms.open", title: "No lean mass data", subtitle: "Log your body composition to see the chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(bodyData.filter { $0.leanBodyMassKg != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("kg", p.leanBodyMassKg!))
+                                .foregroundStyle(Color.accent.cyan.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("kg", p.leanBodyMassKg!))
+                                .foregroundStyle(Color.accent.cyan)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+        }
+        .task(id: period) {
+            let range = dateRange
+            bodyData = await Task.detached(priority: .userInitiated) { [store = dataStore] in
+                store.bodyCompositionPoints(from: range.from, to: range.to)
+            }.value
+        }
     }
+
+    // MARK: – Training Section
 
     private var trainingSection: some View {
-        EmptyStateView(
-            icon: "dumbbell.fill",
-            title: "Training Performance",
-            subtitle: "Charts coming in the next build step"
-        )
+        VStack(spacing: 16) {
+            // Training Volume chart
+            ChartCard(title: "Training Volume", periodLabel: period.rawValue) {
+                if volumeData.isEmpty {
+                    EmptyStateView(icon: "dumbbell.fill", title: "No training data", subtitle: "Log a workout to see your volume chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(volumeData, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("kg", p.volumeKg))
+                                .foregroundStyle(Color.accent.cyan.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("kg", p.volumeKg))
+                                .foregroundStyle(Color.accent.cyan)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                        // TODO: Add gold ★ annotations at PR dates once exercise selection UI is added
+                        // prRecords()[selectedExercise]?.date matching a volumeData point
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Zone 2 chart
+            ChartCard(title: "Zone 2 Cardio", periodLabel: period.rawValue) {
+                if zone2Data.isEmpty {
+                    EmptyStateView(icon: "heart.circle", title: "No Zone 2 data", subtitle: "Log cardio with HR 106–124 bpm to see this chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(zone2Data, id: \.date) { p in
+                            BarMark(x: .value("Date", p.date), y: .value("min", p.minutes))
+                                .foregroundStyle(Color.status.success)
+                        }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+        }
+        .task(id: period) {
+            let range = dateRange
+            async let volumeTask = Task.detached(priority: .userInitiated) { [store = dataStore] in
+                store.trainingVolumePoints(from: range.from, to: range.to)
+            }.value
+            async let zone2Task = Task.detached(priority: .userInitiated) { [store = dataStore] in
+                store.zone2Minutes(from: range.from, to: range.to)
+            }.value
+            volumeData = await volumeTask
+            zone2Data  = await zone2Task
+        }
     }
+
+    // MARK: – Recovery Section
 
     private var recoverySection: some View {
-        EmptyStateView(
-            icon: "waveform.path.ecg",
-            title: "Recovery Metrics",
-            subtitle: "Charts coming in the next build step"
-        )
+        VStack(spacing: 16) {
+            // HRV chart with zone bands
+            ChartCard(title: "HRV", periodLabel: period.rawValue) {
+                if recoveryData.compactMap(\.hrv).isEmpty {
+                    EmptyStateView(icon: "waveform.path.ecg", title: "No HRV data", subtitle: "HRV is recorded via Apple Watch or manual entry")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        // Zone bands behind the line
+                        RectangleMark(
+                            xStart: .value("Start", dateRange.from),
+                            xEnd:   .value("End",   dateRange.to),
+                            yStart: .value("Low",   35.0),
+                            yEnd:   .value("High",  100.0)
+                        )
+                        .foregroundStyle(Color.status.success.opacity(0.08))
+
+                        RectangleMark(
+                            xStart: .value("Start", dateRange.from),
+                            xEnd:   .value("End",   dateRange.to),
+                            yStart: .value("Low",   28.0),
+                            yEnd:   .value("High",  35.0)
+                        )
+                        .foregroundStyle(Color.status.warning.opacity(0.08))
+
+                        RectangleMark(
+                            xStart: .value("Start", dateRange.from),
+                            xEnd:   .value("End",   dateRange.to),
+                            yStart: .value("Low",   0.0),
+                            yEnd:   .value("High",  28.0)
+                        )
+                        .foregroundStyle(Color.status.error.opacity(0.08))
+
+                        ForEach(recoveryData.filter { $0.hrv != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("ms", p.hrv!))
+                                .foregroundStyle(Color.accent.cyan.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("ms", p.hrv!))
+                                .foregroundStyle(Color.accent.cyan)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Resting HR chart
+            ChartCard(title: "Resting Heart Rate", periodLabel: period.rawValue) {
+                if recoveryData.compactMap(\.restingHR).isEmpty {
+                    EmptyStateView(icon: "heart.fill", title: "No resting HR data", subtitle: "Resting HR is recorded via Apple Watch or manual entry")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(recoveryData.filter { $0.restingHR != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("bpm", p.restingHR!))
+                                .foregroundStyle(Color.status.error.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("bpm", p.restingHR!))
+                                .foregroundStyle(Color.status.error)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Sleep Hours chart
+            ChartCard(title: "Sleep Hours", periodLabel: period.rawValue) {
+                if recoveryData.compactMap(\.sleepHours).isEmpty {
+                    EmptyStateView(icon: "bed.double.fill", title: "No sleep data", subtitle: "Sleep is recorded via Apple Watch or manual entry")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(recoveryData.filter { $0.sleepHours != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("hrs", p.sleepHours!))
+                                .foregroundStyle(Color.accent.purple.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("hrs", p.sleepHours!))
+                                .foregroundStyle(Color.accent.purple)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Readiness Score — placeholder for step 5.6
+            ChartCard(title: "Readiness Score", periodLabel: period.rawValue) {
+                EmptyStateView(
+                    icon: "sparkles",
+                    title: "Readiness Score",
+                    subtitle: "Readiness score available after biometric data loads"
+                )
+                .frame(height: 120)
+            }
+        }
+        .task(id: period) {
+            let range = dateRange
+            recoveryData = await Task.detached(priority: .userInitiated) { [store = dataStore] in
+                store.recoveryPoints(from: range.from, to: range.to)
+            }.value
+        }
     }
 
+    // MARK: – Nutrition Section
+
     private var nutritionSection: some View {
-        EmptyStateView(
-            icon: "fork.knife",
-            title: "Nutrition Adherence",
-            subtitle: "Charts coming in the next build step"
-        )
+        VStack(spacing: 16) {
+            // Calories chart
+            ChartCard(title: "Calories", periodLabel: period.rawValue) {
+                if nutritionData.compactMap(\.calories).isEmpty {
+                    EmptyStateView(icon: "fork.knife", title: "No calorie data", subtitle: "Log your meals to see the chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(nutritionData.filter { $0.calories != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("kcal", p.calories!))
+                                .foregroundStyle(Color.appOrange1.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("kcal", p.calories!))
+                                .foregroundStyle(Color.appOrange1)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                        RuleMark(y: .value("Target", Double(dataStore.userProfile.currentPhase.trainingCalories)))
+                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                            .foregroundStyle(Color.appOrange1.opacity(0.5))
+                            .annotation(position: .trailing) {
+                                Text("Target").font(AppType.caption).foregroundStyle(Color.appOrange1)
+                            }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Protein chart
+            ChartCard(title: "Protein", periodLabel: period.rawValue) {
+                if nutritionData.compactMap(\.proteinG).isEmpty {
+                    EmptyStateView(icon: "fork.knife", title: "No protein data", subtitle: "Log your meals to see the chart")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(nutritionData.filter { $0.proteinG != nil }, id: \.date) { p in
+                            AreaMark(x: .value("Date", p.date), y: .value("g", p.proteinG!))
+                                .foregroundStyle(Color.accent.cyan.opacity(0.2).gradient)
+                            LineMark(x: .value("Date", p.date), y: .value("g", p.proteinG!))
+                                .foregroundStyle(Color.accent.cyan)
+                                .lineStyle(StrokeStyle(lineWidth: 2))
+                        }
+                        RuleMark(y: .value("Target", dataStore.userProfile.currentPhase.proteinTargetG.upperBound))
+                            .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                            .foregroundStyle(Color.accent.cyan.opacity(0.5))
+                            .annotation(position: .trailing) {
+                                Text("Target").font(AppType.caption).foregroundStyle(Color.accent.cyan)
+                            }
+                    }
+                    .frame(height: 140)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+
+            // Supplement adherence chart
+            ChartCard(title: "Supplement Adherence", periodLabel: period.rawValue) {
+                if nutritionData.isEmpty {
+                    EmptyStateView(icon: "pill.fill", title: "No supplement data", subtitle: "Log your supplements to see adherence")
+                        .frame(height: 120)
+                } else {
+                    Chart {
+                        ForEach(nutritionData, id: \.date) { p in
+                            BarMark(x: .value("Date", p.date), y: .value("%", p.supplementPct * 100))
+                                .foregroundStyle(Color.accent.gold)
+                        }
+                    }
+                    .frame(height: 140)
+                    .chartYScale(domain: 0...100)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                            AxisGridLine()
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                }
+            }
+        }
+        .task(id: period) {
+            let range = dateRange
+            nutritionData = await Task.detached(priority: .userInitiated) { [store = dataStore] in
+                store.nutritionAdherencePoints(from: range.from, to: range.to)
+            }.value
+        }
     }
 }
 

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -437,14 +437,62 @@ struct StatsView: View {
                 }
             }
 
-            // Readiness Score — placeholder for step 5.6
+            // Readiness Score — filled in step 5.6
             ChartCard(title: "Readiness Score", periodLabel: period.rawValue) {
-                EmptyStateView(
-                    icon: "sparkles",
-                    title: "Readiness Score",
-                    subtitle: "Readiness score available after biometric data loads"
-                )
-                .frame(height: 120)
+                let range = period.dateRange
+                let days: [Date] = {
+                    var result: [Date] = []
+                    var d = range.from
+                    while d <= range.to {
+                        result.append(d)
+                        d = Calendar.current.date(byAdding: .day, value: 1, to: d) ?? d.addingTimeInterval(86400)
+                    }
+                    return result
+                }()
+                let pts: [(date: Date, score: Int)] = days.compactMap { day in
+                    guard let s = dataStore.readinessScore(for: day, fallbackMetrics: healthService.latest) else { return nil }
+                    return (date: day, score: s)
+                }
+                if pts.isEmpty {
+                    EmptyStateView(
+                        icon: "sparkles",
+                        title: "Not Enough Data",
+                        subtitle: "Log biometrics for 3+ days to see your readiness trend"
+                    )
+                    .frame(height: 120)
+                } else {
+                    Chart(pts, id: \.date) { pt in
+                        LineMark(
+                            x: .value("Date", pt.date, unit: .day),
+                            y: .value("Score", pt.score)
+                        )
+                        .foregroundStyle(Color.accent.cyan)
+                        .interpolationMethod(.catmullRom)
+                        AreaMark(
+                            x: .value("Date", pt.date, unit: .day),
+                            y: .value("Score", pt.score)
+                        )
+                        .foregroundStyle(
+                            LinearGradient(colors: [Color.accent.cyan.opacity(0.3), Color.accent.cyan.opacity(0)],
+                                           startPoint: .top, endPoint: .bottom)
+                        )
+                        .interpolationMethod(.catmullRom)
+                    }
+                    .chartYScale(domain: 0...100)
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .day, count: max(1, pts.count / 5))) {
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks(values: [0, 40, 60, 80, 100]) { v in
+                            AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
+                            AxisValueLabel()
+                        }
+                    }
+                    .frame(height: 120)
+                }
             }
         }
         .task(id: period) {

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -80,7 +80,7 @@ struct StatPreviewPill: View {
     let value: String; let label: String
     var body: some View {
         VStack(spacing: 3) {
-            Text(value).font(.system(.title2, design: .monospaced, weight: .bold)).foregroundStyle(.green)
+            Text(value).font(.system(.title2, design: .monospaced, weight: .bold)).foregroundStyle(Color.status.success)
             Text(label).font(.caption2).foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -244,7 +244,7 @@ struct ExerciseRowView: View {
         VStack(alignment: .leading, spacing: 4) {
             Text(exercise.name)
                 .font(.subheadline.weight(.semibold))
-                .strikethrough(status == .completed, color: .green)
+                .strikethrough(status == .completed, color: Color.status.success)
                 .foregroundStyle(status == .completed ? .secondary : .primary)
 
             Text(exercise.muscleGroups.map { $0.rawValue.capitalized }.joined(separator: " · "))
@@ -293,13 +293,13 @@ struct ExerciseRowView: View {
 
     private var accentColor: Color {
         switch status {
-        case .completed: .green; case .partial: .orange; case .missed: .red; case .pending: .secondary
+        case .completed: Color.status.success; case .partial: Color.status.warning; case .missed: Color.status.error; case .pending: .secondary
         }
     }
 
     private var rowBG: Color {
         switch status {
-        case .completed: .green.opacity(0.03); case .missed: .red.opacity(0.03); default: Color(.systemBackground).opacity(0.5)
+        case .completed: Color.status.success.opacity(0.03); case .missed: Color.status.error.opacity(0.03); default: Color(.systemBackground).opacity(0.5)
         }
     }
 
@@ -334,11 +334,11 @@ struct LiftLogPanel: View {
             // Panel header
             HStack {
                 Text("📋 SET LOG")
-                    .font(.caption2.monospaced()).foregroundStyle(.green).tracking(1)
+                    .font(.caption2.monospaced()).foregroundStyle(Color.status.success).tracking(1)
                 Spacer()
                 if exerciseLog.totalVolume > 0 {
                     Text("Total: \(Int(exerciseLog.totalVolume)) kg")
-                        .font(.caption2.monospaced()).foregroundStyle(.green.opacity(0.8))
+                        .font(.caption2.monospaced()).foregroundStyle(Color.status.success.opacity(0.8))
                 }
                 Button {
                     exerciseLog.sets.append(SetLog(
@@ -347,11 +347,11 @@ struct LiftLogPanel: View {
                     ))
                 } label: {
                     Label("Add Set", systemImage: "plus.circle.fill")
-                        .font(.caption.weight(.semibold)).foregroundStyle(.green)
+                        .font(.caption.weight(.semibold)).foregroundStyle(Color.status.success)
                 }
             }
             .padding(.horizontal, 12).padding(.vertical, 8)
-            .background(.green.opacity(0.05))
+            .background(Color.status.success.opacity(0.05))
 
             // Column headers
             HStack(spacing: 0) {
@@ -488,16 +488,16 @@ struct CardioLogPanel: View {
             // Panel header
             HStack {
                 Text(cardioType == .rowing ? "🚣 ROWING LOG" : "🚴 ELLIPTICAL LOG")
-                    .font(.caption2.monospaced()).foregroundStyle(.green).tracking(1)
+                    .font(.caption2.monospaced()).foregroundStyle(Color.status.success).tracking(1)
                 Spacer()
                 if let zone = cardioLog.wasInZone2 {
                     Text(zone ? "✓ Zone 2" : "↑ Above Zone 2")
                         .font(.caption2.monospaced())
-                        .foregroundStyle(zone ? .green : .orange)
+                        .foregroundStyle(zone ? Color.status.success : Color.status.warning)
                 }
             }
             .padding(.horizontal, 12).padding(.vertical, 8)
-            .background(.green.opacity(0.05))
+            .background(Color.status.success.opacity(0.05))
 
             // Metric grid
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
@@ -545,8 +545,8 @@ struct CardioLogPanel: View {
                         }
                         .font(.caption.weight(.semibold))
                         .padding(.horizontal, 10).padding(.vertical, 5)
-                        .background(.green.opacity(0.1), in: Capsule())
-                        .foregroundStyle(.green)
+                        .background(Color.status.success.opacity(0.1), in: Capsule())
+                        .foregroundStyle(Color.status.success)
                     }
                     #endif
 
@@ -831,7 +831,7 @@ struct StatusDropdown: View {
 
     private var color: Color {
         switch status {
-        case .completed: .green; case .partial: .orange; case .missed: .red; case .pending: .secondary
+        case .completed: Color.status.success; case .partial: Color.status.warning; case .missed: Color.status.error; case .pending: .secondary
         }
     }
 }

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -20,6 +20,8 @@ struct TrainingPlanView: View {
     @State private var selectedDay: DayType = .restDay
     @State private var activeDate: Date = Date()
     @State private var log: DailyLog?
+    @State private var showCompletionSheet = false
+    @State private var showNotesEditor     = false
     private let bgOrange1 = Color.appOrange1
     private let bgOrange2 = Color.appOrange2
     private let appBlue   = Color.blue
@@ -37,6 +39,7 @@ struct TrainingPlanView: View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 16) {
                     weekStrip
+                    sessionPicker
                     sessionHeader
                     exerciseSections
                 }
@@ -56,6 +59,34 @@ struct TrainingPlanView: View {
             if let current = log {
                 dataStore.upsertLog(current)
             }
+        }
+        .onChange(of: log) { _, newLog in
+            guard let log = newLog else { return }
+            let exercises = TrainingProgramData.exercises(for: selectedDay)
+            guard !exercises.isEmpty else { return }
+            let allDone = exercises.allSatisfy { log.taskStatuses[$0.id] == .completed }
+            if allDone && !showCompletionSheet {
+                showCompletionSheet = true
+            }
+        }
+        .sheet(isPresented: $showCompletionSheet) {
+            SessionCompletionSheet(
+                log: log,
+                selectedDay: selectedDay,
+                previousLog: previousSameDayLog,
+                onDone: { showCompletionSheet = false },
+                onLogNotes: { showCompletionSheet = false; showNotesEditor = true }
+            )
+            .presentationDetents([.medium, .large])
+            .presentationCornerRadius(24)
+        }
+        .sheet(isPresented: $showNotesEditor) {
+            NotesEditorSheet(notes: Binding(
+                get: { log?.notes ?? "" },
+                set: { log?.notes = $0; saveLog() }
+            ), onDone: { showNotesEditor = false })
+            .presentationDetents([.medium])
+            .presentationCornerRadius(20)
         }
     }
 
@@ -203,6 +234,107 @@ struct TrainingPlanView: View {
                  dayType: selectedDay, recoveryDay: dataStore.userProfile.daysSinceStart)
     }
 
+    // ─────────────────────────────────────────────────────
+    // Suggested day derived from activeDate's weekday
+    // ─────────────────────────────────────────────────────
+
+    private var suggestedDay: DayType {
+        let wd = Calendar.current.component(.weekday, from: activeDate)
+        return TrainingProgramStore.dayType(forWeekday: wd)
+    }
+
+    // ─────────────────────────────────────────────────────
+    // Previous same-day log (for completion sheet comparison)
+    // ─────────────────────────────────────────────────────
+
+    private var previousSameDayLog: DailyLog? {
+        dataStore.dailyLogs
+            .filter {
+                $0.dayType == selectedDay &&
+                !Calendar.current.isDate($0.date, inSameDayAs: log?.date ?? Date())
+            }
+            .sorted { $0.date > $1.date }
+            .first
+    }
+
+    private func saveLog() {
+        if let l = log { dataStore.upsertLog(l) }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // Session type picker (3×2 grid)
+    // ─────────────────────────────────────────────────────
+
+    private var sessionPicker: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],
+            spacing: 10
+        ) {
+            ForEach(DayType.allCases, id: \.self) { dt in
+                SessionTypeButton(
+                    dayType: dt,
+                    isSelected: dt == selectedDay,
+                    isSuggested: dt == suggestedDay
+                ) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedDay = dt
+                        log?.dayType = dt
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Session Type Button
+// ─────────────────────────────────────────────────────────
+
+fileprivate struct SessionTypeButton: View {
+    let dayType:    DayType
+    let isSelected: Bool
+    let isSuggested: Bool
+    let action:     () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 5) {
+                Image(systemName: dayType.icon)
+                    .font(.system(size: 18, weight: .semibold))
+                Text(dayType.rawValue)
+                    .font(.caption2.weight(.semibold))
+                    .multilineTextAlignment(.center)
+            }
+            .foregroundStyle(foregroundColor)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(backgroundColor, in: RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(borderColor, lineWidth: isSelected ? 1.5 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var foregroundColor: Color {
+        if isSelected   { return Color.blue }
+        if isSuggested  { return Color.appOrange2 }
+        return Color.primary
+    }
+
+    private var backgroundColor: Color {
+        if isSelected   { return Color.blue.opacity(0.2) }
+        if isSuggested  { return Color.appOrange1.opacity(0.25) }
+        return Color.secondary.opacity(0.08)
+    }
+
+    private var borderColor: Color {
+        if isSelected   { return Color.blue }
+        if isSuggested  { return Color.appOrange2 }
+        return Color.secondary.opacity(0.2)
+    }
 }
 
 // ─────────────────────────────────────────────────────────
@@ -235,11 +367,24 @@ struct ExerciseSectionBlock: View {
 // ─────────────────────────────────────────────────────────
 
 struct ExerciseRowView: View {
+    @EnvironmentObject var dataStore: EncryptedDataStore
     let exercise: ExerciseDefinition
     let selectedDay: DayType
     @Binding var log: DailyLog?
 
     private var status: TaskStatus { log?.taskStatuses[exercise.id] ?? .pending }
+
+    private var previousSessionLog: ExerciseLog? {
+        dataStore.dailyLogs
+            .filter {
+                $0.dayType == selectedDay &&
+                !Calendar.current.isDateInToday($0.date) &&
+                $0.exerciseLogs[exercise.id] != nil
+            }
+            .sorted { $0.date > $1.date }
+            .first?
+            .exerciseLogs[exercise.id]
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -307,14 +452,15 @@ struct ExerciseRowView: View {
     private var liftPanel: some View {
         LiftLogPanel(
             exercise: exercise,
-                exerciseLog: Binding(
-                    get: { log?.exerciseLogs[exercise.id] ?? ExerciseLog(exerciseID: exercise.id, exerciseName: exercise.name) },
-                    set: {
-                        ensureLogMetadata()
-                        log?.exerciseLogs[exercise.id] = $0
-                    }
-                )
+            previousSessionLog: previousSessionLog,
+            exerciseLog: Binding(
+                get: { log?.exerciseLogs[exercise.id] ?? ExerciseLog(exerciseID: exercise.id, exerciseName: exercise.name) },
+                set: {
+                    ensureLogMetadata()
+                    log?.exerciseLogs[exercise.id] = $0
+                }
             )
+        )
     }
 
     // ── Cardio log panel (elliptical / rowing) with photo upload
@@ -367,6 +513,7 @@ struct ExerciseRowView: View {
 
 struct LiftLogPanel: View {
     let exercise: ExerciseDefinition
+    let previousSessionLog: ExerciseLog?
     @Binding var exerciseLog: ExerciseLog
 
     var body: some View {
@@ -379,6 +526,21 @@ struct LiftLogPanel: View {
                 if exerciseLog.totalVolume > 0 {
                     Text("Total: \(Int(exerciseLog.totalVolume)) kg")
                         .font(.caption2.monospaced()).foregroundStyle(Color.status.success.opacity(0.8))
+                }
+                if let prev = previousSessionLog, exerciseLog.sets.isEmpty {
+                    Button {
+                        exerciseLog.sets = prev.sets.enumerated().map { (i, s) in
+                            SetLog(
+                                setNumber: i + 1,
+                                weightKg: s.weightKg,
+                                repsCompleted: s.repsCompleted
+                            )
+                        }
+                    } label: {
+                        Label("Copy Last", systemImage: "bolt.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Color.accent.cyan)
+                    }
                 }
                 Button {
                     exerciseLog.sets.append(SetLog(
@@ -412,6 +574,7 @@ struct LiftLogPanel: View {
                 SetRowView(
                     setLog: $exerciseLog.sets[i],
                     setNum: i + 1,
+                    previousSet: previousSessionLog?.sets.indices.contains(i) == true ? previousSessionLog?.sets[i] : nil,
                     onDelete: {
                         exerciseLog.sets.remove(at: i)
                         for j in exerciseLog.sets.indices { exerciseLog.sets[j].setNumber = j + 1 }
@@ -441,12 +604,12 @@ struct LiftLogPanel: View {
 struct SetRowView: View {
     @Binding var setLog: SetLog
     let setNum:  Int
+    let previousSet: SetLog?
     let onDelete: () -> Void
 
     @State private var weightStr = ""
     @State private var repsStr   = ""
     @State private var noteStr   = ""
-    @State private var rpe: Double?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -457,30 +620,58 @@ struct SetRowView: View {
                 .frame(width: 32, alignment: .leading)
 
             // Weight
-            TextField("0", text: $weightStr)
-                .font(.system(.body, design: .monospaced))
-                .keyboardType(.decimalPad)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6).padding(.horizontal, 4)
-                .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 5))
-                .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.2)))
-                .onChange(of: weightStr) { _, v in setLog.weightKg = Double(v) }
+            if weightStr.isEmpty, let prev = previousSet, let prevWeight = prev.weightKg {
+                Button {
+                    weightStr = String(format: "%.1f", prevWeight)
+                } label: {
+                    Text(String(format: "%.1f", prevWeight))
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6).padding(.horizontal, 4)
+                        .background(Color.secondary.opacity(0.05), in: RoundedRectangle(cornerRadius: 5))
+                        .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.1)))
+                }
+            } else {
+                TextField("0", text: $weightStr)
+                    .font(.system(.body, design: .monospaced))
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6).padding(.horizontal, 4)
+                    .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 5))
+                    .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.2)))
+                    .onChange(of: weightStr) { _, v in setLog.weightKg = Double(v) }
+            }
 
             // Reps
-            TextField("—", text: $repsStr)
-                .font(.system(.body, design: .monospaced))
-                .keyboardType(.numberPad)
-                .multilineTextAlignment(.center)
-                .frame(width: 48)
-                .padding(.vertical, 6).padding(.horizontal, 4)
-                .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 5))
-                .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.2)))
-                .onChange(of: repsStr) { _, v in setLog.repsCompleted = Int(v) }
+            if repsStr.isEmpty, let prev = previousSet, let prevReps = prev.repsCompleted {
+                Button {
+                    repsStr = String(prevReps)
+                } label: {
+                    Text(String(prevReps))
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 48)
+                        .padding(.vertical, 6).padding(.horizontal, 4)
+                        .background(Color.secondary.opacity(0.05), in: RoundedRectangle(cornerRadius: 5))
+                        .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.1)))
+                }
+            } else {
+                TextField("—", text: $repsStr)
+                    .font(.system(.body, design: .monospaced))
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 48)
+                    .padding(.vertical, 6).padding(.horizontal, 4)
+                    .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 5))
+                    .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.2)))
+                    .onChange(of: repsStr) { _, v in setLog.repsCompleted = Int(v) }
+            }
 
-            // RPE
-            RPEBadge(rpe: Binding(get: { setLog.rpe }, set: { setLog.rpe = $0 }))
-                .frame(width: 40)
+            // RPE — 5-segment tap bar
+            RPETapBar(rpe: Binding(get: { setLog.rpe }, set: { setLog.rpe = $0 }))
+                .frame(maxWidth: .infinity)
 
             // Note
             TextField("—", text: $noteStr)
@@ -806,41 +997,36 @@ struct CardioField: View {
     }
 }
 
-struct RPEBadge: View {
+struct RPETapBar: View {
     @Binding var rpe: Double?
-    @State private var show = false
+
+    private let segments: [Int] = [6, 7, 8, 9, 10]
 
     var body: some View {
-        Button { show.toggle() } label: {
-            Text(rpe.map { String(format: "%.0f", $0) } ?? "—")
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(rpe != nil ? .primary : .tertiary)
-                .frame(width: 34).padding(.vertical, 4)
-                .background(Color(.systemBackground), in: RoundedRectangle(cornerRadius: 5))
-                .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color.secondary.opacity(0.2)))
-        }
-        .popover(isPresented: $show) {
-            VStack(spacing: 2) {
-                Text("RPE").font(.caption.bold()).padding(.top, 8)
-                ForEach([6.0, 7.0, 7.5, 8.0, 8.5, 9.0, 10.0], id: \.self) { v in
-                    Button("\(v == floor(v) ? String(Int(v)) : String(v))  ·  \(rpeLabel(v))") { rpe = v; show = false }
-                        .font(.caption).padding(.vertical, 3)
+        HStack(spacing: 2) {
+            ForEach(segments, id: \.self) { v in
+                let isSelected = rpe.map { Int($0) } == v
+                Button {
+                    rpe = isSelected ? nil : Double(v)
+                } label: {
+                    Text("\(v)")
+                        .font(.system(size: 10, design: .monospaced, weight: isSelected ? .bold : .regular))
+                        .foregroundStyle(isSelected ? Color.black : Color.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 5)
+                        .background(
+                            isSelected
+                                ? Color.appOrange2
+                                : Color(.systemBackground),
+                            in: RoundedRectangle(cornerRadius: 4)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(isSelected ? Color.appOrange2 : Color.secondary.opacity(0.2), lineWidth: 1)
+                        )
                 }
+                .buttonStyle(.plain)
             }
-            .padding()
-            .presentationCompactAdaptation(.popover)
-        }
-    }
-
-    private func rpeLabel(_ v: Double) -> String {
-        switch v {
-        case 6:   "Easy"
-        case 7:   "Moderate"
-        case 7.5: "Somewhat Hard"
-        case 8:   "Hard"
-        case 8.5: "Very Hard"
-        case 9:   "Near Max"
-        default:  "Absolute Max"
         }
     }
 }
@@ -885,5 +1071,198 @@ struct Pill: View {
             .foregroundStyle(.secondary)
             .padding(.horizontal, 6).padding(.vertical, 2)
             .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 4))
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Session Completion Sheet
+// ─────────────────────────────────────────────────────────
+
+struct SessionCompletionSheet: View {
+    let log: DailyLog?
+    let selectedDay: DayType
+    let previousLog: DailyLog?
+    let onDone: () -> Void
+    let onLogNotes: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Header
+                    VStack(spacing: 6) {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.system(size: 48))
+                            .foregroundStyle(Color.status.success)
+                        Text("Session Complete!")
+                            .font(.title2.bold())
+                        Text(selectedDay.rawValue)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.top, 8)
+
+                    // Stats grid: 4 metric tiles
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                        // Total Volume
+                        statTile(
+                            icon: "scalemass.fill",
+                            label: "Volume",
+                            value: totalVolumeStr,
+                            delta: volumeDeltaStr,
+                            color: Color.accent.cyan
+                        )
+                        // Exercises done
+                        statTile(
+                            icon: "checkmark.circle.fill",
+                            label: "Exercises",
+                            value: exerciseSummaryStr,
+                            delta: nil,
+                            color: Color.status.success
+                        )
+                        // Session duration
+                        statTile(
+                            icon: "clock.fill",
+                            label: "Duration",
+                            value: durationStr,
+                            delta: nil,
+                            color: Color.accent.purple
+                        )
+                        // PRs this session (from exerciseLogs bestSet vs previous)
+                        statTile(
+                            icon: "trophy.fill",
+                            label: "PRs",
+                            value: prCountStr,
+                            delta: nil,
+                            color: Color.accent.gold
+                        )
+                    }
+
+                    Divider()
+
+                    // Buttons
+                    VStack(spacing: 12) {
+                        Button(action: onLogNotes) {
+                            Label("Log Notes", systemImage: "note.text")
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 14)
+                                .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 14))
+                        }
+                        .buttonStyle(.plain)
+
+                        Button(action: onDone) {
+                            Text("Done")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 14)
+                                .foregroundStyle(.black)
+                                .background(
+                                    LinearGradient(colors: [Color.status.success, Color.status.success.opacity(0.8)],
+                                                   startPoint: .leading, endPoint: .trailing),
+                                    in: RoundedRectangle(cornerRadius: 14)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 32)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────
+
+    private var totalVolume: Double {
+        log?.exerciseLogs.values.map(\.totalVolume).reduce(0, +) ?? 0
+    }
+
+    private var previousVolume: Double {
+        previousLog?.exerciseLogs.values.map(\.totalVolume).reduce(0, +) ?? 0
+    }
+
+    private var totalVolumeStr: String {
+        totalVolume > 0 ? "\(Int(totalVolume)) kg" : "—"
+    }
+
+    private var volumeDeltaStr: String? {
+        guard totalVolume > 0, previousVolume > 0 else { return nil }
+        let delta = totalVolume - previousVolume
+        return delta >= 0 ? "+\(Int(delta)) kg" : "\(Int(delta)) kg"
+    }
+
+    private var exerciseSummaryStr: String {
+        let total = TrainingProgramData.exercises(for: selectedDay).count
+        let done  = log?.taskStatuses.values.filter { $0 == .completed }.count ?? 0
+        return "\(done)/\(total)"
+    }
+
+    private var durationStr: String {
+        guard let exLogs = log?.exerciseLogs.values, !exLogs.isEmpty else { return "—" }
+        let allTimestamps = exLogs.flatMap { $0.sets }.map(\.timestamp)
+        guard let first = allTimestamps.min(), let last = allTimestamps.max() else { return "—" }
+        let minutes = Int(last.timeIntervalSince(first) / 60)
+        return minutes > 0 ? "\(minutes) min" : "< 1 min"
+    }
+
+    private var prCountStr: String {
+        guard let exLogs = log?.exerciseLogs, let prevExLogs = previousLog?.exerciseLogs else {
+            return "—"
+        }
+        let count = exLogs.filter { (exerciseID, current) in
+            guard let best = current.bestSet?.weightKg,
+                  let prevBest = prevExLogs[exerciseID]?.bestSet?.weightKg else { return false }
+            return best > prevBest
+        }.count
+        return count > 0 ? "\(count)" : "0"
+    }
+
+    @ViewBuilder
+    private func statTile(icon: String, label: String, value: String, delta: String?, color: Color) -> some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(color)
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(value)
+                .font(.title3.bold())
+            if let delta {
+                Text(delta)
+                    .font(.caption2)
+                    .foregroundStyle(delta.hasPrefix("+") ? Color.status.success : Color.status.error)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(14)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Notes Editor Sheet
+// ─────────────────────────────────────────────────────────
+
+struct NotesEditorSheet: View {
+    @Binding var notes: String
+    let onDone: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            TextEditor(text: $notes)
+                .font(.body)
+                .padding()
+                .navigationTitle("Session Notes")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done", action: onDone)
+                    }
+                }
+        }
     }
 }

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -18,6 +18,7 @@ struct TrainingPlanView: View {
 
     private let initialDay: DayType?
     @State private var selectedDay: DayType = .restDay
+    @State private var activeDate: Date = Date()
     @State private var log: DailyLog?
     private let bgOrange1 = Color.appOrange1
     private let bgOrange2 = Color.appOrange2
@@ -35,7 +36,7 @@ struct TrainingPlanView: View {
 
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 16) {
-                    dayPicker
+                    weekStrip
                     sessionHeader
                     exerciseSections
                 }
@@ -59,29 +60,68 @@ struct TrainingPlanView: View {
     }
 
     // ─────────────────────────────────────────────────────
-    // Day picker
+    // Week strip (Mon–Sun)
     // ─────────────────────────────────────────────────────
 
-    private var dayPicker: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(DayType.allCases, id: \.self) { day in
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) { selectedDay = day }
-                    } label: {
-                        HStack(spacing: 5) {
-                            Image(systemName: day.icon).font(.caption2)
-                            Text(day.rawValue).font(.caption.weight(.semibold))
+    private var weekStrip: some View {
+        let calendar = Calendar.current
+        // Build Mon–Sun for the week containing today
+        let today = Date()
+        let weekday = calendar.component(.weekday, from: today) // 1=Sun … 7=Sat
+        // Days offset so Monday is first
+        let daysFromMonday = (weekday + 5) % 7   // Mon=0, Tue=1 … Sun=6
+        let monday = calendar.date(byAdding: .day, value: -daysFromMonday, to: calendar.startOfDay(for: today))!
+        let weekDays = (0..<7).compactMap { calendar.date(byAdding: .day, value: $0, to: monday) }
+
+        return HStack(spacing: 0) {
+            ForEach(weekDays, id: \.self) { day in
+                let wday    = calendar.component(.weekday, from: day)
+                let isToday = calendar.isDateInToday(day)
+                let isActive = calendar.isDate(day, inSameDayAs: activeDate)
+                let isRest  = TrainingProgramStore.restWeekdays.contains(wday)
+                let hasLog  = dataStore.dailyLogs.first {
+                    calendar.isDate($0.date, inSameDayAs: day)
+                }.map { $0.completionPct > 0 } ?? false
+
+                VStack(spacing: 4) {
+                    Text(day.formatted(.dateTime.weekday(.abbreviated)))
+                        .font(AppType.caption)
+                        .foregroundStyle(isActive ? Color.primary : Color.secondary)
+
+                    ZStack {
+                        if isToday {
+                            Circle()
+                                .fill(Color.appOrange1)
+                                .frame(width: 28, height: 28)
+                        } else if isActive {
+                            Circle()
+                                .fill(Color.white.opacity(0.25))
+                                .frame(width: 28, height: 28)
                         }
-                        .padding(.horizontal, 14).padding(.vertical, 8)
-                        .background(selectedDay == day ? Color.blue : Color.white.opacity(0.35), in: Capsule())
-                        .foregroundStyle(selectedDay == day ? .white : .primary)
+                        Text("\(calendar.component(.day, from: day))")
+                            .font(isToday ? AppType.body : AppType.subheading)
+                            .fontWeight(isToday ? .bold : .regular)
+                            .foregroundStyle(isToday ? Color.black : Color.primary)
                     }
-                    .buttonStyle(.plain)
+
+                    // Completion dot
+                    Circle()
+                        .fill(hasLog ? Color.status.success : Color.clear)
+                        .frame(width: 5, height: 5)
+                }
+                .opacity(isRest && !hasLog ? 0.4 : 1.0)
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    activeDate = day
+                    // Derive suggested day type from weekday
+                    let suggested = TrainingProgramStore.dayType(forWeekday: wday)
+                    withAnimation(.easeInOut(duration: 0.2)) { selectedDay = suggested }
                 }
             }
-            .padding(.vertical, 4)
         }
+        .padding(.vertical, 8)
+        .onAppear { activeDate = today }
     }
 
     // ─────────────────────────────────────────────────────


### PR DESCRIPTION
## FitTracker v2.0 — Nutrition, Training, Stats & Home Redesign

### Pass 3 — Nutrition Overhaul

- **MealSectionView**: 4 meal slots (Breakfast / Lunch / Dinner / Snacks) with status borders and "Tap to log" placeholders
- **MealEntrySheet**: 3-tab sheet — Manual entry (name + macros + "Save as Template"), Template library (persisted across restarts), Search (OpenFoodFacts API + barcode scanner on iOS)
- **MacroTargetBar**: Stacked protein/carbs/fat bar with calorie target switching between training-day and rest-day targets from the active program phase
- **Supplement row**: Collapsible Morning/Evening pill buttons with 🔥 streak badge; expands to full `SupplementStackCard`

### Pass 4 — Training Plan Behaviour

- **Session picker**: 6-button grid (Upper Push / Lower Body / Upper Pull / Full Body / Cardio Only / Rest Day) — orange = weekday suggestion, blue = user selection
- **Ghost weights**: Previous same-`dayType` session's weights/reps shown as dimmed placeholders in empty set rows; tap to copy; "⚡ Copy Last" button pre-fills all sets at once
- **RPE tap bar**: Replaces popover — 5 segments `[6 7 8 9 10]`, orange when selected, tap again to clear
- **Completion sheet**: Fires when all exercises are marked complete — shows total volume + delta vs last same-type session, exercises completed, new PRs, session duration, and "Log Notes" editor

### Pass 5 — Home Screen Polish

- **Readiness score**: `readinessScore(for:fallbackMetrics:)` in `EncryptedDataStore` — 30-day HRV/HR/sleep baseline, returns `nil` with <3 data points
- **ReadinessCard**: 5-page `TabView` replacing the static quick-stats row:
  1. Score (0–100) + context label + HRV / RHR / Sleep
  2. Mon–Sun training bars + next session name
  3. Protein progress bar + supplement AM/PM dots + water
  4. 6 trend indicators (Weight, BF, HRV, Sleep, Volume, Steps)
  5. Achievements (streak 🔥, PRs this week 🏆, program day 📅)
  — Auto-cycles every 5 s; swipe resets the timer
- **MainScreenView polish**: Orb glow shadow, angular gradient ring (`appOrange1 → accent.cyan → appOrange1`), `GoalProgressRow` linear gradient fill, 8pt status dots next to Weight/BF with ±0.2 kg / ±0.3% flat-band thresholds
- **Training button**: Label updated to `"💪 {DayType} · {N} ex"`
- **Stats → Recovery tab**: Readiness `ChartCard` filled with real `LineMark + AreaMark` data; falls back to `EmptyStateView` when insufficient history

### Test Checklist

- [ ] Log a meal via Manual → save as template → verify it persists after restart
- [ ] Supplement row collapses / expands; streak badge reflects consecutive complete days
- [ ] Session picker overrides weekday suggestion; selection persists to log
- [ ] Ghost weights populate from the last session of the same type (not calendar date)
- [ ] "⚡ Copy Last" pre-fills all sets; individual ghost tap copies single row
- [ ] RPE tap 6–10 selects segment; tap again clears
- [ ] Mark all exercises complete → completion sheet appears with correct volume delta and PR tiles
- [ ] ReadinessCard cycles every 5 s; manual swipe resets the 5 s timer
- [ ] Readiness score returns `nil` in Simulator (no HealthKit data); shows "–"
- [ ] Stats → Recovery readiness chart renders with seeded data; shows empty state with none
