### PR TITLE
## What's new in v3.0  A full UX/UI improvement pass across the entire app — reduced friction, smarter home screen, enhanced workout flow, polished design, and unified settings.

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		CC000001000000000000AA09 /* MacroTargetBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA09 /* MacroTargetBar.swift */; };
 		CC000001000000000000AA0A /* MealSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0A /* MealSectionView.swift */; };
 		CC000001000000000000AA0B /* MealEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0B /* MealEntrySheet.swift */; };
+		CC000001000000000000AA0C /* RecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0C /* RecoverySupport.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -78,6 +79,7 @@
 		CC000002000000000000AA09 /* MacroTargetBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroTargetBar.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA0A /* MealSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealSectionView.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA0B /* MealEntrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealEntrySheet.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA0C /* RecoverySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverySupport.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -254,6 +256,7 @@
 				CC000002000000000000AA05 /* TrendIndicator.swift */,
 				CC000002000000000000AA06 /* ChartCard.swift */,
 				CC000002000000000000AA07 /* EmptyStateView.swift */,
+				CC000002000000000000AA0C /* RecoverySupport.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				CC000001000000000000AA09 /* MacroTargetBar.swift in Sources */,
 				CC000001000000000000AA0A /* MealSectionView.swift in Sources */,
 				CC000001000000000000AA0B /* MealEntrySheet.swift in Sources */,
+				CC000001000000000000AA0C /* RecoverySupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -28,6 +28,17 @@
 		A1000001000000000000000F /* AccountPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001000000000000000F /* AccountPanelView.swift */; };
 		A10000010000000000000010 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000010 /* SignInView.swift */; };
 		A10000010000000000000011 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000011 /* WelcomeView.swift */; };
+		CC000001000000000000AA01 /* ReadinessCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA01 /* ReadinessCard.swift */; };
+		CC000001000000000000AA02 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA02 /* SectionHeader.swift */; };
+		CC000001000000000000AA03 /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA03 /* StatusBadge.swift */; };
+		CC000001000000000000AA04 /* MetricCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA04 /* MetricCard.swift */; };
+		CC000001000000000000AA05 /* TrendIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA05 /* TrendIndicator.swift */; };
+		CC000001000000000000AA06 /* ChartCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA06 /* ChartCard.swift */; };
+		CC000001000000000000AA07 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA07 /* EmptyStateView.swift */; };
+		CC000001000000000000AA08 /* StatsDataHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA08 /* StatsDataHelpers.swift */; };
+		CC000001000000000000AA09 /* MacroTargetBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA09 /* MacroTargetBar.swift */; };
+		CC000001000000000000AA0A /* MealSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0A /* MealSectionView.swift */; };
+		CC000001000000000000AA0B /* MealEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0B /* MealEntrySheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +67,17 @@
 		A20000010000000000000014 /* FitTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FitTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20000010000000000000001 /* FitTrackerCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitTrackerCoreTests.swift; sourceTree = "<group>"; };
 		B20000010000000000000002 /* FitTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FitTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC000002000000000000AA01 /* ReadinessCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadinessCard.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA02 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA03 /* StatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBadge.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA04 /* MetricCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricCard.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA05 /* TrendIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendIndicator.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA06 /* ChartCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartCard.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA07 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA08 /* StatsDataHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataHelpers.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA09 /* MacroTargetBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroTargetBar.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA0A /* MealSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealSectionView.swift; sourceTree = "<group>"; };
+		CC000002000000000000AA0B /* MealEntrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealEntrySheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +171,7 @@
 				A4000001000000000000000D /* Nutrition */,
 				A4000001000000000000000E /* Stats */,
 				A4000001000000000000000F /* Auth */,
+				CC000001000000000000AA00 /* Shared */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -205,6 +228,9 @@
 			isa = PBXGroup;
 			children = (
 				A2000001000000000000000C /* NutritionView.swift */,
+				CC000002000000000000AA09 /* MacroTargetBar.swift */,
+				CC000002000000000000AA0A /* MealSectionView.swift */,
+				CC000002000000000000AA0B /* MealEntrySheet.swift */,
 			);
 			path = Nutrition;
 			sourceTree = "<group>";
@@ -213,8 +239,23 @@
 			isa = PBXGroup;
 			children = (
 				A2000001000000000000000E /* StatsView.swift */,
+				CC000002000000000000AA08 /* StatsDataHelpers.swift */,
 			);
 			path = Stats;
+			sourceTree = "<group>";
+		};
+		CC000001000000000000AA00 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				CC000002000000000000AA01 /* ReadinessCard.swift */,
+				CC000002000000000000AA02 /* SectionHeader.swift */,
+				CC000002000000000000AA03 /* StatusBadge.swift */,
+				CC000002000000000000AA04 /* MetricCard.swift */,
+				CC000002000000000000AA05 /* TrendIndicator.swift */,
+				CC000002000000000000AA06 /* ChartCard.swift */,
+				CC000002000000000000AA07 /* EmptyStateView.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		A4000001000000000000000F /* Auth */ = {
@@ -351,6 +392,17 @@
 				A1000001000000000000000F /* AccountPanelView.swift in Sources */,
 				A10000010000000000000010 /* SignInView.swift in Sources */,
 				A10000010000000000000011 /* WelcomeView.swift in Sources */,
+				CC000001000000000000AA01 /* ReadinessCard.swift in Sources */,
+				CC000001000000000000AA02 /* SectionHeader.swift in Sources */,
+				CC000001000000000000AA03 /* StatusBadge.swift in Sources */,
+				CC000001000000000000AA04 /* MetricCard.swift in Sources */,
+				CC000001000000000000AA05 /* TrendIndicator.swift in Sources */,
+				CC000001000000000000AA06 /* ChartCard.swift in Sources */,
+				CC000001000000000000AA07 /* EmptyStateView.swift in Sources */,
+				CC000001000000000000AA08 /* StatsDataHelpers.swift in Sources */,
+				CC000001000000000000AA09 /* MacroTargetBar.swift in Sources */,
+				CC000001000000000000AA0A /* MealSectionView.swift in Sources */,
+				CC000001000000000000AA0B /* MealEntrySheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -30,20 +30,27 @@ struct FitTrackerApp: App {
                 // session context at this point, so no extra biometric prompts fire.
                 .onChange(of: biometricAuth.isAuthenticated) { _, authenticated in
                     if authenticated {
-                        Task { await dataStore.loadFromDisk() }
+                        Task {
+                            await dataStore.loadFromDisk()
+                            if scenePhase == .active {
+                                await cloudSync.fetchChanges(dataStore: dataStore)
+                            }
+                        }
                     }
                 }
                 .onChange(of: scenePhase) { _, phase in
                     switch phase {
                     case .active:
                         signIn.restoreSession()
+                        guard biometricAuth.isAuthenticated else { break }
                         Task { await cloudSync.fetchChanges(dataStore: dataStore) }
                     case .background:
+                        biometricAuth.lockOnBackground(clearCryptoSession: false)
                         Task {
                             await dataStore.persistToDisk()
                             await cloudSync.pushPendingChanges(dataStore: dataStore)
+                            await EncryptionService.shared.clearSessionContext()
                         }
-                        biometricAuth.lockOnBackground()
                     case .inactive: break
                     @unknown default: break
                     }

--- a/FitTracker/Models/DomainModels.swift
+++ b/FitTracker/Models/DomainModels.swift
@@ -20,6 +20,8 @@ enum ProgramPhase: String, Codable, CaseIterable, Sendable {
 
     var trainingCalories: Int { switch self { case .recovery: 1800; case .stage1: 1900; case .stage2: 2000 } }
     var restCalories: Int     { switch self { case .recovery: 1600; case .stage1: 1700; case .stage2: 1800 } }
+    /// Intentionally uniform across all phases — protein target does not vary by phase.
+    /// Used as a fallback when lean body mass is unavailable (see StatsView, spec).
     var proteinTargetG: ClosedRange<Double> { 125...135 }
 }
 
@@ -41,9 +43,10 @@ struct DailyLog: Identifiable, Codable, Sendable {
     var nutritionLog:   NutritionLog                = NutritionLog()
     var biometrics:     DailyBiometrics             = DailyBiometrics()
     var notes:          String                      = ""
+    var sessionStartTime: Date?                     // set on first set confirmation
     var mood:           Int?                        // 1–5
-    var energyLevel:    Int?                        // 1–10
-    var cravingLevel:   Int?                        // 1–10
+    var energyLevel:    Int?                        // 1–5
+    var cravingLevel:   Int?                        // 1–5
 
     // CloudKit sync metadata
     var cloudRecordID: String?
@@ -160,9 +163,9 @@ struct CardioLog: Identifiable, Codable, Sendable {
     var summaryImageData:   Data?           // compressed JPEG stored encrypted
     var summaryImageCloudID: String?        // CloudKit CKAsset reference
 
-    var wasInZone2: Bool? {
+    func wasInZone2(lower: Int, upper: Int) -> Bool? {
         guard let avg = avgHeartRate else { return nil }
-        return avg >= 106 && avg <= 124
+        return avg >= Double(lower) && avg <= Double(upper)
     }
 }
 
@@ -275,10 +278,6 @@ struct DailyBiometrics: Codable, Sendable {
     var effectiveRestingHR: Double? { restingHeartRate ?? manualRestingHR }
     var effectiveHRV:       Double? { hrv ?? manualHRV }
     var effectiveSleep:     Double? { sleepHours ?? manualSleepHours }
-
-    var hrOK:  Bool { (effectiveRestingHR ?? 999) < 75 }
-    var hrvOK: Bool { (effectiveHRV ?? 0) >= 28 }
-    var readyForTraining: Bool { hrOK && hrvOK }
 }
 
 // ─────────────────────────────────────────────────────────
@@ -351,6 +350,7 @@ struct UserProfile: Codable, Sendable {
     var targetBFMax:        Double          = 15
     var startWeightKg:      Double          = 70.95
     var startBodyFatPct:    Double          = 21.0
+    var mealSlotNames:      [String]        = ["Breakfast", "Lunch", "Dinner", "Snacks"]
 
     func recoveryDay(for date: Date, calendar: Calendar = .current) -> Int {
         let start = calendar.startOfDay(for: recoveryStart)
@@ -381,6 +381,17 @@ struct UserProfile: Codable, Sendable {
         let bp = bfProgress(current: currentBF)
         return (wp + bp) / 2.0
     }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – User Preferences
+// ─────────────────────────────────────────────────────────
+
+struct UserPreferences: Codable, Equatable, Sendable {
+    var zone2LowerHR: Int     = 106
+    var zone2UpperHR: Int     = 124
+    var hrReadyThreshold: Int = 60
+    var hrvReadyThreshold: Double = 28.0
 }
 
 private func iso(_ s: String) -> Date {

--- a/FitTracker/Models/DomainModels.swift
+++ b/FitTracker/Models/DomainModels.swift
@@ -201,6 +201,24 @@ struct NutritionLog: Codable, Sendable {
     var alluloseTaken:  Bool = false
 }
 
+extension NutritionLog {
+    private func sum<T: BinaryFloatingPoint>(_ values: [T?]) -> Double? {
+        let resolved = values.compactMap { $0.map(Double.init) }
+        guard !resolved.isEmpty else { return nil }
+        return resolved.reduce(0, +)
+    }
+
+    var mealCaloriesTotal: Double? { sum(meals.map(\.calories)) }
+    var mealProteinTotal: Double? { sum(meals.map(\.proteinG)) }
+    var mealCarbsTotal: Double? { sum(meals.map(\.carbsG)) }
+    var mealFatTotal: Double? { sum(meals.map(\.fatG)) }
+
+    var resolvedCalories: Double? { totalCalories ?? mealCaloriesTotal }
+    var resolvedProteinG: Double? { totalProteinG ?? mealProteinTotal }
+    var resolvedCarbsG: Double? { totalCarbsG ?? mealCarbsTotal }
+    var resolvedFatG: Double? { totalFatG ?? mealFatTotal }
+}
+
 struct MealEntry: Identifiable, Codable, Sendable {
     var id:        UUID   = UUID()
     var mealNumber: Int
@@ -334,9 +352,13 @@ struct UserProfile: Codable, Sendable {
     var startWeightKg:      Double          = 70.95
     var startBodyFatPct:    Double          = 21.0
 
-    var daysSinceStart: Int {
-        max(0, Calendar.current.dateComponents([.day], from: recoveryStart, to: Date()).day ?? 0)
+    func recoveryDay(for date: Date, calendar: Calendar = .current) -> Int {
+        let start = calendar.startOfDay(for: recoveryStart)
+        let current = calendar.startOfDay(for: date)
+        return max(0, calendar.dateComponents([.day], from: start, to: current).day ?? 0)
     }
+
+    var daysSinceStart: Int { recoveryDay(for: Date()) }
 
     // Goal progress: 0.0 – 1.0
     func weightProgress(current: Double?) -> Double {

--- a/FitTracker/Services/Auth/SignInService.swift
+++ b/FitTracker/Services/Auth/SignInService.swift
@@ -354,6 +354,12 @@ final class SignInService: NSObject, ObservableObject {
         }
     }
 
+    #if targetEnvironment(simulator)
+    func signInAsTestUser() {
+        simulateSignIn(provider: .apple, name: "Regev", email: "regev@simulator.local")
+    }
+    #endif
+
     private func simulateSignIn(provider: AuthProvider, name: String, email: String) {
         Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(800))

--- a/FitTracker/Services/AuthManager.swift
+++ b/FitTracker/Services/AuthManager.swift
@@ -47,9 +47,10 @@ final class AuthManager: ObservableObject {
         #endif
     }
 
-    func lockOnBackground() {
+    func lockOnBackground(clearCryptoSession: Bool = true) {
         isAuthenticated = false
         authError = nil
+        guard clearCryptoSession else { return }
         // Invalidate the shared session context so the next unlock re-authenticates.
         Task { await EncryptionService.shared.clearSessionContext() }
     }

--- a/FitTracker/Services/AuthManager.swift
+++ b/FitTracker/Services/AuthManager.swift
@@ -4,7 +4,7 @@
 // Also houses TrainingProgramStore
 
 import Foundation
-import LocalAuthentication
+@preconcurrency import LocalAuthentication
 import SwiftUI
 
 // ─────────────────────────────────────────────────────────
@@ -23,9 +23,7 @@ final class AuthManager: ObservableObject {
         #if targetEnvironment(simulator)
         // Skip biometric/passcode prompt on simulator — set authenticated immediately.
         isAuthenticated = true
-        return
-        #endif
-
+        #else
         let ctx = LAContext()
         var err: NSError?
 
@@ -43,9 +41,10 @@ final class AuthManager: ObservableObject {
                 }
             }
         } else {
-            // Simulator / no biometrics configured — mark as authenticated immediately
+            // No biometrics configured — mark as authenticated immediately
             isAuthenticated = true
         }
+        #endif
     }
 
     func lockOnBackground() {

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -353,7 +353,10 @@ final class EncryptedDataStore: ObservableObject {
     // ── CRUD ─────────────────────────────────────────────
 
     func upsertLog(_ log: DailyLog) {
-        var l = log; l.lastModified = Date(); l.needsSync = true
+        var l = log
+        l.nutritionLog = normalizedNutritionLog(l.nutritionLog)
+        l.lastModified = Date()
+        l.needsSync = true
         if let i = dailyLogs.firstIndex(where: { Calendar.current.isDate($0.date, inSameDayAs: log.date) }) {
             dailyLogs[i] = l
         } else {
@@ -522,6 +525,23 @@ final class EncryptedDataStore: ObservableObject {
         )
     }
 
+    private func normalizedNutritionLog(_ nutrition: NutritionLog) -> NutritionLog {
+        var normalized = nutrition
+        if let calories = nutrition.mealCaloriesTotal {
+            normalized.totalCalories = calories
+        }
+        if let protein = nutrition.mealProteinTotal {
+            normalized.totalProteinG = protein
+        }
+        if let carbs = nutrition.mealCarbsTotal {
+            normalized.totalCarbsG = carbs
+        }
+        if let fat = nutrition.mealFatTotal {
+            normalized.totalFatG = fat
+        }
+        return normalized
+    }
+
     private func buildHints(_ logs: [DailyLog]) -> ExportPackage.AIHints {
         let r7  = logs.prefix(7)
         let r28 = logs.prefix(28)
@@ -537,7 +557,7 @@ final class EncryptedDataStore: ObservableObject {
         }
 
         let adh   = r28.map { $0.completionPct }.reduce(0,+) / max(1, Double(r28.count))
-        let prot  = Double(r28.filter { ($0.nutritionLog.totalProteinG ?? 0) >= 125 }.count) / max(1, Double(r28.count))
+        let prot  = Double(r28.filter { ($0.nutritionLog.resolvedProteinG ?? 0) >= 125 }.count) / max(1, Double(r28.count))
         let supp  = Double(r28.filter { $0.supplementLog.morningStatus == .completed }.count) / max(1, Double(r28.count))
         let z2min = r7.flatMap { $0.cardioLogs.values }.compactMap { $0.wasInZone2 == true ? $0.durationMinutes : nil }.reduce(0,+)
 

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -193,7 +193,19 @@ actor EncryptionService {
     }
 
     private func getOrCreateSymmetricKey(tag: String, context: LAContext) throws -> SymmetricKey {
-        if let existing = try? loadKeyFromKeychain(tag: tag, context: context) { return existing }
+        // Use explicit do/catch so that a genuine keychain error (biometric failure,
+        // corrupt entry, locked device, etc.) is propagated rather than silently treated
+        // as "key not found" and overwritten with a freshly generated key.
+        // loadKeyFromKeychain returns nil only for errSecItemNotFound; all other
+        // failures are thrown as FTCryptoError.keychainError — let those bubble up.
+        do {
+            if let existing = try loadKeyFromKeychain(tag: tag, context: context) {
+                return existing
+            }
+        } catch {
+            throw error   // propagate any real keychain error; do NOT generate a new key
+        }
+        // Reaching here means the item genuinely does not exist yet — create it.
         let newKey = SymmetricKey(size: .bits256)
         try saveKeyToKeychain(newKey, tag: tag)
         return newKey
@@ -332,12 +344,13 @@ actor EncryptionService {
 @MainActor
 final class EncryptedDataStore: ObservableObject {
 
-    @Published var dailyLogs:       [DailyLog]        = []
-    @Published var weeklySnapshots: [WeeklySnapshot]  = []
-    @Published var userProfile:     UserProfile       = UserProfile()
-    @Published var mealTemplates:   [MealTemplate]    = []
-    @Published var isLoading:       Bool              = false
-    @Published var lastError:       String?
+    @Published var dailyLogs:        [DailyLog]        = []
+    @Published var weeklySnapshots:  [WeeklySnapshot]  = []
+    @Published var userProfile:      UserProfile       = UserProfile()
+    @Published var mealTemplates:    [MealTemplate]    = []
+    @Published var userPreferences:  UserPreferences   = UserPreferences()
+    @Published var isLoading:        Bool              = false
+    @Published var lastError:        String?
     /// Set when `loadFromDisk` fails; observed by the UI to show an alert.
     @Published var loadError:       String?
 
@@ -378,7 +391,7 @@ final class EncryptedDataStore: ObservableObject {
         let today = Calendar.current.startOfDay(for: Date())
         for log in sorted {
             let logDay = Calendar.current.startOfDay(for: log.date)
-            // Today counts only if fully complete
+            // Skip future-dated logs
             if logDay > today { continue }
             let complete = log.supplementLog.morningStatus == .completed
                         && log.supplementLog.eveningStatus == .completed
@@ -447,18 +460,21 @@ final class EncryptedDataStore: ObservableObject {
             let snapsEnc     = try await EncryptionService.shared.encrypt(weeklySnapshots)
             let profEnc      = try await EncryptionService.shared.encrypt(userProfile)
             let templatesEnc = try await EncryptionService.shared.encrypt(mealTemplates)
+            let prefsEnc     = try await EncryptionService.shared.encrypt(userPreferences)
 
             // .completeFileProtectionUnlessOpen = encrypted at rest, even when locked (iOS only)
             #if os(iOS)
-            try logsEnc.write(to:      url("logs"),          options: .completeFileProtectionUnlessOpen)
-            try snapsEnc.write(to:     url("snaps"),         options: .completeFileProtectionUnlessOpen)
-            try profEnc.write(to:      url("profile"),       options: .completeFileProtectionUnlessOpen)
-            try templatesEnc.write(to: url("mealTemplates"), options: .completeFileProtectionUnlessOpen)
+            try logsEnc.write(to:      url("logs"),             options: .completeFileProtectionUnlessOpen)
+            try snapsEnc.write(to:     url("snaps"),            options: .completeFileProtectionUnlessOpen)
+            try profEnc.write(to:      url("profile"),          options: .completeFileProtectionUnlessOpen)
+            try templatesEnc.write(to: url("mealTemplates"),    options: .completeFileProtectionUnlessOpen)
+            try prefsEnc.write(to:     url("userPreferences"),  options: .completeFileProtectionUnlessOpen)
             #else
             try logsEnc.write(to:      url("logs"))
             try snapsEnc.write(to:     url("snaps"))
             try profEnc.write(to:      url("profile"))
             try templatesEnc.write(to: url("mealTemplates"))
+            try prefsEnc.write(to:     url("userPreferences"))
             #endif
         } catch {
             await MainActor.run { lastError = error.localizedDescription }
@@ -483,6 +499,10 @@ final class EncryptedDataStore: ObservableObject {
             if let d = try? Data(contentsOf: url("mealTemplates")), !d.isEmpty {
                 let v = try await EncryptionService.shared.decrypt(d, as: [MealTemplate].self)
                 await MainActor.run { mealTemplates = v }
+            }
+            if let d = try? Data(contentsOf: url("userPreferences")), !d.isEmpty {
+                let v = try await EncryptionService.shared.decrypt(d, as: UserPreferences.self)
+                await MainActor.run { userPreferences = v }
             }
         } catch {
             await MainActor.run {
@@ -559,11 +579,12 @@ final class EncryptedDataStore: ObservableObject {
         let adh   = r28.map { $0.completionPct }.reduce(0,+) / max(1, Double(r28.count))
         let prot  = Double(r28.filter { ($0.nutritionLog.resolvedProteinG ?? 0) >= 125 }.count) / max(1, Double(r28.count))
         let supp  = Double(r28.filter { $0.supplementLog.morningStatus == .completed }.count) / max(1, Double(r28.count))
-        let z2min = r7.flatMap { $0.cardioLogs.values }.compactMap { $0.wasInZone2 == true ? $0.durationMinutes : nil }.reduce(0,+)
+        let prefs = userPreferences
+        let z2min = r7.flatMap { $0.cardioLogs.values }.compactMap { $0.wasInZone2(lower: prefs.zone2LowerHR, upper: prefs.zone2UpperHR) == true ? $0.durationMinutes : nil }.reduce(0,+)
 
         var flags: [String] = []; var pos: [String] = []
-        if let hrv = logs.first?.biometrics.effectiveHRV, hrv < 28 { flags.append("HRV below 28 ms") }
-        if let rhr = logs.first?.biometrics.effectiveRestingHR, rhr > 75 { flags.append("Resting HR above 75 bpm") }
+        if let hrv = logs.first?.biometrics.effectiveHRV, hrv < prefs.hrvReadyThreshold { flags.append("HRV below \(Int(prefs.hrvReadyThreshold)) ms") }
+        if let rhr = logs.first?.biometrics.effectiveRestingHR, rhr > Double(userPreferences.hrReadyThreshold) { flags.append("Resting HR above \(userPreferences.hrReadyThreshold) bpm") }
         if adh < 70 { flags.append("Task adherence below 70%") }
         if z2min < 90 { flags.append("Zone 2 below 90 min/week") }
         if trend(hrvVals) == "increasing" { pos.append("HRV trend improving") }
@@ -571,7 +592,7 @@ final class EncryptedDataStore: ObservableObject {
         if adh > 85 { pos.append("Excellent task adherence") }
 
         let cw = wVals.last; let cb = bfVals.last
-        let gp = userProfile.overallProgress(currentWeight: cw, currentBF: cb.map { $0 * 100 })
+        let gp = userProfile.overallProgress(currentWeight: cw, currentBF: cb)
 
         return ExportPackage.AIHints(
             hrvTrend: trend(hrvVals), weightTrend: trend(wVals), bfTrend: trend(bfVals),

--- a/FitTracker/Services/HealthKit/HealthKitService.swift
+++ b/FitTracker/Services/HealthKit/HealthKitService.swift
@@ -73,6 +73,7 @@ final class HealthKitService: ObservableObject {
     @Published var isAuthorized   = false
     @Published var latest         = LiveMetrics()
     @Published var errorMessage:  String?
+    @Published var lastSyncDate:  Date?
 
     private let store = HKHealthStore()
     private var observers: [HKObserverQuery] = []
@@ -173,6 +174,7 @@ final class HealthKitService: ObservableObject {
             sleepHours: sleepV.total, deepSleepMin: sleepV.deep,
             remSleepMin: sleepV.rem
         )
+        lastSyncDate = Date()
     }
 
     // ── Historical data for charts ────────────────────────

--- a/FitTracker/Views/Auth/AccountPanelView.swift
+++ b/FitTracker/Views/Auth/AccountPanelView.swift
@@ -1,8 +1,8 @@
 // Views/Auth/AccountPanelView.swift
 // Slide-out panel from the top-right account button.
-// Sections:
-//   1. Account  — avatar / name / email / phone
-//   2. Settings — units (metric ↔ imperial) + appearance (light/dark/system)
+// Structure:
+//   1. Profile card  — avatar / name / email / phone / sign-in provider
+//   2. Settings      — button that opens SettingsView as a sheet
 //   3. Sign Out
 
 import SwiftUI
@@ -14,6 +14,7 @@ struct AccountPanelView: View {
     @Environment(\.dismiss) var dismiss
 
     @State private var showLogoutConfirm = false
+    @State private var showSettings = false
 
     private var session: UserSession? { signIn.currentSession }
 
@@ -29,7 +30,7 @@ struct AccountPanelView: View {
                     HStack(spacing: 16) {
                         avatarView
                         VStack(alignment: .leading, spacing: 3) {
-                            Text(session?.displayName ?? "Regev")
+                            Text(session?.displayName ?? "User")
                                 .font(.headline)
                             HStack(spacing: 6) {
                                 providerBadge
@@ -88,84 +89,15 @@ struct AccountPanelView: View {
                 }
 
                 // ─────────────────────────────────────────
-                // MARK: SETTINGS section
+                // MARK: SETTINGS button
                 // ─────────────────────────────────────────
                 Section {
-
-                    // Unit system
-                    VStack(alignment: .leading, spacing: 10) {
-                        Label("Units", systemImage: "ruler")
-                            .font(.subheadline.weight(.medium))
-
-                        HStack(spacing: 8) {
-                            ForEach(UnitSystem.allCases, id: \.self) { system in
-                                Button {
-                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                        settings.unitSystem = system
-                                    }
-                                } label: {
-                                    VStack(spacing: 4) {
-                                        Text(system.rawValue)
-                                            .font(.subheadline.weight(.semibold))
-                                        Text(system == .metric ? "kg · cm · km" : "lbs · in · mi")
-                                            .font(.system(size: 10))
-                                            .opacity(0.7)
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 10)
-                                    .foregroundStyle(settings.unitSystem == system ? .black : .primary)
-                                    .background(
-                                        settings.unitSystem == system
-                                            ? Color.green
-                                            : Color.secondary.opacity(0.1),
-                                        in: RoundedRectangle(cornerRadius: 10)
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
+                    Button {
+                        showSettings = true
+                    } label: {
+                        Label("Settings", systemImage: "gearshape.fill")
+                            .foregroundStyle(.primary)
                     }
-                    .padding(.vertical, 4)
-
-                    // Appearance
-                    VStack(alignment: .leading, spacing: 10) {
-                        Label("Appearance", systemImage: "paintpalette")
-                            .font(.subheadline.weight(.medium))
-
-                        HStack(spacing: 8) {
-                            ForEach(AppAppearance.allCases, id: \.self) { mode in
-                                Button {
-                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                        settings.appearance = mode
-                                    }
-                                } label: {
-                                    VStack(spacing: 5) {
-                                        Image(systemName: mode.icon)
-                                            .font(.title3)
-                                        Text(mode.rawValue)
-                                            .font(.caption2.weight(.medium))
-                                    }
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 10)
-                                    .foregroundStyle(settings.appearance == mode ? .black : .primary)
-                                    .background(
-                                        settings.appearance == mode
-                                            ? Color.green
-                                            : Color.secondary.opacity(0.1),
-                                        in: RoundedRectangle(cornerRadius: 10)
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
-                    .padding(.vertical, 4)
-
-                } header: {
-                    Label("Settings", systemImage: "gearshape.fill")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .textCase(nil)
                 }
 
                 // ─────────────────────────────────────────
@@ -205,6 +137,10 @@ struct AccountPanelView: View {
             } message: {
                 Text("You'll be returned to the welcome screen. Your encrypted data remains safely stored on this device and in iCloud.")
             }
+            .sheet(isPresented: $showSettings) {
+                NavigationStack { SettingsView() }
+                    .presentationDetents([.large])
+            }
         }
     }
 
@@ -221,9 +157,9 @@ struct AccountPanelView: View {
                 )
                 .frame(width: 52, height: 52)
 
-            Text(session?.initials ?? "R")
+            Text(session?.initials ?? "—")
                 .font(.system(.title2, design: .rounded, weight: .bold))
-                .foregroundStyle(.black)
+                .foregroundStyle(.white)
         }
     }
 

--- a/FitTracker/Views/Auth/SignInView.swift
+++ b/FitTracker/Views/Auth/SignInView.swift
@@ -74,6 +74,23 @@ struct SignInView: View {
                                 signIn.signInWithApple()
                             }
 
+                            #if targetEnvironment(simulator)
+                            Button { signIn.signInAsTestUser() } label: {
+                                HStack(spacing: 12) {
+                                    Image(systemName: "hammer.fill")
+                                        .foregroundStyle(.orange)
+                                    Text("Continue as Test User")
+                                        .font(.subheadline.weight(.semibold))
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+                                .overlay(RoundedRectangle(cornerRadius: 14).stroke(Color.orange.opacity(0.3)))
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(signIn.isLoading)
+                            #endif
+
                         }
 
                         // ── Divider ───────────────────────────────────

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -81,6 +81,7 @@ struct MainScreenView: View {
 
                     SectionHeader(title: "At A Glance")
                     summaryGrid
+                    syncBadge
 
                     SectionHeader(title: "Today Timeline")
                     todayTimeline
@@ -500,6 +501,24 @@ struct MainScreenView: View {
                 trendDelta: readinessContextShort,
                 statusColor: readinessColor
             )
+        }
+    }
+
+    @ViewBuilder
+    private var syncBadge: some View {
+        if let syncDate = healthService.lastSyncDate {
+            let elapsed = Date().timeIntervalSince(syncDate)
+            let label: String
+            if elapsed < 60 {
+                label = "⌚ Just now"
+            } else if elapsed < 3600 {
+                label = "⌚ Synced \(Int(elapsed / 60))m ago"
+            } else {
+                label = "⌚ Synced today"
+            }
+            Text(label)
+                .font(AppType.caption)
+                .foregroundStyle(Color.white.opacity(0.6))
         }
     }
 

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -22,6 +22,14 @@ struct MainScreenView: View {
     @State private var selectedRecoveryRoutine: RecoveryRoutine?
     @State private var selectedDayType:   DayType? = nil   // nil = follow today's schedule
 
+    @State private var readinessHapticDay: Date? = nil
+    @State private var shownMilestoneStreak: Int = 0
+    @State private var animatedWeight: Double? = nil
+    @State private var animatedBF: Double? = nil
+    @State private var shownMilestonePhase: ProgramPhase? = nil
+    @State private var milestoneTitle: String? = nil
+    @State private var milestoneMessage: String? = nil
+
     private var activeDayType: DayType {
         selectedDayType ?? programStore.todayDayType
     }
@@ -43,6 +51,11 @@ struct MainScreenView: View {
     private var readinessScore: Int? {
         dataStore.readinessScore(for: Date(), fallbackMetrics: metrics)
     }
+    private var streakMilestone: Int? {
+        let streak = dataStore.supplementStreak
+        let milestones = [7, 14, 30, 60, 90]
+        return milestones.first(where: { streak == $0 })
+    }
     private var loggedMealCount: Int {
         todayLog?.nutritionLog.meals.filter { $0.status == .completed }.count ?? 0
     }
@@ -58,7 +71,28 @@ struct MainScreenView: View {
         TrainingProgramData.exercises(for: activeDayType).count
     }
     private var recoveryRecommendation: RecoveryRecommendation {
-        RecoveryRoutineLibrary.recommend(dayType: activeDayType, readinessScore: readinessScore, liveMetrics: metrics, log: todayLog)
+        RecoveryRoutineLibrary.recommend(dayType: activeDayType, readinessScore: readinessScore, liveMetrics: metrics, log: todayLog, preferences: dataStore.userPreferences)
+    }
+
+    private var aiTip: String {
+        let logs = Array(dataStore.dailyLogs.prefix(28))
+        let r7 = logs.prefix(7)
+        let prefs = dataStore.userPreferences
+        // dailyLogs is always kept sorted descending; first == most recent
+        if let hrv = logs.first?.biometrics.effectiveHRV, hrv < prefs.hrvReadyThreshold {
+            return "HRV below threshold — consider a walk instead of lifting"
+        }
+        let r7CardioLogs = r7.flatMap { $0.cardioLogs.values }
+        let r7Zone2Logs = r7CardioLogs.filter { $0.wasInZone2(lower: prefs.zone2LowerHR, upper: prefs.zone2UpperHR) == true }
+        let z2min: Double = r7Zone2Logs.compactMap(\.durationMinutes).reduce(0, +)
+        if z2min < 90 {
+            return "Under 90 min Zone 2 — a 20-min walk fills the gap"
+        }
+        let adh = logs.isEmpty ? 0.0 : logs.map { $0.completionPct }.reduce(0, +) / Double(logs.count)
+        if adh < 70 {
+            return "Consistency gap this month — partial sessions count too"
+        }
+        return "All signals green — push hard today"
     }
 
     // Background palette — defined centrally in AppTheme.swift
@@ -67,6 +101,30 @@ struct MainScreenView: View {
     private let bgBlue1   = Color.appBlue1
     private let bgBlue2   = Color.appBlue2
 
+    private func checkMilestones() {
+        // Supplement streak
+        if let milestone = streakMilestone, milestone != shownMilestoneStreak {
+            shownMilestoneStreak = milestone
+            milestoneTitle = "\(milestone)-Day Streak!"
+            milestoneMessage = "\(milestone) days straight. Consistency beats intensity every time."
+            return
+        }
+        // Phase transition
+        let phase = dataStore.userProfile.currentPhase
+        if shownMilestonePhase == nil {
+            shownMilestonePhase = phase   // initialize on first appear, no modal
+            return
+        }
+        if phase != shownMilestonePhase {
+            shownMilestonePhase = phase
+            milestoneTitle = "Phase Complete!"
+            milestoneMessage = "Welcome to \(phase.rawValue). A new chapter begins."
+            let ng = UINotificationFeedbackGenerator()
+            ng.prepare()
+            ng.notificationOccurred(.success)
+        }
+    }
+
     var body: some View {
         ZStack {
             backgroundLayer
@@ -74,7 +132,10 @@ struct MainScreenView: View {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 20) {
                     greetingHeader
+                    readinessHeadline
                     recommendationCard
+                    aiTipChip
+                    wellnessQuickLog
 
                     SectionHeader(title: "Today Actions")
                     actionGrid
@@ -97,9 +158,52 @@ struct MainScreenView: View {
                 .padding(.bottom, 28)
             }
         }
+        .onAppear {
+            checkMilestones()
+            animatedWeight = currentWeight
+            animatedBF = currentBF
+        }
+        .onChange(of: currentWeight) { _, newWeight in
+            withAnimation(.interpolatingSpring(stiffness: 60, damping: 12)) {
+                animatedWeight = newWeight
+            }
+        }
+        .onChange(of: currentBF) { _, newBF in
+            withAnimation(.interpolatingSpring(stiffness: 60, damping: 12)) {
+                animatedBF = newBF
+            }
+        }
+        .onChange(of: dataStore.supplementStreak) { _, _ in checkMilestones() }
+        .onChange(of: dataStore.userProfile.currentPhase) { _, _ in checkMilestones() }
+        .onChange(of: readinessScore) { _, newScore in
+            guard newScore != nil else { return }
+            let today = Calendar.current.startOfDay(for: Date())
+            guard readinessHapticDay.map({ Calendar.current.startOfDay(for: $0) }) != today else { return }
+            readinessHapticDay = today
+            let g = UINotificationFeedbackGenerator()
+            g.prepare()
+            g.notificationOccurred(.success)
+        }
+        .onChange(of: selectedTab) { _, _ in
+            let g = UIImpactFeedbackGenerator(style: .light)
+            g.prepare()
+            g.impactOccurred()
+        }
+        .fullScreenCover(isPresented: Binding(
+            get: { milestoneTitle != nil },
+            set: { if !$0 { milestoneTitle = nil; milestoneMessage = nil } }
+        )) {
+            if let title = milestoneTitle, let msg = milestoneMessage {
+                MilestoneModal(title: title, message: msg) {
+                    milestoneTitle = nil
+                    milestoneMessage = nil
+                }
+            }
+        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbar { toolbarItems }
+        .preferredColorScheme(.dark)
         .sheet(isPresented: $showExerciseSheet) {
             NavigationStack { TrainingPlanView(initialDay: activeDayType) }
                 .presentationDetents([.large])
@@ -131,7 +235,7 @@ struct MainScreenView: View {
             LinearGradient(colors: [bgBlue1, bgBlue2],
                            startPoint: .topLeading, endPoint: .bottomTrailing)
                 .opacity(goalProgress)
-                .animation(.easeInOut(duration: 1.5), value: goalProgress)
+                .animation(.easeOut(duration: 0.6), value: goalProgress)
         }
         .ignoresSafeArea()
     }
@@ -329,6 +433,18 @@ struct MainScreenView: View {
         }
     }
 
+    private var readinessHeadline: some View {
+        VStack(spacing: 4) {
+            Text(readinessScore.map { "\($0)" } ?? "—")
+                .font(.system(size: 48, weight: .bold, design: .rounded))
+                .foregroundStyle(readinessScore != nil ? readinessColor : Color.secondary)
+            Text(readinessContextShort)
+                .font(.subheadline)
+                .foregroundStyle(.black.opacity(0.62))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
     private var recommendationCard: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(alignment: .top) {
@@ -413,6 +529,93 @@ struct MainScreenView: View {
                 .stroke(Color.white.opacity(0.55), lineWidth: 1)
         )
         .shadow(color: recommendationAccent.opacity(0.18), radius: 18, y: 8)
+    }
+
+    private var aiTipChip: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.accent.cyan)
+            Text(aiTip)
+                .font(AppType.subheading)
+                .foregroundStyle(.black.opacity(0.72))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.accent.cyan.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Wellness Quick-Log
+
+    private var wellnessQuickLog: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("How are you feeling?")
+                .font(AppType.caption)
+                .textCase(.uppercase)
+                .tracking(1.5)
+                .foregroundStyle(.black.opacity(0.45))
+
+            wellnessRow(
+                label: "Mood",
+                emojis: ["😴", "😐", "🙂", "😄", "🔥"],
+                current: todayLog?.mood
+            ) { value in saveWellness(\.mood, value: value) }
+
+            wellnessRow(
+                label: "Energy",
+                emojis: ["😴", "😐", "🙂", "😄", "🔥"],
+                current: todayLog?.energyLevel
+            ) { value in saveWellness(\.energyLevel, value: value) }
+
+            wellnessRow(
+                label: "Cravings",
+                emojis: ["🌿", "😕", "😐", "🍕", "🍰"],
+                current: todayLog?.cravingLevel
+            ) { value in saveWellness(\.cravingLevel, value: value) }
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
+        .overlay(RoundedRectangle(cornerRadius: 20).stroke(Color.white.opacity(0.35), lineWidth: 1))
+    }
+
+    private func wellnessRow(label: String, emojis: [String], current: Int?, onSelect: @escaping (Int) -> Void) -> some View {
+        HStack {
+            Text(label)
+                .font(AppType.subheading)
+                .foregroundStyle(.black.opacity(0.65))
+                .frame(width: 70, alignment: .leading)
+            Spacer()
+            HStack(spacing: 6) {
+                ForEach(Array(emojis.enumerated()), id: \.offset) { offset, emoji in
+                    let value = offset + 1
+                    Button {
+                        onSelect(value)
+                    } label: {
+                        Text(emoji)
+                            .font(.system(size: 24))
+                            .opacity(current == nil ? 0.5 : (current == value ? 1.0 : 0.3))
+                            .scaleEffect(current == value ? 1.15 : 1.0)
+                            .animation(.spring(response: 0.2), value: current)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private func saveWellness(_ keyPath: WritableKeyPath<DailyLog, Int?>, value: Int) {
+        var log = dataStore.dailyLogs.first(where: { Calendar.current.isDateInToday($0.date) }) ?? DailyLog(date: Date())
+        log[keyPath: keyPath] = value
+        dataStore.upsertLog(log)
+        Task { await dataStore.persistToDisk() }
     }
 
     private var actionGrid: some View {
@@ -634,7 +837,8 @@ struct MainScreenView: View {
                             }
                             .frame(width: 190, height: 140, alignment: .topLeading)
                             .padding(16)
-                            .background(Color.white.opacity(0.24), in: RoundedRectangle(cornerRadius: 20))
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+                            .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 20)
                                     .stroke(recoveryTint(for: routine).opacity(0.22), lineWidth: 1)
@@ -667,9 +871,10 @@ struct MainScreenView: View {
                         .frame(width: 8, height: 8)
                 }
                 HStack(alignment: .lastTextBaseline, spacing: 3) {
-                    Text(currentWeight.map { settings.unitSystem.displayWeightValue($0) } ?? "—")
+                    Text(animatedWeight.map { settings.unitSystem.displayWeightValue($0) } ?? "—")
                         .font(.system(size: 36, weight: .bold, design: .monospaced))
                         .foregroundStyle(.blue)
+                        .contentTransition(.numericText())
                     Text(settings.unitSystem.weightLabel())
                         .font(.callout)
                         .foregroundStyle(.secondary)
@@ -701,9 +906,10 @@ struct MainScreenView: View {
                         .frame(width: 8, height: 8)
                 }
                 HStack(alignment: .lastTextBaseline, spacing: 3) {
-                    Text(currentBF.map { String(format: "%.1f", $0) } ?? "—")
+                    Text(animatedBF.map { String(format: "%.1f", $0) } ?? "—")
                         .font(.system(size: 36, weight: .bold, design: .monospaced))
                         .foregroundStyle(.orange)
+                        .contentTransition(.numericText())
                     Text("%")
                         .font(.callout)
                         .foregroundStyle(.secondary)
@@ -981,7 +1187,8 @@ struct TodayActionCard: View {
             }
             .padding(16)
             .frame(maxWidth: .infinity, minHeight: 128, alignment: .topLeading)
-            .background(Color.white.opacity(0.24), in: RoundedRectangle(cornerRadius: 22))
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22))
+            .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
             .overlay(
                 RoundedRectangle(cornerRadius: 22)
                     .stroke(tint.opacity(0.28), lineWidth: 1)

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct MainScreenView: View {
 
+    @Binding var selectedTab: AppTab
+
     @EnvironmentObject var dataStore:     EncryptedDataStore
     @EnvironmentObject var healthService: HealthKitService
     @EnvironmentObject var programStore:  TrainingProgramStore
@@ -17,6 +19,7 @@ struct MainScreenView: View {
     @State private var trainingActive     = false
     @State private var showExerciseSheet  = false
     @State private var manualEntry        = false
+    @State private var selectedRecoveryRoutine: RecoveryRoutine?
     @State private var selectedDayType:   DayType? = nil   // nil = follow today's schedule
 
     private var activeDayType: DayType {
@@ -37,6 +40,26 @@ struct MainScreenView: View {
     private var goalProgress: Double {
         profile.overallProgress(currentWeight: currentWeight, currentBF: currentBF)
     }
+    private var readinessScore: Int? {
+        dataStore.readinessScore(for: Date(), fallbackMetrics: metrics)
+    }
+    private var loggedMealCount: Int {
+        todayLog?.nutritionLog.meals.filter { $0.status == .completed }.count ?? 0
+    }
+    private var completedSupplementStacks: Int {
+        let morning = todayLog?.supplementLog.morningStatus == .completed ? 1 : 0
+        let evening = todayLog?.supplementLog.eveningStatus == .completed ? 1 : 0
+        return morning + evening
+    }
+    private var completedExerciseCount: Int {
+        todayLog?.taskStatuses.values.filter { $0 == .completed }.count ?? 0
+    }
+    private var totalExerciseCount: Int {
+        TrainingProgramData.exercises(for: activeDayType).count
+    }
+    private var recoveryRecommendation: RecoveryRecommendation {
+        RecoveryRoutineLibrary.recommend(dayType: activeDayType, readinessScore: readinessScore, liveMetrics: metrics, log: todayLog)
+    }
 
     // Background palette — defined centrally in AppTheme.swift
     private let bgOrange1 = Color.appOrange1
@@ -47,28 +70,31 @@ struct MainScreenView: View {
     var body: some View {
         ZStack {
             backgroundLayer
-            progressTracker
 
-            // All content in a VStack with equal flexible spacers — no scroll
-            VStack(spacing: 0) {
-                greetingHeader
-                Spacer()
-                SectionHeader(title: "Status")
-                metricPair
-                Spacer()
-                SectionHeader(title: "Goal")
-                goalSection
-                Spacer()
-                SectionHeader(title: "Start Training")
-                trainingButton
-                Spacer()
-                SectionHeader(title: "Readiness")
-                quickStats
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 20) {
+                    greetingHeader
+                    recommendationCard
+
+                    SectionHeader(title: "Today Actions")
+                    actionGrid
+
+                    SectionHeader(title: "At A Glance")
+                    summaryGrid
+
+                    SectionHeader(title: "Today Timeline")
+                    todayTimeline
+
+                    SectionHeader(title: "Recovery Studio")
+                    recoveryStudio
+
+                    SectionHeader(title: "Readiness")
+                    quickStats
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 28)
             }
-            .padding(.horizontal, 20)
-            .padding(.trailing, 28)   // room for right-edge tracker
-            .padding(.top, 6)
-            .padding(.bottom, 12)
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
@@ -80,6 +106,16 @@ struct MainScreenView: View {
         .sheet(isPresented: $manualEntry) {
             ManualBiometricEntry()
                 .presentationDetents([.medium])
+        }
+        .sheet(item: $selectedRecoveryRoutine) { routine in
+            NavigationStack {
+                RecoveryRoutineSheet(
+                    routine: routine,
+                    reasons: routine.id == recoveryRecommendation.routine.id ? recoveryRecommendation.reasons : []
+                )
+            }
+            .presentationDetents([.medium, .large])
+            .presentationCornerRadius(24)
         }
     }
 
@@ -148,22 +184,62 @@ struct MainScreenView: View {
     // ─────────────────────────────────────────────────────
 
     private var greetingHeader: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(greeting)
-                    .font(.system(.title2, design: .rounded, weight: .bold))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-                Text(todayFormatted)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(greeting)
+                        .font(.system(.title2, design: .rounded, weight: .bold))
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.8)
+                    Text(todayFormatted)
+                        .font(.subheadline)
+                        .foregroundStyle(.black.opacity(0.65))
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 6) {
+                    StatusBadge(text: "Day \(profile.daysSinceStart)", color: .appOrange2)
+                    StatusBadge(text: profile.currentPhase.rawValue, color: .appBlue1)
+                }
             }
-            Spacer()
-            VStack(alignment: .trailing, spacing: 4) {
-                StatusBadge(text: "Day \(profile.daysSinceStart)", color: .appOrange2)
-                StatusBadge(text: profile.currentPhase.rawValue, color: .appBlue1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    statusChip(
+                        title: "Scheduled",
+                        value: activeDayType.rawValue,
+                        tint: activeDayType.isTrainingDay ? Color.accent.cyan : Color.status.warning
+                    )
+                    statusChip(
+                        title: "Readiness",
+                        value: readinessScore.map { "\($0)" } ?? "—",
+                        tint: readinessColor
+                    )
+                }
+                Text("Today is built around the next best action: capture the essentials quickly, then drill into details only when you need them.")
+                    .font(AppType.subheading)
+                    .foregroundStyle(.black.opacity(0.65))
             }
         }
+    }
+
+    private func statusChip(title: String, value: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.black.opacity(0.45))
+                .tracking(1.2)
+            Text(value)
+                .font(AppType.body)
+                .foregroundStyle(.black.opacity(0.82))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(tint.opacity(0.35), lineWidth: 1)
+        )
     }
 
     private var greeting: String {
@@ -184,6 +260,373 @@ struct MainScreenView: View {
 
     private var todayFormatted: String {
         Self.todayDateFormatter.string(from: Date())
+    }
+
+    private var recommendationAccent: Color {
+        switch readinessScore ?? 65 {
+        case 80...: Color.status.success
+        case 60..<80: Color.accent.cyan
+        case 40..<60: Color.status.warning
+        default: Color.status.error
+        }
+    }
+
+    private var readinessColor: Color { recommendationAccent }
+
+    private var recommendationTitle: String {
+        if recoveryRecommendation.shouldReplaceTraining {
+            return "Run the \(recoveryRecommendation.routine.title.lowercased())"
+        }
+        switch readinessScore ?? 65 {
+        case 80...: return "Push the full \(activeDayType.rawValue.lowercased()) session"
+        case 60..<80: return "Run the planned \(activeDayType.rawValue.lowercased()) session"
+        case 40..<60: return "Train, but trim the volume"
+        default: return "Bias toward recovery and technique"
+        }
+    }
+
+    private var recommendationSubtitle: String {
+        if recoveryRecommendation.shouldReplaceTraining {
+            let reasons = recoveryRecommendation.reasons.joined(separator: " ")
+            return reasons.isEmpty
+                ? "Use guided recovery today: calm the system, move a little, and tighten nutrition."
+                : reasons
+        }
+        switch readinessScore ?? 65 {
+        case 80...: return "Readiness supports a full effort day. Keep the plan intact and push the top sets."
+        case 60..<80: return "You look good enough to stay on schedule. Aim for consistency over hero numbers."
+        case 40..<60: return "Keep the session, but pull back one block or reduce load if the first work sets feel heavy."
+        default: return "Treat today as a lighter practice day. Keep momentum, but protect recovery."
+        }
+    }
+
+    private var estimatedSessionLength: String {
+        if recoveryRecommendation.shouldReplaceTraining {
+            return "\(recoveryRecommendation.routine.durationMinutes)m"
+        }
+        let minutes = max(20, totalExerciseCount * (activeDayType.isTrainingDay ? 6 : 4))
+        return "\(minutes)m"
+    }
+
+    private var recommendationTone: String {
+        guard let score = readinessScore else { return "Baseline building" }
+        switch score {
+        case 80...: return "Full send"
+        case 60..<80: return "On plan"
+        case 40..<60: return "Trim load"
+        default: return "Recover"
+        }
+    }
+
+    private var readinessContextShort: String {
+        guard let score = readinessScore else { return "Need more data" }
+        switch score {
+        case 80...: return "Green light"
+        case 60..<80: return "Steady"
+        case 40..<60: return "Moderate"
+        default: return "Back off"
+        }
+    }
+
+    private var recommendationCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Recommended Right Now")
+                        .font(AppType.caption)
+                        .textCase(.uppercase)
+                        .tracking(1.5)
+                        .foregroundStyle(.black.opacity(0.45))
+                    Text(recommendationTitle)
+                        .font(.system(size: 26, weight: .bold, design: .rounded))
+                        .foregroundStyle(.black.opacity(0.85))
+                    Text(recommendationSubtitle)
+                        .font(AppType.subheading)
+                        .foregroundStyle(.black.opacity(0.62))
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 6) {
+                    Text(estimatedSessionLength)
+                        .font(.system(size: 24, weight: .bold, design: .monospaced))
+                        .foregroundStyle(recommendationAccent)
+                    Text("estimated")
+                        .font(AppType.caption)
+                        .foregroundStyle(.black.opacity(0.45))
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    if recoveryRecommendation.shouldReplaceTraining {
+                        selectedRecoveryRoutine = recoveryRecommendation.routine
+                    } else if activeDayType.isTrainingDay {
+                        showExerciseSheet = true
+                    } else {
+                        selectedRecoveryRoutine = recoveryRecommendation.routine
+                    }
+                } label: {
+                    Label(
+                        recoveryRecommendation.shouldReplaceTraining ? "Start Recovery Flow" : "Start Session",
+                        systemImage: recoveryRecommendation.shouldReplaceTraining ? recoveryRecommendation.routine.icon : "play.fill"
+                    )
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(recommendationAccent, in: RoundedRectangle(cornerRadius: 16))
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(.plain)
+
+                Menu {
+                    Button("Use Today's Schedule") { selectedDayType = nil }
+                    Divider()
+                    ForEach(DayType.allCases, id: \.self) { day in
+                        Button(day.rawValue) { selectedDayType = day }
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "slider.horizontal.3")
+                        Text("Adjust")
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .background(Color.white.opacity(0.45), in: RoundedRectangle(cornerRadius: 16))
+                    .foregroundStyle(.black.opacity(0.78))
+                }
+            }
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .fill(
+                    LinearGradient(
+                        colors: [Color.white.opacity(0.72), recommendationAccent.opacity(0.22)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 24)
+                .stroke(Color.white.opacity(0.55), lineWidth: 1)
+        )
+        .shadow(color: recommendationAccent.opacity(0.18), radius: 18, y: 8)
+    }
+
+    private var actionGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+            spacing: 12
+        ) {
+            TodayActionCard(
+                title: "Weigh In",
+                subtitle: currentWeight.map { "Latest \(settings.unitSystem.displayWeightValue($0)) \(settings.unitSystem.weightLabel())" } ?? "Capture weight and body fat",
+                icon: "scalemass.fill",
+                tint: .blue
+            ) {
+                manualEntry = true
+            }
+
+            TodayActionCard(
+                title: recoveryRecommendation.shouldReplaceTraining ? "Recovery Flow" : "Start Workout",
+                subtitle: recoveryRecommendation.shouldReplaceTraining
+                    ? "\(recoveryRecommendation.routine.title) · \(recoveryRecommendation.routine.durationMinutes) min"
+                    : (totalExerciseCount > 0 ? "\(activeDayType.rawValue) · \(totalExerciseCount) items" : "Open your plan for today"),
+                icon: recoveryRecommendation.shouldReplaceTraining ? recoveryRecommendation.routine.icon : "figure.strengthtraining.traditional",
+                tint: recommendationAccent
+            ) {
+                if recoveryRecommendation.shouldReplaceTraining {
+                    selectedRecoveryRoutine = recoveryRecommendation.routine
+                } else {
+                    showExerciseSheet = true
+                }
+            }
+
+            TodayActionCard(
+                title: "Log Meals",
+                subtitle: loggedMealCount > 0 ? "\(loggedMealCount) meals logged" : "Jump into nutrition tracking",
+                icon: "fork.knife",
+                tint: .accent.cyan
+            ) {
+                selectedTab = .nutrition
+            }
+
+            TodayActionCard(
+                title: "Check Progress",
+                subtitle: "Open trends, charts, and adherence",
+                icon: "chart.line.uptrend.xyaxis",
+                tint: .accent.gold
+            ) {
+                selectedTab = .stats
+            }
+        }
+    }
+
+    private var summaryGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+            spacing: 12
+        ) {
+            MetricCard(
+                icon: "scalemass.fill",
+                label: "Weight",
+                value: currentWeight.map { settings.unitSystem.displayWeightValue($0) } ?? "—",
+                unit: currentWeight == nil ? nil : settings.unitSystem.weightLabel(),
+                trendDelta: weightDelta.isEmpty ? nil : weightDelta,
+                statusColor: weightTrendColor
+            )
+            MetricCard(
+                icon: "drop.fill",
+                label: "Body Fat",
+                value: currentBF.map { String(format: "%.1f", $0) } ?? "—",
+                unit: currentBF == nil ? nil : "%",
+                trendDelta: bfDelta.isEmpty ? nil : bfDelta,
+                statusColor: bfTrendColor
+            )
+            MetricCard(
+                icon: "scope",
+                label: "Goal Progress",
+                value: "\(Int(goalProgress * 100))",
+                unit: "%",
+                trendDelta: recommendationTone,
+                statusColor: recommendationAccent
+            )
+            MetricCard(
+                icon: "sparkles",
+                label: "Readiness",
+                value: readinessScore.map { "\($0)" } ?? "—",
+                unit: readinessScore == nil ? nil : "/100",
+                trendDelta: readinessContextShort,
+                statusColor: readinessColor
+            )
+        }
+    }
+
+    private var todayTimeline: some View {
+        VStack(spacing: 12) {
+            TodayTimelineRow(
+                title: "Body check-in",
+                detail: currentWeight != nil || currentBF != nil ? "Weight or body fat logged" : "Weight and body fat still missing",
+                status: currentWeight != nil || currentBF != nil ? .complete : .pending,
+                accent: .blue
+            )
+            TodayTimelineRow(
+                title: activeDayType.isTrainingDay ? "Workout progress" : "Recovery day",
+                detail: activeDayType.isTrainingDay
+                    ? "\(completedExerciseCount) of \(totalExerciseCount) workout items complete"
+                    : "Use \(recoveryRecommendation.routine.title.lowercased()) and easy movement today",
+                status: activeDayType.isTrainingDay
+                    ? (completedExerciseCount == 0 ? .pending : (completedExerciseCount >= totalExerciseCount ? .complete : .inProgress))
+                    : .inProgress,
+                accent: recommendationAccent
+            )
+            TodayTimelineRow(
+                title: "Nutrition",
+                detail: loggedMealCount > 0 ? "\(loggedMealCount) meals logged today" : "No meals logged yet",
+                status: loggedMealCount == 0 ? .pending : .inProgress,
+                accent: .accent.cyan
+            )
+            TodayTimelineRow(
+                title: "Supplements",
+                detail: "\(completedSupplementStacks) of 2 stacks completed",
+                status: completedSupplementStacks == 0 ? .pending : (completedSupplementStacks == 2 ? .complete : .inProgress),
+                accent: .accent.gold
+            )
+        }
+        .padding(16)
+        .background(Color.white.opacity(0.2), in: RoundedRectangle(cornerRadius: 22))
+        .overlay(
+            RoundedRectangle(cornerRadius: 22)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+    }
+
+    private var recoveryStudio: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Button {
+                selectedRecoveryRoutine = recoveryRecommendation.routine
+            } label: {
+                HStack(alignment: .top, spacing: 14) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Recommended Flow")
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.black.opacity(0.45))
+                            .tracking(1.2)
+                        Text(recoveryRecommendation.routine.title)
+                            .font(.headline)
+                            .foregroundStyle(.black.opacity(0.82))
+                        Text(recoveryRecommendation.routine.focus)
+                            .font(AppType.subheading)
+                            .foregroundStyle(.black.opacity(0.62))
+                        if let reason = recoveryRecommendation.reasons.first {
+                            Text(reason)
+                                .font(.caption)
+                                .foregroundStyle(.black.opacity(0.6))
+                                .lineLimit(2)
+                        }
+                    }
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 6) {
+                        Image(systemName: recoveryRecommendation.routine.icon)
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(recoveryTint(for: recoveryRecommendation.routine))
+                        Text("\(recoveryRecommendation.routine.durationMinutes)m")
+                            .font(.system(.headline, design: .monospaced, weight: .bold))
+                            .foregroundStyle(recoveryTint(for: recoveryRecommendation.routine))
+                        Text(recoveryRecommendation.routine.intensityLabel)
+                            .font(.caption2)
+                            .foregroundStyle(.black.opacity(0.45))
+                    }
+                }
+                .padding(16)
+                .background(Color.white.opacity(0.28), in: RoundedRectangle(cornerRadius: 20))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(recoveryTint(for: recoveryRecommendation.routine).opacity(0.3), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(RecoveryRoutineLibrary.all) { routine in
+                        Button {
+                            selectedRecoveryRoutine = routine
+                        } label: {
+                            VStack(alignment: .leading, spacing: 10) {
+                                HStack {
+                                    Image(systemName: routine.icon)
+                                        .font(.headline)
+                                        .foregroundStyle(recoveryTint(for: routine))
+                                    Spacer()
+                                    Text("\(routine.durationMinutes)m")
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(.black.opacity(0.55))
+                                }
+                                Text(routine.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(.black.opacity(0.82))
+                                    .lineLimit(2)
+                                Text(routine.subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.black.opacity(0.6))
+                                    .lineLimit(3)
+                            }
+                            .frame(width: 190, height: 140, alignment: .topLeading)
+                            .padding(16)
+                            .background(Color.white.opacity(0.24), in: RoundedRectangle(cornerRadius: 20))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 20)
+                                    .stroke(recoveryTint(for: routine).opacity(0.22), lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
     }
 
     // ─────────────────────────────────────────────────────
@@ -424,6 +867,17 @@ struct MainScreenView: View {
         ReadinessCard()
     }
 
+    private func recoveryTint(for routine: RecoveryRoutine) -> Color {
+        switch routine.id {
+        case RecoveryRoutineLibrary.nervousSystemReset.id:
+            return Color.status.warning
+        case RecoveryRoutineLibrary.mobilityFlush.id:
+            return Color.accent.cyan
+        default:
+            return Color.accent.purple
+        }
+    }
+
     // ─────────────────────────────────────────────────────
     // MARK: – Toolbar
     // ─────────────────────────────────────────────────────
@@ -473,6 +927,98 @@ struct GoalProgressRow: View {
 }
 
 // ─────────────────────────────────────────────────────────
+// MARK: – TodayActionCard
+// ─────────────────────────────────────────────────────────
+
+struct TodayActionCard: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let tint: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    Image(systemName: icon)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(tint)
+                    Spacer()
+                    Image(systemName: "arrow.up.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.black.opacity(0.35))
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.black.opacity(0.84))
+                    Text(subtitle)
+                        .font(AppType.subheading)
+                        .foregroundStyle(.black.opacity(0.62))
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 128, alignment: .topLeading)
+            .background(Color.white.opacity(0.24), in: RoundedRectangle(cornerRadius: 22))
+            .overlay(
+                RoundedRectangle(cornerRadius: 22)
+                    .stroke(tint.opacity(0.28), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – TodayTimelineRow
+// ─────────────────────────────────────────────────────────
+
+struct TodayTimelineRow: View {
+    enum RowStatus {
+        case pending
+        case inProgress
+        case complete
+
+        var symbol: String {
+            switch self {
+            case .pending: "circle.dashed"
+            case .inProgress: "arrow.trianglehead.clockwise"
+            case .complete: "checkmark.circle.fill"
+            }
+        }
+    }
+
+    let title: String
+    let detail: String
+    let status: RowStatus
+    let accent: Color
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: status.symbol)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(accent)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.black.opacity(0.82))
+                Text(detail)
+                    .font(AppType.subheading)
+                    .foregroundStyle(.black.opacity(0.6))
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// ─────────────────────────────────────────────────────────
 // MARK: – QuickStatPill
 // ─────────────────────────────────────────────────────────
 
@@ -489,6 +1035,127 @@ struct QuickStatPill: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(label)
         .accessibilityValue(value)
+    }
+}
+
+struct RecoveryRoutineSheet: View {
+    let routine: RecoveryRoutine
+    let reasons: [String]
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .top) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(routine.title)
+                                .font(.system(size: 28, weight: .bold, design: .rounded))
+                            Text(routine.subtitle)
+                                .font(AppType.body)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text("\(routine.durationMinutes)m")
+                            .font(.system(.title2, design: .monospaced, weight: .bold))
+                            .foregroundStyle(Color.accentColor)
+                    }
+
+                    HStack(spacing: 10) {
+                        RecoveryMetaPill(label: routine.intensityLabel, icon: "dial.low")
+                        RecoveryMetaPill(label: routine.focus, icon: routine.icon)
+                    }
+                }
+
+                if !reasons.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Why today")
+                            .font(.headline)
+                        ForEach(reasons, id: \.self) { reason in
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "sparkles")
+                                    .foregroundStyle(Color.accentColor)
+                                    .padding(.top, 2)
+                                Text(reason)
+                                    .font(AppType.subheading)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Flow")
+                        .font(.headline)
+                    ForEach(Array(routine.steps.enumerated()), id: \.element.id) { index, step in
+                        HStack(alignment: .top, spacing: 12) {
+                            ZStack {
+                                Circle()
+                                    .fill(Color.accentColor.opacity(0.14))
+                                    .frame(width: 30, height: 30)
+                                Text("\(index + 1)")
+                                    .font(.caption.weight(.bold))
+                                    .foregroundStyle(Color.accentColor)
+                            }
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text(step.title)
+                                        .font(.subheadline.weight(.semibold))
+                                    Spacer()
+                                    Text("\(step.minutes) min")
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(.secondary)
+                                }
+                                Text(step.detail)
+                                    .font(AppType.subheading)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(14)
+                        .background(Color.secondary.opacity(0.07), in: RoundedRectangle(cornerRadius: 16))
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Coaching note")
+                        .font(.headline)
+                    Text(routine.coachingNote)
+                        .font(AppType.subheading)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(16)
+                .background(Color.accentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 18))
+            }
+            .padding(20)
+        }
+        .navigationTitle("Recovery Flow")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+}
+
+private struct RecoveryMetaPill: View {
+    let label: String
+    let icon: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.caption.weight(.semibold))
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(Color.accentColor)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(Color.accentColor.opacity(0.1), in: Capsule())
     }
 }
 

--- a/FitTracker/Views/Nutrition/MacroTargetBar.swift
+++ b/FitTracker/Views/Nutrition/MacroTargetBar.swift
@@ -77,6 +77,9 @@ struct MacroTargetBar: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .background(Color.white.opacity(0.1), in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Macro targets")
+        .accessibilityValue("\(Int(protein)) grams protein, \(Int(carbs)) grams carbs, \(Int(fat)) grams fat, \(Int(consumedCalories)) of \(targetCalories) calories")
     }
 
     private func macroLabel(_ letter: String, value: Double, unit: String, color: Color) -> some View {
@@ -89,8 +92,12 @@ struct MacroTargetBar: View {
     }
 }
 
-#Preview {
-    MacroTargetBar(protein: 120, carbs: 180, fat: 55, targetCalories: 1900, targetProteinG: 130)
-        .padding()
-        .background(Color.appOrange2)
+#if DEBUG
+struct MacroTargetBar_Previews: PreviewProvider {
+    static var previews: some View {
+        MacroTargetBar(protein: 120, carbs: 180, fat: 55, targetCalories: 1900, targetProteinG: 130)
+            .padding()
+            .background(Color.appOrange2)
+    }
 }
+#endif

--- a/FitTracker/Views/Nutrition/MealEntrySheet.swift
+++ b/FitTracker/Views/Nutrition/MealEntrySheet.swift
@@ -192,30 +192,33 @@ struct MealEntrySheet: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                List(dataStore.mealTemplates) { template in
-                    Button {
-                        fillFromTemplate(template)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(template.name)
-                                .font(AppType.body)
-                                .foregroundColor(.primary)
-                            HStack(spacing: 8) {
-                                if let cal = template.calories {
-                                    Text("\(Int(cal)) kcal")
-                                        .font(AppType.caption)
-                                        .foregroundColor(Color.accent.gold)
-                                }
-                                if let pro = template.proteinG {
-                                    Text("\(Int(pro))g protein")
-                                        .font(AppType.caption)
-                                        .foregroundColor(Color.accent.cyan)
+                List {
+                    ForEach(dataStore.mealTemplates) { template in
+                        Button {
+                            fillFromTemplate(template)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(template.name)
+                                    .font(AppType.body)
+                                    .foregroundColor(.primary)
+                                HStack(spacing: 8) {
+                                    if let cal = template.calories {
+                                        Text("\(Int(cal)) kcal")
+                                            .font(AppType.caption)
+                                            .foregroundColor(Color.accent.gold)
+                                    }
+                                    if let pro = template.proteinG {
+                                        Text("\(Int(pro))g protein")
+                                            .font(AppType.caption)
+                                            .foregroundColor(Color.accent.cyan)
+                                    }
                                 }
                             }
+                            .padding(.vertical, 4)
                         }
-                        .padding(.vertical, 4)
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
+                    .onDelete { offsets in deleteTemplates(at: offsets) }
                 }
                 .listStyle(.plain)
             }
@@ -377,6 +380,11 @@ struct MealEntrySheet: View {
         carbsG   = product.carbsPer100g.map     { formatNum($0) } ?? ""
         fatG     = product.fatPer100g.map       { formatNum($0) } ?? ""
         activeTab = .manual
+    }
+
+    private func deleteTemplates(at offsets: IndexSet) {
+        dataStore.mealTemplates.remove(atOffsets: offsets)
+        Task { await dataStore.persistToDisk() }
     }
 
     private func formatNum(_ v: Double) -> String {

--- a/FitTracker/Views/Nutrition/MealSectionView.swift
+++ b/FitTracker/Views/Nutrition/MealSectionView.swift
@@ -4,26 +4,41 @@ import SwiftUI
 
 struct MealSectionView: View {
     @Binding var nutritionLog: NutritionLog
+    let suggestedMealNumber: Int
     let onTapMeal: (Int) -> Void  // called with mealNumber (1-4) when meal card is tapped
 
+    private var displayedMealNumbers: [Int] {
+        let highestLoggedMeal = nutritionLog.meals.map(\.mealNumber).max() ?? 0
+        let visibleMax = max(4, highestLoggedMeal)
+        return Array(1...visibleMax)
+    }
+
     var body: some View {
-        VStack(spacing: 12) {
-            ForEach(1...4, id: \.self) { mealNumber in
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Meals")
+                    .font(.headline)
+                Text("Fast log from your saved meals, or open a fresh slot.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(displayedMealNumbers, id: \.self) { mealNumber in
                 let entry = nutritionLog.meals.first(where: { $0.mealNumber == mealNumber })
-                MealCard(mealNumber: mealNumber, entry: entry) {
+                MealCard(mealNumber: mealNumber, entry: entry, isSuggested: mealNumber == suggestedMealNumber) {
                     onTapMeal(mealNumber)
                 }
             }
 
             // "+ Add Meal" footer button
             Button {
-                onTapMeal(0)
+                onTapMeal(suggestedMealNumber)
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "plus.circle.fill")
                         .font(AppType.body)
                         .foregroundStyle(Color.accent.cyan)
-                    Text("Add Meal")
+                    Text(suggestedMealNumber > displayedMealNumbers.count ? "Add Meal \(suggestedMealNumber)" : "Add Another Meal")
                         .font(AppType.body)
                         .foregroundStyle(Color.accent.cyan)
                 }
@@ -48,6 +63,7 @@ struct MealSectionView: View {
 private struct MealCard: View {
     let mealNumber: Int
     let entry: MealEntry?
+    let isSuggested: Bool
     let onTap: () -> Void
 
     private var defaultName: String {
@@ -71,11 +87,17 @@ private struct MealCard: View {
         if entry?.status == .completed {
             return Color.status.success
         }
+        if isSuggested {
+            return Color.accent.cyan.opacity(0.45)
+        }
         return Color.secondary.opacity(0.15)
     }
 
     private var borderWidth: CGFloat {
-        entry?.status == .completed ? 1.5 : 1.0
+        if entry?.status == .completed {
+            return 1.5
+        }
+        return isSuggested ? 1.3 : 1.0
     }
 
     private static let timeFormatter: DateFormatter = {
@@ -121,9 +143,9 @@ private struct MealCard: View {
                             }
                         }
                     } else {
-                        Text("Tap to log")
+                        Text(isSuggested ? "Suggested next meal" : "Tap to log")
                             .font(AppType.subheading)
-                            .foregroundStyle(Color.secondary.opacity(0.6))
+                            .foregroundStyle(isSuggested ? Color.accent.cyan : Color.secondary.opacity(0.6))
                     }
                 }
 
@@ -144,7 +166,7 @@ private struct MealCard: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .fill(Color(UIColor.secondarySystemBackground))
+                    .fill(isSuggested ? Color.accent.cyan.opacity(0.08) : Color(UIColor.secondarySystemBackground))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 12)

--- a/FitTracker/Views/Nutrition/MealSectionView.swift
+++ b/FitTracker/Views/Nutrition/MealSectionView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct MealSectionView: View {
     @Binding var nutritionLog: NutritionLog
     let suggestedMealNumber: Int
+    var mealSlotNames: [String]
     let onTapMeal: (Int) -> Void  // called with mealNumber (1-4) when meal card is tapped
 
     private var displayedMealNumbers: [Int] {
@@ -25,35 +26,18 @@ struct MealSectionView: View {
 
             ForEach(displayedMealNumbers, id: \.self) { mealNumber in
                 let entry = nutritionLog.meals.first(where: { $0.mealNumber == mealNumber })
-                MealCard(mealNumber: mealNumber, entry: entry, isSuggested: mealNumber == suggestedMealNumber) {
+                MealCard(mealNumber: mealNumber, entry: entry, isSuggested: mealNumber == suggestedMealNumber, mealSlotNames: mealSlotNames) {
                     onTapMeal(mealNumber)
                 }
             }
 
-            // "+ Add Meal" footer button
-            Button {
-                onTapMeal(suggestedMealNumber)
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "plus.circle.fill")
-                        .font(AppType.body)
-                        .foregroundStyle(Color.accent.cyan)
-                    Text(suggestedMealNumber > displayedMealNumbers.count ? "Add Meal \(suggestedMealNumber)" : "Add Another Meal")
-                        .font(AppType.body)
-                        .foregroundStyle(Color.accent.cyan)
-                }
+            Text("Tap any meal slot to log")
+                .font(AppType.caption)
+                .foregroundStyle(Color.secondary.opacity(0.6))
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.accent.cyan.opacity(0.08))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .strokeBorder(Color.accent.cyan.opacity(0.3), lineWidth: 1)
-                )
-            }
-            .buttonStyle(.plain)
+                .multilineTextAlignment(.center)
+                .padding(.top, 4)
+                .accessibilityHidden(true)
         }
     }
 }
@@ -64,16 +48,15 @@ private struct MealCard: View {
     let mealNumber: Int
     let entry: MealEntry?
     let isSuggested: Bool
+    let mealSlotNames: [String]
     let onTap: () -> Void
 
     private var defaultName: String {
-        switch mealNumber {
-        case 1: return "Breakfast"
-        case 2: return "Lunch"
-        case 3: return "Dinner"
-        case 4: return "Snacks"
-        default: return "Meal \(mealNumber)"
+        let index = mealNumber - 1
+        if mealSlotNames.indices.contains(index) {
+            return mealSlotNames[index]
         }
+        return "Meal \(mealNumber)"
     }
 
     private var displayName: String {

--- a/FitTracker/Views/Nutrition/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/NutritionView.swift
@@ -12,6 +12,7 @@ struct NutritionView: View {
     @State private var log: DailyLog?
     @State private var supplementsExpanded = false
     @State private var editingMealEntry: MealEntry?
+    @State private var showSupplementInfo = false
 
     private var morning: [SupplementDefinition] { TrainingProgramData.morningSupplements }
     private var evening: [SupplementDefinition] { TrainingProgramData.eveningSupplements }
@@ -44,6 +45,7 @@ struct NutritionView: View {
         } // ZStack
         .navigationTitle("Nutrition")
         .navigationBarTitleDisplayMode(.inline)
+        .preferredColorScheme(.dark)
         .onAppear {
             activeDate = Calendar.current.startOfDay(for: Date())
             loadLog(for: activeDate)
@@ -319,6 +321,25 @@ struct NutritionView: View {
                 Spacer()
                 Text("\(taken)/\(total) taken")
                     .font(.caption2.monospaced()).foregroundStyle(.secondary)
+                Button { showSupplementInfo.toggle() } label: {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("About supplement adherence")
+                .popover(isPresented: $showSupplementInfo) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Supplement Adherence")
+                            .font(.headline)
+                        Text("Tracks whether you took all pills in your morning and evening stacks today. The 🔥 streak counts consecutive days with 100% adherence across both stacks.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(16)
+                    .frame(minWidth: 260)
+                    .presentationCompactAdaptation(.popover)
+                }
             }
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
@@ -364,7 +385,7 @@ struct NutritionView: View {
             get: { nutritionLog },
             set: { log?.nutritionLog = $0 }
         )
-        return MealSectionView(nutritionLog: nutritionBinding, suggestedMealNumber: nextMealNumber) { mealNumber in
+        return MealSectionView(nutritionLog: nutritionBinding, suggestedMealNumber: nextMealNumber, mealSlotNames: dataStore.userProfile.mealSlotNames) { mealNumber in
             let existing = log?.nutritionLog.meals.first(where: { $0.mealNumber == mealNumber })
             editingMealEntry = existing ?? MealEntry(mealNumber: max(mealNumber, nextMealNumber))
         }
@@ -995,7 +1016,9 @@ struct SupplementItemRow: View {
 enum HapticFeedback {
     static func impact() {
         #if os(iOS)
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        let g = UIImpactFeedbackGenerator(style: .medium)
+        g.prepare()
+        g.impactOccurred()
         #endif
     }
 }

--- a/FitTracker/Views/Nutrition/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/NutritionView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct NutritionView: View {
 
     @EnvironmentObject var dataStore: EncryptedDataStore
+    @State private var activeDate: Date = Date()
     @State private var log: DailyLog?
     @State private var supplementsExpanded = false
     @State private var editingMealEntry: MealEntry?
@@ -27,7 +28,10 @@ struct NutritionView: View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 20) {
                 dateHeader
+                nutritionCommandDeck
                 macroBar
+                quickLogSection
+                hydrationCard
                 adherenceRow
                 mealSection
                 supplementRow
@@ -40,7 +44,11 @@ struct NutritionView: View {
         } // ZStack
         .navigationTitle("Nutrition")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear { loadLog() }
+        .onAppear {
+            activeDate = Calendar.current.startOfDay(for: Date())
+            loadLog(for: activeDate)
+        }
+        .onDisappear { saveLog() }
         .sheet(item: $editingMealEntry) { entry in
             let entryBinding = Binding<MealEntry>(
                 get: { log?.nutritionLog.meals.first(where: { $0.mealNumber == entry.mealNumber }) ?? entry },
@@ -78,20 +86,141 @@ struct NutritionView: View {
         log?.supplementLog.individualOverrides ?? [:]
     }
 
+    private var nutritionLog: NutritionLog {
+        log?.nutritionLog ?? NutritionLog()
+    }
+
+    private var currentPhase: ProgramPhase {
+        dataStore.userProfile.currentPhase
+    }
+
+    private var isTrainingDay: Bool {
+        (log?.dayType ?? suggestedDay(for: activeDate)).isTrainingDay
+    }
+
+    private var targetCalories: Double {
+        isTrainingDay ? Double(currentPhase.trainingCalories) : Double(currentPhase.restCalories)
+    }
+
+    private var targetProteinG: Double {
+        if let leanMass = log?.biometrics.leanBodyMassKg {
+            return leanMass * 2
+        }
+        return 135
+    }
+
+    private var consumedCalories: Double {
+        nutritionLog.resolvedCalories ?? 0
+    }
+
+    private var consumedProteinG: Double {
+        nutritionLog.resolvedProteinG ?? 0
+    }
+
+    private var remainingCalories: Double {
+        max(targetCalories - consumedCalories, 0)
+    }
+
+    private var remainingProteinG: Double {
+        max(targetProteinG - consumedProteinG, 0)
+    }
+
+    private var nextMealNumber: Int {
+        max((nutritionLog.meals.map(\.mealNumber).max() ?? 0) + 1, 1)
+    }
+
+    private var completionText: String {
+        let completedMeals = nutritionLog.meals.filter { $0.status == .completed }.count
+        let templateCount = dataStore.mealTemplates.count
+        if completedMeals == 0 {
+            return templateCount > 0 ? "Use your saved meals to log faster." : "Log your first meal to start building momentum."
+        }
+        if remainingProteinG > 25 {
+            return "Protein is the main gap right now. A quick repeat meal can close it fast."
+        }
+        if remainingCalories > 400 {
+            return "You still have room in the plan. Finish the day with one more full meal."
+        }
+        return "Nutrition is on track. Keep hydration and supplements tight."
+    }
+
+    private var recentMeals: [MealEntry] {
+        var seen = Set<String>()
+        return dataStore.dailyLogs
+            .sorted { $0.date > $1.date }
+            .filter { !Calendar.current.isDate($0.date, inSameDayAs: activeDate) }
+            .flatMap { $0.nutritionLog.meals }
+            .filter { $0.status == .completed && !$0.name.trimmingCharacters(in: .whitespaces).isEmpty }
+            .filter { meal in
+                let key = meal.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                return seen.insert(key).inserted
+            }
+            .prefix(6)
+            .map { $0 }
+    }
+
     // ─────────────────────────────────────────────────────
     // Sub-views
     // ─────────────────────────────────────────────────────
 
     private var dateHeader: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Nutrition")
-                    .font(.title2.bold())
-                Text(formattedToday)
-                    .font(.subheadline).foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Nutrition")
+                        .font(.title2.bold())
+                    Text(formattedActiveDate)
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+                Spacer()
+                overallBadge
             }
-            Spacer()
-            overallBadge
+
+            HStack(spacing: 10) {
+                Button {
+                    shiftDay(by: -1)
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.primary)
+                        .frame(width: 36, height: 36)
+                        .background(Color.white.opacity(0.7), in: Circle())
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    activeDate = Calendar.current.startOfDay(for: Date())
+                    loadLog(for: activeDate)
+                } label: {
+                    Text(isViewingToday ? "Today" : "Jump to Today")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(isViewingToday ? .secondary : .primary)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 9)
+                        .background(Color.white.opacity(0.58), in: Capsule())
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    shiftDay(by: 1)
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.primary)
+                        .frame(width: 36, height: 36)
+                        .background(Color.white.opacity(0.7), in: Circle())
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                Text(log?.dayType.rawValue ?? suggestedDay(for: activeDate).rawValue)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color.white.opacity(0.5), in: Capsule())
+            }
         }
         .padding(.top, 6)
     }
@@ -104,9 +233,77 @@ struct NutritionView: View {
             Text("\(pct)%")
                 .font(.system(.title3, design: .monospaced, weight: .bold))
                 .foregroundStyle(Color.status.success)
-            Text("today")
+            Text("supps")
                 .font(.caption2).foregroundStyle(.secondary)
         }
+    }
+
+    private var nutritionCommandDeck: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Nutrition Focus")
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .tracking(1)
+                    Text(remainingProteinG > 25 ? "Close the protein gap" : "Stay consistent through the day")
+                        .font(.headline)
+                    Text(completionText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 6) {
+                    Text("\(Int(remainingCalories))")
+                        .font(.system(.title3, design: .monospaced, weight: .bold))
+                        .foregroundStyle(Color.appOrange2)
+                    Text("kcal left")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 10) {
+                quickActionButton(
+                    title: nutritionLog.meals.isEmpty ? "Log First Meal" : "Add Meal",
+                    icon: "plus.circle.fill",
+                    tint: Color.accent.cyan
+                ) {
+                    editingMealEntry = MealEntry(mealNumber: nextMealNumber)
+                }
+
+                quickActionButton(
+                    title: recentMeals.isEmpty ? "Quick Protein" : "Repeat Last",
+                    icon: recentMeals.isEmpty ? "bolt.heart.fill" : "clock.arrow.circlepath",
+                    tint: Color.status.success
+                ) {
+                    if let recent = recentMeals.first {
+                        openPrefilledMeal(recent)
+                    } else {
+                        editingMealEntry = MealEntry(
+                            mealNumber: nextMealNumber,
+                            name: "Protein Shake",
+                            calories: 180,
+                            proteinG: 30,
+                            carbsG: 8,
+                            fatG: 3
+                        )
+                    }
+                }
+            }
+
+            HStack(spacing: 20) {
+                nutritionMetric(title: "Protein left", value: "\(Int(remainingProteinG))g", color: Color.accent.cyan)
+                nutritionMetric(title: "Meals logged", value: "\(nutritionLog.meals.filter { $0.status == .completed }.count)", color: Color.appOrange2)
+                nutritionMetric(title: "Water", value: "\(Int((nutritionLog.waterML ?? 0) / 250)) cups", color: Color.appBlue2)
+            }
+        }
+        .padding(16)
+        .background(Color.white.opacity(0.5), in: RoundedRectangle(cornerRadius: 18))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.white.opacity(0.45), lineWidth: 1)
+        )
     }
 
     private var adherenceRow: some View {
@@ -140,34 +337,135 @@ struct NutritionView: View {
     }
 
     private var macroBar: some View {
-        let nutrition = log?.nutritionLog ?? NutritionLog()
-        let protein   = nutrition.totalProteinG ?? nutrition.meals.compactMap(\.proteinG).reduce(0, +)
-        let carbs     = nutrition.totalCarbsG   ?? nutrition.meals.compactMap(\.carbsG).reduce(0, +)
-        let fat       = nutrition.totalFatG     ?? nutrition.meals.compactMap(\.fatG).reduce(0, +)
-        let phase     = dataStore.userProfile.currentPhase
-        let isTraining = log?.dayType.isTrainingDay ?? false
-        let targetCal = isTraining ? phase.trainingCalories : phase.restCalories
-        let leanMass  = log?.biometrics.leanBodyMassKg
-        let targetPro = leanMass.map { $0 * 2 } ?? 135.0
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Macro Targets")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .tracking(1)
+                Spacer()
+                Text("\(Int(consumedCalories)) / \(Int(targetCalories)) kcal")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
 
-        return MacroTargetBar(
-            protein: protein,
-            carbs: carbs,
-            fat: fat,
-            targetCalories: targetCal,
-            targetProteinG: targetPro
-        )
+            MacroTargetBar(
+                protein: nutritionLog.resolvedProteinG ?? 0,
+                carbs: nutritionLog.resolvedCarbsG ?? 0,
+                fat: nutritionLog.resolvedFatG ?? 0,
+                targetCalories: Int(targetCalories),
+                targetProteinG: targetProteinG
+            )
+        }
     }
 
     private var mealSection: some View {
         let nutritionBinding = Binding<NutritionLog>(
-            get: { log?.nutritionLog ?? NutritionLog() },
+            get: { nutritionLog },
             set: { log?.nutritionLog = $0 }
         )
-        return MealSectionView(nutritionLog: nutritionBinding) { mealNumber in
+        return MealSectionView(nutritionLog: nutritionBinding, suggestedMealNumber: nextMealNumber) { mealNumber in
             let existing = log?.nutritionLog.meals.first(where: { $0.mealNumber == mealNumber })
-            editingMealEntry = existing ?? MealEntry(mealNumber: max(mealNumber, 1))
+            editingMealEntry = existing ?? MealEntry(mealNumber: max(mealNumber, nextMealNumber))
         }
+    }
+
+    private var quickLogSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !dataStore.mealTemplates.isEmpty {
+                quickMealLane(
+                    title: "Favorites",
+                    subtitle: "Saved templates for repeat meals",
+                    meals: dataStore.mealTemplates.prefix(6).map {
+                        MealEntry(
+                            mealNumber: nextMealNumber,
+                            name: $0.name,
+                            calories: $0.calories,
+                            proteinG: $0.proteinG,
+                            carbsG: $0.carbsG,
+                            fatG: $0.fatG
+                        )
+                    }
+                )
+            }
+
+            if !recentMeals.isEmpty {
+                quickMealLane(
+                    title: "Remembered Meals",
+                    subtitle: "Recently logged meals you can reuse",
+                    meals: recentMeals
+                )
+            }
+        }
+    }
+
+    private var hydrationCard: some View {
+        let waterML = nutritionLog.waterML ?? 0
+        let waterTarget = isTrainingDay ? 3500.0 : 2800.0
+        let waterProgress = min(max(waterML / waterTarget, 0), 1)
+
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Hydration")
+                        .font(.headline)
+                    Text(isTrainingDay ? "Training days need a little more water." : "Keep the baseline high even on rest days.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text("\(Int(waterML)) ml")
+                    .font(.system(.title3, design: .monospaced, weight: .bold))
+                    .foregroundStyle(Color.appBlue2)
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.secondary.opacity(0.15))
+                        .frame(height: 8)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(LinearGradient(colors: [Color.appBlue1, Color.appBlue2], startPoint: .leading, endPoint: .trailing))
+                        .frame(width: geo.size.width * waterProgress, height: 8)
+                }
+            }
+            .frame(height: 8)
+
+            HStack(spacing: 10) {
+                ForEach([250.0, 500.0, 1000.0], id: \.self) { amount in
+                    Button {
+                        log?.nutritionLog.waterML = waterML + amount
+                        saveLog()
+                    } label: {
+                        Text("+\(Int(amount)) ml")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Color.appBlue2)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 10)
+                            .background(Color.appBlue1.opacity(0.2), in: Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                Button {
+                    let current = log?.nutritionLog.alluloseTaken ?? false
+                    log?.nutritionLog.alluloseTaken = !current
+                    saveLog()
+                } label: {
+                    Label(log?.nutritionLog.alluloseTaken == true ? "Allulose done" : "Allulose", systemImage: log?.nutritionLog.alluloseTaken == true ? "checkmark.circle.fill" : "circle")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(log?.nutritionLog.alluloseTaken == true ? Color.status.success : .secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color.white.opacity(0.55), in: Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(16)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 16))
     }
 
     // ─────────────────────────────────────────────────────
@@ -384,23 +682,49 @@ struct NutritionView: View {
         return f
     }()
 
-    private var formattedToday: String {
-        Self.todayDateFormatter.string(from: Date())
+    private var formattedActiveDate: String {
+        if Calendar.current.isDateInToday(activeDate) {
+            return "Today"
+        }
+        return Self.todayDateFormatter.string(from: activeDate)
     }
 
     // ─────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────
 
-    private func loadLog() {
-        log = dataStore.todayLog() ?? DailyLog(
-            date: Date(), phase: dataStore.userProfile.currentPhase,
-            dayType: .restDay, recoveryDay: dataStore.userProfile.daysSinceStart
-        )
+    private var isViewingToday: Bool {
+        Calendar.current.isDateInToday(activeDate)
     }
 
     private func saveLog() {
-        if let l = log { dataStore.upsertLog(l) }
+        guard var current = log else { return }
+        current.date = activeDate
+        current.dayType = log?.dayType ?? suggestedDay(for: activeDate)
+        current.recoveryDay = dataStore.userProfile.recoveryDay(for: activeDate)
+        log = current
+        dataStore.upsertLog(current)
+    }
+
+    private func loadLog(for date: Date) {
+        let normalizedDate = Calendar.current.startOfDay(for: date)
+        activeDate = normalizedDate
+        log = dataStore.log(for: normalizedDate) ?? DailyLog(
+            date: normalizedDate,
+            phase: dataStore.userProfile.currentPhase,
+            dayType: suggestedDay(for: normalizedDate),
+            recoveryDay: dataStore.userProfile.recoveryDay(for: normalizedDate)
+        )
+    }
+
+    private func shiftDay(by days: Int) {
+        guard let nextDate = Calendar.current.date(byAdding: .day, value: days, to: activeDate) else { return }
+        saveLog()
+        loadLog(for: nextDate)
+    }
+
+    private func suggestedDay(for date: Date) -> DayType {
+        TrainingProgramStore.dayType(forWeekday: Calendar.current.component(.weekday, from: date))
     }
 
     private func recomputeStackStatus(isEvening: Bool) {
@@ -411,6 +735,93 @@ struct NutritionView: View {
                                : .partial
         if isEvening { log?.supplementLog.eveningStatus = status }
         else          { log?.supplementLog.morningStatus = status }
+    }
+
+    private func openPrefilledMeal(_ meal: MealEntry) {
+        editingMealEntry = MealEntry(
+            mealNumber: nextMealNumber,
+            name: meal.name,
+            calories: meal.calories,
+            proteinG: meal.proteinG,
+            carbsG: meal.carbsG,
+            fatG: meal.fatG
+        )
+    }
+
+    private func quickActionButton(title: String, icon: String, tint: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: icon)
+                .font(.caption.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 12))
+                .foregroundStyle(tint)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func nutritionMetric(title: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(color)
+        }
+    }
+
+    private func quickMealLane(title: String, subtitle: String, meals: [MealEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(meals) { meal in
+                        Button {
+                            openPrefilledMeal(meal)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(meal.name)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(2)
+                                HStack(spacing: 8) {
+                                    if let calories = meal.calories {
+                                        Text("\(Int(calories)) kcal")
+                                            .font(.caption)
+                                            .foregroundStyle(Color.appOrange2)
+                                    }
+                                    if let protein = meal.proteinG {
+                                        Text("\(Int(protein))g protein")
+                                            .font(.caption)
+                                            .foregroundStyle(Color.accent.cyan)
+                                    }
+                                }
+                                Text("Tap to prefill")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .frame(width: 180, alignment: .leading)
+                            .padding(14)
+                            .background(Color.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 16))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(Color.white.opacity(0.5), lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
     }
 }
 

--- a/FitTracker/Views/RootTabView.swift
+++ b/FitTracker/Views/RootTabView.swift
@@ -5,6 +5,22 @@
 
 import SwiftUI
 
+enum AppTab: String, CaseIterable, Hashable {
+    case main       = "Home"
+    case training   = "Training Plan"
+    case nutrition  = "Nutrition"
+    case stats      = "Stats"
+
+    var icon: String {
+        switch self {
+        case .main:      "house.fill"
+        case .training:  "figure.strengthtraining.traditional"
+        case .nutrition: "leaf.fill"
+        case .stats:     "chart.bar.fill"
+        }
+    }
+}
+
 struct RootTabView: View {
 
     @EnvironmentObject var signIn:        SignInService
@@ -19,22 +35,6 @@ struct RootTabView: View {
     @State private var selectedTab:    AppTab = .main
     @State private var showAccount             = false
 
-    enum AppTab: String, CaseIterable, Hashable {
-        case main       = "Home"
-        case training   = "Training Plan"
-        case nutrition  = "Nutrition"
-        case stats      = "Stats"
-
-        var icon: String {
-            switch self {
-            case .main:      "house.fill"
-            case .training:  "figure.strengthtraining.traditional"
-            case .nutrition: "leaf.fill"
-            case .stats:     "chart.bar.fill"
-            }
-        }
-    }
-
     var body: some View {
         Group {
             #if os(iOS)
@@ -45,7 +45,6 @@ struct RootTabView: View {
         }
         .task {
             try? await healthService.requestAuthorization()
-            await cloudSync.fetchChanges(dataStore: dataStore)
         }
         .alert("Data Load Error", isPresented: Binding(
             get: { dataStore.loadError != nil },
@@ -164,7 +163,7 @@ struct RootTabView: View {
     @ViewBuilder
     private func tabContent(_ tab: AppTab) -> some View {
         switch tab {
-        case .main:      MainScreenView()
+        case .main:      MainScreenView(selectedTab: $selectedTab)
         case .training:  TrainingPlanView()
         case .nutrition: NutritionView()
         case .stats:     StatsView()

--- a/FitTracker/Views/Settings/SettingsView.swift
+++ b/FitTracker/Views/Settings/SettingsView.swift
@@ -1,0 +1,219 @@
+// Views/Settings/SettingsView.swift
+
+import SwiftUI
+
+struct SettingsView: View {
+
+    @EnvironmentObject var dataStore:     EncryptedDataStore
+    @EnvironmentObject var healthService: HealthKitService
+    @EnvironmentObject var cloudSync:     CloudKitSyncService
+    @EnvironmentObject var settings:      AppSettings
+
+    @State private var showResetAlert = false
+
+    var body: some View {
+        settingsForm
+    }
+
+    private var settingsForm: some View {
+        Form {
+            // Profile section
+            Section("Profile") {
+                LabeledContent("Name",           value: dataStore.userProfile.name)
+                LabeledContent("Recovery Start", value: Self.recoveryStartFormatter.string(from: dataStore.userProfile.recoveryStart))
+                LabeledContent("Phase",          value: dataStore.userProfile.currentPhase.rawValue)
+                LabeledContent("Recovery Day",   value: "Day \(dataStore.userProfile.daysSinceStart)")
+                LabeledContent("Goal Weight",    value: "\(Int(dataStore.userProfile.targetWeightMin))–\(Int(dataStore.userProfile.targetWeightMax)) kg")
+                LabeledContent("Goal Body Fat",  value: "\(Int(dataStore.userProfile.targetBFMin))–\(Int(dataStore.userProfile.targetBFMax))%")
+            }
+
+            // Health & Watch section
+            Section("Health & Watch") {
+                LabeledContent("HealthKit", value: healthService.isAuthorized ? "Authorized ✓" : "Not authorized")
+                LabeledContent("Apple Watch", value: "Background delivery active")
+                Button("Re-authorize HealthKit") {
+                    Task { try? await healthService.requestAuthorization() }
+                }
+            }
+
+            // iCloud Sync section
+            Section("iCloud Sync") {
+                LabeledContent("Status",  value: cloudSync.status.rawValue)
+                LabeledContent("iCloud",  value: cloudSync.iCloudAvailable ? "Available ✓" : "Unavailable")
+                if let last = cloudSync.lastSyncDate {
+                    LabeledContent("Last Sync", value: Self.lastSyncFormatter.string(from: last))
+                }
+                Button("Sync Now") {
+                    Task { await cloudSync.pushPendingChanges(dataStore: dataStore) }
+                }
+                Button("Fetch from iCloud") {
+                    Task { await cloudSync.fetchChanges(dataStore: dataStore) }
+                }
+            }
+
+            // Security section
+            Section("Security") {
+                LabeledContent("Encryption",      value: "AES-256-GCM + ChaCha20-Poly1305")
+                LabeledContent("Key Storage",     value: "Keychain (biometric-protected)")
+                LabeledContent("Cloud Storage",   value: "Encrypted before upload ✓")
+                LabeledContent("Data Protection", value: "NSFileProtectionCompleteUnlessOpen")
+                LabeledContent("Platforms",       value: "iOS · iPadOS · macOS only")
+            }
+
+            // Preferences section (moved from AccountPanelView)
+            Section("Preferences") {
+                // Unit system picker
+                VStack(alignment: .leading, spacing: 10) {
+                    Label("Units", systemImage: "ruler")
+                        .font(.subheadline.weight(.medium))
+                    HStack(spacing: 8) {
+                        ForEach(UnitSystem.allCases, id: \.self) { system in
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    settings.unitSystem = system
+                                }
+                            } label: {
+                                VStack(spacing: 4) {
+                                    Text(system.rawValue).font(.subheadline.weight(.semibold))
+                                    Text(system == .metric ? "kg · cm · km" : "lbs · in · mi")
+                                        .font(.system(size: 10)).opacity(0.7)
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 10)
+                                .foregroundStyle(settings.unitSystem == system ? .white : .primary)
+                                .background(
+                                    settings.unitSystem == system ? Color.green : Color.secondary.opacity(0.1),
+                                    in: RoundedRectangle(cornerRadius: 10)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+
+                // Appearance picker
+                VStack(alignment: .leading, spacing: 10) {
+                    Label("Appearance", systemImage: "paintpalette")
+                        .font(.subheadline.weight(.medium))
+                    HStack(spacing: 8) {
+                        ForEach(AppAppearance.allCases, id: \.self) { mode in
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    settings.appearance = mode
+                                }
+                            } label: {
+                                VStack(spacing: 5) {
+                                    Image(systemName: mode.icon).font(.title3)
+                                    Text(mode.rawValue).font(.caption2.weight(.medium))
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 10)
+                                .foregroundStyle(settings.appearance == mode ? .white : .primary)
+                                .background(
+                                    settings.appearance == mode ? Color.green : Color.secondary.opacity(0.1),
+                                    in: RoundedRectangle(cornerRadius: 10)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+
+            // Nutrition section
+            Section("Nutrition") {
+                ForEach(dataStore.userProfile.mealSlotNames.indices, id: \.self) { i in
+                    TextField("Slot \(i+1)", text: Binding(
+                        get: { dataStore.userProfile.mealSlotNames.indices.contains(i) ? dataStore.userProfile.mealSlotNames[i] : "Meal \(i+1)" },
+                        set: {
+                            while dataStore.userProfile.mealSlotNames.count <= i {
+                                dataStore.userProfile.mealSlotNames.append("Meal \(dataStore.userProfile.mealSlotNames.count + 1)")
+                            }
+                            dataStore.userProfile.mealSlotNames[i] = $0
+                            Task { await dataStore.persistToDisk() }
+                        }
+                    ))
+                }
+            }
+
+            // Training section
+            Section("Training") {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Zone 2 Lower HR: \(dataStore.userPreferences.zone2LowerHR) bpm")
+                    Slider(value: Binding(
+                        get: { Double(dataStore.userPreferences.zone2LowerHR) },
+                        set: {
+                            let newVal = Int($0)
+                            dataStore.userPreferences.zone2LowerHR = min(newVal, dataStore.userPreferences.zone2UpperHR - 1)
+                        }
+                    ), in: 80...160, step: 1) { _ in
+                        Task { await dataStore.persistToDisk() }
+                    }
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Zone 2 Upper HR: \(dataStore.userPreferences.zone2UpperHR) bpm")
+                    Slider(value: Binding(
+                        get: { Double(dataStore.userPreferences.zone2UpperHR) },
+                        set: {
+                            let newVal = Int($0)
+                            dataStore.userPreferences.zone2UpperHR = max(newVal, dataStore.userPreferences.zone2LowerHR + 1)
+                        }
+                    ), in: 90...180, step: 1) { _ in
+                        Task { await dataStore.persistToDisk() }
+                    }
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Readiness HR Threshold: \(dataStore.userPreferences.hrReadyThreshold) bpm")
+                    Slider(value: Binding(
+                        get: { Double(dataStore.userPreferences.hrReadyThreshold) },
+                        set: { dataStore.userPreferences.hrReadyThreshold = Int($0) }
+                    ), in: 40...80, step: 1) { _ in
+                        Task { await dataStore.persistToDisk() }
+                    }
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Readiness HRV Threshold: \(dataStore.userPreferences.hrvReadyThreshold, specifier: "%.0f") ms")
+                    Slider(value: $dataStore.userPreferences.hrvReadyThreshold, in: 10...80, step: 1) { _ in
+                        Task { await dataStore.persistToDisk() }
+                    }
+                }
+            }
+
+            // Data section
+            Section("Data") {
+                LabeledContent("Daily Logs",       value: "\(dataStore.dailyLogs.count) entries")
+                LabeledContent("Weekly Snapshots", value: "\(dataStore.weeklySnapshots.count) entries")
+                Button("Delete All Local Data", role: .destructive) {
+                    showResetAlert = true
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        .alert("Delete All Data?", isPresented: $showResetAlert) {
+            Button("Delete", role: .destructive) {
+                dataStore.dailyLogs = []
+                dataStore.weeklySnapshots = []
+                Task { await dataStore.persistToDisk() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This permanently removes all locally stored logs. Data will be restored from iCloud on the next sync. To permanently delete, remove FitTracker from your iCloud account in iOS Settings.")
+        }
+    }
+
+    private static let lastSyncFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .short
+        return f
+    }()
+
+    private static let recoveryStartFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .none
+        return f
+    }()
+}

--- a/FitTracker/Views/Shared/ChartCard.swift
+++ b/FitTracker/Views/Shared/ChartCard.swift
@@ -31,10 +31,8 @@ struct ChartCard<Content: View>: View {
             content()
         }
         .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color.white.opacity(0.12))
-        )
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
         .accessibilityElement(children: .contain)
     }
 }

--- a/FitTracker/Views/Shared/ChartCard.swift
+++ b/FitTracker/Views/Shared/ChartCard.swift
@@ -35,17 +35,22 @@ struct ChartCard<Content: View>: View {
             RoundedRectangle(cornerRadius: 16)
                 .fill(Color.white.opacity(0.12))
         )
+        .accessibilityElement(children: .contain)
     }
 }
 
-#Preview {
-    ChartCard(
-        title: "Weekly Activity",
-        periodLabel: "Last 7 days",
-        trendDelta: 12.5,
-        positiveIsGood: true
-    ) {
-        Text("Chart content goes here")
-            .frame(height: 200)
+#if DEBUG
+struct ChartCard_Previews: PreviewProvider {
+    static var previews: some View {
+        ChartCard(
+            title: "Weekly Activity",
+            periodLabel: "Last 7 days",
+            trendDelta: 12.5,
+            positiveIsGood: true
+        ) {
+            Text("Chart content goes here")
+                .frame(height: 200)
+        }
     }
 }
+#endif

--- a/FitTracker/Views/Shared/EmptyStateView.swift
+++ b/FitTracker/Views/Shared/EmptyStateView.swift
@@ -32,13 +32,18 @@ struct EmptyStateView: View {
             }
         }
         .padding(.horizontal, 32)
+        .accessibilityElement(children: .contain)
     }
 }
 
-#Preview {
-    EmptyStateView(
-        icon: "chart.line.uptrend.xyaxis",
-        title: "No data yet",
-        subtitle: "Log a workout to see your stats here"
-    )
+#if DEBUG
+struct EmptyStateView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyStateView(
+            icon: "chart.line.uptrend.xyaxis",
+            title: "No data yet",
+            subtitle: "Log a workout to see your stats here"
+        )
+    }
 }
+#endif

--- a/FitTracker/Views/Shared/MetricCard.swift
+++ b/FitTracker/Views/Shared/MetricCard.swift
@@ -51,8 +51,8 @@ struct MetricCard: View {
                 .frame(width: 8, height: 8)
                 .padding(12)
         }
-        .background(Color.white.opacity(0.15))
-        .cornerRadius(14)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(label)
         .accessibilityValue(accessibilityValue)

--- a/FitTracker/Views/Shared/MetricCard.swift
+++ b/FitTracker/Views/Shared/MetricCard.swift
@@ -23,7 +23,7 @@ struct MetricCard: View {
                 .foregroundColor(.secondary)
 
                 // Middle: value + unit
-                HStack(alignment: .baseline, spacing: 4) {
+                HStack(alignment: .lastTextBaseline, spacing: 4) {
                     Text(value)
                         .font(AppType.display)
                         .lineLimit(1)

--- a/FitTracker/Views/Shared/MetricCard.swift
+++ b/FitTracker/Views/Shared/MetricCard.swift
@@ -53,38 +53,56 @@ struct MetricCard: View {
         }
         .background(Color.white.opacity(0.15))
         .cornerRadius(14)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(accessibilityValue)
+    }
+
+    private var accessibilityValue: String {
+        var parts = [value]
+        if let unit {
+            parts.append(unit)
+        }
+        if let trendDelta {
+            parts.append(trendDelta)
+        }
+        return parts.joined(separator: " ")
     }
 }
 
-#Preview {
-    VStack(spacing: 16) {
-        MetricCard(
-            icon: "scalemass.fill",
-            label: "Weight",
-            value: "67.3",
-            unit: "kg",
-            trendDelta: "↓ 0.5",
-            statusColor: .status.success
-        )
+#if DEBUG
+struct MetricCard_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 16) {
+            MetricCard(
+                icon: "scalemass.fill",
+                label: "Weight",
+                value: "67.3",
+                unit: "kg",
+                trendDelta: "↓ 0.5",
+                statusColor: .status.success
+            )
 
-        MetricCard(
-            icon: "heart.fill",
-            label: "Resting HR",
-            value: "58",
-            unit: "bpm",
-            trendDelta: nil,
-            statusColor: .status.warning
-        )
+            MetricCard(
+                icon: "heart.fill",
+                label: "Resting HR",
+                value: "58",
+                unit: "bpm",
+                trendDelta: nil,
+                statusColor: .status.warning
+            )
 
-        MetricCard(
-            icon: "flame.fill",
-            label: "Calories",
-            value: "2400",
-            unit: nil,
-            trendDelta: "↑ 120",
-            statusColor: .status.error
-        )
+            MetricCard(
+                icon: "flame.fill",
+                label: "Calories",
+                value: "2400",
+                unit: nil,
+                trendDelta: "↑ 120",
+                statusColor: .status.error
+            )
+        }
+        .padding()
+        .background(Color.black.opacity(0.05))
     }
-    .padding()
-    .background(Color.black.opacity(0.05))
 }
+#endif

--- a/FitTracker/Views/Shared/ReadinessCard.swift
+++ b/FitTracker/Views/Shared/ReadinessCard.swift
@@ -10,6 +10,8 @@ struct ReadinessCard: View {
 
     @State private var currentPage = 0
     @State private var timer: Timer?
+    @State private var showReadinessInfo = false
+    @State private var displayedScore: Int = 0
 
     // ── Timer helpers ─────────────────────────────────────
 
@@ -46,10 +48,8 @@ struct ReadinessCard: View {
                 .padding(.bottom, 6)
         }
         .frame(height: 180)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.white.opacity(0.12))
-        )
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
         .onAppear { startTimer() }
         .onDisappear {
             timer?.invalidate()
@@ -88,9 +88,10 @@ struct ReadinessCard: View {
 
         return VStack(spacing: 4) {
             HStack(alignment: .lastTextBaseline, spacing: 4) {
-                Text(score.map { "\($0)" } ?? "–")
+                Text(score != nil ? "\(displayedScore)" : "–")
                     .font(.system(size: 48, weight: .bold))
                     .foregroundStyle(.white)
+                    .contentTransition(.numericText())
                 if score != nil {
                     Text("/ 100")
                         .font(AppType.subheading)
@@ -119,6 +120,36 @@ struct ReadinessCard: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
+        .onAppear {
+            guard let target = score else { return }
+            displayedScore = 0
+            withAnimation(.interpolatingSpring(stiffness: 40, damping: 8)) {
+                displayedScore = target
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            Button { showReadinessInfo.toggle() } label: {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("About readiness score")
+            .popover(isPresented: $showReadinessInfo) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("How Readiness Is Calculated")
+                        .font(.headline)
+                    Text("Readiness = 40% HRV + 30% Resting HR + 30% Sleep quality.\n\n80+ → Green light day\n60–79 → Steady, stay on plan\n40–59 → Trim load\nBelow 40 → Prioritize rest")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(16)
+                .frame(minWidth: 260)
+                .presentationCompactAdaptation(.popover)
+            }
+            .padding(.top, 10)
+            .padding(.trailing, 16)
+        }
     }
 
     private func contextLabel(for score: Int?) -> String {
@@ -444,7 +475,8 @@ struct ReadinessCard: View {
             dayType: todayLog?.dayType ?? .restDay,
             readinessScore: dataStore.readinessScore(for: Date(), fallbackMetrics: healthKit.latest),
             liveMetrics: healthKit.latest,
-            log: todayLog
+            log: todayLog,
+            preferences: dataStore.userPreferences
         )
 
         return VStack(alignment: .leading, spacing: 8) {

--- a/FitTracker/Views/Shared/ReadinessCard.swift
+++ b/FitTracker/Views/Shared/ReadinessCard.swift
@@ -17,7 +17,7 @@ struct ReadinessCard: View {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { _ in
             withAnimation(.easeInOut) {
-                currentPage = (currentPage + 1) % 5
+                currentPage = (currentPage + 1) % 6
             }
         }
     }
@@ -32,6 +32,7 @@ struct ReadinessCard: View {
                 nutritionPage.tag(2)
                 trendsPage.tag(3)
                 achievementsPage.tag(4)
+                recoveryPage.tag(5)
             }
             #if os(iOS)
             .tabViewStyle(.page(indexDisplayMode: .never))
@@ -63,7 +64,7 @@ struct ReadinessCard: View {
 
     private var pageDots: some View {
         HStack(spacing: 5) {
-            ForEach(0..<5, id: \.self) { i in
+            ForEach(0..<6, id: \.self) { i in
                 Circle()
                     .fill(i == currentPage ? Color.white : Color.white.opacity(0.35))
                     .frame(width: i == currentPage ? 7 : 5, height: i == currentPage ? 7 : 5)
@@ -221,7 +222,7 @@ struct ReadinessCard: View {
     private var nutritionPage: some View {
         let todayLog = dataStore.todayLog()
         let nutrition = todayLog?.nutritionLog
-        let protein = nutrition?.totalProteinG ?? 0
+        let protein = nutrition?.resolvedProteinG ?? 0
         let lbm = todayLog?.biometrics.leanBodyMassKg
         let proteinTarget = lbm.map { $0 * 2.0 } ?? 135.0
         let waterML = nutrition?.waterML ?? 0
@@ -435,5 +436,76 @@ struct ReadinessCard: View {
             }
         }
         return prExercises.count
+    }
+
+    private var recoveryPage: some View {
+        let todayLog = dataStore.todayLog()
+        let recommendation = RecoveryRoutineLibrary.recommend(
+            dayType: todayLog?.dayType ?? .restDay,
+            readinessScore: dataStore.readinessScore(for: Date(), fallbackMetrics: healthKit.latest),
+            liveMetrics: healthKit.latest,
+            log: todayLog
+        )
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Recovery Studio")
+                .font(AppType.subheading)
+                .foregroundStyle(.white.opacity(0.7))
+
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(recommendation.routine.title)
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                    Text(recommendation.routine.focus)
+                        .font(AppType.caption)
+                        .foregroundStyle(.white.opacity(0.72))
+                        .lineLimit(2)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("\(recommendation.routine.durationMinutes)m")
+                        .font(.system(.headline, design: .monospaced, weight: .bold))
+                        .foregroundStyle(.white)
+                    Text(recommendation.routine.intensityLabel)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.white.opacity(0.55))
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(recommendation.reasons.prefix(2)), id: \.self) { reason in
+                    HStack(alignment: .top, spacing: 6) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 10))
+                            .foregroundStyle(Color.accent.cyan.opacity(0.9))
+                            .padding(.top, 1)
+                        Text(reason)
+                            .font(AppType.caption)
+                            .foregroundStyle(.white.opacity(0.68))
+                            .lineLimit(2)
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                ForEach(recommendation.routine.steps.prefix(2)) { step in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(step.title)
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .lineLimit(2)
+                        Text("\(step.minutes) min")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.white.opacity(0.55))
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                    .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 }

--- a/FitTracker/Views/Shared/RecoverySupport.swift
+++ b/FitTracker/Views/Shared/RecoverySupport.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+struct RecoveryStep: Identifiable, Hashable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+    let minutes: Int
+}
+
+struct RecoveryRoutine: Identifiable, Hashable, Sendable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let focus: String
+    let icon: String
+    let durationMinutes: Int
+    let intensityLabel: String
+    let coachingNote: String
+    let steps: [RecoveryStep]
+}
+
+struct RecoveryRecommendation: Sendable {
+    let routine: RecoveryRoutine
+    let reasons: [String]
+    let shouldReplaceTraining: Bool
+}
+
+enum RecoveryRoutineLibrary {
+    static let nervousSystemReset = RecoveryRoutine(
+        id: "nervous_system_reset",
+        title: "Nervous System Reset",
+        subtitle: "Breathing, downshifting, and low-demand movement.",
+        focus: "Lower stress load and get the body back to baseline.",
+        icon: "lungs.fill",
+        durationMinutes: 12,
+        intensityLabel: "Low",
+        coachingNote: "Keep effort light. The goal is to leave this feeling calmer than when you started.",
+        steps: [
+            RecoveryStep(id: "reset_1", title: "Box breathing", detail: "Inhale 4, hold 4, exhale 4, hold 4.", minutes: 3),
+            RecoveryStep(id: "reset_2", title: "Supine twist + reach", detail: "Slow alternating trunk rotation and long exhales.", minutes: 3),
+            RecoveryStep(id: "reset_3", title: "Easy walk", detail: "Quiet nasal breathing and relaxed shoulders.", minutes: 6)
+        ]
+    )
+
+    static let mobilityFlush = RecoveryRoutine(
+        id: "mobility_flush",
+        title: "Mobility Flush",
+        subtitle: "Joint prep and tissue-friendly movement for stiff days.",
+        focus: "Open hips, thoracic spine, shoulders, and ankles without fatigue.",
+        icon: "figure.cooldown",
+        durationMinutes: 18,
+        intensityLabel: "Low-Moderate",
+        coachingNote: "Move smoothly, not deeply. This should feel like circulation and range, not stretching pain.",
+        steps: [
+            RecoveryStep(id: "flush_1", title: "Cat-cow + thoracic rotation", detail: "Restore spinal motion and upper-back rotation.", minutes: 4),
+            RecoveryStep(id: "flush_2", title: "90/90 hip flow", detail: "Controlled hip internal and external rotation.", minutes: 5),
+            RecoveryStep(id: "flush_3", title: "Ankle rocks + calf opener", detail: "Drive knee over toe with heel down.", minutes: 4),
+            RecoveryStep(id: "flush_4", title: "Band or wall shoulder opener", detail: "Gentle overhead reach and scap movement.", minutes: 5)
+        ]
+    )
+
+    static let yogaFlow = RecoveryRoutine(
+        id: "yoga_flow",
+        title: "Recovery Yoga Flow",
+        subtitle: "Slow full-body sequence for tired or mentally heavy days.",
+        focus: "Blend breathing, mobility, and light tissue loading.",
+        icon: "figure.yoga",
+        durationMinutes: 24,
+        intensityLabel: "Moderate",
+        coachingNote: "Stay with the breath. If one position feels sticky, shorten the range and keep moving.",
+        steps: [
+            RecoveryStep(id: "yoga_1", title: "Sun-breath warm-up", detail: "Gentle overhead reach, fold, and half-lift rhythm.", minutes: 4),
+            RecoveryStep(id: "yoga_2", title: "World's greatest stretch", detail: "Lunge, rotate, and open the hip flexors.", minutes: 6),
+            RecoveryStep(id: "yoga_3", title: "Down dog to plank wave", detail: "Light shoulder and hamstring loading.", minutes: 6),
+            RecoveryStep(id: "yoga_4", title: "Pigeon or figure-four", detail: "Long exhale hip opener to finish.", minutes: 8)
+        ]
+    )
+
+    static let all: [RecoveryRoutine] = [nervousSystemReset, mobilityFlush, yogaFlow]
+
+    static func recommend(dayType: DayType, readinessScore: Int?, liveMetrics: LiveMetrics, log: DailyLog?) -> RecoveryRecommendation {
+        let sleep = liveMetrics.sleepHours ?? log?.biometrics.effectiveSleep ?? 0
+        let hrv = liveMetrics.hrv ?? log?.biometrics.effectiveHRV ?? 0
+        let restingHR = liveMetrics.restingHR ?? log?.biometrics.effectiveRestingHR ?? 0
+        let protein = log?.nutritionLog.resolvedProteinG ?? 0
+        let water = log?.nutritionLog.waterML ?? 0
+        let completedMeals = log?.nutritionLog.meals.filter { $0.status == .completed }.count ?? 0
+        let score = readinessScore ?? 65
+
+        var reasons: [String] = []
+        if score < 45 { reasons.append("Readiness is low enough to bias recovery over intensity.") }
+        else if score < 60 { reasons.append("Readiness is moderate, so lighter movement will likely give better return today.") }
+
+        if sleep > 0, sleep < 6.5 { reasons.append(String(format: "Sleep came in at %.1f hrs, so downshifting will help more than pushing load.", sleep)) }
+        if hrv > 0, hrv < 28 { reasons.append(String(format: "HRV is %.0f ms, which points toward a lighter nervous-system day.", hrv)) }
+        if restingHR > 0, restingHR >= 75 { reasons.append(String(format: "Resting HR is %.0f bpm, so recovery work is the safer call.", restingHR)) }
+        if protein > 0, protein < 120 { reasons.append("Protein is still behind target, so keep training stress modest until nutrition catches up.") }
+        if water > 0, water < 1800 { reasons.append("Hydration is still low, so use recovery work while you bring fluids up.") }
+        if completedMeals == 0 { reasons.append("No meals logged yet, which is another sign to keep the day restorative.") }
+
+        let routine: RecoveryRoutine
+        let shouldReplaceTraining = !dayType.isTrainingDay || score < 45
+
+        if sleep > 0, sleep < 6.5 || restingHR >= 78 || score < 40 {
+            routine = nervousSystemReset
+        } else if dayType == .lowerBody || dayType == .fullBody || score < 60 {
+            routine = mobilityFlush
+        } else {
+            routine = yogaFlow
+        }
+
+        if reasons.isEmpty {
+            reasons = [
+                shouldReplaceTraining
+                    ? "Use the lighter session to build momentum without adding stress."
+                    : "A short guided recovery block will make the main session feel better."
+            ]
+        }
+
+        return RecoveryRecommendation(routine: routine, reasons: Array(reasons.prefix(3)), shouldReplaceTraining: shouldReplaceTraining)
+    }
+}

--- a/FitTracker/Views/Shared/RecoverySupport.swift
+++ b/FitTracker/Views/Shared/RecoverySupport.swift
@@ -78,7 +78,7 @@ enum RecoveryRoutineLibrary {
 
     static let all: [RecoveryRoutine] = [nervousSystemReset, mobilityFlush, yogaFlow]
 
-    static func recommend(dayType: DayType, readinessScore: Int?, liveMetrics: LiveMetrics, log: DailyLog?) -> RecoveryRecommendation {
+    static func recommend(dayType: DayType, readinessScore: Int?, liveMetrics: LiveMetrics, log: DailyLog?, preferences: UserPreferences = UserPreferences()) -> RecoveryRecommendation {
         let sleep = liveMetrics.sleepHours ?? log?.biometrics.effectiveSleep ?? 0
         let hrv = liveMetrics.hrv ?? log?.biometrics.effectiveHRV ?? 0
         let restingHR = liveMetrics.restingHR ?? log?.biometrics.effectiveRestingHR ?? 0
@@ -92,8 +92,8 @@ enum RecoveryRoutineLibrary {
         else if score < 60 { reasons.append("Readiness is moderate, so lighter movement will likely give better return today.") }
 
         if sleep > 0, sleep < 6.5 { reasons.append(String(format: "Sleep came in at %.1f hrs, so downshifting will help more than pushing load.", sleep)) }
-        if hrv > 0, hrv < 28 { reasons.append(String(format: "HRV is %.0f ms, which points toward a lighter nervous-system day.", hrv)) }
-        if restingHR > 0, restingHR >= 75 { reasons.append(String(format: "Resting HR is %.0f bpm, so recovery work is the safer call.", restingHR)) }
+        if hrv > 0, hrv < preferences.hrvReadyThreshold { reasons.append(String(format: "HRV is %.0f ms, which points toward a lighter nervous-system day.", hrv)) }
+        if restingHR > 0, restingHR >= Double(preferences.hrReadyThreshold) { reasons.append(String(format: "Resting HR is %.0f bpm, so recovery work is the safer call.", restingHR)) }
         if protein > 0, protein < 120 { reasons.append("Protein is still behind target, so keep training stress modest until nutrition catches up.") }
         if water > 0, water < 1800 { reasons.append("Hydration is still low, so use recovery work while you bring fluids up.") }
         if completedMeals == 0 { reasons.append("No meals logged yet, which is another sign to keep the day restorative.") }
@@ -101,7 +101,7 @@ enum RecoveryRoutineLibrary {
         let routine: RecoveryRoutine
         let shouldReplaceTraining = !dayType.isTrainingDay || score < 45
 
-        if sleep > 0, sleep < 6.5 || restingHR >= 78 || score < 40 {
+        if (sleep > 0 && sleep < 6.5) || restingHR >= 78 || score < 40 {
             routine = nervousSystemReset
         } else if dayType == .lowerBody || dayType == .fullBody || score < 60 {
             routine = mobilityFlush

--- a/FitTracker/Views/Shared/SectionHeader.swift
+++ b/FitTracker/Views/Shared/SectionHeader.swift
@@ -24,21 +24,26 @@ struct SectionHeader: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
     }
 }
 
-#Preview {
-    VStack(spacing: 16) {
-        SectionHeader(title: "Today's Metrics")
+#if DEBUG
+struct SectionHeader_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 16) {
+            SectionHeader(title: "Today's Metrics")
 
-        SectionHeader(
-            title: "Recent Workouts",
-            actionLabel: "View All",
-            action: { print("View All tapped") }
-        )
+            SectionHeader(
+                title: "Recent Workouts",
+                actionLabel: "View All",
+                action: { print("View All tapped") }
+            )
 
-        SectionHeader(title: "Health Data")
+            SectionHeader(title: "Health Data")
+        }
+        .padding()
+        .background(Color.black.opacity(0.05))
     }
-    .padding()
-    .background(Color.black.opacity(0.05))
 }
+#endif

--- a/FitTracker/Views/Shared/StatusBadge.swift
+++ b/FitTracker/Views/Shared/StatusBadge.swift
@@ -13,23 +13,29 @@ struct StatusBadge: View {
             .padding(.horizontal, 10)
             .background(color.opacity(0.2))
             .clipShape(Capsule())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(text)
     }
 }
 
-#Preview {
-    VStack(spacing: 12) {
-        HStack(spacing: 8) {
-            StatusBadge(text: "Active", color: .status.success)
-            StatusBadge(text: "Pending", color: .status.warning)
-            StatusBadge(text: "Error", color: .status.error)
-        }
+#if DEBUG
+struct StatusBadge_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                StatusBadge(text: "Active", color: .status.success)
+                StatusBadge(text: "Pending", color: .status.warning)
+                StatusBadge(text: "Error", color: .status.error)
+            }
 
-        HStack(spacing: 8) {
-            StatusBadge(text: "Completed", color: .accent.cyan)
-            StatusBadge(text: "Premium", color: .accent.gold)
-            StatusBadge(text: "Featured", color: .accent.purple)
+            HStack(spacing: 8) {
+                StatusBadge(text: "Completed", color: .accent.cyan)
+                StatusBadge(text: "Premium", color: .accent.gold)
+                StatusBadge(text: "Featured", color: .accent.purple)
+            }
         }
+        .padding()
+        .background(Color.black.opacity(0.05))
     }
-    .padding()
-    .background(Color.black.opacity(0.05))
 }
+#endif

--- a/FitTracker/Views/Shared/TrendIndicator.swift
+++ b/FitTracker/Views/Shared/TrendIndicator.swift
@@ -37,27 +37,34 @@ struct TrendIndicator: View {
             .padding(.horizontal, 8)
             .background(statusColor.opacity(0.2))
             .clipShape(Capsule())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Trend")
+            .accessibilityValue(displayText)
     }
 }
 
-#Preview {
-    VStack(spacing: 12) {
-        HStack(spacing: 12) {
-            TrendIndicator(delta: 0.12, positiveIsGood: true)
-            TrendIndicator(delta: -0.04, positiveIsGood: false)
-            TrendIndicator(delta: 0.0, positiveIsGood: true)
-        }
+#if DEBUG
+struct TrendIndicator_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                TrendIndicator(delta: 0.12, positiveIsGood: true)
+                TrendIndicator(delta: -0.04, positiveIsGood: false)
+                TrendIndicator(delta: 0.0, positiveIsGood: true)
+            }
 
-        HStack(spacing: 12) {
-            TrendIndicator(delta: -0.08, positiveIsGood: true)
-            TrendIndicator(delta: 0.05, positiveIsGood: false)
-        }
+            HStack(spacing: 12) {
+                TrendIndicator(delta: -0.08, positiveIsGood: true)
+                TrendIndicator(delta: 0.05, positiveIsGood: false)
+            }
 
-        HStack(spacing: 12) {
-            TrendIndicator(delta: 0.15, positiveIsGood: false, isPercent: false)
-            TrendIndicator(delta: -2.5, positiveIsGood: false, isPercent: false)
+            HStack(spacing: 12) {
+                TrendIndicator(delta: 0.15, positiveIsGood: false, isPercent: false)
+                TrendIndicator(delta: -2.5, positiveIsGood: false, isPercent: false)
+            }
         }
+        .padding()
+        .background(Color.black.opacity(0.05))
     }
-    .padding()
-    .background(Color.black.opacity(0.05))
 }
+#endif

--- a/FitTracker/Views/Stats/StatsDataHelpers.swift
+++ b/FitTracker/Views/Stats/StatsDataHelpers.swift
@@ -54,9 +54,11 @@ extension EncryptedDataStore {
 
     // MARK: – Zone 2 Cardio
 
-    /// Total cardio duration (minutes) per DailyLog where avgHeartRate is in 106–124 bpm.
+    /// Total cardio duration (minutes) per DailyLog where avgHeartRate is in the configured Zone 2 range.
     func zone2Minutes(from: Date, to: Date) -> [(date: Date, minutes: Double)] {
-        dailyLogs
+        let lower = Double(userPreferences.zone2LowerHR)
+        let upper = Double(userPreferences.zone2UpperHR)
+        return dailyLogs
             .filter { log in
                 log.date >= from && log.date <= to
             }
@@ -64,7 +66,7 @@ extension EncryptedDataStore {
             .compactMap { log in
                 let minutes = log.cardioLogs.values.compactMap { cardioLog -> Double? in
                     guard let hr = cardioLog.avgHeartRate,
-                          hr >= 106 && hr <= 124,
+                          hr >= lower && hr <= upper,
                           let duration = cardioLog.durationMinutes
                     else { return nil }
                     return duration
@@ -143,4 +145,11 @@ extension EncryptedDataStore {
         }
         return records
     }
+}
+
+/// Epley estimated 1-rep max.  Returns nil when reps < 1 or weight ≤ 0.
+func estimated1RM(weightKg: Double, reps: Int) -> Double? {
+    guard reps >= 1, weightKg > 0 else { return nil }
+    if reps == 1 { return weightKg }          // already a 1RM
+    return weightKg * (1 + Double(reps) / 30)
 }

--- a/FitTracker/Views/Stats/StatsDataHelpers.swift
+++ b/FitTracker/Views/Stats/StatsDataHelpers.swift
@@ -113,8 +113,8 @@ extension EncryptedDataStore {
                     (supp.eveningStatus == .completed ? 0.5 : 0.0)
                 return (
                     date: log.date,
-                    calories: nutrition.totalCalories,
-                    proteinG: nutrition.totalProteinG,
+                    calories: nutrition.resolvedCalories,
+                    proteinG: nutrition.resolvedProteinG,
                     supplementPct: supplementPct
                 )
             }

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -231,9 +231,7 @@ struct StatsView: View {
         }
         .task(id: period) {
             let range = dateRange
-            bodyData = await Task.detached(priority: .userInitiated) { [store = dataStore] in
-                store.bodyCompositionPoints(from: range.from, to: range.to)
-            }.value
+            bodyData = dataStore.bodyCompositionPoints(from: range.from, to: range.to)
         }
     }
 
@@ -304,14 +302,8 @@ struct StatsView: View {
         }
         .task(id: period) {
             let range = dateRange
-            async let volumeTask = Task.detached(priority: .userInitiated) { [store = dataStore] in
-                store.trainingVolumePoints(from: range.from, to: range.to)
-            }.value
-            async let zone2Task = Task.detached(priority: .userInitiated) { [store = dataStore] in
-                store.zone2Minutes(from: range.from, to: range.to)
-            }.value
-            volumeData = await volumeTask
-            zone2Data  = await zone2Task
+            volumeData = dataStore.trainingVolumePoints(from: range.from, to: range.to)
+            zone2Data  = dataStore.zone2Minutes(from: range.from, to: range.to)
         }
     }
 
@@ -497,9 +489,7 @@ struct StatsView: View {
         }
         .task(id: period) {
             let range = dateRange
-            recoveryData = await Task.detached(priority: .userInitiated) { [store = dataStore] in
-                store.recoveryPoints(from: range.from, to: range.to)
-            }.value
+            recoveryData = dataStore.recoveryPoints(from: range.from, to: range.to)
         }
     }
 
@@ -612,9 +602,7 @@ struct StatsView: View {
         }
         .task(id: period) {
             let range = dateRange
-            nutritionData = await Task.detached(priority: .userInitiated) { [store = dataStore] in
-                store.nutritionAdherencePoints(from: range.from, to: range.to)
-            }.value
+            nutritionData = dataStore.nutritionAdherencePoints(from: range.from, to: range.to)
         }
     }
 }

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -456,8 +456,6 @@ struct StatsView: View {
                                 .foregroundStyle(Color.accent.cyan)
                                 .lineStyle(StrokeStyle(lineWidth: 2))
                         }
-                        // TODO: Add gold ★ annotations at PR dates once exercise selection UI is added
-                        // prRecords()[selectedExercise]?.date matching a volumeData point
                     }
                     .frame(height: 140)
                     .chartXAxis {

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -14,9 +14,9 @@ enum StatsPeriod: String, CaseIterable {
     var dateRange: (from: Date, to: Date) {
         let to = Date()
         switch self {
-        case .sevenDays:   return (Calendar.current.date(byAdding: .day, value: -7, to: to)!, to)
-        case .thirtyDays:  return (Calendar.current.date(byAdding: .day, value: -30, to: to)!, to)
-        case .ninetyDays:  return (Calendar.current.date(byAdding: .day, value: -90, to: to)!, to)
+        case .sevenDays:   return (Calendar.current.date(byAdding: .day, value: -7, to: to) ?? Date.distantPast, to)
+        case .thirtyDays:  return (Calendar.current.date(byAdding: .day, value: -30, to: to) ?? Date.distantPast, to)
+        case .ninetyDays:  return (Calendar.current.date(byAdding: .day, value: -90, to: to) ?? Date.distantPast, to)
         case .allTime:     return (Date.distantPast, to)
         }
     }
@@ -476,10 +476,8 @@ struct StatsView: View {
             }
         }
         .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.16))
-        )
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
     }
 
     private var latestSnapshotCard: some View {
@@ -520,10 +518,8 @@ struct StatsView: View {
             }
         }
         .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.14))
-        )
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
     }
 
     private var insightFeedCard: some View {
@@ -544,10 +540,8 @@ struct StatsView: View {
             }
         }
         .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color.white.opacity(0.12))
-        )
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
     }
 
     // MARK: – Training Section
@@ -645,7 +639,7 @@ struct StatsView: View {
             // Zone 2 chart
             ChartCard(title: "Zone 2 Cardio", periodLabel: period.rawValue) {
                 if zone2Data.isEmpty {
-                    EmptyStateView(icon: "heart.circle", title: "No Zone 2 data", subtitle: "Log cardio with HR 106–124 bpm to see this chart",
+                    EmptyStateView(icon: "heart.circle", title: "No Zone 2 data", subtitle: "Log cardio with HR \(dataStore.userPreferences.zone2LowerHR)–\(dataStore.userPreferences.zone2UpperHR) bpm to see this chart",
                                    ctaLabel: "Open Training Plan", ctaAction: { showTrainingPlan = true })
                         .frame(height: 120)
                 } else {
@@ -1230,100 +1224,7 @@ private extension StatsView {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(12)
-        .background(Color.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
-    }
-}
-
-// ─────────────────────────────────────────────────────────
-// MARK: – Settings View
-// ─────────────────────────────────────────────────────────
-
-struct SettingsView: View {
-
-    @EnvironmentObject var dataStore:     EncryptedDataStore
-    @EnvironmentObject var healthService: HealthKitService
-    @EnvironmentObject var cloudSync:     CloudKitSyncService
-    @EnvironmentObject var settings:      AppSettings
-
-    @State private var showResetAlert = false
-
-    var body: some View {
-        #if os(macOS)
-        NavigationStack { settingsForm }
-        #else
-        settingsForm
-        #endif
-    }
-
-    private var settingsForm: some View {
-        Form {
-            Section("Profile") {
-                LabeledContent("Name",          value: dataStore.userProfile.name)
-                LabeledContent("Recovery Start", value: "Jan 29, 2026")
-                LabeledContent("Phase",         value: dataStore.userProfile.currentPhase.rawValue)
-                LabeledContent("Recovery Day",  value: "Day \(dataStore.userProfile.daysSinceStart)")
-                LabeledContent("Goal Weight",   value: "\(Int(dataStore.userProfile.targetWeightMin))–\(Int(dataStore.userProfile.targetWeightMax)) kg")
-                LabeledContent("Goal Body Fat", value: "\(Int(dataStore.userProfile.targetBFMin))–\(Int(dataStore.userProfile.targetBFMax))%")
-            }
-
-            Section("Apple Health") {
-                LabeledContent("HealthKit", value: healthService.isAuthorized ? "Authorized ✓" : "Not authorized")
-                LabeledContent("Apple Watch", value: "Background delivery active")
-                Button("Re-authorize HealthKit") {
-                    Task { try? await healthService.requestAuthorization() }
-                }
-            }
-
-            Section("iCloud Sync") {
-                LabeledContent("Status",     value: cloudSync.status.rawValue)
-                LabeledContent("iCloud",     value: cloudSync.iCloudAvailable ? "Available ✓" : "Unavailable")
-                if let last = cloudSync.lastSyncDate {
-                    LabeledContent("Last Sync", value: lastSyncFormatted(last))
-                }
-                Button("Sync Now") {
-                    Task { await cloudSync.pushPendingChanges(dataStore: dataStore) }
-                }
-                Button("Fetch from iCloud") {
-                    Task { await cloudSync.fetchChanges(dataStore: dataStore) }
-                }
-            }
-
-            Section("Security") {
-                LabeledContent("Encryption",      value: "AES-256-GCM + ChaCha20-Poly1305")
-                LabeledContent("Key Storage",     value: "Keychain (biometric-protected)")
-                LabeledContent("Cloud Storage",   value: "Encrypted before upload ✓")
-                LabeledContent("Data Protection", value: "NSFileProtectionCompleteUnlessOpen")
-                LabeledContent("Platforms",       value: "iOS · iPadOS · macOS only")
-            }
-
-            Section("Data") {
-                LabeledContent("Daily Logs",       value: "\(dataStore.dailyLogs.count) entries")
-                LabeledContent("Weekly Snapshots", value: "\(dataStore.weeklySnapshots.count) entries")
-                Button("Delete All Local Data", role: .destructive) {
-                    showResetAlert = true
-                }
-            }
-        }
-        .navigationTitle("Settings")
-        .alert("Delete All Data?", isPresented: $showResetAlert) {
-            Button("Delete", role: .destructive) {
-                dataStore.dailyLogs = []
-                dataStore.weeklySnapshots = []
-                Task { await dataStore.persistToDisk() }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This permanently removes all locally stored logs. iCloud copies are not deleted.")
-        }
-    }
-
-    private static let lastSyncFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .short; f.timeStyle = .short
-        return f
-    }()
-
-    private func lastSyncFormatted(_ date: Date) -> String {
-        Self.lastSyncFormatter.string(from: date)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
     }
 }

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -60,14 +60,15 @@ struct StatsView: View {
     private var dateRange: (from: Date, to: Date) { period.dateRange }
 
     private var latestBodyLog: DailyLog? {
-        dataStore.dailyLogs
-            .filter {
-                let biometrics = $0.biometrics
-                return biometrics.weightKg != nil ||
-                    biometrics.bodyFatPercent != nil ||
-                    biometrics.leanBodyMassKg != nil ||
-                    biometrics.bodyWaterPercent != nil ||
-                    biometrics.visceralFatRating != nil
+        let (from, to) = dateRange
+        return dataStore.dailyLogs
+            .filter { log in
+                log.date >= from && log.date <= to &&
+                (log.biometrics.weightKg != nil ||
+                 log.biometrics.bodyFatPercent != nil ||
+                 log.biometrics.leanBodyMassKg != nil ||
+                 log.biometrics.bodyWaterPercent != nil ||
+                 log.biometrics.visceralFatRating != nil)
             }
             .sorted { $0.date > $1.date }
             .first
@@ -75,23 +76,23 @@ struct StatsView: View {
 
     private var bodyInsights: [String] {
         guard !bodyData.isEmpty else {
-            return ["Log body metrics a few times this week to unlock weekly averages and trend stories."]
+            return ["Log body metrics a few times this period to unlock period averages and trend stories."]
         }
 
         var notes: [String] = []
 
-        let recentWeight = bodyData.suffix(7).compactMap(\.weightKg)
-        let recentBF = bodyData.suffix(7).compactMap(\.bodyFatPercent)
-        let recentLean = bodyData.suffix(7).compactMap(\.leanBodyMassKg)
+        let recentWeight = bodyData.compactMap(\.weightKg)
+        let recentBF = bodyData.compactMap(\.bodyFatPercent)
+        let recentLean = bodyData.compactMap(\.leanBodyMassKg)
 
         if recentWeight.count >= 2 {
             let delta = recentWeight.last! - recentWeight.first!
             if abs(delta) < 0.2 {
-                notes.append("Weight has been steady over the recent check-ins, which usually means the trend is reliable.")
+                notes.append("Weight has been steady over the selected period, which usually means the trend is reliable.")
             } else if delta < 0 {
-                notes.append(String(format: "Weight is down %.1f kg across recent entries, which is aligned with the cut.", abs(delta)))
+                notes.append(String(format: "Weight is down %.1f kg across entries this period, which is aligned with the cut.", abs(delta)))
             } else {
-                notes.append(String(format: "Weight is up %.1f kg across recent entries, so review calorie consistency before changing training.", delta))
+                notes.append(String(format: "Weight is up %.1f kg across entries this period, so review calorie consistency before changing training.", delta))
             }
         }
 
@@ -100,14 +101,14 @@ struct StatsView: View {
             if delta < -0.2 {
                 notes.append(String(format: "Body fat is trending down by %.1f%%, which is a strong signal that the plan is working.", abs(delta)))
             } else if delta > 0.2 {
-                notes.append(String(format: "Body fat is up %.1f%% recently, so use nutrition and recovery consistency as the first correction.", delta))
+                notes.append(String(format: "Body fat is up %.1f%% this period, so use nutrition and recovery consistency as the first correction.", delta))
             }
         }
 
         if recentLean.count >= 2 {
             let delta = recentLean.last! - recentLean.first!
             if delta > 0.2 {
-                notes.append(String(format: "Lean mass is up %.1f kg across recent logs, which is the best sign the cut is preserving muscle.", delta))
+                notes.append(String(format: "Lean mass is up %.1f kg across entries this period, which is the best sign the cut is preserving muscle.", delta))
             } else if delta < -0.2 {
                 notes.append(String(format: "Lean mass is off by %.1f kg, so keep protein and recovery high while you monitor the next few entries.", abs(delta)))
             }
@@ -125,10 +126,9 @@ struct StatsView: View {
     }
 
     private var weeklyAverageSummary: [(label: String, value: String, tint: Color)] {
-        let weekly = bodyData.suffix(7)
-        let weightAvg = average(of: weekly.compactMap(\.weightKg))
-        let bfAvg = average(of: weekly.compactMap(\.bodyFatPercent))
-        let leanAvg = average(of: weekly.compactMap(\.leanBodyMassKg))
+        let weightAvg = average(of: bodyData.compactMap(\.weightKg))
+        let bfAvg = average(of: bodyData.compactMap(\.bodyFatPercent))
+        let leanAvg = average(of: bodyData.compactMap(\.leanBodyMassKg))
 
         return [
             ("Avg Weight", weightAvg.map { String(format: "%.1f kg", $0) } ?? "—", Color.appOrange2),
@@ -209,7 +209,7 @@ struct StatsView: View {
                 .presentationDetents([.medium])
         }
         .sheet(isPresented: $showTrainingPlan) {
-            NavigationStack { TrainingPlanView() }
+            TrainingPlanView()
                 .presentationDetents([.large])
         }
         .alert("Log Your Nutrition", isPresented: $showNutritionAlert) {
@@ -223,9 +223,11 @@ struct StatsView: View {
 
     private var bodySection: some View {
         VStack(spacing: 16) {
-            bodyStoryCard
+            if !bodyData.isEmpty {
+                bodyStoryCard
+                insightFeedCard
+            }
             latestSnapshotCard
-            insightFeedCard
 
             // Weight chart
             ChartCard(title: "Weight", periodLabel: period.rawValue) {
@@ -344,7 +346,7 @@ struct StatsView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Progress Story")
                         .font(AppType.headline)
-                    Text("Weekly averages make the signal easier to trust than any single weigh-in.")
+                    Text("Period averages make the signal easier to trust than any single weigh-in.")
                         .font(AppType.subheading)
                         .foregroundStyle(.secondary)
                 }
@@ -418,7 +420,7 @@ struct StatsView: View {
             Text("Insight Feed")
                 .font(AppType.headline)
 
-            ForEach(bodyInsights, id: \.self) { insight in
+            ForEach(Array(bodyInsights.enumerated()), id: \.offset) { _, insight in
                 HStack(alignment: .top, spacing: 10) {
                     Image(systemName: "sparkles")
                         .font(.caption.weight(.semibold))

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -43,6 +43,9 @@ struct StatsView: View {
     @State private var showTrainingPlan   = false
     @State private var showNutritionAlert = false
 
+    // Shared chart tooltip state — one tooltip shows at a time
+    @State private var chartSelection: (date: Date, label: String)? = nil
+
     // Body section data
     @State private var bodyData: [(date: Date, weightKg: Double?, bodyFatPercent: Double?, leanBodyMassKg: Double?)] = []
 
@@ -264,6 +267,42 @@ struct StatsView: View {
                             AxisValueLabel()
                         }
                     }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = bodyData.filter({ $0.weightKg != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.1f kg", pt.weightKg!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
 
@@ -299,6 +338,42 @@ struct StatsView: View {
                             AxisValueLabel()
                         }
                     }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = bodyData.filter({ $0.bodyFatPercent != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.1f%%", pt.bodyFatPercent!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
 
@@ -329,6 +404,42 @@ struct StatsView: View {
                         AxisMarks { _ in
                             AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
                             AxisValueLabel()
+                        }
+                    }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = bodyData.filter({ $0.leanBodyMassKg != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.1f kg", pt.leanBodyMassKg!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
                         }
                     }
                 }
@@ -492,6 +603,42 @@ struct StatsView: View {
                             AxisValueLabel()
                         }
                     }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = volumeData
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    let formatted = pt.volumeKg >= 1000
+                                                        ? String(format: "%,.0f kg vol", pt.volumeKg)
+                                                        : String(format: "%.0f kg vol", pt.volumeKg)
+                                                    chartSelection = (date: pt.date, label: formatted)
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
 
@@ -588,6 +735,42 @@ struct StatsView: View {
                             AxisValueLabel()
                         }
                     }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = recoveryData.filter({ $0.hrv != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.0f ms", pt.hrv!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
 
@@ -619,6 +802,42 @@ struct StatsView: View {
                             AxisValueLabel()
                         }
                     }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = recoveryData.filter({ $0.restingHR != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.0f bpm", pt.restingHR!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
 
@@ -648,6 +867,42 @@ struct StatsView: View {
                         AxisMarks { _ in
                             AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
                             AxisValueLabel()
+                        }
+                    }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = recoveryData.filter({ $0.sleepHours != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.1f hrs", pt.sleepHours!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
                         }
                     }
                 }
@@ -708,6 +963,42 @@ struct StatsView: View {
                         }
                     }
                     .frame(height: 120)
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = pts
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: "Score: \(pt.score)"
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
         }
@@ -756,6 +1047,43 @@ struct StatsView: View {
                             AxisValueLabel()
                         }
                     }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = nutritionData.filter({ $0.calories != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    let kcal = pt.calories!
+                                                    let formatted = kcal >= 1000
+                                                        ? String(format: "%,.0f kcal", kcal)
+                                                        : String(format: "%.0f kcal", kcal)
+                                                    chartSelection = (date: pt.date, label: formatted)
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
+                        }
+                    }
                 }
             }
 
@@ -792,6 +1120,42 @@ struct StatsView: View {
                         AxisMarks { _ in
                             AxisGridLine().foregroundStyle(Color.white.opacity(0.2))
                             AxisValueLabel()
+                        }
+                    }
+                    .chartOverlay { proxy in
+                        GeometryReader { geo in
+                            Rectangle().fill(.clear).contentShape(Rectangle())
+                                .gesture(
+                                    DragGesture(minimumDistance: 0)
+                                        .onChanged { value in
+                                            let x = value.location.x - geo[proxy.plotAreaFrame].origin.x
+                                            if let date: Date = proxy.value(atX: x) {
+                                                if let pt = nutritionData.filter({ $0.proteinG != nil })
+                                                    .min(by: { abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date)) }) {
+                                                    chartSelection = (
+                                                        date: pt.date,
+                                                        label: String(format: "%.0f g", pt.proteinG!)
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        .onEnded { _ in chartSelection = nil }
+                                )
+                        }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        if let sel = chartSelection {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(sel.date.formatted(.dateTime.month(.abbreviated).day()))
+                                    .font(AppType.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(sel.label)
+                                    .font(AppType.body.weight(.semibold))
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                            .padding(.top, 4)
+                            .padding(.leading, 8)
                         }
                     }
                 }

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -458,6 +458,26 @@ struct StatsView: View {
                                 .foregroundStyle(Color.accent.cyan)
                                 .lineStyle(StrokeStyle(lineWidth: 2))
                         }
+                        // PR gold star annotations — one star per date a personal record was set
+                        let prDates: Set<Date> = {
+                            let (from, to) = dateRange
+                            let cal = Calendar.current
+                            return Set(
+                                dataStore.prRecords().values
+                                    .filter { $0.date >= from && $0.date <= to }
+                                    .map { cal.startOfDay(for: $0.date) }
+                            )
+                        }()
+                        ForEach(volumeData.filter { prDates.contains(Calendar.current.startOfDay(for: $0.date)) }, id: \.date) { p in
+                            PointMark(x: .value("Date", p.date), y: .value("kg", p.volumeKg))
+                                .foregroundStyle(Color.accent.gold)
+                                .symbolSize(120)
+                                .annotation(position: .top) {
+                                    Text("★")
+                                        .font(.caption.weight(.bold))
+                                        .foregroundStyle(Color.accent.gold)
+                                }
+                        }
                     }
                     .frame(height: 140)
                     .chartXAxis {

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -38,6 +38,11 @@ struct StatsView: View {
     @State private var period:   StatsPeriod   = .thirtyDays
     @State private var category: StatsCategory = .body
 
+    // CTA sheet state
+    @State private var showBiometricEntry = false
+    @State private var showTrainingPlan   = false
+    @State private var showNutritionAlert = false
+
     // Body section data
     @State private var bodyData: [(date: Date, weightKg: Double?, bodyFatPercent: Double?, leanBodyMassKg: Double?)] = []
 
@@ -53,6 +58,84 @@ struct StatsView: View {
     @State private var nutritionData: [(date: Date, calories: Double?, proteinG: Double?, supplementPct: Double)] = []
 
     private var dateRange: (from: Date, to: Date) { period.dateRange }
+
+    private var latestBodyLog: DailyLog? {
+        dataStore.dailyLogs
+            .filter {
+                let biometrics = $0.biometrics
+                return biometrics.weightKg != nil ||
+                    biometrics.bodyFatPercent != nil ||
+                    biometrics.leanBodyMassKg != nil ||
+                    biometrics.bodyWaterPercent != nil ||
+                    biometrics.visceralFatRating != nil
+            }
+            .sorted { $0.date > $1.date }
+            .first
+    }
+
+    private var bodyInsights: [String] {
+        guard !bodyData.isEmpty else {
+            return ["Log body metrics a few times this week to unlock weekly averages and trend stories."]
+        }
+
+        var notes: [String] = []
+
+        let recentWeight = bodyData.suffix(7).compactMap(\.weightKg)
+        let recentBF = bodyData.suffix(7).compactMap(\.bodyFatPercent)
+        let recentLean = bodyData.suffix(7).compactMap(\.leanBodyMassKg)
+
+        if recentWeight.count >= 2 {
+            let delta = recentWeight.last! - recentWeight.first!
+            if abs(delta) < 0.2 {
+                notes.append("Weight has been steady over the recent check-ins, which usually means the trend is reliable.")
+            } else if delta < 0 {
+                notes.append(String(format: "Weight is down %.1f kg across recent entries, which is aligned with the cut.", abs(delta)))
+            } else {
+                notes.append(String(format: "Weight is up %.1f kg across recent entries, so review calorie consistency before changing training.", delta))
+            }
+        }
+
+        if recentBF.count >= 2 {
+            let delta = recentBF.last! - recentBF.first!
+            if delta < -0.2 {
+                notes.append(String(format: "Body fat is trending down by %.1f%%, which is a strong signal that the plan is working.", abs(delta)))
+            } else if delta > 0.2 {
+                notes.append(String(format: "Body fat is up %.1f%% recently, so use nutrition and recovery consistency as the first correction.", delta))
+            }
+        }
+
+        if recentLean.count >= 2 {
+            let delta = recentLean.last! - recentLean.first!
+            if delta > 0.2 {
+                notes.append(String(format: "Lean mass is up %.1f kg across recent logs, which is the best sign the cut is preserving muscle.", delta))
+            } else if delta < -0.2 {
+                notes.append(String(format: "Lean mass is off by %.1f kg, so keep protein and recovery high while you monitor the next few entries.", abs(delta)))
+            }
+        }
+
+        if let latest = latestBodyLog?.biometrics.bodyWaterPercent, latest < 50 {
+            notes.append(String(format: "Body water is %.1f%%, so hydration probably needs attention before interpreting the next weigh-in too aggressively.", latest))
+        }
+
+        if notes.isEmpty {
+            notes.append("The current body data set is still small, so focus on logging a few more consistent check-ins before reacting to single-day swings.")
+        }
+
+        return Array(notes.prefix(3))
+    }
+
+    private var weeklyAverageSummary: [(label: String, value: String, tint: Color)] {
+        let weekly = bodyData.suffix(7)
+        let weightAvg = average(of: weekly.compactMap(\.weightKg))
+        let bfAvg = average(of: weekly.compactMap(\.bodyFatPercent))
+        let leanAvg = average(of: weekly.compactMap(\.leanBodyMassKg))
+
+        return [
+            ("Avg Weight", weightAvg.map { String(format: "%.1f kg", $0) } ?? "—", Color.appOrange2),
+            ("Avg Body Fat", bfAvg.map { String(format: "%.1f%%", $0) } ?? "—", Color.status.warning),
+            ("Avg Lean Mass", leanAvg.map { String(format: "%.1f kg", $0) } ?? "—", Color.accent.cyan)
+        ]
+    }
 
     var body: some View {
         ZStack {
@@ -121,16 +204,34 @@ struct StatsView: View {
         }
         .navigationTitle("Stats")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showBiometricEntry) {
+            ManualBiometricEntry()
+                .presentationDetents([.medium])
+        }
+        .sheet(isPresented: $showTrainingPlan) {
+            NavigationStack { TrainingPlanView() }
+                .presentationDetents([.large])
+        }
+        .alert("Log Your Nutrition", isPresented: $showNutritionAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Switch to the Nutrition tab to log your meals and supplements.")
+        }
     }
 
     // MARK: – Body Section
 
     private var bodySection: some View {
         VStack(spacing: 16) {
+            bodyStoryCard
+            latestSnapshotCard
+            insightFeedCard
+
             // Weight chart
             ChartCard(title: "Weight", periodLabel: period.rawValue) {
                 if bodyData.compactMap(\.weightKg).isEmpty {
-                    EmptyStateView(icon: "scalemass", title: "No weight data", subtitle: "Log your weight to see the chart")
+                    EmptyStateView(icon: "scalemass", title: "No weight data", subtitle: "Log your weight to see the chart",
+                                   ctaLabel: "Log Weight", ctaAction: { showBiometricEntry = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -167,7 +268,8 @@ struct StatsView: View {
             // Body Fat chart
             ChartCard(title: "Body Fat %", periodLabel: period.rawValue) {
                 if bodyData.compactMap(\.bodyFatPercent).isEmpty {
-                    EmptyStateView(icon: "drop", title: "No body fat data", subtitle: "Log your body fat to see the chart")
+                    EmptyStateView(icon: "drop", title: "No body fat data", subtitle: "Log your body fat to see the chart",
+                                   ctaLabel: "Log Body Fat", ctaAction: { showBiometricEntry = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -201,7 +303,8 @@ struct StatsView: View {
             // Lean Mass chart
             ChartCard(title: "Lean Mass", periodLabel: period.rawValue) {
                 if bodyData.compactMap(\.leanBodyMassKg).isEmpty {
-                    EmptyStateView(icon: "figure.arms.open", title: "No lean mass data", subtitle: "Log your body composition to see the chart")
+                    EmptyStateView(icon: "figure.arms.open", title: "No lean mass data", subtitle: "Log your body composition to see the chart",
+                                   ctaLabel: "Log Body Composition", ctaAction: { showBiometricEntry = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -235,6 +338,105 @@ struct StatsView: View {
         }
     }
 
+    private var bodyStoryCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Progress Story")
+                        .font(AppType.headline)
+                    Text("Weekly averages make the signal easier to trust than any single weigh-in.")
+                        .font(AppType.subheading)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if let latestDate = latestBodyLog?.date {
+                    Text(latestDate.formatted(.dateTime.month(.abbreviated).day()))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 12) {
+                ForEach(weeklyAverageSummary, id: \.label) { item in
+                    StatPreviewPill(value: item.value, label: item.label, color: item.tint)
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(Color.white.opacity(0.16))
+        )
+    }
+
+    private var latestSnapshotCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Latest Body Snapshot")
+                    .font(AppType.headline)
+                Spacer()
+                Text(latestBodyLog?.date.formatted(.dateTime.month(.abbreviated).day()) ?? "No data")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let latest = latestBodyLog?.biometrics {
+                let items: [(String, String, Color)] = [
+                    ("Weight", latest.weightKg.map { String(format: "%.1f kg", $0) } ?? "—", Color.appOrange2),
+                    ("Body Fat", latest.bodyFatPercent.map { String(format: "%.1f%%", $0) } ?? "—", Color.status.warning),
+                    ("Lean Mass", latest.leanBodyMassKg.map { String(format: "%.1f kg", $0) } ?? "—", Color.accent.cyan),
+                    ("Body Water", latest.bodyWaterPercent.map { String(format: "%.1f%%", $0) } ?? "—", Color.appBlue2),
+                    ("Muscle Mass", latest.muscleMassKg.map { String(format: "%.1f kg", $0) } ?? "—", Color.status.success),
+                    ("Visceral Fat", latest.visceralFatRating.map(String.init) ?? "—", Color.accent.purple)
+                ]
+
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                    ForEach(items, id: \.0) { item in
+                        bodySnapshotTile(title: item.0, value: item.1, tint: item.2)
+                    }
+                }
+            } else {
+                EmptyStateView(
+                    icon: "figure.arms.open",
+                    title: "No composition snapshot yet",
+                    subtitle: "Once you log weight and body composition, this section becomes your latest trusted check-in.",
+                    ctaLabel: "Log Metrics",
+                    ctaAction: { showBiometricEntry = true }
+                )
+                .frame(height: 120)
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(Color.white.opacity(0.14))
+        )
+    }
+
+    private var insightFeedCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Insight Feed")
+                .font(AppType.headline)
+
+            ForEach(bodyInsights, id: \.self) { insight in
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "sparkles")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.accent.cyan)
+                        .padding(.top, 2)
+                    Text(insight)
+                        .font(AppType.subheading)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(Color.white.opacity(0.12))
+        )
+    }
+
     // MARK: – Training Section
 
     private var trainingSection: some View {
@@ -242,7 +444,8 @@ struct StatsView: View {
             // Training Volume chart
             ChartCard(title: "Training Volume", periodLabel: period.rawValue) {
                 if volumeData.isEmpty {
-                    EmptyStateView(icon: "dumbbell.fill", title: "No training data", subtitle: "Log a workout to see your volume chart")
+                    EmptyStateView(icon: "dumbbell.fill", title: "No training data", subtitle: "Log a workout to see your volume chart",
+                                   ctaLabel: "Open Training Plan", ctaAction: { showTrainingPlan = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -275,7 +478,8 @@ struct StatsView: View {
             // Zone 2 chart
             ChartCard(title: "Zone 2 Cardio", periodLabel: period.rawValue) {
                 if zone2Data.isEmpty {
-                    EmptyStateView(icon: "heart.circle", title: "No Zone 2 data", subtitle: "Log cardio with HR 106–124 bpm to see this chart")
+                    EmptyStateView(icon: "heart.circle", title: "No Zone 2 data", subtitle: "Log cardio with HR 106–124 bpm to see this chart",
+                                   ctaLabel: "Open Training Plan", ctaAction: { showTrainingPlan = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -500,7 +704,8 @@ struct StatsView: View {
             // Calories chart
             ChartCard(title: "Calories", periodLabel: period.rawValue) {
                 if nutritionData.compactMap(\.calories).isEmpty {
-                    EmptyStateView(icon: "fork.knife", title: "No calorie data", subtitle: "Log your meals to see the chart")
+                    EmptyStateView(icon: "fork.knife", title: "No calorie data", subtitle: "Log your meals to see the chart",
+                                   ctaLabel: "Go to Nutrition", ctaAction: { showNutritionAlert = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -537,7 +742,8 @@ struct StatsView: View {
             // Protein chart
             ChartCard(title: "Protein", periodLabel: period.rawValue) {
                 if nutritionData.compactMap(\.proteinG).isEmpty {
-                    EmptyStateView(icon: "fork.knife", title: "No protein data", subtitle: "Log your meals to see the chart")
+                    EmptyStateView(icon: "fork.knife", title: "No protein data", subtitle: "Log your meals to see the chart",
+                                   ctaLabel: "Go to Nutrition", ctaAction: { showNutritionAlert = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -574,7 +780,8 @@ struct StatsView: View {
             // Supplement adherence chart
             ChartCard(title: "Supplement Adherence", periodLabel: period.rawValue) {
                 if nutritionData.isEmpty {
-                    EmptyStateView(icon: "pill.fill", title: "No supplement data", subtitle: "Log your supplements to see adherence")
+                    EmptyStateView(icon: "pill.fill", title: "No supplement data", subtitle: "Log your supplements to see adherence",
+                                   ctaLabel: "Go to Nutrition", ctaAction: { showNutritionAlert = true })
                         .frame(height: 120)
                 } else {
                     Chart {
@@ -608,13 +815,38 @@ struct StatsView: View {
 }
 
 struct StatPreviewPill: View {
-    let value: String; let label: String
+    let value: String
+    let label: String
+    var color: Color = Color.status.success
     var body: some View {
         VStack(spacing: 3) {
-            Text(value).font(.system(.title2, design: .monospaced, weight: .bold)).foregroundStyle(Color.status.success)
+            Text(value).font(.system(.title2, design: .monospaced, weight: .bold)).foregroundStyle(color)
             Text(label).font(.caption2).foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
+    }
+}
+
+private extension StatsView {
+    func average(of values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    @ViewBuilder
+    func bodySnapshotTile(title: String, value: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .tracking(1)
+            Text(value)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(tint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
     }
 }
 

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -22,12 +22,14 @@ struct TrainingPlanView: View {
     @State private var log: DailyLog?
     @State private var showCompletionSheet = false
     @State private var showNotesEditor     = false
+    @State private var showFocusMode       = false
     @State private var focusedExerciseID: String?
     @State private var restTimerEnd: Date?
     @State private var restPresetSeconds = 90
+    @State private var didHapticAt10 = false
+    @State private var didHapticAt0 = false
     private let bgOrange1 = Color.appOrange1
     private let bgOrange2 = Color.appOrange2
-    private let appBlue   = Color.blue
 
     init(initialDay: DayType? = nil) {
         self.initialDay = initialDay
@@ -51,9 +53,26 @@ struct TrainingPlanView: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 40)
             }
+
+            // Floating rest timer — bottom-right corner, safe-area aware
+            GeometryReader { geo in
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        floatingRestTimer
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                    .padding(.bottom, geo.safeAreaInsets.bottom + 56)
+                    .padding(.trailing, 16)
+                }
+            }
+            .allowsHitTesting(restTimerEnd != nil)
+            .animation(.spring(response: 0.35), value: restTimerEnd != nil)
         }
         .navigationTitle("Training Plan")
         .navigationBarTitleDisplayMode(.inline)
+        .preferredColorScheme(.dark)
         .onAppear {
             activeDate = Calendar.current.startOfDay(for: Date())
             loadLog(for: activeDate, preferredDay: initialDay ?? programStore.todayDayType)
@@ -82,6 +101,7 @@ struct TrainingPlanView: View {
                 log: log,
                 selectedDay: selectedDay,
                 previousLog: previousSameDayLog,
+                streak: dataStore.supplementStreak,
                 onDone: { showCompletionSheet = false },
                 onLogNotes: { showCompletionSheet = false; showNotesEditor = true }
             )
@@ -96,6 +116,20 @@ struct TrainingPlanView: View {
             .presentationDetents([.medium])
             .presentationCornerRadius(20)
         }
+        .fullScreenCover(isPresented: $showFocusMode) {
+            if let exercise = focusedExercise {
+                FocusModeView(
+                    exercise: exercise,
+                    exerciseLog: Binding(
+                        get: { log?.exerciseLogs[exercise.id] ?? ExerciseLog(exerciseID: exercise.id, exerciseName: exercise.name) },
+                        set: {
+                            log?.exerciseLogs[exercise.id] = $0
+                        }
+                    ),
+                    onExit: { showFocusMode = false }
+                )
+            }
+        }
     }
 
     // ─────────────────────────────────────────────────────
@@ -109,7 +143,7 @@ struct TrainingPlanView: View {
         let weekday = calendar.component(.weekday, from: today) // 1=Sun … 7=Sat
         // Days offset so Monday is first
         let daysFromMonday = (weekday + 5) % 7   // Mon=0, Tue=1 … Sun=6
-        let monday = calendar.date(byAdding: .day, value: -daysFromMonday, to: calendar.startOfDay(for: today))!
+        let monday = calendar.date(byAdding: .day, value: -daysFromMonday, to: calendar.startOfDay(for: today)) ?? calendar.startOfDay(for: today)
         let weekDays = (0..<7).compactMap { calendar.date(byAdding: .day, value: $0, to: monday) }
 
         return HStack(spacing: 0) {
@@ -259,6 +293,18 @@ struct TrainingPlanView: View {
                         .foregroundStyle(.black.opacity(0.78))
                 }
                 .buttonStyle(.plain)
+
+                Button {
+                    showFocusMode = true
+                } label: {
+                    Label("Focus Mode", systemImage: "eye.fill")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.black.opacity(0.65), in: RoundedRectangle(cornerRadius: 12))
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(.plain)
+                .disabled(focusedExercise == nil)
             }
         }
         .padding(16)
@@ -290,6 +336,51 @@ struct TrainingPlanView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background(Color.black.opacity(0.06), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    @ViewBuilder
+    private var floatingRestTimer: some View {
+        if restTimerEnd != nil {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                let remaining = restTimeRemaining(at: context.date)
+                let isDone = remaining == 0
+
+                Button {
+                    restTimerEnd = nil
+                    didHapticAt10 = false
+                    didHapticAt0 = false
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: isDone ? "checkmark.circle.fill" : "timer")
+                            .font(.system(size: 14, weight: .semibold))
+                        Text(isDone ? "Done — tap to clear" : restTimeString(at: context.date))
+                            .font(.system(size: 15, weight: .bold, design: .monospaced))
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(
+                        isDone ? Color.status.success : Color.black.opacity(0.75),
+                        in: Capsule()
+                    )
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.25), radius: 8, y: 4)
+                }
+                .buttonStyle(.plain)
+                .onChange(of: remaining) { _, newRemaining in
+                    if newRemaining == 10 && !didHapticAt10 {
+                        let g = UIImpactFeedbackGenerator(style: .light)
+                        g.prepare()
+                        g.impactOccurred()
+                        didHapticAt10 = true
+                    } else if newRemaining == 0 && !didHapticAt0 {
+                        let g = UINotificationFeedbackGenerator()
+                        g.prepare()
+                        g.notificationOccurred(.success)
+                        didHapticAt0 = true
+                    }
+                }
+            }
+        }
     }
 
     private var exerciseQueueStrip: some View {
@@ -453,6 +544,8 @@ struct TrainingPlanView: View {
 
     private func startRestTimer() {
         restTimerEnd = Date().addingTimeInterval(TimeInterval(restPresetSeconds))
+        didHapticAt10 = false
+        didHapticAt0 = false
     }
 
     private func restTimeRemaining(at date: Date) -> Int {
@@ -719,7 +812,12 @@ struct ExerciseRowView: View {
                     log?.exerciseLogs[exercise.id] = $0
                 }
             ),
-            onStartRest: onStartRest
+            onStartRest: onStartRest,
+            onSetCompleted: {
+                if log?.sessionStartTime == nil {
+                    log?.sessionStartTime = Date()
+                }
+            }
         )
     }
 
@@ -779,6 +877,7 @@ struct LiftLogPanel: View {
     let previousSessionLog: ExerciseLog?
     @Binding var exerciseLog: ExerciseLog
     let onStartRest: () -> Void
+    var onSetCompleted: (() -> Void)? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -805,6 +904,26 @@ struct LiftLogPanel: View {
                             value: prev.totalVolume > 0 ? "\(Int(prev.totalVolume)) kg" : "—"
                         )
                     }
+                }
+
+                // Estimated 1RM from current session best set
+                if let best = exerciseLog.bestSet,
+                   let weight = best.weightKg,
+                   let reps = best.repsCompleted,
+                   let orm = estimated1RM(weightKg: weight, reps: reps) {
+                    Text("Est. 1RM ~\(Int(orm.rounded())) kg")
+                        .font(.caption)
+                        .foregroundStyle(Color.accent.cyan)
+                        .padding(.horizontal, 12)
+                        .padding(.top, 2)
+                }
+
+                if let suggestion = overloadSuggestion {
+                    Text(suggestion)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.accent.cyan)
+                        .padding(.horizontal, 12)
+                        .padding(.top, 2)
                 }
 
                 HStack(spacing: 10) {
@@ -867,7 +986,9 @@ struct LiftLogPanel: View {
                     previousSet: previousSessionLog?.sets.indices.contains(i) == true ? previousSessionLog?.sets[i] : nil,
                     onCompleteSet: {
                         exerciseLog.sets[i].timestamp = Date()
+                        onSetCompleted?()
                         onStartRest()
+                        let hap = UIImpactFeedbackGenerator(style: .medium); hap.prepare(); hap.impactOccurred()
                     },
                     onDelete: {
                         exerciseLog.sets.remove(at: i)
@@ -894,6 +1015,28 @@ struct LiftLogPanel: View {
         }
     }
 
+    private var overloadSuggestion: String? {
+        guard let prev = previousSessionLog else { return nil }
+        // Exclude warmup sets from both the target check and best-weight calculation
+        let workingSets = prev.sets.filter { !$0.isWarmup }
+        guard !workingSets.isEmpty else { return nil }
+        // Parse minimum reps from targetReps string (e.g., "8-12" → 8, "10" → 10)
+        let minTargetReps = exercise.targetReps
+            .components(separatedBy: CharacterSet.decimalDigits.inverted)
+            .compactMap { Int($0) }
+            .first ?? 0
+        guard minTargetReps > 0 else { return nil }
+        // Check all working sets hit target reps
+        let allHitTarget = workingSets.allSatisfy { ($0.repsCompleted ?? 0) >= minTargetReps }
+        guard allHitTarget else { return nil }
+        // Suggest +2.5 kg from previous best working weight
+        guard let bestWeight = workingSets.compactMap(\.weightKg).max() else { return nil }
+        let suggested = bestWeight + 2.5
+        let fmt = suggested.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(suggested)) : String(format: "%.1f", suggested)
+        return "→ Try \(fmt) kg today (+2.5)"
+    }
+
     private func previousPerformanceTile(title: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(title)
@@ -917,9 +1060,10 @@ struct SetRowView: View {
     let onCompleteSet: () -> Void
     let onDelete: () -> Void
 
-    @State private var weightStr = ""
-    @State private var repsStr   = ""
-    @State private var noteStr   = ""
+    @State private var weightStr  = ""
+    @State private var repsStr    = ""
+    @State private var noteStr    = ""
+    @State private var flashGreen = false
 
     private var setIsComplete: Bool {
         setLog.weightKg != nil && setLog.repsCompleted != nil
@@ -1000,8 +1144,14 @@ struct SetRowView: View {
                 .frame(maxWidth: .infinity)
                 .onChange(of: noteStr) { _, v in setLog.notes = v }
 
-            // Delete
-            Button(action: onCompleteSet) {
+            // Done / complete-set
+            Button {
+                onCompleteSet()
+                withAnimation(.easeOut(duration: 0.1)) { flashGreen = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    withAnimation(.easeIn(duration: 0.25)) { flashGreen = false }
+                }
+            } label: {
                 Image(systemName: setIsComplete ? "checkmark.circle.fill" : "timer")
                     .foregroundStyle(setIsComplete ? Color.status.success : Color.appOrange2)
                     .font(.caption)
@@ -1014,7 +1164,7 @@ struct SetRowView: View {
             .frame(width: 28)
         }
         .padding(.horizontal, 12).padding(.vertical, 7)
-        .background(setIsComplete ? Color.status.success.opacity(0.03) : Color.clear)
+        .background(flashGreen ? Color.status.success.opacity(0.12) : (setIsComplete ? Color.status.success.opacity(0.03) : Color.clear))
         .onAppear {
             weightStr = setLog.weightKg.map(formattedWeight) ?? ""
             repsStr   = setLog.repsCompleted.map { String($0) } ?? ""
@@ -1034,6 +1184,7 @@ struct SetRowView: View {
 // ─────────────────────────────────────────────────────────
 
 struct CardioLogPanel: View {
+    @EnvironmentObject var dataStore: EncryptedDataStore
     let cardioType: CardioType
     @Binding var cardioLog: CardioLog
 
@@ -1050,7 +1201,7 @@ struct CardioLogPanel: View {
                 Text(cardioType == .rowing ? "🚣 ROWING LOG" : "🚴 ELLIPTICAL LOG")
                     .font(.caption2.monospaced()).foregroundStyle(Color.status.success).tracking(1)
                 Spacer()
-                if let zone = cardioLog.wasInZone2 {
+                if let zone = cardioLog.wasInZone2(lower: dataStore.userPreferences.zone2LowerHR, upper: dataStore.userPreferences.zone2UpperHR) {
                     Text(zone ? "✓ Zone 2" : "↑ Above Zone 2")
                         .font(.caption2.monospaced())
                         .foregroundStyle(zone ? Color.status.success : Color.status.warning)
@@ -1411,8 +1562,15 @@ struct SessionCompletionSheet: View {
     let log: DailyLog?
     let selectedDay: DayType
     let previousLog: DailyLog?
+    let streak: Int
     let onDone: () -> Void
     let onLogNotes: () -> Void
+
+    @EnvironmentObject var dataStore: EncryptedDataStore
+
+    @State private var milestoneTitle: String? = nil
+    @State private var milestoneMessage: String? = nil
+    @State private var hasShownMilestone = false
 
     var body: some View {
         NavigationStack {
@@ -1430,6 +1588,13 @@ struct SessionCompletionSheet: View {
                             .foregroundStyle(.secondary)
                     }
                     .padding(.top, 8)
+
+                    // Warm completion micro-copy
+                    Text(completionMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 8)
 
                     // Stats grid: 4 metric tiles
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
@@ -1496,8 +1661,36 @@ struct SessionCompletionSheet: View {
                 }
                 .padding(.horizontal, 24)
                 .padding(.bottom, 32)
+                .onAppear {
+                    guard !hasShownMilestone else { return }
+                    hasShownMilestone = true
+                    let totalCompleted = dataStore.dailyLogs.filter {
+                        $0.taskStatuses.values.contains(.completed)
+                    }.count
+                    if totalCompleted == 1 {
+                        milestoneTitle = "First Workout Complete!"
+                        milestoneMessage = "That's day one. The hardest one. Every session from here builds on this."
+                    } else if let name = firstPRExerciseName {
+                        milestoneTitle = "New Personal Record!"
+                        milestoneMessage = "New record on \(name). You're stronger than last week."
+                        let g = UIImpactFeedbackGenerator(style: .medium)
+                        g.prepare()
+                        g.impactOccurred()
+                    }
+                    let ng = UINotificationFeedbackGenerator()
+                    ng.prepare()
+                    ng.notificationOccurred(.success)
+                }
             }
             .navigationBarTitleDisplayMode(.inline)
+        }
+        .fullScreenCover(isPresented: Binding(get: { milestoneTitle != nil }, set: { if !$0 { milestoneTitle = nil; milestoneMessage = nil } })) {
+            if let title = milestoneTitle, let message = milestoneMessage {
+                MilestoneModal(title: title, message: message) {
+                    milestoneTitle = nil
+                    milestoneMessage = nil
+                }
+            }
         }
     }
 
@@ -1527,12 +1720,19 @@ struct SessionCompletionSheet: View {
         return "\(done)/\(total)"
     }
 
-    private var durationStr: String {
-        guard let exLogs = log?.exerciseLogs.values, !exLogs.isEmpty else { return "—" }
-        let allTimestamps = exLogs.flatMap { $0.sets }.map(\.timestamp)
-        guard let first = allTimestamps.min(), let last = allTimestamps.max() else { return "—" }
-        let minutes = Int(last.timeIntervalSince(first) / 60)
+    private func formatSessionDuration(since start: Date) -> String {
+        let minutes = max(0, Int(Date().timeIntervalSince(start) / 60))
+        if minutes >= 60 {
+            let h = minutes / 60
+            let m = minutes % 60
+            return m > 0 ? "\(h)h \(m)m" : "\(h)h"
+        }
         return minutes > 0 ? "\(minutes) min" : "< 1 min"
+    }
+
+    private var durationStr: String {
+        guard let start = log?.sessionStartTime else { return "—" }
+        return formatSessionDuration(since: start)
     }
 
     private var prCountStr: String {
@@ -1545,6 +1745,38 @@ struct SessionCompletionSheet: View {
             return best > prevBest
         }.count
         return count > 0 ? "\(count)" : "0"
+    }
+
+    private var firstPRExerciseName: String? {
+        guard let exLogs = log?.exerciseLogs, let prevExLogs = previousLog?.exerciseLogs else { return nil }
+        // Sort by biggest weight improvement for a deterministic, most-impressive PR
+        let bestEntry = exLogs
+            .filter { (exerciseID, current) in
+                guard let best = current.bestSet?.weightKg,
+                      let prevBest = prevExLogs[exerciseID]?.bestSet?.weightKg else { return false }
+                return best > prevBest
+            }
+            .max { a, b in
+                let aGain = (a.value.bestSet?.weightKg ?? 0) - (prevExLogs[a.key]?.bestSet?.weightKg ?? 0)
+                let bGain = (b.value.bestSet?.weightKg ?? 0) - (prevExLogs[b.key]?.bestSet?.weightKg ?? 0)
+                return aGain < bGain
+            }
+        return bestEntry.map { exerciseID, _ in
+            TrainingProgramData.allExercises.first { $0.id == exerciseID }?.name ?? exerciseID
+        }
+    }
+
+    private var completionMessage: String {
+        if previousLog == nil {
+            return "That's day one. The hardest one."
+        }
+        if let firstPRExercise = firstPRExerciseName {
+            return "New record on \(firstPRExercise). You're stronger than last week."
+        }
+        if streak >= 7 {
+            return "\(streak) days straight. Consistency beats intensity every time."
+        }
+        return "Good work. Come back stronger."
     }
 
     @ViewBuilder
@@ -1592,6 +1824,180 @@ struct NotesEditorSheet: View {
                         Button("Done", action: onDone)
                     }
                 }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────
+// MARK: – Focus Mode (distraction-free)
+// ─────────────────────────────────────────────────────────
+
+struct FocusModeView: View {
+    let exercise: ExerciseDefinition
+    @Binding var exerciseLog: ExerciseLog
+    let onExit: () -> Void
+
+    @State private var weightStr = ""
+    @State private var repsStr   = ""
+
+    private var nextIncompleteSetIndex: Int? {
+        exerciseLog.sets.indices.first {
+            exerciseLog.sets[$0].weightKg == nil || exerciseLog.sets[$0].repsCompleted == nil
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            VStack(spacing: 32) {
+                // Exit button
+                HStack {
+                    Spacer()
+                    Button(action: onExit) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.white.opacity(0.5))
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+
+                Spacer()
+
+                // Exercise name
+                Text(exercise.name)
+                    .font(.system(.title, design: .rounded, weight: .bold))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+
+                // Set info
+                if let idx = nextIncompleteSetIndex {
+                    VStack(spacing: 8) {
+                        Text("Set \(idx + 1)")
+                            .font(.system(size: 18, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Color.white.opacity(0.55))
+                        Text(exercise.targetReps)
+                            .font(.system(size: 36, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white)
+                    }
+                } else {
+                    Text("All sets done ✓")
+                        .font(.title2.bold())
+                        .foregroundStyle(Color.status.success)
+                }
+
+                // Weight + Reps fields
+                HStack(spacing: 16) {
+                    focusField(placeholder: "kg", text: $weightStr)
+                    Text("×")
+                        .font(.system(size: 28, weight: .bold))
+                        .foregroundStyle(Color.white.opacity(0.5))
+                    focusField(placeholder: "reps", text: $repsStr)
+                }
+                .padding(.horizontal, 32)
+
+                // Done button
+                Button {
+                    guard let idx = nextIncompleteSetIndex else { onExit(); return }
+                    exerciseLog.sets[idx].weightKg      = Double(weightStr.replacingOccurrences(of: ",", with: "."))
+                    exerciseLog.sets[idx].repsCompleted = Int(repsStr)
+                    exerciseLog.sets[idx].timestamp     = Date()
+                    let hap = UIImpactFeedbackGenerator(style: .medium); hap.prepare(); hap.impactOccurred()
+                    repsStr = ""
+                    // Prefill weight for the next incomplete set from the one just completed
+                    if let kg = exerciseLog.sets[idx].weightKg {
+                        weightStr = kg.truncatingRemainder(dividingBy: 1) == 0
+                            ? String(Int(kg)) : String(kg)
+                    } else {
+                        weightStr = ""
+                    }
+                } label: {
+                    Text(nextIncompleteSetIndex != nil ? "Done" : "Finish")
+                        .font(.system(size: 22, weight: .bold, design: .rounded))
+                        .foregroundStyle(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 20)
+                        .background(Color.status.success, in: RoundedRectangle(cornerRadius: 20))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 32)
+                .disabled(nextIncompleteSetIndex == nil)
+
+                Spacer()
+            }
+        }
+        .persistentSystemOverlays(.hidden)
+        .onAppear {
+            // Prefill weight from last set that has a weight logged
+            if let kg = exerciseLog.sets.last(where: { $0.weightKg != nil })?.weightKg {
+                weightStr = kg.truncatingRemainder(dividingBy: 1) == 0
+                    ? String(Int(kg)) : String(kg)
+            }
+        }
+    }
+
+    private func focusField(placeholder: String, text: Binding<String>) -> some View {
+        TextField(placeholder, text: text)
+            .font(.system(size: 42, weight: .bold, design: .monospaced))
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.center)
+            .keyboardType(.decimalPad)
+            .padding(16)
+            .background(Color.white.opacity(0.1), in: RoundedRectangle(cornerRadius: 16))
+            .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - MilestoneModal
+
+struct MilestoneModal: View {
+    let title: String
+    let message: String
+    let onDismiss: () -> Void
+
+    @State private var autoDismissTimer: Timer? = nil
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.85).ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                Text("🎉")
+                    .font(.system(size: 72))
+
+                Text(title)
+                    .font(.system(.title, design: .rounded, weight: .bold))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+
+                Button("Continue") {
+                    autoDismissTimer?.invalidate()
+                    onDismiss()
+                }
+                .font(.headline)
+                .padding(.horizontal, 40)
+                .padding(.vertical, 14)
+                .background(Color.white.opacity(0.2), in: RoundedRectangle(cornerRadius: 20))
+                .foregroundStyle(.white)
+            }
+            .padding(32)
+        }
+        .onAppear {
+            autoDismissTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { _ in
+                onDismiss()
+            }
+        }
+        .onDisappear {
+            autoDismissTimer?.invalidate()
         }
     }
 }

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -1010,7 +1010,7 @@ struct RPETapBar: View {
                     rpe = isSelected ? nil : Double(v)
                 } label: {
                     Text("\(v)")
-                        .font(.system(size: 10, design: .monospaced, weight: isSelected ? .bold : .regular))
+                        .font(.system(size: 10, weight: isSelected ? .bold : .regular, design: .monospaced))
                         .foregroundStyle(isSelected ? Color.black : Color.secondary)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 5)

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -22,6 +22,9 @@ struct TrainingPlanView: View {
     @State private var log: DailyLog?
     @State private var showCompletionSheet = false
     @State private var showNotesEditor     = false
+    @State private var focusedExerciseID: String?
+    @State private var restTimerEnd: Date?
+    @State private var restPresetSeconds = 90
     private let bgOrange1 = Color.appOrange1
     private let bgOrange2 = Color.appOrange2
     private let appBlue   = Color.blue
@@ -41,6 +44,8 @@ struct TrainingPlanView: View {
                     weekStrip
                     sessionPicker
                     sessionHeader
+                    sessionCommandDeck
+                    exerciseQueueStrip
                     exerciseSections
                 }
                 .padding(.horizontal, 16)
@@ -50,24 +55,27 @@ struct TrainingPlanView: View {
         .navigationTitle("Training Plan")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            selectedDay = initialDay ?? programStore.todayDayType
-            log = dataStore.todayLog() ?? makeBlankLog()
+            activeDate = Calendar.current.startOfDay(for: Date())
+            loadLog(for: activeDate, preferredDay: initialDay ?? programStore.todayDayType)
         }
         .onDisappear {
             // Persist on disappear; the scene .background handler in FitTrackerApp
             // ensures this reaches disk even if the app is about to be suspended.
-            if let current = log {
-                dataStore.upsertLog(current)
-            }
+            saveLog()
         }
         .onChange(of: log) { _, newLog in
             guard let log = newLog else { return }
             let exercises = TrainingProgramData.exercises(for: selectedDay)
+            syncFocusedExercise()
             guard !exercises.isEmpty else { return }
             let allDone = exercises.allSatisfy { log.taskStatuses[$0.id] == .completed }
             if allDone && !showCompletionSheet {
                 showCompletionSheet = true
             }
+        }
+        .onChange(of: selectedDay) { _, _ in
+            syncFocusedExercise()
+            restPresetSeconds = focusedExercise?.restSeconds ?? 90
         }
         .sheet(isPresented: $showCompletionSheet) {
             SessionCompletionSheet(
@@ -144,26 +152,43 @@ struct TrainingPlanView: View {
                 .frame(maxWidth: .infinity)
                 .contentShape(Rectangle())
                 .onTapGesture {
+                    saveLog()
                     activeDate = day
-                    // Derive suggested day type from weekday
                     let suggested = TrainingProgramStore.dayType(forWeekday: wday)
-                    withAnimation(.easeInOut(duration: 0.2)) { selectedDay = suggested }
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        loadLog(for: day, preferredDay: suggested)
+                    }
                 }
             }
         }
         .padding(.vertical, 8)
-        .onAppear { activeDate = today }
     }
 
     // ─────────────────────────────────────────────────────
     // Session summary header
     // ─────────────────────────────────────────────────────
 
+    private var exercisesForSelectedDay: [ExerciseDefinition] {
+        TrainingProgramData.exercises(for: selectedDay)
+    }
+
+    private var focusedExercise: ExerciseDefinition? {
+        if let focusedExerciseID,
+           let selected = exercisesForSelectedDay.first(where: { $0.id == focusedExerciseID }) {
+            return selected
+        }
+        return nextExercise
+    }
+
+    private var nextExercise: ExerciseDefinition? {
+        exercisesForSelectedDay.first { (log?.taskStatuses[$0.id] ?? .pending) != .completed }
+    }
+
     private var sessionHeader: some View {
-        let exercises = TrainingProgramData.exercises(for: selectedDay)
+        let exercises = exercisesForSelectedDay
         let done = exercises.filter { log?.taskStatuses[$0.id] == .completed }.count
         let total = exercises.count
-        let summaryText = total == 0 ? "Active rest - walk, yoga, recover" : "\(total) exercises - \(done) done"
+        let summaryText = total == 0 ? "Active rest - walk, yoga, recover" : "\(done) of \(total) complete · \(max(total - done, 0)) left"
 
         return HStack(spacing: 16) {
             VStack(alignment: .leading, spacing: 2) {
@@ -179,6 +204,134 @@ struct TrainingPlanView: View {
         }
         .padding(14)
         .background(Color.white.opacity(0.35), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var sessionCommandDeck: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Current Focus")
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .tracking(1)
+                    Text(focusedExercise?.name ?? "Recovery and movement")
+                        .font(.headline)
+                    Text(sessionFocusSubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                restTimerCard
+            }
+
+            if let focusedExercise {
+                HStack(spacing: 8) {
+                    Label(focusedExercise.targetReps, systemImage: "repeat")
+                    Label("Rest \(focusedExercise.restSeconds)s", systemImage: "timer")
+                    Label("\(focusedExercise.targetSets) sets", systemImage: "number.square")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    if let next = nextExercise {
+                        focusedExerciseID = next.id
+                        restPresetSeconds = next.restSeconds
+                    }
+                } label: {
+                    Label("Jump To Next", systemImage: "arrow.down.circle.fill")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.accent.cyan, in: RoundedRectangle(cornerRadius: 12))
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    startRestTimer()
+                } label: {
+                    Label(restTimerEnd == nil ? "Start Rest" : "Restart Rest", systemImage: "timer")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.white.opacity(0.7), in: RoundedRectangle(cornerRadius: 12))
+                        .foregroundStyle(.black.opacity(0.78))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(16)
+        .background(Color.white.opacity(0.48), in: RoundedRectangle(cornerRadius: 18))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.white.opacity(0.45), lineWidth: 1)
+        )
+    }
+
+    private var restTimerCard: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                Text(restTimeString(at: context.date))
+                    .font(.system(size: 22, weight: .bold, design: .monospaced))
+                    .foregroundStyle(restTimeRemaining(at: context.date) > 0 ? Color.appOrange2 : Color.black.opacity(0.78))
+            }
+            Text(restTimerEnd == nil ? "rest preset" : "remaining")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Stepper(value: $restPresetSeconds, in: 30...180, step: 15) {
+                Text("\(restPresetSeconds)s")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .labelsHidden()
+            .frame(width: 90)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.black.opacity(0.06), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var exerciseQueueStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(exercisesForSelectedDay) { exercise in
+                    let isFocused = exercise.id == focusedExercise?.id
+                    let status = log?.taskStatuses[exercise.id] ?? .pending
+                    Button {
+                        focusedExerciseID = exercise.id
+                        restPresetSeconds = exercise.restSeconds
+                    } label: {
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 6) {
+                                Circle()
+                                    .fill(queueColor(for: status))
+                                    .frame(width: 7, height: 7)
+                                Text(exercise.name)
+                                    .font(.caption.weight(.semibold))
+                                    .lineLimit(1)
+                            }
+                            Text(status.rawValue.capitalized)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .frame(width: 146, alignment: .leading)
+                        .background(
+                            isFocused ? Color.appBlue1.opacity(0.35) : Color.white.opacity(0.28),
+                            in: RoundedRectangle(cornerRadius: 14)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 14)
+                                .stroke(isFocused ? Color.blue : Color.white.opacity(0.3), lineWidth: isFocused ? 1.5 : 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 2)
+        }
     }
 
     private func completionRing(done: Int, total: Int) -> some View {
@@ -202,7 +355,7 @@ struct TrainingPlanView: View {
     // ─────────────────────────────────────────────────────
 
     private var exerciseSections: some View {
-        let exercises = TrainingProgramData.exercises(for: selectedDay)
+        let exercises = exercisesForSelectedDay
         let grouped = groupedExercises(exercises)
 
         return ForEach(grouped, id: \.title) { group in
@@ -211,7 +364,13 @@ struct TrainingPlanView: View {
                     title: group.title,
                     exercises: group.exercises,
                     selectedDay: selectedDay,
-                    log: $log
+                    focusedExerciseID: $focusedExerciseID,
+                    log: $log,
+                    onFocusExercise: { exercise in
+                        focusedExerciseID = exercise.id
+                        restPresetSeconds = exercise.restSeconds
+                    },
+                    onStartRest: startRestTimer
                 )
             }
         }
@@ -230,8 +389,12 @@ struct TrainingPlanView: View {
     }
 
     private func makeBlankLog() -> DailyLog {
-        DailyLog(date: Date(), phase: dataStore.userProfile.currentPhase,
-                 dayType: selectedDay, recoveryDay: dataStore.userProfile.daysSinceStart)
+        DailyLog(
+            date: activeDate,
+            phase: dataStore.userProfile.currentPhase,
+            dayType: selectedDay,
+            recoveryDay: dataStore.userProfile.recoveryDay(for: activeDate)
+        )
     }
 
     // ─────────────────────────────────────────────────────
@@ -258,7 +421,77 @@ struct TrainingPlanView: View {
     }
 
     private func saveLog() {
-        if let l = log { dataStore.upsertLog(l) }
+        guard var current = log else { return }
+        current.date = activeDate
+        current.dayType = selectedDay
+        current.recoveryDay = dataStore.userProfile.recoveryDay(for: activeDate)
+        log = current
+        dataStore.upsertLog(current)
+    }
+
+    private func loadLog(for date: Date, preferredDay: DayType) {
+        let normalizedDate = Calendar.current.startOfDay(for: date)
+        activeDate = normalizedDate
+        if let existing = dataStore.log(for: normalizedDate) {
+            log = existing
+            selectedDay = existing.dayType
+        } else {
+            selectedDay = preferredDay
+            log = makeBlankLog()
+        }
+        syncFocusedExercise()
+        restPresetSeconds = focusedExercise?.restSeconds ?? 90
+    }
+
+    private func syncFocusedExercise() {
+        let exerciseIDs = Set(exercisesForSelectedDay.map(\.id))
+        if let focusedExerciseID, exerciseIDs.contains(focusedExerciseID) {
+            return
+        }
+        focusedExerciseID = nextExercise?.id ?? exercisesForSelectedDay.first?.id
+    }
+
+    private func startRestTimer() {
+        restTimerEnd = Date().addingTimeInterval(TimeInterval(restPresetSeconds))
+    }
+
+    private func restTimeRemaining(at date: Date) -> Int {
+        guard let restTimerEnd else { return 0 }
+        return max(0, Int(restTimerEnd.timeIntervalSince(date)))
+    }
+
+    private func restTimeString(at date: Date) -> String {
+        let remaining = restTimeRemaining(at: date)
+        if remaining == 0 {
+            return restTimerEnd == nil ? "--:--" : "Done"
+        }
+        return String(format: "%02d:%02d", remaining / 60, remaining % 60)
+    }
+
+    private var sessionFocusSubtitle: String {
+        guard let focusedExercise else {
+            return "Use today for walking, mobility, and recovery notes."
+        }
+        let status = log?.taskStatuses[focusedExercise.id] ?? .pending
+        switch status {
+        case .completed:
+            return "Completed. Review the next queue item or move to session notes."
+        case .partial:
+            return "In progress. Finish the work sets or log what changed."
+        case .missed:
+            return "Marked missed. Either swap the movement or move on."
+        case .pending:
+            return "Your next working block. Use the previous-performance hints below."
+        }
+    }
+
+    private func queueColor(for status: TaskStatus) -> Color {
+        switch status {
+        case .completed: Color.status.success
+        case .partial: Color.status.warning
+        case .missed: Color.status.error
+        case .pending: Color.secondary
+        }
     }
 
     // ─────────────────────────────────────────────────────
@@ -345,7 +578,10 @@ struct ExerciseSectionBlock: View {
     let title:     String
     let exercises: [ExerciseDefinition]
     let selectedDay: DayType
+    @Binding var focusedExerciseID: String?
     @Binding var log: DailyLog?
+    let onFocusExercise: (ExerciseDefinition) -> Void
+    let onStartRest: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -356,7 +592,14 @@ struct ExerciseSectionBlock: View {
                 .padding(.leading, 2)
 
             ForEach(exercises) { ex in
-                ExerciseRowView(exercise: ex, selectedDay: selectedDay, log: $log)
+                ExerciseRowView(
+                    exercise: ex,
+                    selectedDay: selectedDay,
+                    isFocused: focusedExerciseID == ex.id,
+                    onFocus: { onFocusExercise(ex) },
+                    log: $log,
+                    onStartRest: onStartRest
+                )
             }
         }
     }
@@ -370,7 +613,10 @@ struct ExerciseRowView: View {
     @EnvironmentObject var dataStore: EncryptedDataStore
     let exercise: ExerciseDefinition
     let selectedDay: DayType
+    let isFocused: Bool
+    let onFocus: () -> Void
     @Binding var log: DailyLog?
+    let onStartRest: () -> Void
 
     private var status: TaskStatus { log?.taskStatuses[exercise.id] ?? .pending }
 
@@ -378,7 +624,7 @@ struct ExerciseRowView: View {
         dataStore.dailyLogs
             .filter {
                 $0.dayType == selectedDay &&
-                !Calendar.current.isDateInToday($0.date) &&
+                !Calendar.current.isDate($0.date, inSameDayAs: log?.date ?? Date()) &&
                 $0.exerciseLogs[exercise.id] != nil
             }
             .sorted { $0.date > $1.date }
@@ -400,6 +646,8 @@ struct ExerciseRowView: View {
                 }
             }
             .padding(12)
+            .contentShape(Rectangle())
+            .onTapGesture { onFocus() }
 
             // Expanded log panel (only when completed or partial)
             if status == .completed || status == .partial {
@@ -412,7 +660,7 @@ struct ExerciseRowView: View {
             }
         }
         .background(rowBG, in: RoundedRectangle(cornerRadius: 12))
-        .overlay(RoundedRectangle(cornerRadius: 12).stroke(accentColor.opacity(0.25), lineWidth: 1))
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(isFocused ? Color.blue.opacity(0.8) : accentColor.opacity(0.25), lineWidth: isFocused ? 1.5 : 1))
         .animation(.easeInOut(duration: 0.25), value: status)
     }
 
@@ -427,10 +675,20 @@ struct ExerciseRowView: View {
     // ── Exercise info block
     private var exerciseInfo: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(exercise.name)
-                .font(.subheadline.weight(.semibold))
-                .strikethrough(status == .completed, color: Color.status.success)
-                .foregroundStyle(status == .completed ? .secondary : .primary)
+            HStack(spacing: 8) {
+                Text(exercise.name)
+                    .font(.subheadline.weight(.semibold))
+                    .strikethrough(status == .completed, color: Color.status.success)
+                    .foregroundStyle(status == .completed ? .secondary : .primary)
+                if isFocused {
+                    Text("LIVE")
+                        .font(.system(size: 9, weight: .bold, design: .monospaced))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(Color.blue.opacity(0.12), in: Capsule())
+                        .foregroundStyle(Color.blue)
+                }
+            }
 
             Text(exercise.muscleGroups.map { $0.rawValue.capitalized }.joined(separator: " · "))
                 .font(.caption2).foregroundStyle(.secondary)
@@ -452,6 +710,7 @@ struct ExerciseRowView: View {
     private var liftPanel: some View {
         LiftLogPanel(
             exercise: exercise,
+            isFocused: isFocused,
             previousSessionLog: previousSessionLog,
             exerciseLog: Binding(
                 get: { log?.exerciseLogs[exercise.id] ?? ExerciseLog(exerciseID: exercise.id, exerciseName: exercise.name) },
@@ -459,7 +718,8 @@ struct ExerciseRowView: View {
                     ensureLogMetadata()
                     log?.exerciseLogs[exercise.id] = $0
                 }
-            )
+            ),
+            onStartRest: onStartRest
         )
     }
 
@@ -485,7 +745,9 @@ struct ExerciseRowView: View {
 
     private var rowBG: Color {
         switch status {
-        case .completed: Color.status.success.opacity(0.03); case .missed: Color.status.error.opacity(0.03); default: Color(.systemBackground).opacity(0.5)
+        case .completed: Color.status.success.opacity(0.03)
+        case .missed: Color.status.error.opacity(0.03)
+        default: isFocused ? Color.white.opacity(0.72) : Color(.systemBackground).opacity(0.5)
         }
     }
 
@@ -513,47 +775,75 @@ struct ExerciseRowView: View {
 
 struct LiftLogPanel: View {
     let exercise: ExerciseDefinition
+    let isFocused: Bool
     let previousSessionLog: ExerciseLog?
     @Binding var exerciseLog: ExerciseLog
+    let onStartRest: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
             // Panel header
-            HStack {
-                Text("📋 SET LOG")
-                    .font(.caption2.monospaced()).foregroundStyle(Color.status.success).tracking(1)
-                Spacer()
-                if exerciseLog.totalVolume > 0 {
-                    Text("Total: \(Int(exerciseLog.totalVolume)) kg")
-                        .font(.caption2.monospaced()).foregroundStyle(Color.status.success.opacity(0.8))
-                }
-                if let prev = previousSessionLog, exerciseLog.sets.isEmpty {
-                    Button {
-                        exerciseLog.sets = prev.sets.enumerated().map { (i, s) in
-                            SetLog(
-                                setNumber: i + 1,
-                                weightKg: s.weightKg,
-                                repsCompleted: s.repsCompleted
-                            )
-                        }
-                    } label: {
-                        Label("Copy Last", systemImage: "bolt.fill")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(Color.accent.cyan)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text(isFocused ? "LIVE SET LOG" : "SET LOG")
+                        .font(.caption2.monospaced()).foregroundStyle(isFocused ? Color.blue : Color.status.success).tracking(1)
+                    Spacer()
+                    if exerciseLog.totalVolume > 0 {
+                        Text("Total: \(Int(exerciseLog.totalVolume)) kg")
+                            .font(.caption2.monospaced()).foregroundStyle(Color.status.success.opacity(0.8))
                     }
                 }
-                Button {
-                    exerciseLog.sets.append(SetLog(
-                        setNumber: exerciseLog.sets.count + 1,
-                        weightKg: exerciseLog.sets.last?.weightKg
-                    ))
-                } label: {
-                    Label("Add Set", systemImage: "plus.circle.fill")
-                        .font(.caption.weight(.semibold)).foregroundStyle(Color.status.success)
+
+                if let prev = previousSessionLog {
+                    HStack(spacing: 10) {
+                        previousPerformanceTile(
+                            title: "Last Best",
+                            value: prev.bestSet.map { "\((Int(($0.weightKg ?? 0).rounded()))) kg x \($0.repsCompleted ?? 0)" } ?? "—"
+                        )
+                        previousPerformanceTile(
+                            title: "Last Volume",
+                            value: prev.totalVolume > 0 ? "\(Int(prev.totalVolume)) kg" : "—"
+                        )
+                    }
+                }
+
+                HStack(spacing: 10) {
+                    if let prev = previousSessionLog, exerciseLog.sets.isEmpty {
+                        Button {
+                            exerciseLog.sets = prev.sets.enumerated().map { (i, s) in
+                                SetLog(
+                                    setNumber: i + 1,
+                                    weightKg: s.weightKg,
+                                    repsCompleted: s.repsCompleted
+                                )
+                            }
+                        } label: {
+                            Label("Copy Last", systemImage: "bolt.fill")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Color.accent.cyan)
+                        }
+                    }
+                    Button {
+                        exerciseLog.sets.append(SetLog(
+                            setNumber: exerciseLog.sets.count + 1,
+                            weightKg: exerciseLog.sets.last?.weightKg
+                        ))
+                    } label: {
+                        Label("Add Set", systemImage: "plus.circle.fill")
+                            .font(.caption.weight(.semibold)).foregroundStyle(Color.status.success)
+                    }
+                    Spacer()
+                    Button {
+                        onStartRest()
+                    } label: {
+                        Label("Start Rest", systemImage: "timer")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Color.appOrange2)
+                    }
                 }
             }
             .padding(.horizontal, 12).padding(.vertical, 8)
-            .background(Color.status.success.opacity(0.05))
+            .background((isFocused ? Color.blue.opacity(0.06) : Color.status.success.opacity(0.05)))
 
             // Column headers
             HStack(spacing: 0) {
@@ -562,7 +852,7 @@ struct LiftLogPanel: View {
                 Text("REPS").frame(width: 52)
                 Text("RPE").frame(width: 44)
                 Text("NOTE").frame(maxWidth: .infinity)
-                Spacer().frame(width: 28)
+                Text("DONE").frame(width: 56)
             }
             .font(.system(size: 9, design: .monospaced))
             .foregroundStyle(.tertiary)
@@ -575,6 +865,10 @@ struct LiftLogPanel: View {
                     setLog: $exerciseLog.sets[i],
                     setNum: i + 1,
                     previousSet: previousSessionLog?.sets.indices.contains(i) == true ? previousSessionLog?.sets[i] : nil,
+                    onCompleteSet: {
+                        exerciseLog.sets[i].timestamp = Date()
+                        onStartRest()
+                    },
                     onDelete: {
                         exerciseLog.sets.remove(at: i)
                         for j in exerciseLog.sets.indices { exerciseLog.sets[j].setNumber = j + 1 }
@@ -599,17 +893,44 @@ struct LiftLogPanel: View {
             .padding(10)
         }
     }
+
+    private func previousPerformanceTile(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.6), in: RoundedRectangle(cornerRadius: 10))
+    }
 }
 
 struct SetRowView: View {
     @Binding var setLog: SetLog
     let setNum:  Int
     let previousSet: SetLog?
+    let onCompleteSet: () -> Void
     let onDelete: () -> Void
 
     @State private var weightStr = ""
     @State private var repsStr   = ""
     @State private var noteStr   = ""
+
+    private var setIsComplete: Bool {
+        setLog.weightKg != nil && setLog.repsCompleted != nil
+    }
+
+    private func formattedWeight(_ value: Double) -> String {
+        if value.rounded() == value {
+            return String(Int(value))
+        }
+        return String(format: "%.1f", value)
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -622,9 +943,9 @@ struct SetRowView: View {
             // Weight
             if weightStr.isEmpty, let prev = previousSet, let prevWeight = prev.weightKg {
                 Button {
-                    weightStr = String(format: "%.1f", prevWeight)
+                    weightStr = formattedWeight(prevWeight)
                 } label: {
-                    Text(String(format: "%.1f", prevWeight))
+                    Text(formattedWeight(prevWeight))
                         .font(.system(.body, design: .monospaced))
                         .foregroundStyle(.tertiary)
                         .frame(maxWidth: .infinity)
@@ -680,20 +1001,28 @@ struct SetRowView: View {
                 .onChange(of: noteStr) { _, v in setLog.notes = v }
 
             // Delete
+            Button(action: onCompleteSet) {
+                Image(systemName: setIsComplete ? "checkmark.circle.fill" : "timer")
+                    .foregroundStyle(setIsComplete ? Color.status.success : Color.appOrange2)
+                    .font(.caption)
+            }
+            .frame(width: 28)
+
             Button(action: onDelete) {
                 Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary).font(.caption)
             }
             .frame(width: 28)
         }
         .padding(.horizontal, 12).padding(.vertical, 7)
+        .background(setIsComplete ? Color.status.success.opacity(0.03) : Color.clear)
         .onAppear {
-            weightStr = setLog.weightKg.map { String($0) } ?? ""
+            weightStr = setLog.weightKg.map(formattedWeight) ?? ""
             repsStr   = setLog.repsCompleted.map { String($0) } ?? ""
             noteStr   = setLog.notes
         }
         // Re-sync local strings if the binding is updated externally (e.g. CloudKit merge).
         .onChange(of: setLog) { _, newLog in
-            weightStr = newLog.weightKg.map { String($0) } ?? ""
+            weightStr = newLog.weightKg.map(formattedWeight) ?? ""
             repsStr   = newLog.repsCompleted.map { String($0) } ?? ""
             noteStr   = newLog.notes
         }

--- a/FitTrackerTests/FitTrackerCoreTests.swift
+++ b/FitTrackerTests/FitTrackerCoreTests.swift
@@ -94,4 +94,39 @@ final class FitTrackerCoreTests: XCTestCase {
         XCTAssertGreaterThan(progress, 0)
         XCTAssertLessThan(progress, 1)
     }
+
+    func testNutritionAdherencePointsFallBackToMealEntriesWhenTotalsAreMissing() {
+        let store = EncryptedDataStore()
+        var log = DailyLog(
+            date: Date(),
+            phase: .recovery,
+            dayType: .restDay,
+            recoveryDay: 1
+        )
+        log.nutritionLog.meals = [
+            MealEntry(mealNumber: 1, name: "Breakfast", calories: 400, proteinG: 30, carbsG: 20, fatG: 10, eatenAt: Date(), status: .completed),
+            MealEntry(mealNumber: 2, name: "Lunch", calories: 600, proteinG: 45, carbsG: 50, fatG: 15, eatenAt: Date(), status: .completed),
+        ]
+        store.dailyLogs = [log]
+
+        let points = store.nutritionAdherencePoints(from: .distantPast, to: .distantFuture)
+
+        XCTAssertEqual(points.count, 1)
+        XCTAssertEqual(points[0].calories, 1000, accuracy: 0.001)
+        XCTAssertEqual(points[0].proteinG, 75, accuracy: 0.001)
+    }
+
+    func testRecoveryDayUsesStartOfDayBoundaries() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate]
+        let profile = UserProfile(recoveryStart: formatter.date(from: "2026-01-29")!)
+
+        let sameDayLate = calendar.date(from: DateComponents(year: 2026, month: 1, day: 29, hour: 23, minute: 59))!
+        let nextDayEarly = calendar.date(from: DateComponents(year: 2026, month: 1, day: 30, hour: 0, minute: 1))!
+
+        XCTAssertEqual(profile.recoveryDay(for: sameDayLate, calendar: calendar), 0)
+        XCTAssertEqual(profile.recoveryDay(for: nextDayEarly, calendar: calendar), 1)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,24 +1,79 @@
 # FitTracker v2.0 — iOS · iPadOS · macOS
+
 ## Regev's Personal Training, Recovery & Body Composition Tracker
 
 ---
 
 ## 📋 Changelog
 
+### v2.0 — Full Redesign (March 2026)
+
+#### Design System
+
+- `AppTheme.swift`: added `Color.status` namespace (`success` #34C759, `warning` #FF9500, `error` #FF3B30) and `Color.accent` namespace (`cyan` #5AC8FA, `purple` #BF5AF2, `gold` #FFD60A)
+- `AppTheme.swift`: added `AppType` enum with type scale — `display` (34/bold), `headline` (20/semibold), `body` (15/medium), `subheading` (13/regular), `caption` (11/regular)
+- New shared components: `MetricCard`, `TrendIndicator`, `SectionHeader`, `StatusBadge`, `EmptyStateView`, `ChartCard`
+- All views migrated from hardcoded color/font literals to semantic tokens
+
+#### Home Screen
+
+- `ReadinessCard`: 5-page `TabView` replacing the static quick-stats row — Score + context, weekly training bars, nutrition snapshot, 6-metric trend indicators, achievements panel. Auto-cycles every 5 s; swipe resets timer
+- `readinessScore(for:fallbackMetrics:)`: 0–100 score from 30-day HRV/HR/sleep baseline; returns `nil` with <3 data points
+- Visual polish: orb glow shadow, angular gradient ring (`appOrange1 → accent.cyan → appOrange1`), linear gradient fill on goal progress bars
+- Weight/BF trend status dots (8pt circle) — green/red/yellow based on ±0.2 kg / ±0.3% BF over 7 days
+- Training button shows active day type and exercise count: `"💪 {DayType} · {N} ex"`
+
+#### Stats — Full Chart Implementation
+
+- Period picker (7D / 30D / 90D / All) + category tab bar (Body / Training / Recovery / Nutrition)
+- `StatsDataHelpers.swift`: pure data helpers — body composition points, training volume, Zone 2 minutes, recovery metrics, nutrition adherence, all-time PR records per exercise
+- **Body Composition tab**: Weight, Body Fat %, Lean Mass — `LineMark + AreaMark` with 7-day rolling average, target `RuleMark`, tap tooltip, drag scrub
+- **Training Performance tab**: Volume per session with PR annotations, per-exercise best set picker, Zone 2 minutes
+- **Recovery tab**: HRV with zone bands, Resting HR, Sleep, Readiness Score chart
+- **Nutrition Adherence tab**: Calories vs target (switches training/rest), Protein vs target, Supplement adherence %
+
+#### Nutrition — Meal Tracking
+
+- `MacroTargetBar`: stacked protein/carbs/fat bar with calorie target switching between training-day and rest-day targets
+- `MealSectionView`: 4 meal slots (Breakfast / Lunch / Dinner / Snacks) with status borders and placeholders
+- `MealEntrySheet`: 3-tab sheet — Manual entry with "Save as Template", Template library (persisted to disk), Search via OpenFoodFacts API + barcode scanner (iOS)
+- `mealTemplates` persistence in `EncryptedDataStore` — AES-256-GCM encrypted, not CloudKit-synced
+- Supplement row collapsed to pill buttons (Morning / Evening) + 🔥 streak badge + expand chevron
+
+#### Training Plan
+
+- 7-day week strip (Mon–Sun) replaces day type scroll picker — TODAY highlighted in orange, completion dot per day, rest days dimmed
+- Session type picker grid (6 buttons) below week strip — orange = suggested, blue = selected
+- Ghost weights: previous same-`dayType` session values shown as dimmed placeholders in empty set rows; tap to copy; "⚡ Copy Last" pre-fills all sets
+- RPE tap bar replaces popover — 5 segments `[6 7 8 9 10]`, tap again to clear
+- Session completion sheet: fires when all exercises marked complete — total volume + delta, exercises done, new PRs, session duration, "Log Notes" editor
+- `TrainingProgramStore.restWeekdays`: `[1, 4]` (Sunday + Wednesday)
+
+#### Auth Cleanup
+
+- `WelcomeView`: removed "Create Account" button + "Coming Soon" alert
+- `SignInView`: removed Google + Facebook sign-in rows; removed YubiKey info chip
+- `Info.plist`: removed `NSMicrophoneUsageDescription`
+
+---
+
 ### Code Quality & Security Hardening (March 2026)
 
-**Security — Critical fixes**
+#### Security — Critical Fixes
+
 - `EncryptionService`: fix `loadKeyFromKeychain` to pass `LAContext` and remove `kSecAttrAccessible` from query — prevents silent key regeneration on cold launch (was causing all encrypted data to become permanently unreadable)
 - `EncryptionService`: fix `rotateKeys` to re-encrypt all blobs before deleting old keys — prevents catastrophic data loss on partial failure
 - `CloudKitSyncService`: replace `try?` with proper `do/catch` on decrypt calls — decryption errors now logged instead of silently dropping records
 - `CloudKitSyncService`: removed 200-record hard limit — all records now fetched (was silently truncating data after ~6.5 months)
 - `EncryptionService`: guard `completeFileProtectionUnlessOpen` with `#if os(iOS)` — fixes macOS build
 
-**Concurrency**
+#### Concurrency
+
 - `HealthKitService`: call `done()` before `Task` in `HKObserverQuery` — fixes broken background delivery (future deliveries were silently stopping)
 - `AuthManager`: replace `DispatchQueue.main.async` with `Task { @MainActor in }` inside `@MainActor` class
 
-**Correctness**
+#### Correctness
+
 - `SignInService`: cache window before `performRequests()` — prevents `DispatchQueue.main.sync` deadlock on macOS
 - `SignInService`: store `userIdentifier` instead of `authorizationCode` as session token (single-use code must not be persisted)
 - `HealthKitService`: check `authorizationStatus` after `requestAuthorization` — `isAuthorized` now reflects actual permission state
@@ -26,26 +81,31 @@
 - `TrainingPlanView`: re-sync `SetRowView` local strings on binding change — prevents stale UI after CloudKit merge
 - `DomainModels`: replace `JSONEncoder`-based `DailyLog.==` with `id + date` comparison — fixes non-deterministic equality and unnecessary allocs
 
-**Architecture**
+#### Architecture
+
 - Extract `TrainingProgramStore` to its own file (`Services/TrainingProgramStore.swift`)
 - Add `AppTheme.swift` with shared `Color.appOrange1/2` and `Color.appBlue1/2` — removes copy-pasted palette constants from all four views
 
-**UI & Accessibility**
+#### UI & Accessibility
+
 - Add `.accessibilityLabel` / `.accessibilityValue` to `QuickStatPill` and `GoalProgressRow`
 - Dynamic Face ID / Touch ID label in `LockScreenView` via `LAContext.biometryType`
 - `WatchConnectivityService`: add `isWatchAppInstalled` check and `appNotInstalled` status case
 
-**Performance**
+#### Performance
+
 - Cache `DateFormatter` as `private static let` in `MainScreenView`, `NutritionView`, `CloudKitSyncService` — removes allocations on every body evaluation
 
-**Dead code**
+#### Dead Code
+
 - Remove unused `RecoveryBanner` component from `MainScreenView`
 
 ---
 
 ### Watch Connectivity & Navigation Bar (March 2026)
 
-**Watch Indicator (top-right)**
+#### Watch Indicator (top-right)
+
 - Replaced CloudKit sync status with Apple Watch connectivity indicator
 - New `WatchConnectivityService` using `WCSession` delegate — updates in real-time
 - 🟢 green dot + black **"Connected"** when watch is reachable
@@ -53,7 +113,8 @@
 - Faded dot + black **"No Watch"** / **"App Not Installed"** for pairing states
 - No pill/container background — blends into gradient
 
-**Hamburger Menu (top-left)**
+#### Hamburger Menu (top-left)
+
 - Icon changed from white to blue
 - No circular container or system background
 
@@ -61,7 +122,8 @@
 
 ### Home Screen Layout & Spacing (March 2026)
 
-**Equal spacing**
+#### Equal Spacing
+
 - Replace `Spacer(minLength: 10)` with `Spacer()` — SwiftUI now distributes remaining screen height equally across all four section gaps
 - `QuickStatPill` HStack spacing set to `0` — pills fill equal widths via `.frame(maxWidth: .infinity)`
 
@@ -69,7 +131,8 @@
 
 ### UI Refresh (March 2026)
 
-**Home Screen — Layout & Design**
+#### Home Screen — Layout & Design
+
 - Replaced scrollable layout with a fixed no-scroll VStack that fills the screen
 - Dynamic gradient background (orange → blue) that shifts based on overall goal progress
 - Right-edge vertical progress tracker bar
@@ -78,20 +141,24 @@
 - Start Training: play/pause button + dropdown to override today's day type inline
 - Renamed main tab from "Main" to "Home"
 
-**Navigation Bar**
+#### Navigation Bar
+
 - Hamburger menu button added (top-left) — opens account/settings panel as a sheet
 - Toolbar background hidden on Home tab — gradient shows through the nav bar
 
-**Colors & Contrast**
+#### Colors & Contrast
+
 - Replaced light blue tint with standard `.blue` across interactive elements for better contrast on the orange gradient
 - Warm palette applied consistently across Training Plan, Nutrition, and Stats tabs
 
-**Section Headers**
+#### Section Headers
+
 - Increased from 10pt semibold to 13pt black weight
 - Color changed from `.secondary` to `black.opacity(0.75)`
 - Added top/bottom padding for better spacing between header and content
 
-**Other**
+#### Other
+
 - `.gitignore` added; Xcode user state files removed from tracking
 - Various navigation UX fixes (NavigationStack, tab title display modes)
 
@@ -99,21 +166,23 @@
 
 ## 📁 File Structure
 
-```
+```text
 FitTracker/
 ├── FitTrackerApp.swift                     App entry point, lifecycle, service wiring
 ├── Models/
-│   ├── DomainModels.swift                  All data types (Codable, Sendable)
+│   ├── DomainModels.swift                  All data types (Codable, Sendable) incl. MealTemplate
 │   └── TrainingProgramData.swift           Complete 6-day program + supplements (static)
 ├── Services/
-│   ├── AppTheme.swift                      Shared Color constants (appOrange1/2, appBlue1/2)
+│   ├── AppTheme.swift                      Color tokens (appOrange, status.*, accent.*) + AppType scale
 │   ├── AppSettings.swift                   Unit system, appearance preferences
 │   ├── AuthManager.swift                   Face ID / Touch ID / Passcode biometric lock
-│   ├── TrainingProgramStore.swift          Today's day type detection + program store
+│   ├── TrainingProgramStore.swift          Today's day type detection + restWeekdays constant
 │   ├── WatchConnectivityService.swift      Apple Watch reachability via WCSession (iOS only)
 │   ├── Encryption/
 │   │   └── EncryptionService.swift         AES-256-GCM + ChaCha20-Poly1305 double encryption
 │   │                                       + EncryptedDataStore (persist/load/export)
+│   │                                       + mealTemplates persistence + supplementStreak
+│   │                                       + readinessScore(for:fallbackMetrics:)
 │   ├── CloudKit/
 │   │   └── CloudKitSyncService.swift       iCloud Private DB — encrypts BEFORE upload
 │   ├── HealthKit/
@@ -122,14 +191,27 @@ FitTracker/
 │       └── SignInService.swift             Passkey / Apple Sign-In authentication
 ├── Views/
 │   ├── RootTabView.swift                   4-tab navigation (iPhone tab bar / iPad sidebar)
+│   ├── Shared/
+│   │   ├── MetricCard.swift                Icon + value + unit + optional trend pill
+│   │   ├── TrendIndicator.swift            Coloured delta pill (↑/↓ %, auto status colour)
+│   │   ├── SectionHeader.swift             Bold section header with optional action button
+│   │   ├── StatusBadge.swift               Capsule pill with colour + text
+│   │   ├── EmptyStateView.swift            Icon + title + subtitle + optional CTA
+│   │   ├── ChartCard.swift                 Titled chart container with period label + trend
+│   │   └── ReadinessCard.swift             5-page auto-cycling readiness summary card
 │   ├── Main/
-│   │   └── MainScreenView.swift            Home: gradient bg, status cards, goal ring, training button
+│   │   └── MainScreenView.swift            Home: gradient bg, goal ring, ReadinessCard, training button
 │   ├── Training/
-│   │   └── TrainingPlanView.swift          Training plan: exercises + set/rep/weight log + cardio photo
+│   │   └── TrainingPlanView.swift          7-day week strip, session picker, ghost weights,
+│   │                                       RPE tap bar, completion summary sheet
 │   ├── Nutrition/
-│   │   └── NutritionView.swift             Supplement tracking: morning + evening stacks
+│   │   ├── NutritionView.swift             MacroTargetBar + meal section + collapsible supplements
+│   │   ├── MacroTargetBar.swift            Stacked macro bar with training/rest calorie targets
+│   │   ├── MealSectionView.swift           4 meal slot cards with status borders
+│   │   └── MealEntrySheet.swift            Manual / Template / Search (OpenFoodFacts + barcode)
 │   ├── Stats/
-│   │   └── StatsView.swift                 Stats (placeholder) + Settings view
+│   │   ├── StatsView.swift                 Period picker + Body/Training/Recovery/Nutrition charts
+│   │   └── StatsDataHelpers.swift          Pure data helpers for all chart data + PR records
 │   └── Auth/
 │       └── AccountPanelView.swift          Account sheet: profile, settings, sign out
 ├── FitTracker.entitlements                 HealthKit + CloudKit + Keychain + App Sandbox
@@ -141,6 +223,7 @@ FitTracker/
 ## 🛠 Xcode Setup — Step by Step
 
 ### Prerequisites
+
 - **Xcode 15.2+** (download from Mac App Store or developer.apple.com)
 - **Apple Developer Account** — any plan ($0/free for local testing, $99/yr for device + CloudKit)
 - **Real iPhone or iPad** — HealthKit doesn't run in Simulator
@@ -148,7 +231,7 @@ FitTracker/
 
 ### 1. Create the Xcode Project
 
-```
+```text
 File → New → Project
 Platform: iOS
 Template: App
@@ -164,6 +247,7 @@ Minimum Deployments: iOS 17.0
 ### 2. Import Source Files
 
 Drag the entire folder structure into Xcode's project navigator:
+
 - Tick **"Copy items if needed"**
 - Tick **"Add to target: FitTracker"**
 - Tick **"Create groups"**
@@ -173,7 +257,7 @@ Drag the entire folder structure into Xcode's project navigator:
 In **Xcode → Target → Signing & Capabilities**, add:
 
 | Capability | Settings |
-|---|---|
+| --- | --- |
 | **HealthKit** | Check "Background Delivery" + "Clinical Health Records" |
 | **iCloud** | Select "CloudKit", add container: `iCloud.com.fittracker.regev` |
 | **Keychain Sharing** | Add group: `com.fittracker.regev` |
@@ -182,26 +266,24 @@ In **Xcode → Target → Signing & Capabilities**, add:
 ### 4. CloudKit Schema Setup
 
 After adding iCloud capability:
+
 1. Open **CloudKit Console** → cloudkit.apple.com
-2. Select your container: `iCloud.com.fittracker.regev`
-3. Go to **Development → Record Types**, create these types:
+1. Select your container: `iCloud.com.fittracker.regev`
+1. Go to **Development → Record Types**, create these types:
 
 | Record Type | Fields |
-|---|---|
+| --- | --- |
 | `EncryptedDailyLog` | `encryptedBlob` (Bytes), `logicDate` (Date/Time), `recordVersion` (Int64) |
 | `EncryptedWeeklySnapshot` | `encryptedBlob` (Bytes), `logicDate` (Date/Time), `recordVersion` (Int64) |
 | `EncryptedUserProfile` | `encryptedBlob` (Bytes), `recordVersion` (Int64) |
 | `EncryptedCardioAsset` | `assetData` (Asset), `assetRef` (String), `recordVersion` (Int64) |
 
-4. Add an index on `logicDate` (sortable) for each record type.
+Add an index on `logicDate` (sortable) for each record type.
 
 > **Important:** CloudKit stores only encrypted blobs. The field names are non-sensitive. Never add plaintext fields.
+> **Note:** `mealTemplates` are stored on-device only — they are not synced to CloudKit.
 
-### 5. PhotosUI Permission (for cardio image capture)
-
-Already in `Info.plist`. No additional steps needed.
-
-### 6. Build & Run
+### 5. Build & Run
 
 ```bash
 # Command line (optional)
@@ -219,8 +301,8 @@ Or press **⌘R** in Xcode with your device selected.
 
 ### Double Encryption (every piece of data, always)
 
-```
-Plaintext  (DailyLog, ExerciseLog, CardioLog, etc.)
+```text
+Plaintext  (DailyLog, ExerciseLog, CardioLog, MealTemplate, etc.)
     │
     ▼ JSONEncoder
 Raw JSON bytes
@@ -250,6 +332,7 @@ Raw JSON bytes
 ```
 
 ### Three Separate Keys
+
 - `AES-256 key` — stored in Keychain, ACL: biometric OR device passcode
 - `ChaCha20 key` — stored in Keychain, ACL: biometric OR device passcode
 - `HMAC-SHA512 key` — stored in Keychain, ACL: biometric OR device passcode
@@ -257,6 +340,7 @@ Raw JSON bytes
 All three keys are: 256-bit random, device-only (not iCloud Keychain), access requires Face ID or passcode.
 
 ### Apple-Only Platform Enforcement
+
 - **iOS/iPadOS**: App Store distribution = Apple devices only, no sideloading without Apple account
 - **macOS**: Mac App Store + Hardened Runtime + App Sandbox
 - **Code-level**: `HealthKit`, `CryptoKit`, `LocalAuthentication`, `CloudKit` = Apple frameworks only
@@ -267,70 +351,89 @@ All three keys are: 256-bit random, device-only (not iCloud Keychain), access re
 
 ## 📱 App Screens
 
-### Tab 1 — Main Screen
+### Tab 1 — Home Screen
+
 - **Time-aware greeting**: Good morning / afternoon / evening / night
 - **Today's date** + recovery day counter + phase badge
-- **Dynamic gradient background**: orange → blue, shifts based on goal progress (0% = full orange, 100% = full blue)
+- **Dynamic gradient background**: orange → blue, shifts based on goal progress
 - **Right-edge vertical progress tracker**: thin bar showing overall goal completion
-- **Side-by-side status cards**: Weight (kg) and Body Fat (%) displayed as a pair. Tap pencil icon to log manually
-- **Goal section**: circular ring + Weight/Body Fat progress bars toward 65–68 kg @ 13–15% BF
-- **Start Training button**: play/pause control + dropdown to override today's scheduled day type
-- **Quick stats row**: HRV · Resting HR · Sleep · Steps (all from Apple Watch)
-- **Section headers**: bold, black, uppercase with letter-spacing — STATUS / GOAL / START TRAINING / METRICS
-- **Hamburger menu** (top-left): blue icon, no container, blends into gradient background
-- **Watch indicator** (top-right): green dot = Connected, faded dot = Offline/No Watch — black text, no pill container
+- **Side-by-side status cards**: Weight (kg) and Body Fat (%) with trend status dots (↑/↓/flat)
+- **Goal section**: circular ring with orb glow + Weight/Body Fat progress bars (angular gradient fill)
+- **ReadinessCard** (5-page, auto-cycles every 5 s):
+  - Page 1: Readiness score (0–100) + context label + HRV / Resting HR / Sleep
+  - Page 2: Mon–Sun weekly training bars + next session name
+  - Page 3: Protein progress + AM/PM supplement dots + water intake
+  - Page 4: 6-metric trend indicators (Weight, BF, HRV, Sleep, Volume, Steps)
+  - Page 5: Achievements — supplement streak 🔥, PRs this week 🏆, program day 📅
+- **Training button**: `"💪 {DayType} · {N} ex"` — shows exercise count for today
+- **Hamburger menu** (top-left): blue icon, no container
+- **Watch indicator** (top-right): green dot = Connected, faded dot = Offline/No Watch
 
 ### Tab 2 — Training Plan
-- **Day type picker**: scroll horizontally to switch between all 6 day types
+
+- **7-day week strip**: Mon–Sun with TODAY highlighted in orange; completion dot per day; rest days dimmed
+- **Session type picker**: 6-button grid — orange = weekday suggestion, blue = user override
 - **Session completion ring**: exercises done / total
 - **Exercise sections**: Machines → Free Weights → Calisthenics → Core → Cardio
 - **Per exercise**: coaching cue, muscle groups, target sets/reps/rest
 - **Status dropdown**: Completed / Partial / Missed / Reset
-- **On Completed → Lift panel**: set-by-set table (weight × reps × RPE × notes)
-- **On Completed → Cardio panel**: duration, avg HR, max HR, calories + type-specific fields
-- **Photo upload for Elliptical + Rowing**: Take Photo (camera) or Choose from Library
-- Uploaded photo stored as encrypted JPEG in `CardioLog.summaryImageData` and synced via CloudKit as `CKAsset`
+- **On Completed → Lift panel**: set-by-set table with ghost weights from last same-type session; tap ghost to copy; "⚡ Copy Last" pre-fills all sets; RPE tap bar (6–10, tap to deselect)
+- **On Completed → Cardio panel**: duration, avg HR, max HR, calories + type-specific fields; photo upload for Elliptical + Rowing
+- **Session completion sheet**: triggers when all exercises done — volume + delta vs previous session, PRs detected, session duration, notes editor
 
 ### Tab 3 — Nutrition
-- **Morning Stack** (7 supplements): per-supplement checkboxes + bulk "Mark all" dropdown
-- **Evening Stack** (3 supplements): same pattern
-- **Progress bar**: taken / total supplements for today
-- **Expandable rows**: tap ℹ️ to see full benefit rationale and timing notes
+
+- **MacroTargetBar**: stacked protein / carbs / fat bar; calorie target switches between training-day and rest-day targets from the active program phase
+- **Meal section**: 4 meal slots (Breakfast / Lunch / Dinner / Snacks); tap to open `MealEntrySheet`
+  - **Manual tab**: name + kcal + P/C/F; "Save as Template" persists entry for reuse
+  - **Template tab**: saved templates list; tap to auto-fill Manual tab
+  - **Search tab**: OpenFoodFacts API search + barcode scanner (iOS); results fill Manual tab
+- **Supplement row** (collapsible): Morning / Evening pill buttons + 🔥 streak badge; expand for full supplement cards with checkboxes and ℹ️ benefit details
 - **Haptic feedback** on every checkbox toggle
 
 ### Tab 4 — Stats
-- Empty placeholder, shows data counts
-- Scaffolded for future Charts integration (Apple Charts framework, iOS 16+ built-in)
+
+- **Period picker**: 7D / 30D / 90D / All (segmented, updates all charts)
+- **Category tabs**: Body / Training / Recovery / Nutrition
+- **Body Composition**: Weight (rolling avg + target line), Body Fat % (target line), Lean Mass — line + area charts; tap tooltip; drag scrub
+- **Training Performance**: Volume per session with PR stars, per-exercise best set (exercise picker), Zone 2 minutes
+- **Recovery**: HRV (zone bands), Resting HR, Sleep, Readiness Score trend
+- **Nutrition Adherence**: Calories vs target, Protein vs target, Supplement adherence %
+- Empty state shown for each chart when no data exists in the selected period
 
 ---
 
 ## 🎨 Figma → Xcode Workflow
 
-FitTracker ships with minimal styling — you style it in Figma, then bring tokens into Xcode.
+FitTracker ships with a full design token system in `AppTheme.swift`.
 
-### Recommended process:
-1. **Figma Desktop** → design at 390pt (iPhone 15 Pro canvas)
-2. Install **iOS 17 UI Kit** from Figma Community
-3. Use **Figma Variables** for colors/typography:
-   - Create a `FitTracker` library
-   - Define tokens: `color/accent`, `color/surface`, `color/background`, etc.
-4. Export tokens as JSON via **Tokens Studio** Figma plugin
-5. Convert to Swift using this pattern:
+### Token Reference
 
 ```swift
-// Generated from Figma tokens
-extension Color {
-    static let ftAccent      = Color("ftAccent")       // in Assets.xcassets
-    static let ftSurface     = Color("ftSurface")
-    static let ftBackground  = Color("ftBackground")
-}
+// Semantic status colours
+Color.status.success   // #34C759 — green
+Color.status.warning   // #FF9500 — orange
+Color.status.error     // #FF3B30 — red
+
+// Accent colours
+Color.accent.cyan      // #5AC8FA
+Color.accent.purple    // #BF5AF2
+Color.accent.gold      // #FFD60A
+
+// Type scale
+AppType.display        // 34pt bold
+AppType.headline       // 20pt semibold
+AppType.body           // 15pt medium
+AppType.subheading     // 13pt regular
+AppType.caption        // 11pt regular
 ```
 
-6. Add color sets to `Assets.xcassets` in Xcode (light + dark variants)
+### Recommended Process
 
-### Figma Dev Mode API (optional):
-- `api.figma.com/v1/files/{fileKey}` → JSON of all design tokens
-- Use this to auto-generate `Assets.xcassets` color sets if you want full automation
+1. **Figma Desktop** → design at 390pt (iPhone 15 Pro canvas)
+1. Install **iOS 17 UI Kit** from Figma Community
+1. Map Figma styles to `AppTheme` tokens above
+1. Export new tokens as JSON via **Tokens Studio** plugin, then add to `AppTheme.swift`
 
 ---
 
@@ -338,7 +441,7 @@ extension Color {
 
 Cursor supports Swift natively. Add this `.cursorrules` file to the project root:
 
-```
+```text
 # .cursorrules — FitTracker v2.0
 
 ## Project context
@@ -353,6 +456,7 @@ Cursor supports Swift natively. Add this `.cursorrules` file to the project root
 - Encryption: Services/Encryption/EncryptionService.swift (actor, thread-safe)
 - CloudKit: Services/CloudKit/CloudKitSyncService.swift (@MainActor)
 - Health: Services/HealthKit/HealthKitService.swift (@MainActor)
+- Design tokens: Services/AppTheme.swift (Color.status.*, Color.accent.*, AppType)
 
 ## Rules
 - NEVER store plaintext health data to disk
@@ -360,9 +464,11 @@ Cursor supports Swift natively. Add this `.cursorrules` file to the project root
 - Use async/await, never callbacks or DispatchQueue directly
 - Use @EnvironmentObject for dataStore, healthService, cloudSync, programStore
 - Use #if os(iOS) / #if os(macOS) for platform-specific code
-- New UI components go in the relevant Views/ subfolder
+- New UI components go in Views/Shared/ or the relevant Views/ subfolder
 - All new models must be Codable + Sendable
 - Encrypt any new persistent field before storage
+- Use Color.status.* / Color.accent.* instead of hardcoded color literals
+- Use AppType.* instead of .font(.system(size:))
 
 ## SwiftUI patterns used
 - @StateObject for service ownership in FitTrackerApp
@@ -377,14 +483,15 @@ Cursor supports Swift natively. Add this `.cursorrules` file to the project root
 ## 🚀 No External Dependencies
 
 | Framework | Use | Source |
-|---|---|---|
+| --- | --- | --- |
 | `SwiftUI` | All UI | Built-in |
+| `Charts` | Stats charts (iOS 16+) | Built-in |
 | `HealthKit` | Apple Watch / Health data | Built-in |
 | `CryptoKit` | AES-256-GCM + ChaCha20 + HMAC | Built-in |
 | `CloudKit` | iCloud encrypted sync | Built-in |
 | `LocalAuthentication` | Face ID / Passcode | Built-in |
 | `PhotosUI` | Photo picker for cardio images | Built-in |
+| `AVFoundation` | Barcode scanner in MealEntrySheet (iOS) | Built-in |
 | `WatchConnectivity` | Apple Watch reachability indicator | Built-in |
-| `Charts` | Stats charts (future) | Built-in (iOS 16+) |
 
 **Zero SPM / CocoaPods / Carthage dependencies required.**


### PR DESCRIPTION
## What's new in v3.0

A full UX/UI improvement pass across the entire app — reduced friction, smarter home screen, enhanced workout flow, polished design, and unified settings.

---

### 🏠 Smarter Home Screen
- Readiness score is now the headline element — large, colour-banded (green/cyan/orange/red), with a one-line context label
- AI coach tip chip that surfaces personalised hints based on HRV, Zone 2 minutes, and supplement adherence
- Inline emoji quick-log for Mood, Energy, and Cravings — single tap, no sheet
- Milestone celebration modals for first PR, 7/14/30/60/90-day streaks, and phase transitions

### 🏋️ Better Workout Flow
- Sets auto-advance after confirmation with a green flash + haptic
- Rest timer overlay starts automatically after each set, with haptic at T-0
- Estimated 1RM shown below each exercise using the Epley formula
- Progressive overload suggestions ("Try +2.5 kg today") when all reps were hit last session
- Distraction-free focus mode — full screen, hides all navigation chrome
- Session duration tracked from first set and shown on the completion sheet

### 📊 Richer Stats & Charts
- Tap any line chart to see a floating date + value tooltip
- ⓘ info buttons on readiness score and supplement streak explaining the calculation
- Empty states now have CTAs that link directly to the relevant logging screen

### ⚙️ Unified Settings
- All settings consolidated into one sheet (7 sections: Profile, Health & Watch, iCloud Sync, Security, Preferences, Nutrition, Training, Data)
- Zone 2 HR range and readiness thresholds are now user-configurable with live-preview sliders
- Meal slot names (Breakfast / Lunch / Dinner / Snacks) are editable per user

### 🎨 Design Polish
- Cards upgraded to `.ultraThinMaterial` with subtle shadows throughout
- Haptic feedback added at meaningful moments: set done, PR hit, supplement toggled, readiness loaded
- Animated number counters: readiness score counts up on appear, weight/BF values roll on HealthKit update
- Dark-mode status bar on all gradient-background screens
- Goal progress bar uses a clean one-shot ease-out animation instead of continuous looping

---

## Bug Fixes
- Fixed operator-precedence bug in recovery routine selection that was routing users to the wrong routine
- Wellness quick-log now goes through `upsertLog` so CloudKit sync correctly picks up mood/energy/craving changes
- Fixed silent keychain key regeneration — previously any keychain load error (not just "not found") would silently orphan all encrypted data and generate a new key
- Removed force-unwraps on `Calendar.date(byAdding:)` in StatsView and TrainingPlanView
- Fixed body-fat ×100 multiplication error in the AI export that was reporting 0% goal progress
- All hardcoded Zone 2 (106/124 bpm), HRV (28 ms), and resting HR (75 bpm) thresholds replaced with user-configurable `UserPreferences`

---

## Test Checklist
- [ ] Build succeeds with zero new warnings
- [ ] Readiness score headline is the first element on Home, colour changes with score range
- [ ] Tapping an emoji in the wellness quick-log saves immediately with no sheet
- [ ] Milestone modal fires on first PR and auto-dismisses after 2 seconds
- [ ] Rest timer starts after confirming a set; haptic fires when it hits zero
- [ ] Settings sheet opens from the profile panel with all 7 sections visible
- [ ] Changing Zone 2 range in Settings updates the Zone 2 stats immediately
- [ ] Editing a meal slot name in Settings appears in the Nutrition view
- [ ] Tapping a line chart shows a floating tooltip with date and value
