### PR TITLE
Extract auth redesign into merge-ready branch

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		A1000001000000000000000F /* AccountPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001000000000000000F /* AccountPanelView.swift */; };
 		A10000010000000000000010 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000010 /* SignInView.swift */; };
 		A10000010000000000000011 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000011 /* WelcomeView.swift */; };
+		A10000010000000000000015 /* AuthValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000015 /* AuthValidation.swift */; };
+		A10000010000000000000016 /* AuthHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000016 /* AuthHubView.swift */; };
 		CC000001000000000000AA01 /* ReadinessCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA01 /* ReadinessCard.swift */; };
 		CC000001000000000000AA02 /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA02 /* SectionHeader.swift */; };
 		CC000001000000000000AA03 /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA03 /* StatusBadge.swift */; };
@@ -64,6 +66,8 @@
 		A2000001000000000000000F /* AccountPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountPanelView.swift; sourceTree = "<group>"; };
 		A20000010000000000000010 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		A20000010000000000000011 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
+		A20000010000000000000015 /* AuthValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthValidation.swift; sourceTree = "<group>"; };
+		A20000010000000000000016 /* AuthHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHubView.swift; sourceTree = "<group>"; };
 		A20000010000000000000012 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A20000010000000000000013 /* FitTracker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FitTracker.entitlements; sourceTree = "<group>"; };
 		A20000010000000000000014 /* FitTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FitTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -185,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000010000000000000005 /* SignInService.swift */,
+				A20000010000000000000015 /* AuthValidation.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -276,6 +281,7 @@
 			isa = PBXGroup;
 			children = (
 				A2000001000000000000000F /* AccountPanelView.swift */,
+				A20000010000000000000016 /* AuthHubView.swift */,
 				A20000010000000000000010 /* SignInView.swift */,
 				A20000010000000000000011 /* WelcomeView.swift */,
 			);
@@ -391,6 +397,7 @@
 				A10000010000000000000003 /* TrainingProgramData.swift in Sources */,
 				A10000010000000000000004 /* AuthManager.swift in Sources */,
 				A10000010000000000000005 /* SignInService.swift in Sources */,
+				A10000010000000000000015 /* AuthValidation.swift in Sources */,
 				A10000010000000000000006 /* HealthKitService.swift in Sources */,
 				A10000010000000000000007 /* CloudKitSyncService.swift in Sources */,
 				A10000010000000000000008 /* AppSettings.swift in Sources */,
@@ -404,6 +411,7 @@
 				A1000001000000000000000D /* TrainingPlanView.swift in Sources */,
 				A1000001000000000000000E /* StatsView.swift in Sources */,
 				A1000001000000000000000F /* AccountPanelView.swift in Sources */,
+				A10000010000000000000016 /* AuthHubView.swift in Sources */,
 				A10000010000000000000010 /* SignInView.swift in Sources */,
 				A10000010000000000000011 /* WelcomeView.swift in Sources */,
 				CC000001000000000000AA01 /* ReadinessCard.swift in Sources */,

--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -24,10 +24,8 @@ struct FitTrackerApp: App {
             rootView
                 // Apply appearance preference from settings
                 .preferredColorScheme(settings.appearance.colorScheme)
-                // Load encrypted data after biometric auth — EncryptionService has a valid
-                // session context at this point, so no extra biometric prompts fire.
-                .onChange(of: biometricAuth.isAuthenticated) { _, authenticated in
-                    if authenticated {
+                .onChange(of: signIn.activeSession) { _, session in
+                    if session != nil {
                         Task {
                             await dataStore.loadFromDisk()
                             if scenePhase == .active {
@@ -40,10 +38,14 @@ struct FitTrackerApp: App {
                     switch phase {
                     case .active:
                         signIn.restoreSession()
-                        guard biometricAuth.isAuthenticated else { break }
-                        Task { await cloudSync.fetchChanges(dataStore: dataStore) }
+                        guard signIn.isAuthenticated else { break }
+                        Task {
+                            await dataStore.loadFromDisk()
+                            await cloudSync.fetchChanges(dataStore: dataStore)
+                        }
                     case .background:
                         if settings.requireBiometricUnlockOnReopen {
+                            signIn.lockForReopen()
                             biometricAuth.lockOnBackground(clearCryptoSession: false)
                         }
                         Task {
@@ -68,6 +70,7 @@ struct FitTrackerApp: App {
                     .environmentObject(healthService)
                     .environmentObject(cloudSync)
                     .environmentObject(settings)
+                    .environmentObject(watchService)
         }
         #endif
     }
@@ -76,29 +79,21 @@ struct FitTrackerApp: App {
     // welcome → signIn (sheet) → authenticated → biometricLock → app
     @ViewBuilder
     private var rootView: some View {
-        switch signIn.state {
-
-        case .welcome, .signIn, .error:
-            // Not yet signed in → show welcome / sign-in flow
-            WelcomeView()
+        if signIn.isAuthenticated {
+            RootTabView()
                 .environmentObject(signIn)
-
-        case .authenticated:
-            // Signed in → check biometric lock
-            if !biometricAuth.isAuthenticated {
-                LockScreenView()
-                    .environmentObject(biometricAuth)
-            } else {
-                RootTabView()
-                    .environmentObject(signIn)
-                    .environmentObject(biometricAuth)
-                    .environmentObject(healthService)
-                    .environmentObject(dataStore)
-                    .environmentObject(cloudSync)
-                    .environmentObject(programStore)
-                    .environmentObject(settings)
-                    .environmentObject(watchService)
-            }
+                .environmentObject(biometricAuth)
+                .environmentObject(healthService)
+                .environmentObject(dataStore)
+                .environmentObject(cloudSync)
+                .environmentObject(programStore)
+                .environmentObject(settings)
+                .environmentObject(watchService)
+        } else {
+            AuthHubView()
+                .environmentObject(signIn)
+                .environmentObject(biometricAuth)
+                .environmentObject(settings)
         }
     }
 }

--- a/FitTracker/Services/AppTheme.swift
+++ b/FitTracker/Services/AppTheme.swift
@@ -4,11 +4,25 @@
 
 import SwiftUI
 
+enum AppBrand {
+    static let name = "FitMe"
+}
+
 extension Color {
     static let appOrange1 = Color(red: 1.0,  green: 0.89, blue: 0.73)
     static let appOrange2 = Color(red: 1.0,  green: 0.78, blue: 0.54)
+    static let appOrange3 = Color(red: 0.98, green: 0.56, blue: 0.25)
     static let appBlue1   = Color(red: 0.73, green: 0.89, blue: 1.0)
     static let appBlue2   = Color(red: 0.54, green: 0.78, blue: 1.0)
+    static let appBlue3   = Color(red: 0.87, green: 0.95, blue: 1.0)
+    static let appBlue4   = Color(red: 0.94, green: 0.98, blue: 1.0)
+    static let appSurface = Color.white.opacity(0.72)
+    static let appStroke  = Color.white.opacity(0.54)
+    static let appTextPrimary = Color.black.opacity(0.84)
+    static let appTextSecondary = Color.black.opacity(0.58)
+    static let appTextTertiary = Color.black.opacity(0.42)
+    static let appAccentPrimary = appOrange3
+    static let appAccentSoft = appOrange1.opacity(0.34)
 
     // Status colour tokens
     enum status {
@@ -32,4 +46,20 @@ enum AppType {
     static let body       = Font.system(size: 15, weight: .medium)
     static let subheading = Font.system(size: 13, weight: .regular)
     static let caption    = Font.system(size: 11, weight: .regular)
+}
+
+enum AppGradient {
+    static let screenBackground = LinearGradient(
+        colors: [.appBlue4, .appBlue3, .appBlue1, .appBlue2.opacity(0.9)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    static let authBackground = screenBackground
+
+    static let brand = LinearGradient(
+        colors: [.appOrange3, .appOrange2, .appOrange1],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
 }

--- a/FitTracker/Services/Auth/AuthValidation.swift
+++ b/FitTracker/Services/Auth/AuthValidation.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+struct PasswordValidationResult: Equatable {
+    var issues: [String]
+    var isValid: Bool { issues.isEmpty }
+}
+
+enum PasswordRuleEvaluator {
+    static let minimumLength = 8
+    static let guidanceText = "Use 8 or more characters. Longer passphrases work great."
+
+    static func validate(_ password: String) -> PasswordValidationResult {
+        var issues: [String] = []
+
+        if password.count < minimumLength {
+            issues.append("Use at least \(minimumLength) characters.")
+        }
+
+        return PasswordValidationResult(issues: issues)
+    }
+}
+
+enum AuthInputValidator {
+    static func isValidEmail(_ email: String) -> Bool {
+        let pattern = #"^[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}$"#
+        return email.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+}
+
+struct EmailRegistrationFormState: Equatable, Sendable {
+    var firstName = ""
+    var lastName = ""
+    var email = ""
+    var password = ""
+    var confirmPassword = ""
+
+    func normalizedDraft() -> PendingEmailRegistration {
+        PendingEmailRegistration(
+            firstName: firstName.trimmingCharacters(in: .whitespacesAndNewlines),
+            lastName: lastName.trimmingCharacters(in: .whitespacesAndNewlines),
+            email: email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+            password: password
+        )
+    }
+
+    func validationErrors() -> [String: String] {
+        var errors: [String: String] = [:]
+
+        if firstName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors["firstName"] = "Enter your first name."
+        }
+        if lastName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors["lastName"] = "Enter your last name."
+        }
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedEmail.isEmpty {
+            errors["email"] = "Enter your email address."
+        } else if !AuthInputValidator.isValidEmail(normalizedEmail) {
+            errors["email"] = "Enter a valid email address."
+        }
+
+        let passwordResult = PasswordRuleEvaluator.validate(password)
+        if !passwordResult.isValid {
+            errors["password"] = passwordResult.issues.first
+        }
+        if confirmPassword.isEmpty {
+            errors["confirmPassword"] = "Confirm your password."
+        } else if confirmPassword != password {
+            errors["confirmPassword"] = "Passwords must match."
+        }
+
+        return errors
+    }
+
+    var isValid: Bool { validationErrors().isEmpty }
+}
+
+struct EmailLoginFormState: Equatable, Sendable {
+    var email = ""
+    var password = ""
+
+    var normalizedEmail: String {
+        email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    func validationError() -> String? {
+        if normalizedEmail.isEmpty {
+            return "Enter your email address."
+        }
+        if !AuthInputValidator.isValidEmail(normalizedEmail) {
+            return "Enter a valid email address."
+        }
+        if password.isEmpty {
+            return "Enter your password."
+        }
+        return nil
+    }
+}
+
+enum VerificationCodeState: Equatable {
+    case idle
+    case invalid(String)
+    case verifying
+    case accepted
+}

--- a/FitTracker/Services/Auth/SignInService.swift
+++ b/FitTracker/Services/Auth/SignInService.swift
@@ -1,12 +1,8 @@
 // Services/Auth/SignInService.swift
-// Full sign-in service:
-//   - Sign in with Apple   (AuthenticationServices — native, no SDK)
-//   - Google Sign-In       (GoogleSignIn SDK via SPM)
-//   - Facebook Login       (FacebookSDK via SPM)
-//   - Passkey / WebAuthn   (AuthenticationServices ASAuthorizationController)
-//   - YubiKey / FIDO2 hardware key (ASAuthorizationPlatformPublicKeyCredentialProvider)
-//
-// Platform: iOS 17+, iPadOS 17+, macOS 14+
+// Session + auth flow manager for:
+//   - Sign in with Apple
+//   - Email registration / verification / login (adapter-backed, mockable)
+//   - Passkey / WebAuthn login and registration
 
 import Foundation
 import AuthenticationServices
@@ -18,26 +14,20 @@ import UIKit
 import AppKit
 #endif
 
-#if os(iOS)
-typealias PlatformViewController = UIViewController
-#elseif os(macOS)
-typealias PlatformViewController = NSViewController
-#endif
-
 // ─────────────────────────────────────────────────────────
 // MARK: – Session model
 // ─────────────────────────────────────────────────────────
 
 struct UserSession: Codable, Sendable, Equatable {
     var provider:      AuthProvider
-    var userID:        String       // provider's unique user ID
+    var userID:        String
     var displayName:   String
     var email:         String?
     var phone:         String?
     var avatarURL:     URL?
-    var sessionToken:  String       // provider access token / Apple auth code
-    var credentialID:  Data?        // passkey credential ID (if passkey login)
-    var signedInAt:    Date         = Date()
+    var sessionToken:  String
+    var credentialID:  Data?
+    var signedInAt:    Date = Date()
 
     var initials: String {
         let parts = displayName.split(separator: " ")
@@ -49,14 +39,9 @@ struct UserSession: Codable, Sendable, Equatable {
 
 enum AuthProvider: String, Codable, Sendable {
     case apple    = "Apple"
-    case google   = "Google"
-    case facebook = "Facebook"
     case passkey  = "Passkey"
+    case email    = "Email"
 }
-
-// ─────────────────────────────────────────────────────────
-// MARK: – Auth state
-// ─────────────────────────────────────────────────────────
 
 enum AuthState: Equatable {
     case welcome
@@ -65,65 +50,369 @@ enum AuthState: Equatable {
     case error(String)
 }
 
-// ─────────────────────────────────────────────────────────
-// MARK: – Sign-In Service
-// ─────────────────────────────────────────────────────────
+enum AuthRoute: Hashable {
+    case emailVerification
+    case passwordReset(prefillEmail: String)
+}
+
+struct PendingEmailRegistration: Codable, Hashable, Sendable {
+    var firstName: String
+    var lastName: String
+    var email: String
+    var password: String
+
+    var fullName: String {
+        [firstName, lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+struct EmailRegistrationChallenge: Codable, Hashable, Sendable {
+    var email: String
+    var expectedCode: String
+    var expiresAt: Date
+}
+
+protocol AppleAuthProviding {
+    @MainActor
+    func startSignIn(using service: SignInService)
+}
+
+protocol EmailAuthProviding {
+    func register(_ draft: PendingEmailRegistration) async throws -> EmailRegistrationChallenge
+    func verify(code: String, challenge: EmailRegistrationChallenge, draft: PendingEmailRegistration) async throws -> UserSession
+    func login(email: String, password: String) async throws -> UserSession
+    func resendRegistrationCode(challenge: EmailRegistrationChallenge, draft: PendingEmailRegistration) async throws -> EmailRegistrationChallenge
+    func requestPasswordReset(email: String) async throws
+}
+
+struct SystemAppleAuthProvider: AppleAuthProviding {
+    @MainActor
+    func startSignIn(using service: SignInService) {
+        service.startSystemAppleSignIn()
+    }
+}
+
+struct MockEmailAuthProvider: EmailAuthProviding {
+    func register(_ draft: PendingEmailRegistration) async throws -> EmailRegistrationChallenge {
+        try await Task.sleep(for: .milliseconds(600))
+        return EmailRegistrationChallenge(
+            email: draft.email,
+            expectedCode: "48291",
+            expiresAt: Date().addingTimeInterval(600)
+        )
+    }
+
+    func verify(code: String, challenge: EmailRegistrationChallenge, draft: PendingEmailRegistration) async throws -> UserSession {
+        try await Task.sleep(for: .milliseconds(400))
+
+        guard Date() <= challenge.expiresAt else {
+            throw NSError(
+                domain: "FitTracker.Auth",
+                code: 410,
+                userInfo: [NSLocalizedDescriptionKey: "This verification code expired. Please request a new one."]
+            )
+        }
+
+        guard code == challenge.expectedCode else {
+            throw NSError(
+                domain: "FitTracker.Auth",
+                code: 401,
+                userInfo: [NSLocalizedDescriptionKey: "The verification code is incorrect."]
+            )
+        }
+
+        return UserSession(
+            provider: .email,
+            userID: draft.email.lowercased(),
+            displayName: draft.fullName,
+            email: draft.email,
+            sessionToken: UUID().uuidString
+        )
+    }
+
+    func login(email: String, password: String) async throws -> UserSession {
+        try await Task.sleep(for: .milliseconds(500))
+
+        guard !email.isEmpty, !password.isEmpty else {
+            throw NSError(
+                domain: "FitTracker.Auth",
+                code: 400,
+                userInfo: [NSLocalizedDescriptionKey: "Enter your email and password to continue."]
+            )
+        }
+
+        let inferredName = email.split(separator: "@").first
+            .map { $0.replacingOccurrences(of: ".", with: " ").capitalized }
+            ?? "\(AppBrand.name) User"
+
+        return UserSession(
+            provider: .email,
+            userID: email.lowercased(),
+            displayName: inferredName,
+            email: email,
+            sessionToken: UUID().uuidString
+        )
+    }
+
+    func resendRegistrationCode(challenge: EmailRegistrationChallenge, draft: PendingEmailRegistration) async throws -> EmailRegistrationChallenge {
+        try await Task.sleep(for: .milliseconds(350))
+
+        return EmailRegistrationChallenge(
+            email: draft.email,
+            expectedCode: challenge.expectedCode,
+            expiresAt: Date().addingTimeInterval(600)
+        )
+    }
+
+    func requestPasswordReset(email: String) async throws {
+        try await Task.sleep(for: .milliseconds(450))
+
+        guard !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw NSError(
+                domain: "FitTracker.Auth",
+                code: 400,
+                userInfo: [NSLocalizedDescriptionKey: "Enter your email address to continue."]
+            )
+        }
+    }
+}
 
 @MainActor
 final class SignInService: NSObject, ObservableObject {
 
-    @Published var state:      AuthState = .welcome
-    @Published var isLoading:  Bool      = false
+    @Published var isLoading = false
+    @Published var navigationPath: [AuthRoute] = []
+    @Published var authErrorMessage: String?
+    @Published var statusMessage: String?
+    @Published private(set) var activeSession: UserSession?
+    @Published private(set) var storedSession: UserSession?
+    @Published private(set) var pendingEmailRegistration: PendingEmailRegistration?
+    @Published private(set) var pendingEmailChallenge: EmailRegistrationChallenge?
+    @Published private(set) var hasRegisteredPasskey: Bool
 
-    // Passkey / YubiKey challenge (from server in production)
+    private let appleProvider: AppleAuthProviding
+    private let emailProvider: EmailAuthProviding
+
     private var currentChallenge: Data = Data()
+    private var pendingUserHandle: String = ""
+    private var pendingDisplayName: String = ""
 
-    // Stored before performRequests() so the nonisolated delegate callback can read them.
-    private var pendingUserHandle:   String = ""
-    private var pendingDisplayName:  String = ""
-
-    // Cached window reference for ASAuthorizationControllerPresentationContextProviding.
-    // Populated on the main actor before performRequests() is called, so the nonisolated
-    // delegate callback never needs to call DispatchQueue.main.sync (which deadlocks on macOS
-    // when the delegate is invoked from the main thread).
     #if os(iOS)
     private var cachedWindow: UIWindow?
     #elseif os(macOS)
     private var cachedWindow: NSWindow?
     #endif
 
-    var isAuthenticated: Bool {
-        if case .authenticated = state { return true }
-        return false
+    override init() {
+        self.appleProvider = SystemAppleAuthProvider()
+        self.emailProvider = MockEmailAuthProvider()
+        self.hasRegisteredPasskey = UserDefaults.standard.bool(forKey: Self.passkeyRegisteredKey)
+        super.init()
     }
 
-    var currentSession: UserSession? {
-        if case .authenticated(let s) = state { return s }
-        return nil
+    init(
+        appleProvider: AppleAuthProviding,
+        emailProvider: EmailAuthProviding
+    ) {
+        self.appleProvider = appleProvider
+        self.emailProvider = emailProvider
+        self.hasRegisteredPasskey = UserDefaults.standard.bool(forKey: Self.passkeyRegisteredKey)
+        super.init()
     }
 
-    var isPasskeyConfigured: Bool {
-        passkeyRelyingPartyIdentifier != nil
+    static let sessionKey = "ft.session"
+    private static let passkeyRegisteredKey = "ft.passkeyRegistered"
+
+    var state: AuthState {
+        if let activeSession {
+            return .authenticated(activeSession)
+        }
+        if let authErrorMessage {
+            return .error(authErrorMessage)
+        }
+        return .welcome
     }
 
-    // ── Restore session from Keychain on launch ───────────
+    var isAuthenticated: Bool { activeSession != nil }
+    var currentSession: UserSession? { activeSession ?? storedSession }
+    var hasStoredSession: Bool { storedSession != nil }
+    var isPasskeyConfigured: Bool { passkeyRelyingPartyIdentifier != nil }
+    var canShowPasskeyLogin: Bool { hasRegisteredPasskey && isPasskeyConfigured }
+
     func restoreSession() {
-        if let data = KeychainHelper.load(key: "ft.session"),
+        guard activeSession == nil else { return }
+
+        if let data = KeychainHelper.load(key: Self.sessionKey),
            let session = try? JSONDecoder().decode(UserSession.self, from: data) {
-            state = .authenticated(session)
+            storedSession = session
         } else {
-            state = .welcome
+            storedSession = nil
         }
     }
 
-    // ─────────────────────────────────────────────────────
-    // MARK: – Sign in with Apple
-    // ─────────────────────────────────────────────────────
+    func lockForReopen() {
+        activeSession = nil
+        statusMessage = nil
+        authErrorMessage = nil
+        navigationPath.removeAll()
+    }
+
+    func resumeStoredSession() {
+        guard let storedSession else { return }
+        activeSession = storedSession
+        authErrorMessage = nil
+        statusMessage = nil
+        navigationPath.removeAll()
+    }
+
+    func signOut() {
+        KeychainHelper.delete(key: Self.sessionKey)
+        activeSession = nil
+        storedSession = nil
+        pendingEmailRegistration = nil
+        pendingEmailChallenge = nil
+        navigationPath.removeAll()
+        authErrorMessage = nil
+        statusMessage = nil
+    }
+
+    func showPasswordReset(prefillEmail: String = "") {
+        authErrorMessage = nil
+        statusMessage = nil
+        navigationPath = [.passwordReset(prefillEmail: prefillEmail)]
+    }
+
+    func clearFeedback() {
+        authErrorMessage = nil
+        statusMessage = nil
+    }
+
+    func resetToEntry(keepingStatus: Bool = false) {
+        authErrorMessage = nil
+        if !keepingStatus {
+            statusMessage = nil
+        }
+        navigationPath.removeAll()
+    }
+
+    func startEmailRegistration(_ draft: PendingEmailRegistration) async {
+        isLoading = true
+        authErrorMessage = nil
+        statusMessage = nil
+
+        do {
+            let challenge = try await emailProvider.register(draft)
+            pendingEmailRegistration = draft
+            pendingEmailChallenge = challenge
+            navigationPath = [.emailVerification]
+            isLoading = false
+        } catch {
+            isLoading = false
+            authErrorMessage = error.localizedDescription
+        }
+    }
+
+    func verifyEmailRegistrationCode(_ code: String) async {
+        guard let draft = pendingEmailRegistration,
+              let challenge = pendingEmailChallenge else {
+            authErrorMessage = "Your registration session expired. Please start again."
+            resetToEntry()
+            return
+        }
+
+        isLoading = true
+        authErrorMessage = nil
+
+        do {
+            let session = try await emailProvider.verify(code: code, challenge: challenge, draft: draft)
+            pendingEmailRegistration = nil
+            pendingEmailChallenge = nil
+            finishSignIn(session)
+            statusMessage = "Your email is verified and your account is ready."
+        } catch {
+            isLoading = false
+            authErrorMessage = error.localizedDescription
+        }
+    }
+
+    func resendEmailRegistrationCode() async {
+        guard let draft = pendingEmailRegistration,
+              let challenge = pendingEmailChallenge else {
+            authErrorMessage = "Your registration session expired. Please start again."
+            resetToEntry()
+            return
+        }
+
+        isLoading = true
+        authErrorMessage = nil
+        statusMessage = nil
+
+        do {
+            let refreshedChallenge = try await emailProvider.resendRegistrationCode(challenge: challenge, draft: draft)
+            pendingEmailChallenge = refreshedChallenge
+            statusMessage = "We sent a fresh verification code."
+            isLoading = false
+        } catch {
+            isLoading = false
+            authErrorMessage = error.localizedDescription
+        }
+    }
+
+    func signInWithEmail(email: String, password: String) async {
+        isLoading = true
+        authErrorMessage = nil
+        statusMessage = nil
+
+        do {
+            let session = try await emailProvider.login(email: email, password: password)
+            finishSignIn(session)
+        } catch {
+            isLoading = false
+            authErrorMessage = error.localizedDescription
+        }
+    }
+
+    func requestPasswordReset(email: String) async {
+        isLoading = true
+        authErrorMessage = nil
+        statusMessage = nil
+
+        do {
+            try await emailProvider.requestPasswordReset(email: email)
+            statusMessage = "If that email is registered, a password reset link is on the way."
+            isLoading = false
+        } catch {
+            isLoading = false
+            authErrorMessage = error.localizedDescription
+        }
+    }
 
     func signInWithApple() {
+        authErrorMessage = nil
+        statusMessage = nil
         isLoading = true
-        // Cache the window on the main actor NOW, before handing off to the delegate which
-        // is nonisolated. This avoids the DispatchQueue.main.sync deadlock on macOS.
+        appleProvider.startSignIn(using: self)
+    }
+
+    func prepareAppleSignInRequest(_ request: ASAuthorizationAppleIDRequest) {
+        authErrorMessage = nil
+        statusMessage = nil
+        isLoading = true
+
+        let nonce = generateNonce()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+    }
+
+    func handleAppleSignInResult(_ result: Result<ASAuthorization, Error>) {
+        handleAuthorizationResult(result)
+    }
+
+    @MainActor
+    func startSystemAppleSignIn() {
         #if os(iOS)
         cachedWindow = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
@@ -133,7 +422,7 @@ final class SignInService: NSObject, ObservableObject {
         cachedWindow = NSApplication.shared.windows.first
         #endif
 
-        let nonce   = generateNonce()
+        let nonce = generateNonce()
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.fullName, .email]
         request.nonce = sha256(nonce)
@@ -144,96 +433,17 @@ final class SignInService: NSObject, ObservableObject {
         controller.performRequests()
     }
 
-    // ─────────────────────────────────────────────────────
-    // MARK: – Sign in with Google
-    // ─────────────────────────────────────────────────────
-    // Google Sign-In SDK: add to SPM as https://github.com/google/GoogleSignIn-iOS
-    // Client ID in Info.plist key: GIDClientID = YOUR_CLIENT_ID.apps.googleusercontent.com
-
-    func signInWithGoogle(presenting: PlatformViewController?) {
+    func signInWithPasskey(userHandle: String? = nil) {
         isLoading = true
+        authErrorMessage = nil
+        statusMessage = nil
 
-        // ── SPM dependency: GoogleSignIn ────────────────
-        // import GoogleSignIn (uncomment when SDK added to project)
-        //
-        // GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: googleClientID)
-        // GIDSignIn.sharedInstance.signIn(withPresenting: presenting ?? UIViewController()) { result, error in
-        //     Task { @MainActor in
-        //         self.isLoading = false
-        //         if let error { self.state = .error(error.localizedDescription); return }
-        //         guard let user = result?.user else { return }
-        //         let session = UserSession(
-        //             provider: .google,
-        //             userID: user.userID ?? UUID().uuidString,
-        //             displayName: user.profile?.name ?? "Google User",
-        //             email: user.profile?.email,
-        //             sessionToken: user.idToken?.tokenString ?? ""
-        //         )
-        //         self.finishSignIn(session)
-        //     }
-        // }
-
-        // ── Fallback stub until SDK is added ──────────
-        simulateSignIn(provider: .google, name: "Google User", email: "user@gmail.com")
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Sign in with Facebook
-    // ─────────────────────────────────────────────────────
-    // Facebook SDK: add to SPM as https://github.com/facebook/facebook-ios-sdk
-    // App ID in Info.plist: FacebookAppID, FacebookClientToken, LSApplicationQueriesSchemes
-
-    func signInWithFacebook(presenting: PlatformViewController?) {
-        isLoading = true
-
-        // ── SPM dependency: FacebookLogin ───────────────
-        // import FacebookLogin (uncomment when SDK added to project)
-        //
-        // let manager = LoginManager()
-        // manager.logIn(permissions: [.publicProfile, .email], from: presenting) { result, error in
-        //     Task { @MainActor in
-        //         self.isLoading = false
-        //         if let error { self.state = .error(error.localizedDescription); return }
-        //         guard case .success(let granted, _, let token) = result, !granted.isEmpty else { return }
-        //
-        //         // Fetch profile via Graph API
-        //         GraphRequest(graphPath: "me", parameters: ["fields": "id,name,email"]).start { _, result, _ in
-        //             Task { @MainActor in
-        //                 let dict = result as? [String: String] ?? [:]
-        //                 let session = UserSession(
-        //                     provider: .facebook,
-        //                     userID: dict["id"] ?? UUID().uuidString,
-        //                     displayName: dict["name"] ?? "Facebook User",
-        //                     email: dict["email"],
-        //                     sessionToken: token?.tokenString ?? ""
-        //                 )
-        //                 self.finishSignIn(session)
-        //             }
-        //         }
-        //     }
-        // }
-
-        // ── Fallback stub until SDK is added ──────────
-        simulateSignIn(provider: .facebook, name: "Facebook User", email: "user@facebook.com")
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Passkey / YubiKey (WebAuthn / FIDO2)
-    // ─────────────────────────────────────────────────────
-    // No external SDK — uses AuthenticationServices natively (iOS 16+)
-    // Supports:
-    //   • Device passkey (synced via iCloud Keychain)
-    //   • Physical FIDO2 key: YubiKey 5 NFC, Security Key NFC, YubiKey Bio
-    //   • NFC or USB-A/C via Lightning adapter
-
-    func signInWithPasskey(userHandle: String = "regev") {
-        isLoading = true
         guard let relyingPartyID = passkeyRelyingPartyIdentifier else {
             isLoading = false
-            state = .error("Passkey is not configured. Add PasskeyRelyingPartyID to Info.plist.")
+            authErrorMessage = "Passkey is not configured. Add PasskeyRelyingPartyID to Info.plist."
             return
         }
-        // Cache window reference on main actor before delegate callback runs.
+
         #if os(iOS)
         cachedWindow = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
@@ -243,48 +453,33 @@ final class SignInService: NSObject, ObservableObject {
         cachedWindow = NSApplication.shared.windows.first
         #endif
 
-        // Cache user handle so the nonisolated delegate callback can read it.
-        pendingUserHandle  = userHandle
-        pendingDisplayName = currentSession?.displayName ?? "User"
-
-        // In production: fetch challenge from your server (prevents replay attacks)
+        pendingUserHandle = userHandle ?? storedSession?.userID ?? activeSession?.userID ?? "fittracker-user"
+        pendingDisplayName = currentSession?.displayName ?? "\(AppBrand.name) User"
         currentChallenge = generateRandomBytes(count: 32)
 
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: relyingPartyID
-        )
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: relyingPartyID)
+        let assertionRequest = provider.createCredentialAssertionRequest(challenge: currentChallenge)
 
-        // Assertion request — authenticate with existing passkey
-        let assertionRequest = provider.createCredentialAssertionRequest(
-            challenge: currentChallenge
-        )
+        let securityKeyProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: relyingPartyID)
+        let securityKeyRequest = securityKeyProvider.createCredentialAssertionRequest(challenge: currentChallenge)
 
-        // Also allow security keys (YubiKey, etc.)
-        let securityKeyProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
-            relyingPartyIdentifier: relyingPartyID
-        )
-        let securityKeyRequest = securityKeyProvider.createCredentialAssertionRequest(
-            challenge: currentChallenge
-        )
-
-        let controller = ASAuthorizationController(authorizationRequests: [
-            assertionRequest,
-            securityKeyRequest,        // includes YubiKey FIDO2
-        ])
+        let controller = ASAuthorizationController(authorizationRequests: [assertionRequest, securityKeyRequest])
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()
     }
 
-    // Register a new passkey (called during first-time setup)
-    func registerPasskey(userHandle: String = "regev", displayName: String = "") {
+    func registerPasskey(userHandle: String = "fittracker-user", displayName: String = "") {
         isLoading = true
+        authErrorMessage = nil
+        statusMessage = nil
+
         guard let relyingPartyID = passkeyRelyingPartyIdentifier else {
             isLoading = false
-            state = .error("Passkey is not configured. Add PasskeyRelyingPartyID to Info.plist.")
+            authErrorMessage = "Passkey is not configured. Add PasskeyRelyingPartyID to Info.plist."
             return
         }
-        // Cache window reference on main actor before delegate callback runs.
+
         #if os(iOS)
         cachedWindow = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
@@ -293,41 +488,33 @@ final class SignInService: NSObject, ObservableObject {
         #elseif os(macOS)
         cachedWindow = NSApplication.shared.windows.first
         #endif
-        // Cache handles so the nonisolated delegate callback can read them.
-        // Use the current session display name if no explicit name is provided.
-        pendingUserHandle  = userHandle
-        pendingDisplayName = displayName.isEmpty ? (currentSession?.displayName ?? "User") : displayName
-        currentChallenge   = generateRandomBytes(count: 32)
 
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: relyingPartyID
-        )
+        let session = currentSession
+        pendingUserHandle = session?.userID ?? userHandle
+        pendingDisplayName = displayName.isEmpty ? (session?.displayName ?? "\(AppBrand.name) User") : displayName
+        currentChallenge = generateRandomBytes(count: 32)
 
-        let userID = (userHandle.data(using: .utf8) ?? Data())
-        let regRequest = provider.createCredentialRegistrationRequest(
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: relyingPartyID)
+        let userID = pendingUserHandle.data(using: .utf8) ?? Data()
+
+        let platformRequest = provider.createCredentialRegistrationRequest(
             challenge: currentChallenge,
-            name: displayName,
+            name: pendingDisplayName,
             userID: userID
         )
-        regRequest.userVerificationPreference = .required
+        platformRequest.userVerificationPreference = .required
 
-        // Also allow security key registration
-        let secKeyProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
-            relyingPartyIdentifier: relyingPartyID
-        )
-        let secKeyRegRequest = secKeyProvider.createCredentialRegistrationRequest(
+        let securityKeyProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: relyingPartyID)
+        let securityKeyRequest = securityKeyProvider.createCredentialRegistrationRequest(
             challenge: currentChallenge,
-            displayName: displayName,
-            name: userHandle,
+            displayName: pendingDisplayName,
+            name: pendingUserHandle,
             userID: userID
         )
-        secKeyRegRequest.attestationPreference = .direct
-        secKeyRegRequest.userVerificationPreference = .required
+        securityKeyRequest.attestationPreference = .direct
+        securityKeyRequest.userVerificationPreference = .required
 
-        let controller = ASAuthorizationController(authorizationRequests: [
-            regRequest,
-            secKeyRegRequest,
-        ])
+        let controller = ASAuthorizationController(authorizationRequests: [platformRequest, securityKeyRequest])
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()
@@ -336,54 +523,48 @@ final class SignInService: NSObject, ObservableObject {
     func addPasskeyForCurrentUser() {
         let session = currentSession
         registerPasskey(
-            userHandle: session?.userID ?? "regev",
-            displayName: session?.displayName ?? "FitTracker User"
+            userHandle: session?.userID ?? "fittracker-user",
+            displayName: session?.displayName ?? "\(AppBrand.name) User"
         )
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Sign out
-    // ─────────────────────────────────────────────────────
-
-    func signOut() {
-        KeychainHelper.delete(key: "ft.session")
-        withAnimation(.easeInOut(duration: 0.4)) {
-            state = .welcome
-        }
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Private helpers
-    // ─────────────────────────────────────────────────────
-
-    private func finishSignIn(_ session: UserSession) {
-        isLoading = false
-        if let encoded = try? JSONEncoder().encode(session) {
-            KeychainHelper.save(key: "ft.session", data: encoded)
-        }
-        withAnimation(.easeInOut(duration: 0.5)) {
-            state = .authenticated(session)
-        }
     }
 
     #if targetEnvironment(simulator)
     func signInAsTestUser() {
-        simulateSignIn(provider: .apple, name: "Regev", email: "regev@simulator.local")
+        let session = UserSession(
+            provider: .apple,
+            userID: UUID().uuidString,
+            displayName: "Regev",
+            email: "regev@simulator.local",
+            sessionToken: UUID().uuidString
+        )
+        finishSignIn(session)
     }
     #endif
 
-    private func simulateSignIn(provider: AuthProvider, name: String, email: String) {
-        Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(800))
-            let session = UserSession(
-                provider: provider,
-                userID: UUID().uuidString,
-                displayName: name,
-                email: email,
-                sessionToken: UUID().uuidString
-            )
-            self?.finishSignIn(session)
+    private func finishSignIn(_ session: UserSession) {
+        activeSession = session
+        storedSession = session
+        saveSession(session)
+        navigationPath.removeAll()
+        pendingEmailRegistration = nil
+        pendingEmailChallenge = nil
+        authErrorMessage = nil
+        isLoading = false
+
+        if session.provider == .passkey {
+            setHasRegisteredPasskey(true)
         }
+    }
+
+    private func saveSession(_ session: UserSession) {
+        if let encoded = try? JSONEncoder().encode(session) {
+            KeychainHelper.save(key: Self.sessionKey, data: encoded)
+        }
+    }
+
+    private func setHasRegisteredPasskey(_ value: Bool) {
+        hasRegisteredPasskey = value
+        UserDefaults.standard.set(value, forKey: Self.passkeyRegisteredKey)
     }
 
     private func generateNonce() -> String {
@@ -403,14 +584,70 @@ final class SignInService: NSObject, ObservableObject {
         return Data(bytes)
     }
 
-    private var googleClientID: String {
-        Bundle.main.object(forInfoDictionaryKey: "GIDClientID") as? String ?? ""
-    }
-
     private var passkeyRelyingPartyIdentifier: String? {
-        let value = (Bundle.main.object(forInfoDictionaryKey: "PasskeyRelyingPartyID") as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = (Bundle.main.object(forInfoDictionaryKey: "PasskeyRelyingPartyID") as? String ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty, value.contains(".") else { return nil }
         return value
+    }
+
+    private func handleAuthorizationResult(_ result: Result<ASAuthorization, Error>) {
+        isLoading = false
+
+        switch result {
+        case let .success(authorization):
+            switch authorization.credential {
+            case let cred as ASAuthorizationAppleIDCredential:
+                let name = [cred.fullName?.givenName, cred.fullName?.familyName]
+                    .compactMap { $0 }
+                    .joined(separator: " ")
+
+                let session = Self.mergedAppleSession(
+                    userID: cred.user,
+                    incomingName: name,
+                    incomingEmail: cred.email,
+                    existingAppleSession: storedSession?.provider == .apple ? storedSession : nil
+                )
+                finishSignIn(session)
+
+            case let cred as ASAuthorizationPlatformPublicKeyCredentialAssertion:
+                let session = UserSession(
+                    provider: .passkey,
+                    userID: String(data: cred.userID, encoding: .utf8) ?? pendingUserHandle,
+                    displayName: pendingDisplayName.isEmpty ? (currentSession?.displayName ?? "User") : pendingDisplayName,
+                    email: storedSession?.email,
+                    sessionToken: cred.signature.base64EncodedString(),
+                    credentialID: cred.credentialID
+                )
+                finishSignIn(session)
+
+            case let cred as ASAuthorizationSecurityKeyPublicKeyCredentialAssertion:
+                let session = UserSession(
+                    provider: .passkey,
+                    userID: String(data: cred.userID, encoding: .utf8) ?? pendingUserHandle,
+                    displayName: pendingDisplayName.isEmpty ? (currentSession?.displayName ?? "User") : pendingDisplayName,
+                    email: storedSession?.email,
+                    sessionToken: cred.signature.base64EncodedString(),
+                    credentialID: cred.credentialID
+                )
+                finishSignIn(session)
+
+            case _ as ASAuthorizationPlatformPublicKeyCredentialRegistration,
+                 _ as ASAuthorizationSecurityKeyPublicKeyCredentialRegistration:
+                setHasRegisteredPasskey(true)
+                statusMessage = "Passkey added. You can use it from the login screen next time."
+                authErrorMessage = nil
+
+            default:
+                authErrorMessage = "Unknown credential type received."
+            }
+
+        case let .failure(error):
+            let authError = error as? ASAuthorizationError
+            if authError?.code != .canceled {
+                authErrorMessage = error.localizedDescription
+            }
+        }
     }
 }
 
@@ -428,7 +665,6 @@ extension SignInService {
             email: incomingEmail ?? existingAppleSession?.email,
             phone: existingAppleSession?.phone,
             avatarURL: existingAppleSession?.avatarURL,
-            // Use the stable Apple user identifier; authorizationCode is single-use.
             sessionToken: userID
         )
     }
@@ -445,71 +681,7 @@ extension SignInService: ASAuthorizationControllerDelegate {
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
         Task { @MainActor in
-            isLoading = false
-
-            switch authorization.credential {
-
-            // ── Apple ID ──────────────────────────────
-            case let cred as ASAuthorizationAppleIDCredential:
-                let name = [cred.fullName?.givenName, cred.fullName?.familyName]
-                    .compactMap { $0 }.joined(separator: " ")
-                let session = Self.mergedAppleSession(
-                    userID: cred.user,
-                    incomingName: name,
-                    incomingEmail: cred.email,
-                    existingAppleSession: currentSession?.provider == .apple ? currentSession : nil
-                )
-                finishSignIn(session)
-
-            // ── Passkey assertion (device or YubiKey) ─
-            // cred.userID is the user handle bytes set during registration.
-            case let cred as ASAuthorizationPlatformPublicKeyCredentialAssertion:
-                let session = UserSession(
-                    provider: .passkey,
-                    userID: String(data: cred.userID, encoding: .utf8) ?? pendingUserHandle,
-                    displayName: pendingDisplayName.isEmpty ? (currentSession?.displayName ?? "User") : pendingDisplayName,
-                    sessionToken: cred.signature.base64EncodedString(),
-                    credentialID: cred.credentialID
-                )
-                finishSignIn(session)
-
-            // ── Security key (YubiKey) assertion ─────
-            case let cred as ASAuthorizationSecurityKeyPublicKeyCredentialAssertion:
-                let session = UserSession(
-                    provider: .passkey,
-                    userID: String(data: cred.userID, encoding: .utf8) ?? pendingUserHandle,
-                    displayName: pendingDisplayName.isEmpty ? (currentSession?.displayName ?? "User") : pendingDisplayName,
-                    sessionToken: cred.signature.base64EncodedString(),
-                    credentialID: cred.credentialID
-                )
-                finishSignIn(session)
-
-            // ── Passkey registration ──────────────────
-            // Use pendingUserHandle (stored before performRequests) as the stable userID.
-            case let cred as ASAuthorizationPlatformPublicKeyCredentialRegistration:
-                let session = UserSession(
-                    provider: .passkey,
-                    userID: pendingUserHandle,
-                    displayName: pendingDisplayName,
-                    sessionToken: cred.rawAttestationObject?.base64EncodedString() ?? "",
-                    credentialID: cred.credentialID
-                )
-                finishSignIn(session)
-
-            // ── Security key registration ─────────────
-            case let cred as ASAuthorizationSecurityKeyPublicKeyCredentialRegistration:
-                let session = UserSession(
-                    provider: .passkey,
-                    userID: pendingUserHandle,
-                    displayName: pendingDisplayName,
-                    sessionToken: cred.rawAttestationObject?.base64EncodedString() ?? "",
-                    credentialID: cred.credentialID
-                )
-                finishSignIn(session)
-
-            default:
-                state = .error("Unknown credential type received.")
-            }
+            handleAuthorizationResult(.success(authorization))
         }
     }
 
@@ -518,12 +690,7 @@ extension SignInService: ASAuthorizationControllerDelegate {
         didCompleteWithError error: Error
     ) {
         Task { @MainActor in
-            isLoading = false
-            let authError = error as? ASAuthorizationError
-            // Code 1001 = user cancelled — don't show error
-            if authError?.code != .canceled {
-                state = .error(error.localizedDescription)
-            }
+            handleAuthorizationResult(.failure(error))
         }
     }
 }
@@ -533,8 +700,6 @@ extension SignInService: ASAuthorizationControllerDelegate {
 // ─────────────────────────────────────────────────────────
 
 extension SignInService: ASAuthorizationControllerPresentationContextProviding {
-    // cachedWindow is always populated before performRequests() is called (on the main actor),
-    // so this nonisolated callback can safely return it without any cross-thread dispatch.
     nonisolated func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         MainActor.assumeIsolated { presentationAnchorOnMainActor() }
     }
@@ -567,30 +732,36 @@ enum KeychainHelper {
     private static let service = "com.fittracker.regev"
 
     static func save(key: String, data: Data) {
-        let q: [CFString: Any] = [kSecClass: kSecClassGenericPassword,
-                                  kSecAttrService: service,
-                                  kSecAttrAccount: key,
-                                  kSecValueData: data,
-                                  kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly]
+        let q: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        ]
         SecItemDelete(q as CFDictionary)
         SecItemAdd(q as CFDictionary, nil)
     }
 
     static func load(key: String) -> Data? {
-        let q: [CFString: Any] = [kSecClass: kSecClassGenericPassword,
-                                  kSecAttrService: service,
-                                  kSecAttrAccount: key,
-                                  kSecReturnData: true,
-                                  kSecMatchLimit: kSecMatchLimitOne]
+        let q: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
         var result: AnyObject?
         SecItemCopyMatching(q as CFDictionary, &result)
         return result as? Data
     }
 
     static func delete(key: String) {
-        let q: [CFString: Any] = [kSecClass: kSecClassGenericPassword,
-                                  kSecAttrService: service,
-                                  kSecAttrAccount: key]
+        let q: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key,
+        ]
         SecItemDelete(q as CFDictionary)
     }
 }

--- a/FitTracker/Services/AuthManager.swift
+++ b/FitTracker/Services/AuthManager.swift
@@ -6,44 +6,63 @@ import Foundation
 @preconcurrency import LocalAuthentication
 import SwiftUI
 
+@MainActor
+protocol BiometricQuickUnlockProviding {
+    var isAvailable: Bool { get }
+    var biometricLabel: String { get }
+    var biometricName: String { get }
+    var biometricIcon: String { get }
+    func authenticateForQuickUnlock() async -> Bool
+}
+
 // ─────────────────────────────────────────────────────────
 // MARK: – Biometric Lock Manager
 // ─────────────────────────────────────────────────────────
 
 @MainActor
-final class AuthManager: ObservableObject {
+final class AuthManager: ObservableObject, BiometricQuickUnlockProviding {
 
     @Published var isAuthenticated = false
     @Published var authError: String?
 
-    init() { authenticate() }
+    init() {}
 
     func authenticate() {
+        Task {
+            _ = await authenticateForQuickUnlock()
+        }
+    }
+
+    func authenticateForQuickUnlock() async -> Bool {
         #if targetEnvironment(simulator)
-        // Skip biometric prompt on simulator — set authenticated immediately.
         isAuthenticated = true
         authError = nil
+        return true
         #else
         let ctx = LAContext()
         ctx.localizedFallbackTitle = ""
         var err: NSError?
 
         if ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &err) {
-            ctx.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics,
-                               localizedReason: "Unlock FitTracker to access your encrypted health data") { ok, e in
-                Task { @MainActor [weak self] in
-                    self?.isAuthenticated = ok
-                    self?.authError = ok ? nil : e?.localizedDescription
-                    if ok {
-                        // Share the authenticated context with EncryptionService so all crypto
-                        // operations in this session reuse it without re-prompting biometrics.
-                        await EncryptionService.shared.setSessionContext(ctx)
+            return await withCheckedContinuation { continuation in
+                ctx.evaluatePolicy(
+                    .deviceOwnerAuthenticationWithBiometrics,
+                    localizedReason: "Unlock \(AppBrand.name) to access your encrypted health data"
+                ) { ok, e in
+                    Task { @MainActor [weak self] in
+                        self?.isAuthenticated = ok
+                        self?.authError = ok ? nil : e?.localizedDescription
+                        if ok {
+                            await EncryptionService.shared.setSessionContext(ctx)
+                        }
+                        continuation.resume(returning: ok)
                     }
                 }
             }
         } else {
             isAuthenticated = false
-            authError = "Face ID or Touch ID is required to unlock FitTracker. Set up biometrics in device settings, then try again."
+            authError = "Face ID or Touch ID is required to unlock \(AppBrand.name). Set up biometrics in device settings, then try again."
+            return false
         }
         #endif
     }
@@ -54,6 +73,53 @@ final class AuthManager: ObservableObject {
         guard clearCryptoSession else { return }
         // Invalidate the shared session context so the next unlock re-authenticates.
         Task { await EncryptionService.shared.clearSessionContext() }
+    }
+
+    var isAvailable: Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        let ctx = LAContext()
+        var error: NSError?
+        return ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+        #endif
+    }
+
+    var biometricType: LABiometryType? {
+        #if targetEnvironment(simulator)
+        return .faceID
+        #else
+        let ctx = LAContext()
+        var error: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return nil
+        }
+        return ctx.biometryType
+        #endif
+    }
+
+    var biometricLabel: String {
+        switch biometricType {
+        case .faceID: "Use Face ID"
+        case .touchID: "Use Touch ID"
+        default: "Use Biometrics"
+        }
+    }
+
+    var biometricName: String {
+        switch biometricType {
+        case .faceID: "Face ID"
+        case .touchID: "Touch ID"
+        default: "biometric unlock"
+        }
+    }
+
+    var biometricIcon: String {
+        switch biometricType {
+        case .faceID: "faceid"
+        case .touchID: "touchid"
+        default: "lock.open.fill"
+        }
     }
 }
 
@@ -92,7 +158,7 @@ struct LockScreenView: View {
                     }
 
                     VStack(spacing: 8) {
-                        Text("Unlock FitTracker")
+                        Text("Unlock \(AppBrand.name)")
                             .font(.system(.title2, design: .rounded, weight: .bold))
                             .foregroundStyle(.white)
                         Text("Use \(biometricName) to reopen your encrypted data.")
@@ -134,36 +200,7 @@ struct LockScreenView: View {
         }
     }
 
-    private var biometricType: LABiometryType? {
-        let ctx = LAContext()
-        var error: NSError?
-        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
-            return nil
-        }
-        return ctx.biometryType
-    }
-
-    private var biometricLabel: String {
-        switch biometricType {
-        case .faceID:  "Unlock with Face ID"
-        case .touchID: "Unlock with Touch ID"
-        default:       "Unlock"
-        }
-    }
-
-    private var biometricName: String {
-        switch biometricType {
-        case .faceID:  "Face ID"
-        case .touchID: "Touch ID"
-        default:       "biometric unlock"
-        }
-    }
-
-    private var biometricIcon: String {
-        switch biometricType {
-        case .faceID:  "faceid"
-        case .touchID: "touchid"
-        default:       "lock.open.fill"
-        }
-    }
+    private var biometricLabel: String { auth.biometricLabel.replacingOccurrences(of: "Use", with: "Unlock with") }
+    private var biometricName: String { auth.biometricName }
+    private var biometricIcon: String { auth.biometricIcon }
 }

--- a/FitTracker/Views/Auth/AccountPanelView.swift
+++ b/FitTracker/Views/Auth/AccountPanelView.swift
@@ -15,6 +15,7 @@ struct AccountPanelView: View {
     @EnvironmentObject var healthService: HealthKitService
     @EnvironmentObject var cloudSync: CloudKitSyncService
     @EnvironmentObject var settings:  AppSettings
+    @EnvironmentObject var watchService: WatchConnectivityService
     @Environment(\.dismiss) var dismiss
 
     @State private var showLogoutConfirm = false
@@ -24,23 +25,26 @@ struct AccountPanelView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 18) {
-                    accountHeroCard
-                    accessCard
-                    settingsCard
-                    signOutCard
+            ZStack {
+                AppGradient.screenBackground
+                    .ignoresSafeArea()
+
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 18) {
+                        accountHeroCard
+                        settingsLauncherCard
+                        signOutCard
+                    }
+                    .padding(20)
                 }
-                .padding(20)
             }
-            .background(Color(.systemGroupedBackground))
             .navigationTitle("Account")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                         .fontWeight(.semibold)
-                        .foregroundStyle(.green)
+                        .foregroundStyle(Color.appAccentPrimary)
                 }
             }
             .alert("Sign Out?", isPresented: $showLogoutConfirm) {
@@ -53,15 +57,14 @@ struct AccountPanelView: View {
                 Text("You'll be returned to the welcome screen. Your encrypted data remains safely stored on this device and in iCloud.")
             }
             .sheet(isPresented: $showSettings) {
-                NavigationStack {
-                    SettingsView()
-                        .environmentObject(signIn)
-                        .environmentObject(biometricAuth)
-                        .environmentObject(dataStore)
-                        .environmentObject(healthService)
-                        .environmentObject(cloudSync)
-                        .environmentObject(settings)
-                }
+                SettingsView()
+                    .environmentObject(signIn)
+                    .environmentObject(biometricAuth)
+                    .environmentObject(dataStore)
+                    .environmentObject(healthService)
+                    .environmentObject(cloudSync)
+                    .environmentObject(settings)
+                    .environmentObject(watchService)
                     .presentationDetents([.large])
             }
         }
@@ -101,9 +104,9 @@ struct AccountPanelView: View {
         .background(cardBackground)
     }
 
-    private var accessCard: some View {
+    private var settingsLauncherCard: some View {
         VStack(alignment: .leading, spacing: 14) {
-            sectionTitle("Access")
+            sectionTitle("Settings")
 
             HStack(spacing: 10) {
                 accessPill(
@@ -115,19 +118,25 @@ struct AccountPanelView: View {
                 if session?.provider == .passkey {
                     accessPill(icon: "key.fill", label: "Passkey Active", tint: .purple)
                 }
+
+                accessPill(
+                    icon: "applewatch",
+                    label: watchService.status.label,
+                    tint: watchService.status.dotColor
+                )
             }
 
             Button {
                 showSettings = true
             } label: {
                 HStack(spacing: 12) {
-                    Image(systemName: "faceid")
-                        .foregroundStyle(.green)
+                    Image(systemName: "gearshape.fill")
+                        .foregroundStyle(Color.appAccentPrimary)
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Security and Access Settings")
+                        Text("Open Full Settings")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.primary)
-                        Text("Manage reopen lock, passkeys, sync, and device protection.")
+                        Text("Manage account security, HealthKit, goals, training preferences, and sync.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -138,36 +147,6 @@ struct AccountPanelView: View {
                 }
                 .padding(14)
                 .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(18)
-        .background(cardBackground)
-    }
-
-    private var settingsCard: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            sectionTitle("App")
-
-            HStack(spacing: 12) {
-                settingsMiniTile(title: settings.unitSystem.rawValue, subtitle: "Units", icon: "ruler", tint: .blue)
-                settingsMiniTile(title: settings.appearance.rawValue, subtitle: "Appearance", icon: "paintpalette.fill", tint: .indigo)
-            }
-
-            Button {
-                showSettings = true
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: "gearshape.fill")
-                        .foregroundStyle(.blue)
-                    Text("Open Full Settings")
-                        .font(.subheadline.weight(.semibold))
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.vertical, 4)
             }
             .buttonStyle(.plain)
         }
@@ -218,7 +197,11 @@ struct AccountPanelView: View {
 
     private var cardBackground: some View {
         RoundedRectangle(cornerRadius: 22)
-            .fill(Color(.secondarySystemGroupedBackground))
+            .fill(Color.appSurface.opacity(0.96))
+            .overlay(
+                RoundedRectangle(cornerRadius: 22)
+                    .stroke(Color.appStroke, lineWidth: 1)
+            )
     }
 
     private var dividerLine: some View {
@@ -267,22 +250,6 @@ struct AccountPanelView: View {
         .background(tint.opacity(0.12), in: Capsule())
     }
 
-    private func settingsMiniTile(title: String, subtitle: String, icon: String, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Image(systemName: icon)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(tint)
-            Text(title)
-                .font(.subheadline.weight(.semibold))
-            Text(subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
-    }
-
     @ViewBuilder
     private var providerBadge: some View {
         let provider = session?.provider ?? .apple
@@ -300,18 +267,16 @@ struct AccountPanelView: View {
     private func providerIcon(_ p: AuthProvider) -> String {
         switch p {
         case .apple:    "apple.logo"
-        case .google:   "globe"
-        case .facebook: "person.2.fill"
         case .passkey:  "key.fill"
+        case .email:    "envelope.fill"
         }
     }
 
     private func providerColor(_ p: AuthProvider) -> Color {
         switch p {
         case .apple:    .primary
-        case .google:   Color(red: 0.26, green: 0.52, blue: 0.96)
-        case .facebook: Color(red: 0.23, green: 0.35, blue: 0.60)
         case .passkey:  .purple
+        case .email:    .appBlue2
         }
     }
 }

--- a/FitTracker/Views/Auth/AuthHubView.swift
+++ b/FitTracker/Views/Auth/AuthHubView.swift
@@ -1,0 +1,1175 @@
+import SwiftUI
+import AuthenticationServices
+#if os(macOS)
+import AppKit
+#endif
+
+struct AuthHubView: View {
+    @EnvironmentObject private var signIn: SignInService
+    @State private var mode: AuthMode = .login
+    @State private var registrationForm = EmailRegistrationFormState()
+    @State private var loginForm = EmailLoginFormState()
+
+    var body: some View {
+        NavigationStack(path: $signIn.navigationPath) {
+            AuthScaffold {
+                AuthLandingView(
+                    mode: $mode,
+                    registrationForm: $registrationForm,
+                    loginForm: $loginForm
+                )
+            }
+            .navigationDestination(for: AuthRoute.self) { route in
+                switch route {
+                case .emailVerification:
+                    AuthScaffold {
+                        EmailVerificationView(
+                            mode: $mode,
+                            registrationForm: $registrationForm
+                        )
+                    }
+                case let .passwordReset(prefillEmail):
+                    AuthScaffold {
+                        PasswordResetView(
+                            mode: $mode,
+                            initialEmail: prefillEmail
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum AuthMode: String, CaseIterable, Identifiable {
+    case login = "Log In"
+    case register = "Create Account"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .login:
+            return "Welcome back"
+        case .register:
+            return "Create your account"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .login:
+            return "Private training, nutrition, and recovery data protected from the moment you enter."
+        case .register:
+            return "Set up a secure FitMe account with Apple or email in under a minute."
+        }
+    }
+
+    var appleButtonTitle: String {
+        switch self {
+        case .login:
+            return "Sign in with Apple"
+        case .register:
+            return "Continue with Apple"
+        }
+    }
+
+    var emailSectionTitle: String {
+        switch self {
+        case .login:
+            return "Use email instead"
+        case .register:
+            return "Create with email"
+        }
+    }
+}
+
+private enum AuthField: Hashable {
+    case loginEmail
+    case loginPassword
+    case registerFirstName
+    case registerLastName
+    case registerEmail
+    case registerPassword
+    case registerConfirmPassword
+    case resetEmail
+}
+
+private struct AuthScaffold<Content: View>: View {
+    @EnvironmentObject private var signIn: SignInService
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        ZStack {
+            AppGradient.authBackground
+                .ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 16) {
+                    if let error = signIn.authErrorMessage {
+                        AuthBannerView(
+                            icon: "exclamationmark.triangle.fill",
+                            text: error,
+                            tint: .status.error
+                        )
+                    } else if let status = signIn.statusMessage {
+                        AuthBannerView(
+                            icon: "checkmark.circle.fill",
+                            text: status,
+                            tint: .status.success
+                        )
+                    }
+
+                    content
+                }
+                .frame(maxWidth: 620)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 18)
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .scrollDismissesKeyboardCompat()
+    }
+}
+
+private struct AuthLandingView: View {
+    @EnvironmentObject private var signIn: SignInService
+    @EnvironmentObject private var biometricAuth: AuthManager
+
+    @Binding var mode: AuthMode
+    @Binding var registrationForm: EmailRegistrationFormState
+    @Binding var loginForm: EmailLoginFormState
+
+    @State private var registrationErrors: [String: String] = [:]
+    @State private var loginError: String?
+    @FocusState private var focusedField: AuthField?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            AuthHeroSection(mode: mode)
+
+            if showQuickReturn {
+                QuickReturnSection(
+                    canUseBiometrics: biometricAuth.isAvailable && signIn.hasStoredSession,
+                    biometricLabel: biometricAuth.biometricName,
+                    biometricIcon: biometricAuth.biometricIcon,
+                    canUsePasskey: signIn.canShowPasskeyLogin,
+                    biometricAction: quickUnlock,
+                    passkeyAction: { signIn.signInWithPasskey() }
+                )
+            }
+
+            AuthSurfaceCard {
+                VStack(alignment: .leading, spacing: 18) {
+                    Picker("Authentication mode", selection: $mode) {
+                        ForEach(AuthMode.allCases) { currentMode in
+                            Text(currentMode.rawValue).tag(currentMode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityHint("Switch between login and account creation.")
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(mode.title)
+                            .font(AppType.headline.weight(.bold))
+                            .foregroundStyle(Color.appTextPrimary)
+
+                        Text(mode.subtitle)
+                            .font(AppType.body)
+                            .foregroundStyle(Color.appTextSecondary)
+                    }
+
+                    ApplePrimaryButton(mode: mode)
+
+                    AuthDividerLabel(text: "or use email")
+
+                    if mode == .login {
+                        EmailLoginSection(
+                            form: $loginForm,
+                            localError: $loginError,
+                            focusedField: $focusedField
+                        )
+                    } else {
+                        EmailRegistrationSection(
+                            form: $registrationForm,
+                            errors: $registrationErrors,
+                            focusedField: $focusedField
+                        )
+                    }
+                }
+            }
+
+            AuthFootnote(mode: mode)
+        }
+        .onChange(of: mode) { _, _ in
+            signIn.clearFeedback()
+            loginError = nil
+            registrationErrors = [:]
+            focusedField = nil
+        }
+        .onChange(of: loginForm.email) { _, _ in
+            if loginError != nil {
+                loginError = nil
+            }
+        }
+        .onChange(of: loginForm.password) { _, _ in
+            if loginError != nil {
+                loginError = nil
+            }
+        }
+        .onChange(of: registrationForm) { _, _ in
+            if !registrationErrors.isEmpty {
+                registrationErrors = [:]
+            }
+        }
+    }
+
+    private var showQuickReturn: Bool {
+        (biometricAuth.isAvailable && signIn.hasStoredSession) || signIn.canShowPasskeyLogin
+    }
+
+    private func quickUnlock() {
+        Task {
+            let success = await biometricAuth.authenticateForQuickUnlock()
+            if success {
+                if signIn.hasStoredSession {
+                    signIn.resumeStoredSession()
+                } else {
+                    signIn.clearFeedback()
+                }
+            }
+        }
+    }
+}
+
+private struct AuthHeroSection: View {
+    let mode: AuthMode
+
+    private let trustItems: [(icon: String, title: String)] = [
+        ("lock.shield.fill", "Encrypted on device"),
+        ("icloud.fill", "Apple ecosystem ready"),
+        ("heart.text.square.fill", "Health data stays private"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(AppBrand.name)
+                    .font(.system(size: 38, weight: .bold, design: .rounded))
+                    .foregroundStyle(.clear)
+                    .overlay(
+                        AppGradient.brand.mask(
+                            Text(AppBrand.name)
+                                .font(.system(size: 38, weight: .bold, design: .rounded))
+                        )
+                    )
+
+                Text(mode == .login ? "Your secure fitness command center." : "A calmer way to track training, recovery, and nutrition.")
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .foregroundStyle(Color.appTextPrimary)
+
+                Text("Sign in quickly, keep your data encrypted, and get back to the workouts, meals, and recovery signals that matter today.")
+                    .font(AppType.body)
+                    .foregroundStyle(Color.appTextSecondary)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(trustItems, id: \.title) { item in
+                        HStack(spacing: 8) {
+                            Image(systemName: item.icon)
+                                .font(.system(size: 13, weight: .semibold))
+                            Text(item.title)
+                                .font(AppType.subheading.weight(.semibold))
+                        }
+                        .foregroundStyle(Color.appTextPrimary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color.white.opacity(0.55), in: Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(Color.appStroke, lineWidth: 1)
+                        )
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+}
+
+private struct QuickReturnSection: View {
+    let canUseBiometrics: Bool
+    let biometricLabel: String
+    let biometricIcon: String
+    let canUsePasskey: Bool
+    let biometricAction: () -> Void
+    let passkeyAction: () -> Void
+
+    var body: some View {
+        AuthSurfaceCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Quick return")
+                    .font(AppType.headline.weight(.semibold))
+                    .foregroundStyle(Color.appTextPrimary)
+
+                Text("For returning users only. Standard login options are still available below.")
+                    .font(AppType.subheading)
+                    .foregroundStyle(Color.appTextSecondary)
+
+                if canUseBiometrics {
+                    Button(action: biometricAction) {
+                        AuthQuickReturnRow(
+                            icon: biometricIcon,
+                            title: "Use \(biometricLabel)",
+                            subtitle: "Reopen the last secure session on this device"
+                        )
+                    }
+                    .buttonStyle(AuthCardButtonStyle(baseFill: Color.white.opacity(0.6)))
+                    .accessibilityHint("Authenticate with biometrics and reopen your saved session.")
+                }
+
+                if canUsePasskey {
+                    Button(action: passkeyAction) {
+                        AuthQuickReturnRow(
+                            icon: "key.fill",
+                            title: "Use Passkey",
+                            subtitle: "Sign in with a saved passkey or security key"
+                        )
+                    }
+                    .buttonStyle(AuthCardButtonStyle(baseFill: Color.white.opacity(0.6)))
+                    .accessibilityHint("Sign in with a saved passkey.")
+                }
+            }
+        }
+    }
+}
+
+private struct ApplePrimaryButton: View {
+    @EnvironmentObject private var signIn: SignInService
+    let mode: AuthMode
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SignInWithAppleButton(
+                mode == .register ? .continue : .signIn,
+                onRequest: signIn.prepareAppleSignInRequest,
+                onCompletion: signIn.handleAppleSignInResult
+            )
+            .signInWithAppleButtonStyle(.black)
+            .frame(height: 56)
+            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .accessibilityLabel(mode.appleButtonTitle)
+            .accessibilityHint("Uses your Apple Account for a secure \(mode == .login ? "login" : "account setup").")
+
+            Text(mode == .login ? "Fastest way back into your encrypted data." : "Fastest way to create a secure account with less typing.")
+                .font(AppType.subheading)
+                .foregroundStyle(Color.appTextSecondary)
+        }
+    }
+}
+
+private struct EmailLoginSection: View {
+    @EnvironmentObject private var signIn: SignInService
+    @Binding var form: EmailLoginFormState
+    @Binding var localError: String?
+    let focusedField: FocusState<AuthField?>.Binding
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Use email instead")
+                .font(AppType.body.weight(.semibold))
+                .foregroundStyle(Color.appTextPrimary)
+
+            AuthTextInput(
+                title: "Email",
+                text: $form.email,
+                keyboard: .emailAddress,
+                contentType: .username,
+                textInputAutocapitalization: .never,
+                submitLabel: .next,
+                focusedField: focusedField,
+                equals: .loginEmail,
+                onSubmitAction: { focusedField.wrappedValue = .loginPassword }
+            )
+
+            AuthSecureInput(
+                title: "Password",
+                text: $form.password,
+                contentType: .password,
+                submitLabel: .go,
+                focusedField: focusedField,
+                equals: .loginPassword,
+                onSubmitAction: submit
+            )
+
+            HStack {
+                Spacer()
+                Button("Forgot password?") {
+                    signIn.showPasswordReset(prefillEmail: form.normalizedEmail)
+                }
+                .buttonStyle(.plain)
+                .font(AppType.subheading.weight(.semibold))
+                .foregroundStyle(Color.accent.cyan)
+                .accessibilityHint("Open password reset.")
+            }
+
+            if let localError {
+                AuthInlineError(text: localError)
+            }
+
+            Button(signIn.isLoading ? "Logging in..." : "Log In", action: submit)
+                .buttonStyle(AuthPrimaryButtonStyle())
+                .disabled(signIn.isLoading)
+                .accessibilityHint("Log in using your email and password.")
+        }
+    }
+
+    private func submit() {
+        if let error = form.validationError() {
+            localError = error
+            return
+        }
+
+        localError = nil
+        signIn.clearFeedback()
+        Task {
+            await signIn.signInWithEmail(email: form.normalizedEmail, password: form.password)
+        }
+    }
+}
+
+private struct EmailRegistrationSection: View {
+    @EnvironmentObject private var signIn: SignInService
+    @Binding var form: EmailRegistrationFormState
+    @Binding var errors: [String: String]
+    let focusedField: FocusState<AuthField?>.Binding
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Create with email")
+                .font(AppType.body.weight(.semibold))
+                .foregroundStyle(Color.appTextPrimary)
+
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    AuthTextInput(
+                        title: "First name",
+                        text: $form.firstName,
+                        contentType: .givenName,
+                        submitLabel: .next,
+                        focusedField: focusedField,
+                        equals: .registerFirstName,
+                        onSubmitAction: { focusedField.wrappedValue = .registerLastName }
+                    )
+
+                    if let error = errors["firstName"] {
+                        AuthInlineError(text: error)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    AuthTextInput(
+                        title: "Last name",
+                        text: $form.lastName,
+                        contentType: .familyName,
+                        submitLabel: .next,
+                        focusedField: focusedField,
+                        equals: .registerLastName,
+                        onSubmitAction: { focusedField.wrappedValue = .registerEmail }
+                    )
+
+                    if let error = errors["lastName"] {
+                        AuthInlineError(text: error)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                AuthTextInput(
+                    title: "Email",
+                    text: $form.email,
+                    keyboard: .emailAddress,
+                    contentType: .emailAddress,
+                    textInputAutocapitalization: .never,
+                    submitLabel: .next,
+                    focusedField: focusedField,
+                    equals: .registerEmail,
+                    onSubmitAction: { focusedField.wrappedValue = .registerPassword }
+                )
+
+                if let error = errors["email"] {
+                    AuthInlineError(text: error)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                AuthSecureInput(
+                    title: "Password",
+                    text: $form.password,
+                    contentType: .newPassword,
+                    submitLabel: .next,
+                    focusedField: focusedField,
+                    equals: .registerPassword,
+                    onSubmitAction: { focusedField.wrappedValue = .registerConfirmPassword }
+                )
+
+                Text(PasswordRuleEvaluator.guidanceText)
+                    .font(AppType.subheading)
+                    .foregroundStyle(Color.appTextSecondary)
+
+                if let error = errors["password"] {
+                    AuthInlineError(text: error)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                AuthSecureInput(
+                    title: "Confirm password",
+                    text: $form.confirmPassword,
+                    contentType: .newPassword,
+                    submitLabel: .go,
+                    focusedField: focusedField,
+                    equals: .registerConfirmPassword,
+                    onSubmitAction: submit
+                )
+
+                if let error = errors["confirmPassword"] {
+                    AuthInlineError(text: error)
+                }
+            }
+
+            Button(signIn.isLoading ? "Creating account..." : "Create Account", action: submit)
+                .buttonStyle(AuthPrimaryButtonStyle())
+                .disabled(signIn.isLoading)
+                .accessibilityHint("Create an account with email and continue to verification.")
+        }
+    }
+
+    private func submit() {
+        let currentErrors = form.validationErrors()
+        errors = currentErrors
+
+        guard currentErrors.isEmpty else { return }
+
+        signIn.clearFeedback()
+        Task {
+            await signIn.startEmailRegistration(form.normalizedDraft())
+        }
+    }
+}
+
+private struct EmailVerificationView: View {
+    @EnvironmentObject private var signIn: SignInService
+    @Binding var mode: AuthMode
+    @Binding var registrationForm: EmailRegistrationFormState
+    @State private var code = ""
+    @State private var localError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            AuthFlowHeader(
+                title: "Verify your email",
+                subtitle: "Enter the code sent to \(signIn.pendingEmailRegistration?.email ?? registrationForm.email)."
+            )
+
+            AuthSurfaceCard {
+                VStack(alignment: .leading, spacing: 14) {
+                    OTPCodeEntryField(code: $code, digitCount: 5)
+                        .accessibilityLabel("Verification code")
+                        .accessibilityHint("Enter the 5 digit code from your email.")
+
+                    expiryNote
+
+                    if let localError {
+                        AuthInlineError(text: localError)
+                    }
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button("Change email") {
+                    localError = nil
+                    signIn.resetToEntry()
+                    mode = .register
+                }
+                .buttonStyle(AuthSecondaryButtonStyle())
+                .accessibilityHint("Go back and edit your email address.")
+
+                Button(signIn.isLoading ? "Sending..." : "Resend code") {
+                    localError = nil
+                    Task {
+                        await signIn.resendEmailRegistrationCode()
+                        if let message = signIn.authErrorMessage {
+                            localError = message
+                        }
+                    }
+                }
+                .buttonStyle(AuthSecondaryButtonStyle())
+                .disabled(signIn.isLoading)
+                .accessibilityHint("Send a fresh verification code.")
+            }
+
+            Button(signIn.isLoading ? "Verifying..." : "Verify Email") {
+                let trimmedCode = code.filter(\.isNumber)
+                guard trimmedCode.count == 5 else {
+                    localError = "Enter the 5-digit code."
+                    return
+                }
+
+                localError = nil
+                Task {
+                    await signIn.verifyEmailRegistrationCode(trimmedCode)
+                    if let message = signIn.authErrorMessage {
+                        localError = message
+                    }
+                }
+            }
+            .buttonStyle(AuthPrimaryButtonStyle())
+            .disabled(signIn.isLoading)
+            .accessibilityHint("Complete account verification.")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var expiryNote: some View {
+        if let expiresAt = signIn.pendingEmailChallenge?.expiresAt {
+            (
+                Text("Code expires in ")
+                    .foregroundStyle(Color.appTextSecondary)
+                + Text(expiresAt, style: .timer)
+                    .foregroundStyle(Color.appTextPrimary)
+                + Text(". AutoFill and paste are supported.")
+                    .foregroundStyle(Color.appTextSecondary)
+            )
+            .font(AppType.subheading)
+        }
+        else {
+            Text("AutoFill and paste are supported.")
+                .font(AppType.subheading)
+                .foregroundStyle(Color.appTextSecondary)
+        }
+    }
+}
+
+private struct PasswordResetView: View {
+    @EnvironmentObject private var signIn: SignInService
+    @Binding var mode: AuthMode
+    let initialEmail: String
+
+    @State private var email = ""
+    @State private var localError: String?
+    @FocusState private var focusedField: AuthField?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            AuthFlowHeader(
+                title: "Reset your password",
+                subtitle: "We’ll send a reset link if the email belongs to an existing account."
+            )
+
+            AuthSurfaceCard {
+                VStack(alignment: .leading, spacing: 14) {
+                    AuthTextInput(
+                        title: "Email",
+                        text: $email,
+                        keyboard: .emailAddress,
+                        contentType: .emailAddress,
+                        textInputAutocapitalization: .never,
+                        submitLabel: .go,
+                        focusedField: $focusedField,
+                        equals: .resetEmail,
+                        onSubmitAction: sendReset
+                    )
+
+                    if let localError {
+                        AuthInlineError(text: localError)
+                    }
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button("Back to login") {
+                    localError = nil
+                    mode = .login
+                    signIn.resetToEntry()
+                }
+                .buttonStyle(AuthSecondaryButtonStyle())
+
+                Button(signIn.isLoading ? "Sending..." : "Send Reset Link", action: sendReset)
+                    .buttonStyle(AuthPrimaryButtonStyle())
+                    .disabled(signIn.isLoading)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear {
+            if email.isEmpty {
+                email = initialEmail
+            }
+            focusedField = .resetEmail
+        }
+    }
+
+    private func sendReset() {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmedEmail.isEmpty else {
+            localError = "Enter your email address."
+            return
+        }
+        guard AuthInputValidator.isValidEmail(trimmedEmail) else {
+            localError = "Enter a valid email address."
+            return
+        }
+
+        localError = nil
+        Task {
+            await signIn.requestPasswordReset(email: trimmedEmail)
+            if let message = signIn.authErrorMessage {
+                localError = message
+            } else {
+                mode = .login
+                signIn.resetToEntry(keepingStatus: true)
+            }
+        }
+    }
+}
+
+private struct AuthFlowHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .foregroundStyle(Color.appTextPrimary)
+
+            Text(subtitle)
+                .font(AppType.body)
+                .foregroundStyle(Color.appTextSecondary)
+        }
+    }
+}
+
+private struct AuthSurfaceCard<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            content
+        }
+        .padding(18)
+        .background(Color.appSurface, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(Color.appStroke, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.05), radius: 14, y: 8)
+    }
+}
+
+private struct AuthBannerView: View {
+    let icon: String
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+
+            Text(text)
+                .font(AppType.subheading)
+                .foregroundStyle(Color.appTextPrimary)
+
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(Color.white.opacity(0.82), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(tint.opacity(0.18), lineWidth: 1)
+        )
+    }
+}
+
+private struct AuthQuickReturnRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.accent.cyan)
+                .frame(width: 26)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(AppType.body.weight(.semibold))
+                    .foregroundStyle(Color.appTextPrimary)
+                Text(subtitle)
+                    .font(AppType.subheading)
+                    .foregroundStyle(Color.appTextSecondary)
+            }
+
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.appTextTertiary)
+        }
+    }
+}
+
+private struct AuthDividerLabel: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Rectangle()
+                .fill(Color.white.opacity(0.5))
+                .frame(height: 1)
+
+            Text(text.uppercased())
+                .font(AppType.caption.weight(.semibold))
+                .foregroundStyle(Color.appTextTertiary)
+
+            Rectangle()
+                .fill(Color.white.opacity(0.5))
+                .frame(height: 1)
+        }
+    }
+}
+
+private struct AuthTextInput: View {
+    let title: String
+    @Binding var text: String
+    var keyboard: UIKeyboardTypeCompat = .default
+    var contentType: AuthTextContentType?
+    var textInputAutocapitalization: TextInputAutocapitalization = .words
+    var submitLabel: SubmitLabel = .next
+    var focusedField: FocusState<AuthField?>.Binding? = nil
+    var equals: AuthField? = nil
+    var onSubmitAction: (() -> Void)? = nil
+
+    var body: some View {
+        Group {
+            if let focusedField, let equals {
+                TextField(title, text: $text)
+                    .focused(focusedField, equals: equals)
+                    .onSubmit { onSubmitAction?() }
+            } else {
+                TextField(title, text: $text)
+                    .onSubmit { onSubmitAction?() }
+            }
+        }
+        .authTextInputAutocapitalization(textInputAutocapitalization)
+        .authAutocorrectionDisabled()
+        .font(AppType.body)
+        .authKeyboardType(keyboard)
+        .authTextContentType(contentType)
+        .submitLabel(submitLabel)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
+        .background(Color.white.opacity(0.74), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+        .accessibilityLabel(title)
+    }
+}
+
+private struct AuthSecureInput: View {
+    let title: String
+    @Binding var text: String
+    var contentType: AuthTextContentType?
+    var submitLabel: SubmitLabel = .next
+    var focusedField: FocusState<AuthField?>.Binding? = nil
+    var equals: AuthField? = nil
+    var onSubmitAction: (() -> Void)? = nil
+    @State private var isRevealed = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Group {
+                if isRevealed {
+                    secureInputField(revealed: true)
+                } else {
+                    secureInputField(revealed: false)
+                }
+            }
+
+            Button(isRevealed ? "Hide" : "Show") {
+                isRevealed.toggle()
+            }
+            .buttonStyle(.plain)
+            .font(AppType.subheading.weight(.semibold))
+            .foregroundStyle(Color.accent.cyan)
+            .accessibilityLabel(isRevealed ? "Hide password" : "Show password")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
+        .background(Color.white.opacity(0.74), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+        .accessibilityLabel(title)
+    }
+
+    @ViewBuilder
+    private func secureInputField(revealed: Bool) -> some View {
+        Group {
+            if revealed {
+                if let focusedField, let equals {
+                    TextField(title, text: $text)
+                        .focused(focusedField, equals: equals)
+                        .onSubmit { onSubmitAction?() }
+                } else {
+                    TextField(title, text: $text)
+                        .onSubmit { onSubmitAction?() }
+                }
+            } else {
+                if let focusedField, let equals {
+                    SecureField(title, text: $text)
+                        .focused(focusedField, equals: equals)
+                        .onSubmit { onSubmitAction?() }
+                } else {
+                    SecureField(title, text: $text)
+                        .onSubmit { onSubmitAction?() }
+                }
+            }
+        }
+        .authTextInputAutocapitalization(.never)
+        .authAutocorrectionDisabled()
+        .font(AppType.body)
+        .authTextContentType(contentType)
+        .submitLabel(submitLabel)
+    }
+}
+
+private struct AuthInlineError: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(AppType.subheading)
+            .foregroundStyle(Color.status.error)
+            .accessibilityLabel("Error: \(text)")
+    }
+}
+
+private struct AuthFootnote: View {
+    let mode: AuthMode
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(mode == .login ? "New here? Switch to Create Account above if you’re setting up FitMe for the first time." : "Already have an account? Switch to Log In above to use your existing Apple, email, or passkey sign-in.")
+                .font(AppType.subheading)
+                .foregroundStyle(Color.appTextSecondary)
+
+            Text("Passkeys can be added later in Settings after your first successful sign-in.")
+                .font(AppType.caption)
+                .foregroundStyle(Color.appTextTertiary)
+        }
+        .padding(.horizontal, 4)
+    }
+}
+
+private struct AuthPrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(AppType.body.weight(.semibold))
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: configuration.isPressed
+                                ? [Color.appOrange3.opacity(0.92), Color.appOrange2.opacity(0.92)]
+                                : [Color.appOrange3, Color.appOrange2],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+            )
+            .scaleEffect(configuration.isPressed ? 0.99 : 1)
+    }
+}
+
+private struct AuthSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(AppType.body.weight(.semibold))
+            .foregroundStyle(Color.appTextPrimary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.white.opacity(configuration.isPressed ? 0.62 : 0.72))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.appStroke, lineWidth: 1)
+            )
+            .scaleEffect(configuration.isPressed ? 0.99 : 1)
+    }
+}
+
+private struct AuthCardButtonStyle: ButtonStyle {
+    var baseFill: Color = Color.appSurface
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(baseFill.opacity(configuration.isPressed ? 0.9 : 1))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Color.appStroke, lineWidth: 1)
+            )
+            .scaleEffect(configuration.isPressed ? 0.99 : 1)
+    }
+}
+
+#if os(iOS)
+private typealias UIKeyboardTypeCompat = UIKeyboardType
+private typealias AuthTextContentType = UITextContentType
+#else
+private enum UIKeyboardTypeCompat {
+    case `default`
+    case emailAddress
+}
+private typealias AuthTextContentType = NSTextContentType
+#endif
+
+private extension View {
+    @ViewBuilder
+    func authKeyboardType(_ type: UIKeyboardTypeCompat) -> some View {
+        #if os(iOS)
+        keyboardType(type)
+        #else
+        self
+        #endif
+    }
+
+    @ViewBuilder
+    func authTextContentType(_ type: AuthTextContentType?) -> some View {
+        #if os(iOS)
+        textContentType(type)
+        #elseif os(macOS)
+        if let type {
+            textContentType(type)
+        } else {
+            self
+        }
+        #endif
+    }
+
+    @ViewBuilder
+    func authTextInputAutocapitalization(_ value: TextInputAutocapitalization) -> some View {
+        #if os(iOS)
+        textInputAutocapitalization(value)
+        #else
+        self
+        #endif
+    }
+
+    @ViewBuilder
+    func authAutocorrectionDisabled() -> some View {
+        #if os(iOS)
+        autocorrectionDisabled()
+        #else
+        self
+        #endif
+    }
+
+    @ViewBuilder
+    func scrollDismissesKeyboardCompat() -> some View {
+        #if os(iOS)
+        scrollDismissesKeyboard(.interactively)
+        #else
+        self
+        #endif
+    }
+}
+
+#if os(iOS)
+private struct OTPCodeEntryField: View {
+    @Binding var code: String
+    let digitCount: Int
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        ZStack {
+            TextField("", text: Binding(
+                get: { code },
+                set: { newValue in
+                    code = String(newValue.filter(\.isNumber).prefix(digitCount))
+                }
+            ))
+            .keyboardType(.numberPad)
+            .textContentType(.oneTimeCode)
+            .focused($isFocused)
+            .opacity(0.01)
+
+            HStack(spacing: 10) {
+                ForEach(0..<digitCount, id: \.self) { index in
+                    let digit = Array(code).dropFirst(index).first.map(String.init) ?? ""
+
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color.white.opacity(0.74))
+                        .frame(height: 58)
+                        .overlay(
+                            Text(digit)
+                                .font(.system(size: 24, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Color.appTextPrimary)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .stroke(index == min(code.count, digitCount - 1) && code.count < digitCount ? Color.appBlue2 : Color.clear, lineWidth: 1.5)
+                        )
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isFocused = true
+            }
+        }
+        .onAppear {
+            isFocused = true
+        }
+    }
+}
+#else
+private struct OTPCodeEntryField: View {
+    @Binding var code: String
+    let digitCount: Int
+
+    var body: some View {
+        TextField("12345", text: Binding(
+            get: { code },
+            set: { newValue in
+                code = String(newValue.filter(\.isNumber).prefix(digitCount))
+            }
+        ))
+        .font(AppType.body)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
+        .background(Color.white.opacity(0.74), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+    }
+}
+#endif

--- a/FitTracker/Views/Auth/SignInView.swift
+++ b/FitTracker/Views/Auth/SignInView.swift
@@ -33,7 +33,7 @@ struct SignInView: View {
                                 )
                                 .padding(.top, 8)
 
-                            Text("Continue to FitTracker")
+                            Text("Continue to \(AppBrand.name)")
                                 .font(.system(.title, design: .rounded, weight: .bold))
 
                             Text("Use Apple or a passkey to get back to your encrypted training data.")
@@ -208,63 +208,46 @@ struct SocialSignInButton: View {
             Image(systemName: "apple.logo")
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundStyle(labelColor)
-        case .google:
-            // Google "G" drawn with SF Symbols approximation
-            ZStack {
-                Circle().fill(Color.white).frame(width: 26, height: 26)
-                Text("G")
-                    .font(.system(size: 16, weight: .bold, design: .rounded))
-                    .foregroundStyle(Color(red: 0.26, green: 0.52, blue: 0.96))
-            }
-        case .facebook:
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color(red: 0.23, green: 0.35, blue: 0.60))
-                    .frame(width: 28, height: 28)
-                Text("f")
-                    .font(.system(size: 18, weight: .bold, design: .serif))
-                    .foregroundStyle(.white)
-            }
         case .passkey:
             Image(systemName: "key.fill")
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(.purple)
+        case .email:
+            Image(systemName: "envelope.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.appBlue2)
         }
     }
 
     private var bgColor: Color {
         switch provider {
         case .apple:    return Color(.label)            // black in light, white in dark
-        case .google:   return Color(.systemBackground)
-        case .facebook: return Color(red: 0.23, green: 0.35, blue: 0.60)
         case .passkey:  return Color.purple.opacity(0.08)
+        case .email:    return Color.appBlue2.opacity(0.08)
         }
     }
 
     private var labelColor: Color {
         switch provider {
         case .apple:    return Color(.systemBackground) // white in dark, black in light
-        case .google:   return Color(.label)
-        case .facebook: return .white
         case .passkey:  return .purple
+        case .email:    return .appBlue2
         }
     }
 
     private var borderColor: Color {
         switch provider {
         case .apple:    return .clear
-        case .google:   return Color.secondary.opacity(0.25)
-        case .facebook: return .clear
         case .passkey:  return Color.purple.opacity(0.25)
+        case .email:    return Color.appBlue2.opacity(0.25)
         }
     }
 
     private var shadowColor: Color {
         switch provider {
         case .apple:    return Color.black.opacity(0.15)
-        case .google:   return Color.black.opacity(0.06)
-        case .facebook: return Color(red: 0.23, green: 0.35, blue: 0.60).opacity(0.3)
         case .passkey:  return .purple.opacity(0.1)
+        case .email:    return Color.appBlue2.opacity(0.14)
         }
     }
 }

--- a/FitTracker/Views/Auth/WelcomeView.swift
+++ b/FitTracker/Views/Auth/WelcomeView.swift
@@ -77,7 +77,7 @@ struct WelcomeView: View {
                     .opacity(logoOpacity)
 
                     VStack(spacing: 8) {
-                        Text("FitTracker")
+                        Text(AppBrand.name)
                             .font(.system(size: 38, weight: .bold, design: .rounded))
                             .foregroundStyle(.white)
 
@@ -85,7 +85,7 @@ struct WelcomeView: View {
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(.white.opacity(0.9))
 
-                        Text("Apple sign-in and passkeys are supported. FitTracker keeps your health data encrypted on device and before sync.")
+                        Text("Apple sign-in and passkeys are supported. \(AppBrand.name) keeps your health data encrypted on device and before sync.")
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)

--- a/FitTrackerTests/FitTrackerCoreTests.swift
+++ b/FitTrackerTests/FitTrackerCoreTests.swift
@@ -129,4 +129,46 @@ final class FitTrackerCoreTests: XCTestCase {
         XCTAssertEqual(profile.recoveryDay(for: sameDayLate, calendar: calendar), 0)
         XCTAssertEqual(profile.recoveryDay(for: nextDayEarly, calendar: calendar), 1)
     }
+
+    func testPasswordRuleEvaluatorRejectsMissingRequirements() {
+        let result = PasswordRuleEvaluator.validate("short")
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.issues.contains("Use at least 8 characters."))
+    }
+
+    func testPasswordRuleEvaluatorAcceptsValidPassword() {
+        let result = PasswordRuleEvaluator.validate("correct horse battery staple")
+
+        XCTAssertTrue(result.isValid)
+        XCTAssertTrue(result.issues.isEmpty)
+    }
+
+    func testEmailRegistrationResendRefreshesChallengeExpiry() async throws {
+        let service = SignInService()
+        let draft = PendingEmailRegistration(
+            firstName: "Regev",
+            lastName: "Barak",
+            email: "regev@example.com",
+            password: "correct horse battery staple"
+        )
+
+        await service.startEmailRegistration(draft)
+        let initialExpiry = try XCTUnwrap(service.pendingEmailChallenge?.expiresAt)
+
+        await service.resendEmailRegistrationCode()
+        let refreshedExpiry = try XCTUnwrap(service.pendingEmailChallenge?.expiresAt)
+
+        XCTAssertGreaterThan(refreshedExpiry, initialExpiry)
+        XCTAssertEqual(service.navigationPath, [.emailVerification])
+    }
+
+    func testPasswordResetRequestUsesGenericSuccessMessage() async throws {
+        let service = SignInService()
+
+        await service.requestPasswordReset(email: "regev@example.com")
+
+        XCTAssertNil(service.authErrorMessage)
+        XCTAssertEqual(service.statusMessage, "If that email is registered, a password reset link is on the way.")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The current app is built around a `Today`-first experience:
 - biometric unlock for encryption keys
 - optional `Require Face ID/Touch ID on Reopen` behavior in Settings
 - Apple Sign In plus passkey support
+- a trust-first auth hub with `Log In` and `Create Account` modes on one screen
+- inline email sign-up and login alongside Apple Sign In
+- password reset, resend verification code, and quick-return biometric/passkey entry
 - simplified welcome, sign-in, lock, account, and settings flows
 
 ## What Changed Recently
@@ -65,7 +68,10 @@ The current app is built around a `Today`-first experience:
 - removed the intrusive iPhone passcode fallback for app unlock
 - added biometric reopen preference in Settings
 - added passkey creation from Settings
-- simplified the welcome and sign-in experience
+- replaced the old auth method chooser with a single login/create-account hub
+- added inline email registration and login, verification resend, and password reset flows
+- simplified password rules to support stronger passphrase-style passwords
+- improved auth form focus flow, submit behavior, and accessibility messaging
 - reorganized account and settings information architecture
 - added stats-carousel controls in Settings so users can personalize which metrics appear on the stats screen
 


### PR DESCRIPTION
## Summary
- extract the finished auth/login redesign from ci-check-test onto a clean branch from main
- replace the old auth chooser flow with a single trust-first auth hub for login and account creation
- add inline email login and registration, verification resend, password reset, and quick-return biometric and passkey paths
- document the new auth flow in the README

## Testing
- /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination id=7208AC4D-2C86-481D-9440-59266D0CED17 -resultBundlePath /tmp/fittracker-auth-merge-tests.xcresult CODE_SIGNING_ALLOWED=NO
- TEST SUCCEEDED
