### PR TITLE
feat(home): unified body composition card with drill-down

### DIFF
--- a/.claude/features/home-status-goal-card/prd.md
+++ b/.claude/features/home-status-goal-card/prd.md
@@ -1,0 +1,295 @@
+# PRD: Home — Status+Goal Merged Card (Body Composition Card)
+
+> **Owner:** Regev
+> **Date:** 2026-04-09
+> **Phase:** Phase 1 — PRD
+> **Status:** Draft for approval
+> **Parent feature:** home-today-screen v2 (PR #61)
+> **Tracking:** [regevba/fittracker2#64](https://github.com/Regevba/FitTracker2/issues/64)
+> **Branch:** `feature/home-status-goal-card`
+> **Deferred from:** F11 (goal drill-down), F13 (macro strip), OQ-3, OQ-4, OQ-7-folded
+
+---
+
+## Purpose
+
+Replace the separate Status card and Goal card on Home v2 with a single unified **Body Composition Card** that shows current metrics, progress toward goals, and an optional macro strip — with a tappable drill-down to a detailed trend view. Reduces vertical fragmentation (~250pt → ~180pt) while adding more meaningful context.
+
+## Business Objective
+
+The Home screen is the first thing users see. Two adjacent cards showing related body-composition data (weight/BF + goal progress) fragment the story. A unified card answers "where am I vs where I want to be" in one glance, and the drill-down enables data exploration that was previously impossible (no goal detail view exists).
+
+## Target Persona(s)
+
+| Persona | Relevance |
+|---|---|
+| The Consistent Lifter | Tracks weight/BF against strength goals; wants quick visual of progress |
+| Health-Conscious Professional | Monitors body composition trends; values the trend chart drill-down |
+| Data-Driven Optimizer | Wants all metrics in context; drill-down feeds their need for detail |
+
+## Has UI?
+
+Yes — 1 new card component + 1 new detail sheet view.
+
+## Functional Requirements
+
+| # | Requirement | Priority | Details |
+|---|---|---|---|
+| 1 | Unified body-composition card on Home | P0 | Replaces both statusCard and goalCard in v2 MainScreenView |
+| 2 | Hero values: weight + body fat | P0 | Large `AppText.metric` values with unit + target range below each |
+| 3 | Overall progress bar | P0 | Linear progress bar showing combined goal progress (replaces `AppProgressRing`) |
+| 4 | Recommendation line | P0 | `HomeRecommendationProvider` output — encouraging copy |
+| 5 | Drill-down on tap | P0 | Card tap → `BodyCompositionDetailView` sheet |
+| 6 | Drill-down: trend charts | P0 | Weight + BF trend lines over 7d / 30d / 90d / all with goal line overlay |
+| 7 | Drill-down: per-metric progress bars | P1 | Weight progress + BF progress separately |
+| 8 | Drill-down: "Log" CTA | P0 | Opens manual biometric entry from the detail view |
+| 9 | Compact macro strip | P1 | Protein progress inside the card (`142g / 180g protein`) |
+| 10 | Empty state | P0 | When no weight/BF data — "Log your metrics" CTA (reuses existing `onLogTap` pattern) |
+| 11 | Drill-down chevron affordance | P1 | Visible `▸` indicator that the card is tappable |
+| 12 | Card EYEBROW header | P0 | "BODY COMPOSITION" with `.isHeader` accessibility trait |
+
+## Card layout
+
+```
+┌─────────────────────────────────────────────────┐
+│  BODY COMPOSITION                          ▸    │
+│                                                  │
+│  67.2 kg        14.8%                           │
+│  Weight          Body Fat                        │
+│  Target: 65-68   Target: 13-15%                 │
+│                                                  │
+│  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 72%  │
+│                                                  │
+│  🥩 142g / 180g protein                         │
+│                                                  │
+│  You're on track — keep going! 💪               │
+└─────────────────────────────────────────────────┘
+```
+
+## Drill-down view (BodyCompositionDetailView)
+
+```
+┌──────────────────────────────────────────────────┐
+│  Body Composition                        Done    │
+│                                                   │
+│  ┌─────────────────────────────────────────────┐ │
+│  │  Weight trend chart (7d/30d/90d/all)        │ │
+│  │  Current: 67.2 kg  Goal: 65-68 kg           │ │
+│  │  ──────────────────── goal line ───────────  │ │
+│  │  ╱╲  ╱╲                                      │ │
+│  │ ╱  ╲╱  ╲───                                  │ │
+│  └─────────────────────────────────────────────┘ │
+│                                                   │
+│  ┌─────────────────────────────────────────────┐ │
+│  │  Body Fat trend chart                        │ │
+│  │  Current: 14.8%  Goal: 13-15%               │ │
+│  └─────────────────────────────────────────────┘ │
+│                                                   │
+│  Weight progress  ━━━━━━━━━━━━━━━━━━━━━━━ 85%  │
+│  Body Fat progress ━━━━━━━━━━━━━━━━━━━━━━ 60%  │
+│                                                   │
+│  ┌────────────────────────────────────┐          │
+│  │         📊 Log Metrics             │          │
+│  └────────────────────────────────────┘          │
+└──────────────────────────────────────────────────┘
+```
+
+## User Flows
+
+### Primary: View body composition on Home
+1. User opens app → Home shows Body Composition Card
+2. Sees weight 67.2 kg, body fat 14.8%, progress 72%, encouraging message
+3. Glances at macro strip (142g / 180g protein)
+
+### Primary: Drill down for trends
+1. User taps the Body Composition Card (or `▸` chevron)
+2. → `home_body_comp_tap` analytics event fires
+3. `BodyCompositionDetailView` sheet opens
+4. User sees weight + BF trend charts with goal lines
+5. Switches between time ranges (7d / 30d / 90d / all)
+6. Taps "Log Metrics" → manual biometric entry sheet
+
+### Empty state
+1. No weight/BF data logged
+2. Card shows "Log your first metrics" CTA instead of values
+3. Tapping opens manual biometric entry
+
+---
+
+## Analytics Spec
+
+### New events
+
+| Event Name | GA4 Type | Screen/Trigger | Conversion? | Notes |
+|---|---|---|---|---|
+| `home_body_comp_tap` | Custom | User taps Body Composition Card | No | Drill-down engagement |
+| `home_body_comp_period_changed` | Custom | User switches time range in detail view | No | Engagement depth |
+| `home_body_comp_log_tap` | Custom | User taps "Log Metrics" in detail view | No | Logging intent from drill-down |
+
+### Event parameters
+
+#### `home_body_comp_tap`
+
+| Parameter | Type | Allowed Values | Notes |
+|---|---|---|---|
+| `has_weight` | string | `true`, `false` | Whether weight data exists |
+| `has_body_fat` | string | `true`, `false` | Whether BF data exists |
+| `progress_percent` | int | 0-100 | Current overall goal progress |
+
+#### `home_body_comp_period_changed`
+
+| Parameter | Type | Allowed Values | Notes |
+|---|---|---|---|
+| `period` | string | `7d`, `30d`, `90d`, `all` | Selected time range |
+
+#### `home_body_comp_log_tap`
+
+| Parameter | Type | Allowed Values | Notes |
+|---|---|---|---|
+| `source` | string | `body_comp_detail` | Always from the detail view |
+
+### New screen
+
+| Screen Name | View Name | SwiftUI View | Category |
+|---|---|---|---|
+| Body Composition Detail | `body_comp_detail` | `BodyCompositionDetailView` | core |
+
+### Naming validation checklist
+
+- [x] All event names: snake_case, <40 chars, `home_` prefixed
+- [x] All parameter names: snake_case, <40 chars
+- [x] No reserved prefixes (`ga_`, `firebase_`, `google_`)
+- [x] No duplicate names (checked against existing 27 events + 26 params)
+- [x] No PII
+- [x] ≤25 parameters per event (max 3)
+- [x] Parameter values max 100 chars
+- [x] Conversion events: none (drill-down is engagement, not conversion)
+
+### Files to update
+
+- [ ] `AnalyticsProvider.swift` — 3 events + 3 params + 1 screen
+- [ ] `AnalyticsService.swift` — 3 convenience methods
+- [ ] `analytics-taxonomy.csv` — 3 event rows + 1 screen row
+
+---
+
+## Success Metrics
+
+### Primary metric
+
+| Metric | Baseline | Target | Instrumentation |
+|---|---|---|---|
+| Body comp drill-down rate | N/A (new) | >20% of sessions include `home_body_comp_tap` | GA4 custom event |
+
+### Secondary metrics
+
+| Metric | Baseline | Target | Instrumentation |
+|---|---|---|---|
+| Biometric logging frequency | Current manual log rate | +15% increase from drill-down CTA | GA4 `biometric_log` with `source: body_comp_detail` |
+| Time range exploration | N/A | >30% of drill-downs switch period | GA4 `home_body_comp_period_changed` |
+| Home scroll depth | Current (unknown) | Card higher in stack → more visible | Implicit from card position |
+
+### Guardrail metrics
+
+| Metric | Current | Acceptable Range |
+|---|---|---|
+| Crash-free rate | >99.5% | Must stay >99.5% |
+| Cold start time | <2s | Must stay <2s |
+| Existing home_action_tap rate | Current (from Home v2) | Must not degrade |
+
+### Leading indicators
+- >20% of sessions include a body comp drill-down within 7 days
+- "Log Metrics" tap rate from detail view > 10% of drill-downs
+
+### Lagging indicators
+- Biometric logging frequency increases 15%+ within 30 days
+- Cross-feature WAU stable or improving
+
+---
+
+## Acceptance Criteria
+
+### Card
+- [ ] Unified Body Composition Card replaces both statusCard and goalCard in v2 MainScreenView
+- [ ] Hero weight + body fat values with `AppText.metric` + unit + target range
+- [ ] Linear progress bar showing overall goal % (replaces `AppProgressRing`)
+- [ ] Compact macro strip showing protein progress (P1)
+- [ ] Recommendation line from `HomeRecommendationProvider`
+- [ ] `▸` chevron indicating tappability
+- [ ] "BODY COMPOSITION" eyebrow with `.isHeader` trait
+- [ ] Empty state: "Log your first metrics" CTA when no data
+- [ ] All design system tokens — zero raw literals
+- [ ] Card tappable → opens `BodyCompositionDetailView`
+
+### Drill-down
+- [ ] `BodyCompositionDetailView` opens as `.medium`/`.large` detent sheet
+- [ ] Weight trend chart with goal line overlay
+- [ ] Body fat trend chart with goal line overlay
+- [ ] Time range picker (7d / 30d / 90d / all)
+- [ ] Per-metric progress bars (weight + BF separately)
+- [ ] "Log Metrics" CTA → opens manual biometric entry
+- [ ] "Done" toolbar button to dismiss
+
+### Analytics
+- [ ] `home_body_comp_tap` fires on card tap
+- [ ] `home_body_comp_period_changed` fires on time range switch
+- [ ] `home_body_comp_log_tap` fires on Log CTA in detail view
+- [ ] `.analyticsScreen(.bodyCompDetail)` on detail view
+- [ ] All events consent-gated
+- [ ] `analytics-taxonomy.csv` updated
+
+### Accessibility
+- [ ] Card: `.accessibilityLabel` with weight + BF + progress summary
+- [ ] Card: `.accessibilityHint("Tap for details")`
+- [ ] Detail view: chart has `.accessibilityValue` text summary
+- [ ] All tap targets ≥ 44pt
+- [ ] Dynamic Type scaling
+
+---
+
+## Kill Criteria
+
+School project, loose thresholds:
+- If drill-down causes crash-free rate < 99.5% → hotfix
+- If card causes cold start regression > 200ms → investigate
+- Otherwise: iterate, don't kill
+
+## Review Cadence
+
+1 week post-merge. School project — relax to 30-day if no signal.
+
+---
+
+## Key Files
+
+| File | Action |
+|---|---|
+| `FitTracker/Views/Main/v2/MainScreenView.swift` | **Modify** — replace statusCard + goalCard with BodyCompositionCard |
+| `FitTracker/Views/Main/BodyCompositionCard.swift` | **New** — unified card component |
+| `FitTracker/Views/Main/BodyCompositionDetailView.swift` | **New** — drill-down sheet |
+| `FitTracker/Services/Analytics/AnalyticsProvider.swift` | **Modify** — 3 events + 3 params + 1 screen |
+| `FitTracker/Services/Analytics/AnalyticsService.swift` | **Modify** — 3 convenience methods |
+| `docs/product/analytics-taxonomy.csv` | **Modify** — 3 event rows + 1 screen |
+
+## Estimated Effort
+
+| Phase | Effort |
+|---|---|
+| PRD (this) | 0.5 day |
+| Tasks | 0.25 day |
+| UX Spec | 0.5 day |
+| Implementation | 3 days |
+| Testing | 0.5 day |
+| Review + Merge + Docs | 0.5 day |
+| **Total** | **~5 days** |
+
+---
+
+## Dependencies & Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Trend chart needs historical data | Medium | Use existing `dataStore` biometric history; fallback to "Not enough data" message |
+| Macro strip adds density | Low | P1 — can defer if card feels too dense |
+| `AppProgressRing` removal may break expectations | Low | Ring was already temporary per Home v2 decisions; linear bar is more compact |
+| Detail view chart rendering perf | Low | Use SwiftUI Charts (iOS 16+); lazy rendering |

--- a/.claude/features/home-status-goal-card/research.md
+++ b/.claude/features/home-status-goal-card/research.md
@@ -1,0 +1,116 @@
+# home-status-goal-card — Research
+
+> **Phase:** 0 (Research)
+> **Parent:** home-today-screen v2 (PR #61)
+> **Deferred from:** F11 (goal drill-down), F13 (macro strip), OQ-3 (merged card), OQ-4 (macro placement), OQ-7-folded (drill-down folds in)
+
+---
+
+## 1. What is this?
+
+Merge the separate Status card (weight + body fat) and Goal card (progress ring + bars) on Home v2 into a single unified **body-composition card**. Add a goal drill-down view (tap → detail), and place the compact macro strip semantically within the card.
+
+Currently Home v2 has two adjacent cards:
+- **Status card** — two `AppMetricColumn` instances (weight + body fat) with "Log" CTA when empty
+- **Goal card** — `AppProgressRing` (overall progress %) + two `progressLine` bars (weight/BF progress) + essentials summary
+
+These occupy ~250pt of vertical space. A merged card reduces to ~180pt while showing more meaningful context (the relationship between current values and goals).
+
+## 2. Why merge?
+
+- **Hick's Law**: Two cards for related data creates unnecessary visual fragmentation. Weight/BF and goals are the same conceptual unit — "where am I vs where I want to be"
+- **Progressive disclosure**: The merged card shows the summary; drill-down reveals the full picture
+- **Consistency**: Apple Health, Withings, and Noom all present body metrics + goal in one unified view
+- **Scroll real estate**: Saves ~70pt vertical space, pushing metrics row higher
+
+## 3. Competitive patterns
+
+| App | Pattern | Hero metric | Goal viz | Drill-down? | Secondary data |
+|---|---|---|---|---|---|
+| **Withings Health Mate** | Single dashboard card | Weight (large) | Horizontal progress bar + "X kg to go" | Yes → full chart with overlays | Body fat %, muscle mass, water % stacked below |
+| **MyFitnessPal** | Weight progress card | Weight | Linear bar (start → current → goal) + % complete | Yes → weight log chart | None in card (separate nutrition view) |
+| **Noom** | Weight graph hero | Trend line | Goal line overlaid on chart + badge | Yes → annotated full chart | Daily dots + smoothed trend |
+| **Lose It!** | Circular progress | Weight | Progress ring + "X lbs to goal" | Yes → detailed chart | Calorie budget |
+| **Apple Health** | Separate metric cards | Each metric individual | No goal ring (just trend sparklines) | Yes → day/week/month chart | Sparkline per card |
+
+**Key insight**: The Withings model (hero weight + stacked secondary metrics + goal progress bar) is the strongest pattern for a single unified card in a fitness context.
+
+## 4. Approach comparison
+
+| Approach | Pros | Cons | Effort | Chosen? |
+|---|---|---|---|---|
+| **A: Withings-style unified card** — Hero weight + BF below + progress bar + drill-down | Dense info, clear hierarchy, industry-proven | New card layout (not just combining existing) | 3-4 days | **Yes** |
+| **B: Tab-based card** — Two tabs (Status / Goal) in one card container | Saves space, familiar pattern | Hides half the data behind a tap; violates Recognition over Recall | 2-3 days | No |
+| **C: Accordion card** — Status visible, Goal expands on tap | Compact default, progressive | Non-standard on iOS; unexpected behavior | 3 days | No |
+| **D: Keep separate, add drill-down only** — Two cards stay, goal ring becomes tappable | Minimal change | Doesn't address the fragmentation problem | 1 day | No |
+
+## 5. Proposed design: Unified Body Composition Card
+
+```
+┌─────────────────────────────────────────────────┐
+│  BODY COMPOSITION                          ▸    │  ← eyebrow + drill-down chevron
+│                                                  │
+│  67.2 kg        14.8%                           │  ← hero values (AppText.metric)
+│  Weight          Body Fat                        │  ← labels (AppText.caption)
+│  Target: 65-68   Target: 13-15%                 │  ← target ranges (AppText.footnote)
+│                                                  │
+│  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 72%  │  ← overall progress bar
+│                                                  │
+│  🥩 142g / 180g protein                         │  ← compact macro strip (optional)
+│                                                  │
+│  You're on track — keep going! 💪               │  ← recommendation line
+└─────────────────────────────────────────────────┘
+```
+
+### Drill-down view (new sheet)
+
+Tapping the card (or the chevron) opens a detail sheet:
+- Full-height chart showing weight + BF trends over time (7d / 30d / 90d / all)
+- Goal lines overlaid
+- Per-metric progress bars (weight and BF separately)
+- "Log" CTA at bottom
+- Milestone history
+
+## 6. Technical feasibility
+
+**Low risk:**
+- Reuses existing `AppMetricColumn` (or adapts it for inline layout)
+- Reuses `AppProgressRing` (or replaces with linear progress bar)
+- `HomeRecommendationProvider` already provides the recommendation text
+- `profile.overallProgress()`, `profile.weightProgress()`, `profile.bfProgress()` already exist
+- Macro data available via `todayLog?.nutritionLog`
+
+**New work:**
+- `BodyCompositionCard` view (replaces both statusCard + goalCard in v2 MainScreenView)
+- `BodyCompositionDetailView` (new sheet for drill-down) — **new file**
+- Compact macro strip sub-view (optional, can defer to v2.1)
+- Analytics event: `home_body_comp_tap` (drill-down)
+
+**Dependencies:**
+- None external. All data sources exist.
+
+## 7. Proposed success metrics
+
+| Metric | Baseline | Target |
+|---|---|---|
+| **Primary:** Body comp card drill-down rate | N/A (new) | >20% of sessions include a drill-down |
+| **Secondary:** Biometric logging frequency | Current manual log rate | +15% increase in weight/BF logs from the drill-down CTA |
+| **Secondary:** Home scroll depth | Current (unknown) | Card is higher in stack → more visible |
+| **Guardrail:** Crash-free rate | >99.5% | Must not degrade |
+| **Guardrail:** Cold start time | <2s | Must not degrade |
+
+## 8. Macro strip decision
+
+Per OQ-4, placement is decided semantically (not arbitrary). Two options:
+
+**Option A:** Inside the body-composition card (shown above) — protein progress line contextualizes the body comp data. "You're eating toward your goal."
+
+**Option B:** Separate compact row below the card — cleaner separation, but loses the contextual link.
+
+**Recommendation:** Option A (inside the card). The macro strip is most meaningful next to the body metrics it's driving. If it feels too dense, defer to v2.1 as originally planned in Home v2.
+
+## 9. Decision
+
+**Recommended: Approach A (Withings-style unified card)** with drill-down sheet. Macro strip included as P1 (can ship without it, add in follow-up if the card feels too dense).
+
+Estimated effort: ~3-4 days implementation + 1 day testing.

--- a/.claude/features/home-status-goal-card/state.json
+++ b/.claude/features/home-status-goal-card/state.json
@@ -1,0 +1,86 @@
+{
+  "feature": "home-status-goal-card",
+  "created": "2026-04-09T19:00:00Z",
+  "updated": "2026-04-09T23:00:00Z",
+  "branch": "feature/home-status-goal-card",
+  "current_phase": "implementation",
+  "work_type": "feature",
+  "work_subtype": "new_ui",
+  "has_ui": true,
+  "requires_analytics": true,
+  "github_issue_number": 64,
+  "parent_feature": "home-today-screen",
+  "description": "Merge separate Status and Goal cards on Home v2 into a unified body-composition card. Includes goal drill-down (tap ring → detail view) and macro strip placement. Deferred from Home v2 per Decisions Log OQ-3, OQ-7-folded, OQ-4.",
+  "deferred_from": {
+    "feature": "home-today-screen",
+    "findings": ["F11 (goal drill-down)", "F13 (macro strip)"],
+    "decisions": ["OQ-3 (merged card as own PM cycle)", "OQ-7-folded (goal drill-down folds in)", "OQ-4 (macro strip semantically placed)"]
+  },
+  "transitions": [
+    {
+      "from": "init",
+      "to": "research",
+      "timestamp": "2026-04-09T19:00:00Z",
+      "approved_by": "system",
+      "note": "Feature initialized. Full lifecycle. Sub-feature of home-today-screen v2 (PR #61). Deferred items: F11, F13, OQ-3, OQ-4, OQ-7-folded."
+    },
+    {
+      "from": "research",
+      "to": "prd",
+      "timestamp": "2026-04-09T20:00:00Z",
+      "approved_by": "user",
+      "note": "Phase 0 approved. Withings-style unified card chosen (Approach A). Drill-down to new BodyCompositionDetailView. Macro strip inside card as P1."
+    },
+    {
+      "from": "prd",
+      "to": "tasks",
+      "timestamp": "2026-04-09T21:00:00Z",
+      "approved_by": "user",
+      "note": "Phase 1 approved. PRD with 12 requirements, 3 analytics events, ~5 day estimate. Analytics spec validated."
+    },
+    {
+      "from": "tasks",
+      "to": "ux_or_integration",
+      "timestamp": "2026-04-09T22:00:00Z",
+      "approved_by": "user",
+      "note": "Phase 2 approved. 9 tasks, critical path ~2.5 days. T2+T3 parallel foundation, T5 assembly, T6-T9 verification."
+    },
+    {
+      "from": "ux_or_integration",
+      "to": "implementation",
+      "timestamp": "2026-04-09T23:00:00Z",
+      "approved_by": "user",
+      "note": "Phase 3 approved. UX spec, compliance 5/5, validation 13/13. No handoff prompts (sub-feature, context in spec)."
+    }
+  ],
+  "phases": {
+    "research": { "status": "approved", "started_at": "2026-04-09T19:00:00Z", "approved_at": "2026-04-09T20:00:00Z", "approved_by": "user", "sources": [".claude/features/home-status-goal-card/research.md", ".claude/features/home-today-screen/v2-audit-report.md (F11, F13, OQ-3, OQ-4)"] },
+    "prd": { "status": "approved", "started_at": "2026-04-09T20:00:00Z", "approved_at": "2026-04-09T21:00:00Z", "approved_by": "user", "analytics_spec_complete": true, "path": ".claude/features/home-status-goal-card/prd.md" },
+    "tasks": { "status": "approved", "started_at": "2026-04-09T21:00:00Z", "approved_at": "2026-04-09T22:00:00Z", "approved_by": "user", "v2_count": 9, "task_file": ".claude/features/home-status-goal-card/tasks.md" },
+    "ux_or_integration": { "status": "approved", "started_at": "2026-04-09T22:00:00Z", "approved_at": "2026-04-09T23:00:00Z", "approved_by": "user", "type": "ux", "compliance_gateway": "5/5 pass", "heuristic_validation": "13/13 pass" },
+    "implementation": { "status": "in_progress", "started_at": "2026-04-09T23:00:00Z", "commits": [] },
+    "testing": { "status": "pending", "ci_passed": false, "tests_added": 0, "instrumentation_verified": false, "analytics_tests_added": 0, "analytics_verification_passed": false },
+    "review": { "status": "pending", "risks": [] },
+    "merge": { "status": "pending", "pr_number": null },
+    "documentation": { "status": "pending" },
+    "metrics": {
+      "primary": { "name": "", "baseline": null, "target": null, "current": null },
+      "secondary": [],
+      "guardrails": [],
+      "instrumentation_ready": false,
+      "first_review_date": null,
+      "kill_criteria": ""
+    }
+  },
+  "tasks": [
+    {"id": "T1", "title": "Add analytics enums + taxonomy rows", "type": "analytics", "skill": "analytics", "status": "pending", "priority": "high", "effort_days": 0.25, "depends_on": [], "completed_at": null},
+    {"id": "T2", "title": "Create BodyCompositionCard view", "type": "ui", "skill": "dev", "status": "pending", "priority": "critical", "effort_days": 1.0, "depends_on": [], "completed_at": null},
+    {"id": "T3", "title": "Create BodyCompositionDetailView (drill-down sheet)", "type": "ui", "skill": "dev", "status": "pending", "priority": "critical", "effort_days": 1.5, "depends_on": [], "completed_at": null},
+    {"id": "T4", "title": "Compact macro strip sub-view (P1)", "type": "ui", "skill": "dev", "status": "pending", "priority": "medium", "effort_days": 0.25, "depends_on": [], "completed_at": null},
+    {"id": "T5", "title": "Wire BodyCompositionCard into MainScreenView", "type": "ui", "skill": "dev", "status": "pending", "priority": "critical", "effort_days": 0.25, "depends_on": ["T2", "T3"], "completed_at": null},
+    {"id": "T6", "title": "Remove old statusCard + goalCard code", "type": "ui", "skill": "dev", "status": "pending", "priority": "high", "effort_days": 0.15, "depends_on": ["T5"], "completed_at": null},
+    {"id": "T7", "title": "Accessibility pass on card + detail view", "type": "ui", "skill": "dev", "status": "pending", "priority": "critical", "effort_days": 0.25, "depends_on": ["T5"], "completed_at": null},
+    {"id": "T8", "title": "Analytics tests + build verification", "type": "test", "skill": "qa", "status": "pending", "priority": "high", "effort_days": 0.5, "depends_on": ["T1", "T5"], "completed_at": null},
+    {"id": "T9", "title": "Full build + CI verification", "type": "test", "skill": "dev", "status": "pending", "priority": "critical", "effort_days": 0.25, "depends_on": ["T5", "T6", "T7", "T8"], "completed_at": null}
+  ]
+}

--- a/.claude/features/home-status-goal-card/tasks.md
+++ b/.claude/features/home-status-goal-card/tasks.md
@@ -1,0 +1,115 @@
+# home-status-goal-card — Task Breakdown
+
+> **Phase:** 2 (Tasks)
+> **Source:** `.claude/features/home-status-goal-card/prd.md`
+
+---
+
+## Dependency graph
+
+```
+T1 (analytics enums) ─────────────┐
+T2 (BodyCompositionCard view) ────┤
+T3 (BodyCompositionDetailView) ───┤──→ T5 (wire into MainScreenView) ──→ T7 (a11y pass)
+T4 (macro strip sub-view) ────────┘                                        │
+                                                                           ├──→ T8 (tests)
+T6 (remove old statusCard + goalCard) ── depends on T5                     │
+                                                                           └──→ T9 (checklist)
+```
+
+---
+
+## Tasks
+
+### T1 — Add analytics enums + taxonomy rows
+- **Type:** analytics | **Skill:** analytics | **Priority:** high | **Effort:** 0.25d
+- **Depends on:** —
+- Add to `AnalyticsEvent`: `homeBodyCompTap`, `homeBodyCompPeriodChanged`, `homeBodyCompLogTap`
+- Add to `AnalyticsParam`: `hasWeight`, `hasBodyFat`, `progressPercent`, `period`
+- Add to `AnalyticsScreen`: `bodyCompDetail`
+- Add 3 convenience methods to `AnalyticsService.swift`
+- Update `analytics-taxonomy.csv` with 3 event rows + 1 screen row
+
+### T2 — Create BodyCompositionCard view
+- **Type:** ui | **Skill:** dev | **Priority:** critical | **Effort:** 1d
+- **Depends on:** —
+- New file: `FitTracker/Views/Main/BodyCompositionCard.swift`
+- Layout per PRD wireframe: eyebrow + chevron, hero weight/BF values, target ranges, linear progress bar, macro strip slot, recommendation line
+- Use `AppMetricColumn` for weight/BF (or adapt for inline horizontal layout)
+- Linear progress bar using existing `progressLine` pattern or new `AppProgressBar`
+- Empty state: "Log your first metrics" CTA
+- `onTap` callback for drill-down
+- All design system tokens, zero raw literals
+
+### T3 — Create BodyCompositionDetailView
+- **Type:** ui | **Skill:** dev | **Priority:** critical | **Effort:** 1.5d
+- **Depends on:** —
+- New file: `FitTracker/Views/Main/BodyCompositionDetailView.swift`
+- Sheet with `.medium`/`.large` detents
+- Weight trend chart (SwiftUI Charts) with goal line overlay
+- Body fat trend chart with goal line overlay
+- Time range picker: segmented control (7d / 30d / 90d / all)
+- Per-metric progress bars (weight + BF separately)
+- "Log Metrics" CTA → opens manual biometric entry
+- `.analyticsScreen(.bodyCompDetail)`
+- Fire `home_body_comp_period_changed` on segment switch
+- Fire `home_body_comp_log_tap` on Log CTA
+
+### T4 — Compact macro strip sub-view (P1)
+- **Type:** ui | **Skill:** dev | **Priority:** medium | **Effort:** 0.25d
+- **Depends on:** —
+- Inline row: icon + "142g / 180g protein" with progress bar
+- Data from `todayLog?.nutritionLog` (protein consumed vs target)
+- Use `AppText.caption` + `AppColor.Chart.nutritionFat`
+- Can be omitted from T2 initially and added after
+
+### T5 — Wire BodyCompositionCard into MainScreenView
+- **Type:** ui | **Skill:** dev | **Priority:** critical | **Effort:** 0.25d
+- **Depends on:** T2, T3
+- Replace `statusCard` + `goalCard` sections in v2 MainScreenView with single `BodyCompositionCard`
+- Wire `onTap` to present `BodyCompositionDetailView` sheet
+- Fire `home_body_comp_tap` on tap
+- Add `@State private var showBodyCompDetail = false`
+
+### T6 — Remove old statusCard + goalCard code
+- **Type:** ui | **Skill:** dev | **Priority:** high | **Effort:** 0.15d
+- **Depends on:** T5
+- Delete `statusCard()` and `goalCard()` private functions from v2 MainScreenView
+- Delete `progressLine()` helper if no longer used
+- Clean up unused computed properties if any
+
+### T7 — Accessibility pass
+- **Type:** ui | **Skill:** dev | **Priority:** critical | **Effort:** 0.25d
+- **Depends on:** T5
+- Card: `.accessibilityLabel` summarizing weight + BF + progress
+- Card: `.accessibilityHint("Tap for details")`
+- Detail view: chart text summaries via `.accessibilityValue`
+- All tap targets ≥ 44pt
+- Dynamic Type verified on both views
+
+### T8 — Tests
+- **Type:** test | **Skill:** qa | **Priority:** high | **Effort:** 0.5d
+- **Depends on:** T1, T5
+- Analytics tests: 3 events fire correctly with params, consent-gated
+- Build verification: `xcodebuild build`
+- Test suite: `xcodebuild test` green
+
+### T9 — Build + CI verification
+- **Type:** test | **Skill:** dev | **Priority:** critical | **Effort:** 0.25d
+- **Depends on:** T5, T6, T7, T8
+- Full build green
+- All existing tests pass (no regressions)
+- Diff review against main
+
+---
+
+## Summary
+
+| Category | Tasks | Effort |
+|---|---|---|
+| Foundation (parallel) | T1, T2, T3, T4 | 3d |
+| Assembly | T5, T6 | 0.4d |
+| Verification | T7, T8, T9 | 1d |
+| **Total** | **9 tasks** | **~4.4 days** |
+
+**Critical path:** T2+T3 (parallel, 1.5d) → T5 (0.25d) → T6+T7 (parallel, 0.25d) → T8+T9 (0.5d) = **~2.5 days effective**

--- a/.claude/features/home-status-goal-card/ux-spec.md
+++ b/.claude/features/home-status-goal-card/ux-spec.md
@@ -1,0 +1,176 @@
+# home-status-goal-card — UX Spec
+
+> **Phase:** 3 (UX)
+> **Input:** research.md, prd.md, Home v2 ux-spec.md
+> **Parent:** Inherits all UX foundations compliance from home-today-screen v2
+
+---
+
+## 1. Components
+
+### BodyCompositionCard (new)
+
+**Location:** `FitTracker/Views/Main/BodyCompositionCard.swift`
+
+```
+┌─────────────────────────────────────────────────┐
+│  BODY COMPOSITION                          ▸    │  ← AppText.eyebrow + SF Symbol chevron.right
+│                                                  │
+│  67.2 kg        14.8%                           │  ← AppText.metric + AppText.footnote (unit)
+│  Weight          Body Fat                        │  ← AppText.caption, AppColor.Text.secondary
+│  Target: 65-68   Target: 13-15%                 │  ← AppText.footnote, AppColor.Text.tertiary
+│                                                  │
+│  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 72%  │  ← Progress bar: AppColor.Accent.primary fill
+│                                                  │     AppColor.Surface.tertiary track
+│  🥩 142g / 180g protein                         │  ← AppText.caption + compact bar (P1)
+│                                                  │
+│  You're on track — keep going! 💪               │  ← AppText.callout, HomeRecommendationProvider
+└─────────────────────────────────────────────────┘
+```
+
+**Parameters:**
+- `currentWeight: Double?`
+- `currentBF: Double?`
+- `weightTarget: ClosedRange<Double>?`
+- `bfTarget: ClosedRange<Double>?`
+- `overallProgress: Double` (0-1)
+- `proteinConsumed: Double?`, `proteinTarget: Double?` (P1 macro strip)
+- `recommendation: HomeRecommendation`
+- `onTap: () -> Void`
+- `onLogTap: () -> Void` (empty state)
+
+**Card container:** `AppCard` (Tone=Elevated) or manual `surfaceElevated` + `radiusMedium` + `elevationCard` (matching Home v2 pattern).
+
+### BodyCompositionDetailView (new)
+
+**Location:** `FitTracker/Views/Main/BodyCompositionDetailView.swift`
+
+**Presentation:** `.sheet` with `.presentationDetents([.medium, .large])`
+
+**Layout:**
+```
+NavigationStack {
+  ScrollView {
+    VStack(spacing: AppSpacing.medium) {
+      // Weight chart section
+      VStack(alignment: .leading) {
+        SectionHeader("Weight")
+        Chart { ... }  // SwiftUI Charts: LineMark for data + RuleMark for goal
+        // Current: 67.2 kg | Goal: 65-68 kg
+      }
+
+      // Body Fat chart section
+      VStack(alignment: .leading) {
+        SectionHeader("Body Fat")
+        Chart { ... }
+        // Current: 14.8% | Goal: 13-15%
+      }
+
+      // Time range picker
+      AppSegmentedControl(options: ["7d", "30d", "90d", "All"])
+
+      // Per-metric progress
+      progressBar("Weight", progress: weightProgress)
+      progressBar("Body Fat", progress: bfProgress)
+
+      // Log CTA
+      AppButton("Log Metrics", hierarchy: .primary, onTap: logAction)
+    }
+  }
+  .navigationTitle("Body Composition")
+  .navigationBarTitleDisplayMode(.inline)
+  .toolbar { ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } } }
+  .analyticsScreen(.bodyCompDetail)
+}
+```
+
+---
+
+## 2. Token Map
+
+| Element | Token |
+|---|---|
+| Card background | `AppColor.Surface.elevated` |
+| Card radius | `AppRadius.medium` (via variable binding) |
+| Card shadow | `effect/elevation-card` |
+| Card padding | `AppSpacing.small` (16pt) |
+| Card item spacing | `AppSpacing.xSmall` (12pt) |
+| Eyebrow "BODY COMPOSITION" | `AppText.eyebrow`, `AppColor.Text.secondary` |
+| Chevron icon | `AppText.caption`, `AppColor.Text.tertiary` |
+| Hero values (67.2 / 14.8) | `AppText.metric` |
+| Value units (kg / %) | `AppText.footnote`, `AppColor.Text.secondary` |
+| Labels (Weight / Body Fat) | `AppText.caption`, `AppColor.Text.secondary` |
+| Target ranges | `AppText.footnote`, `AppColor.Text.tertiary` |
+| Progress bar fill | `AppColor.Accent.primary` |
+| Progress bar track | `AppColor.Surface.tertiary` |
+| Progress bar height | `AppSize.progressBarHeight` (4pt) |
+| Progress bar radius | `AppRadius.micro` (4pt) |
+| Progress percentage | `AppText.caption`, `AppColor.Text.secondary` |
+| Macro strip icon | `AppText.iconSmall` |
+| Macro strip text | `AppText.caption` |
+| Recommendation line | `AppText.callout`, `AppColor.Text.primary` |
+| Detail chart | SwiftUI Charts with `AppColor.Chart.weight`, `AppColor.Chart.body` |
+| Detail goal line | `AppColor.Status.warning` (dashed RuleMark) |
+| Detail segmented control | `AppSegmentedControl` component |
+| Detail CTA | `AppButton` (Hierarchy=Primary) |
+
+---
+
+## 3. State Matrix
+
+| State | Card | Detail |
+|---|---|---|
+| **Default** | Both values shown + progress + recommendation | Charts with data, goal overlays |
+| **Partial** | One value shown, other shows "Log" CTA | One chart, other shows empty message |
+| **Empty** | "Log your first metrics" CTA, no values | Not reachable (card tap disabled when empty) |
+| **Loading** | Skeleton placeholder | Spinner while data loads |
+| **Error** | Falls back to manual data if HealthKit fails | Error message + retry |
+
+---
+
+## 4. Accessibility
+
+| Element | Label | Hint | Value | Traits |
+|---|---|---|---|---|
+| Card (overall) | "Body composition" | "Tap for details" | "Weight {X} kg, body fat {X} percent, {X} percent toward goal" | — |
+| Eyebrow | "Body composition" | — | — | `.isHeader` |
+| Progress bar | "Goal progress" | — | "{X} percent" | — |
+| Macro strip | "Protein" | — | "{X} of {Y} grams" | — |
+| Chevron | hidden (card tap handles it) | — | — | `.isHidden` |
+| Detail: chart | "Weight trend" / "Body fat trend" | — | "Current {X}, goal {Y}" | — |
+| Detail: segment picker | "Time range" | — | "{selected}" | — |
+| Detail: Log CTA | "Log metrics" | "Opens metric entry" | — | `.isButton` |
+
+---
+
+## 5. Motion
+
+| Animation | Token | Trigger | Reduce-motion |
+|---|---|---|---|
+| Card press | Scale 0.98 + `AppSpring.snappy` | Touch down | Opacity only |
+| Progress bar fill | `AppEasing.standard` (0.3s) | Data change | Instant |
+| Detail sheet present | System sheet animation | Tap card | System handles |
+| Chart line draw | `AppEasing.standard` | Detail appears | Instant |
+
+---
+
+## 6. Compliance Gateway
+
+| Check | Status | Details |
+|---|---|---|
+| Token compliance | **Pass** | All values from AppText/AppSpacing/AppColor/AppRadius/AppSize |
+| Component reuse | **Pass** | Reuses AppButton, AppSegmentedControl, SectionHeader. New card is justified (unique layout) |
+| Pattern consistency | **Pass** | Card + drill-down sheet matches Home v2 pattern (ReadinessCard tap → cycle) |
+| Accessibility | **Pass** | All elements labeled, 44pt targets, Dynamic Type, VoiceOver |
+| Motion | **Pass** | All tokenized, reduce-motion respected |
+
+---
+
+## 7. Analytics Mapping
+
+| Interaction | Event | Params |
+|---|---|---|
+| Tap card | `home_body_comp_tap` | has_weight, has_body_fat, progress_percent |
+| Switch time range | `home_body_comp_period_changed` | period (7d/30d/90d/all) |
+| Tap Log CTA in detail | `home_body_comp_log_tap` | source: body_comp_detail |
+| Detail screen view | `.analyticsScreen(.bodyCompDetail)` | — |

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		HV100000000000000000AA04 /* ManualBiometricEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = HV200000000000000000AA04 /* ManualBiometricEntry.swift */; };
 		HV100000000000000000AA05 /* RecoveryRoutineSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = HV200000000000000000AA05 /* RecoveryRoutineSheet.swift */; };
 		HV100000000000000000AA06 /* SyncStatusIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = HV200000000000000000AA06 /* SyncStatusIndicator.swift */; };
+		BC100000000000000000AA01 /* BodyCompositionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC200000000000000000AA01 /* BodyCompositionCard.swift */; };
+		BC100000000000000000AA02 /* BodyCompositionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC200000000000000000AA02 /* BodyCompositionDetailView.swift */; };
 		HV100000000000000000AA03 /* HomeRecommendationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = HV200000000000000000AA03 /* HomeRecommendationProvider.swift */; };
 		FC1000000000000000000001 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = FC2000000000000000000001 /* FirebaseCore */; };
 		FC1000000000000000000002 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = FC2000000000000000000002 /* FirebaseAnalytics */; };
@@ -210,6 +212,8 @@
 		HV200000000000000000AA04 /* ManualBiometricEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualBiometricEntry.swift; sourceTree = "<group>"; };
 		HV200000000000000000AA05 /* RecoveryRoutineSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryRoutineSheet.swift; sourceTree = "<group>"; };
 		HV200000000000000000AA06 /* SyncStatusIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusIndicator.swift; sourceTree = "<group>"; };
+		BC200000000000000000AA01 /* BodyCompositionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyCompositionCard.swift; sourceTree = "<group>"; };
+		BC200000000000000000AA02 /* BodyCompositionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyCompositionDetailView.swift; sourceTree = "<group>"; };
 		HV200000000000000000AA03 /* HomeRecommendationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRecommendationProvider.swift; sourceTree = "<group>"; };
 		FF000002000000000000AA01 /* FitMeLogoLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitMeLogoLoader.swift; sourceTree = "<group>"; };
 		FF000002000000000000AA02 /* LiveInfoStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveInfoStrip.swift; sourceTree = "<group>"; };
@@ -395,6 +399,8 @@
 			children = (
 				A2000001000000000000000B /* MainScreenView.swift */,
 				HV200000000000000000AA02 /* HomeEmptyStateView.swift */,
+				BC200000000000000000AA01 /* BodyCompositionCard.swift */,
+				BC200000000000000000AA02 /* BodyCompositionDetailView.swift */,
 				HV300000000000000000AA01 /* v2 */,
 			);
 			path = Main;
@@ -688,6 +694,8 @@
 				HV100000000000000000AA04 /* ManualBiometricEntry.swift in Sources */,
 				HV100000000000000000AA05 /* RecoveryRoutineSheet.swift in Sources */,
 				HV100000000000000000AA06 /* SyncStatusIndicator.swift in Sources */,
+				BC100000000000000000AA01 /* BodyCompositionCard.swift in Sources */,
+				BC100000000000000000AA02 /* BodyCompositionDetailView.swift in Sources */,
 				HV100000000000000000AA03 /* HomeRecommendationProvider.swift in Sources */,
 				A1000001000000000000000C /* NutritionView.swift in Sources */,
 				A1000001000000000000000D /* TrainingPlanView.swift in Sources */,

--- a/FitTracker/Services/Analytics/AnalyticsProvider.swift
+++ b/FitTracker/Services/Analytics/AnalyticsProvider.swift
@@ -122,6 +122,12 @@ enum AnalyticsEvent {
     static let homeActionCompleted = "home_action_completed"
     /// Home screen shows an empty state (no data available)
     static let homeEmptyStateShown = "home_empty_state_shown"
+    /// User taps the body composition card on the Home screen
+    static let homeBodyCompTap = "home_body_comp_tap"
+    /// User changes the period on the body composition card
+    static let homeBodyCompPeriodChanged = "home_body_comp_period_changed"
+    /// User taps the log CTA on the body composition card
+    static let homeBodyCompLogTap = "home_body_comp_log_tap"
 }
 
 // MARK: - Parameter Constants
@@ -185,6 +191,12 @@ enum AnalyticsParam {
     static let emptyReason        = "empty_reason"     // no_healthkit/no_data/first_launch
     static let ctaShown           = "cta_shown"        // connect_health/log_manually/both
 
+    // Body composition parameters
+    static let hasWeight          = "has_weight"         // true/false
+    static let hasBodyFat         = "has_body_fat"       // true/false
+    static let progressPercent    = "progress_percent"   // 0-100
+    static let period             = "period"             // week/month/quarter/year
+
     // Onboarding parameters
     static let stepIndex          = "step_index"       // 0-4
     static let stepName           = "step_name"        // welcome/goals/profile/healthkit/first_action
@@ -227,6 +239,7 @@ enum AnalyticsScreen {
     static let onboardingFirstAction = "onboarding_first_action"
     static let deleteAccount     = "delete_account"
     static let exportData        = "export_data"
+    static let bodyCompDetail    = "body_comp_detail"
 }
 
 // MARK: - User Property Constants

--- a/FitTracker/Services/Analytics/AnalyticsService.swift
+++ b/FitTracker/Services/Analytics/AnalyticsService.swift
@@ -329,6 +329,27 @@ final class AnalyticsService: ObservableObject {
         ])
     }
 
+    /// User taps the body composition card on the Home screen
+    func logHomeBodyCompTap(hasWeight: Bool, hasBodyFat: Bool, progressPercent: Int) {
+        logEvent(AnalyticsEvent.homeBodyCompTap, parameters: [
+            AnalyticsParam.hasWeight: hasWeight ? "true" : "false",
+            AnalyticsParam.hasBodyFat: hasBodyFat ? "true" : "false",
+            AnalyticsParam.progressPercent: progressPercent,
+        ])
+    }
+
+    /// User changes the period on the body composition card
+    func logHomeBodyCompPeriodChanged(period: String) {
+        logEvent(AnalyticsEvent.homeBodyCompPeriodChanged, parameters: [
+            AnalyticsParam.period: period,
+        ])
+    }
+
+    /// User taps the log CTA on the body composition card
+    func logHomeBodyCompLogTap() {
+        logEvent(AnalyticsEvent.homeBodyCompLogTap, parameters: nil)
+    }
+
     // MARK: - Settings Events
 
     func logSettingsChanged(settingName: String, newValue: String) {

--- a/FitTracker/Views/Main/BodyCompositionCard.swift
+++ b/FitTracker/Views/Main/BodyCompositionCard.swift
@@ -1,0 +1,285 @@
+// FitTracker/Views/Main/BodyCompositionCard.swift
+// Composite card: weight + body-fat metrics, overall progress bar,
+// optional protein strip, and AI recommendation — tappable surface.
+import SwiftUI
+
+struct BodyCompositionCard: View {
+
+    // MARK: - Inputs
+
+    let currentWeight: Double?
+    let currentBF: Double?
+    let weightTarget: (min: Double, max: Double)?
+    let bfTarget: (min: Double, max: Double)?
+    let overallProgress: Double
+    let proteinConsumed: Double?
+    let proteinTarget: Double?
+    let recommendation: HomeRecommendation
+    let onTap: () -> Void
+    let onLogTap: () -> Void
+
+    // MARK: - State
+
+    @State private var isPressed = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // MARK: - Computed
+
+    private var hasData: Bool {
+        currentWeight != nil || currentBF != nil
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            if hasData {
+                filledCard
+                    .onTapGesture { onTap() }
+                    .onLongPressGesture(
+                        minimumDuration: .infinity,
+                        pressing: { pressing in
+                            withAnimation(reduceMotion ? .none : AppSpring.snappy) {
+                                isPressed = pressing
+                            }
+                        },
+                        perform: {}
+                    )
+            } else {
+                emptyCard
+            }
+        }
+        .scaleEffect(isPressed ? 0.98 : 1.0)
+        .motionSafe(AppSpring.snappy, value: isPressed)
+    }
+
+    // MARK: - Filled card
+
+    private var filledCard: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            // 1 — Eyebrow + chevron
+            eyebrowRow
+
+            // 2 — Weight + Body Fat columns
+            metricsRow
+
+            // 3 — Progress bar
+            progressBar
+
+            // 4 — Protein strip (P1, conditional)
+            if let consumed = proteinConsumed, let target = proteinTarget {
+                proteinStrip(consumed: consumed, target: target)
+            }
+
+            // 5 — Recommendation
+            Text(recommendation.title)
+                .font(AppText.callout)
+                .foregroundStyle(recommendation.accentColor)
+                .lineLimit(2)
+                .accessibilityLabel("Recommendation: \(recommendation.title)")
+        }
+        .padding(AppSpacing.small)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.medium, style: .continuous)
+                .fill(AppColor.Surface.elevated)
+        )
+        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Body composition card")
+        .accessibilityHint("Double-tap for details")
+    }
+
+    // MARK: - Empty card
+
+    private var emptyCard: some View {
+        VStack(spacing: AppSpacing.xSmall) {
+            eyebrowRow
+
+            Spacer()
+
+            Button(action: onLogTap) {
+                Text("Log your first metrics")
+                    .font(AppText.button)
+                    .foregroundStyle(AppColor.Accent.primary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Log your first metrics")
+            .accessibilityHint("Opens the metrics logging screen")
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .padding(AppSpacing.small)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.medium, style: .continuous)
+                .fill(AppColor.Surface.elevated)
+        )
+        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Body composition card, empty")
+    }
+
+    // MARK: - Subviews
+
+    private var eyebrowRow: some View {
+        HStack {
+            Text("BODY COMPOSITION")
+                .font(AppText.eyebrow)
+                .foregroundStyle(AppColor.Text.tertiary)
+                .accessibilityAddTraits(.isHeader)
+            Spacer()
+            Image(systemName: AppIcon.forward)
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.tertiary)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var metricsRow: some View {
+        HStack(alignment: .top, spacing: AppSpacing.small) {
+            // Weight column
+            valueColumn(
+                value: currentWeight.map { String(format: "%.1f", $0) },
+                unit: "kg",
+                target: weightTarget.map { "Target: \(String(format: "%.0f", $0.min))–\(String(format: "%.0f", $0.max))" }
+            )
+
+            // Body fat column
+            valueColumn(
+                value: currentBF.map { String(format: "%.1f", $0) },
+                unit: "%",
+                target: bfTarget.map { "Target: \(String(format: "%.0f", $0.min))–\(String(format: "%.0f", $0.max))%" }
+            )
+        }
+    }
+
+    private func valueColumn(value: String?, unit: String, target: String?) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
+            if let value {
+                HStack(alignment: .lastTextBaseline, spacing: AppSpacing.micro) {
+                    Text(value)
+                        .font(AppText.metricM)
+                        .monospacedDigit()
+                        .foregroundStyle(AppColor.Text.primary)
+                    Text(unit)
+                        .font(AppText.footnote.weight(.medium))
+                        .foregroundStyle(AppColor.Text.tertiary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityValue("\(value) \(unit)")
+            } else {
+                Text("—")
+                    .font(AppText.metricM)
+                    .foregroundStyle(AppColor.Text.tertiary)
+            }
+
+            if let target {
+                Text(target)
+                    .font(AppText.caption)
+                    .foregroundStyle(AppColor.Text.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var progressBar: some View {
+        HStack(spacing: AppSpacing.xxSmall) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    // Track
+                    RoundedRectangle(cornerRadius: AppRadius.micro, style: .continuous)
+                        .fill(AppColor.Surface.tertiary)
+
+                    // Fill
+                    RoundedRectangle(cornerRadius: AppRadius.micro, style: .continuous)
+                        .fill(AppColor.Accent.primary)
+                        .frame(width: geo.size.width * min(max(overallProgress, 0), 1))
+                }
+            }
+            .frame(height: AppSize.progressBarHeight)
+
+            Text("\(Int(overallProgress * 100))%")
+                .font(AppText.caption)
+                .monospacedDigit()
+                .foregroundStyle(AppColor.Text.secondary)
+                .accessibilityLabel("Overall progress \(Int(overallProgress * 100)) percent")
+        }
+    }
+
+    private func proteinStrip(consumed: Double, target: Double) -> some View {
+        Text("\u{1F969} \(Int(consumed))g / \(Int(target))g protein")
+            .font(AppText.caption)
+            .foregroundStyle(AppColor.Text.secondary)
+            .accessibilityLabel("Protein: \(Int(consumed)) of \(Int(target)) grams")
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Filled") {
+    BodyCompositionCard(
+        currentWeight: 82.5,
+        currentBF: 18.2,
+        weightTarget: (min: 78, max: 82),
+        bfTarget: (min: 14, max: 16),
+        overallProgress: 0.64,
+        proteinConsumed: 120,
+        proteinTarget: 180,
+        recommendation: HomeRecommendation(
+            tone: .encouraging,
+            title: "Looking good — steady effort today",
+            subtitle: "",
+            accentColor: AppColor.Accent.primary
+        ),
+        onTap: {},
+        onLogTap: {}
+    )
+    .padding(AppSpacing.small)
+    .background(AppGradient.screenBackground)
+}
+
+#Preview("No Protein") {
+    BodyCompositionCard(
+        currentWeight: 82.5,
+        currentBF: nil,
+        weightTarget: (min: 78, max: 82),
+        bfTarget: nil,
+        overallProgress: 0.35,
+        proteinConsumed: nil,
+        proteinTarget: nil,
+        recommendation: HomeRecommendation(
+            tone: .cautious,
+            title: "Take it easy today",
+            subtitle: "",
+            accentColor: AppColor.Status.warning
+        ),
+        onTap: {},
+        onLogTap: {}
+    )
+    .padding(AppSpacing.small)
+    .background(AppGradient.screenBackground)
+}
+
+#Preview("Empty State") {
+    BodyCompositionCard(
+        currentWeight: nil,
+        currentBF: nil,
+        weightTarget: nil,
+        bfTarget: nil,
+        overallProgress: 0,
+        proteinConsumed: nil,
+        proteinTarget: nil,
+        recommendation: HomeRecommendation(
+            tone: .encouraging,
+            title: "Ready to start?",
+            subtitle: "",
+            accentColor: AppColor.Accent.primary
+        ),
+        onTap: {},
+        onLogTap: {}
+    )
+    .padding(AppSpacing.small)
+    .background(AppGradient.screenBackground)
+}
+#endif

--- a/FitTracker/Views/Main/BodyCompositionDetailView.swift
+++ b/FitTracker/Views/Main/BodyCompositionDetailView.swift
@@ -1,0 +1,476 @@
+// FitTracker/Views/Main/BodyCompositionDetailView.swift
+// Full-screen body composition detail — weight & body fat charts, time-range
+// picker, progress bars, and manual-entry CTA.
+// Launched from the Home status card tap.
+
+import SwiftUI
+import Charts
+
+struct BodyCompositionDetailView: View {
+
+    // MARK: - External dependencies
+
+    @EnvironmentObject var dataStore: EncryptedDataStore
+    @EnvironmentObject var healthService: HealthKitService
+    @EnvironmentObject var settings: AppSettings
+    @EnvironmentObject var analytics: AnalyticsService
+
+    @Environment(\.dismiss) var dismiss
+
+    // MARK: - Local state
+
+    @State private var selectedPeriod = 0  // 0=7d, 1=30d, 2=90d, 3=all
+    @State private var showManualEntry = false
+
+    // MARK: - Period helpers
+
+    private let periodLabels = ["7d", "30d", "90d", "All"]
+
+    private var periodDays: Int? {
+        switch selectedPeriod {
+        case 0: return 7
+        case 1: return 30
+        case 2: return 90
+        default: return nil // all
+        }
+    }
+
+    private var cutoffDate: Date? {
+        guard let days = periodDays else { return nil }
+        return Calendar.current.date(byAdding: .day, value: -days, to: Date())
+    }
+
+    // MARK: - Derived data
+
+    private var profile: UserProfile { dataStore.userProfile }
+
+    private var filteredLogs: [DailyLog] {
+        let logs = dataStore.dailyLogs
+        guard let cutoff = cutoffDate else { return logs }
+        return logs.filter { $0.date >= cutoff }
+    }
+
+    /// Weight data points: (date, kg value).
+    private var weightDataPoints: [(date: Date, value: Double)] {
+        filteredLogs.compactMap { log in
+            guard let w = log.biometrics.weightKg else { return nil }
+            return (date: log.date, value: w)
+        }.sorted { $0.date < $1.date }
+    }
+
+    /// Body fat data points: (date, percentage).
+    private var bodyFatDataPoints: [(date: Date, value: Double)] {
+        filteredLogs.compactMap { log in
+            guard let bf = log.biometrics.bodyFatPercent else { return nil }
+            return (date: log.date, value: bf)
+        }.sorted { $0.date < $1.date }
+    }
+
+    private var currentWeight: Double? {
+        weightDataPoints.last?.value
+    }
+
+    private var currentBF: Double? {
+        bodyFatDataPoints.last?.value
+    }
+
+    private var weightProgress: Double {
+        profile.weightProgress(current: currentWeight)
+    }
+
+    private var bfProgress: Double {
+        profile.bfProgress(current: currentBF)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: AppSpacing.medium) {
+                    periodPicker
+                    weightChartSection
+                    bodyFatChartSection
+                    progressBarsSection
+                    logMetricsCTA
+                }
+                .padding(.horizontal, AppSpacing.medium)
+                .padding(.vertical, AppSpacing.small)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .background(AppColor.Background.appPrimary)
+            .navigationTitle("Body Composition")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                        .font(AppText.button)
+                        .foregroundStyle(AppColor.Accent.primary)
+                }
+            }
+            .analyticsScreen(AnalyticsScreen.bodyCompDetail)
+            .sheet(isPresented: $showManualEntry) {
+                ManualBiometricEntry()
+                    .presentationDetents([.medium])
+            }
+        }
+    }
+
+    // MARK: - Period picker
+
+    private var periodPicker: some View {
+        Picker("Time Range", selection: $selectedPeriod) {
+            ForEach(0..<periodLabels.count, id: \.self) { index in
+                Text(periodLabels[index]).tag(index)
+            }
+        }
+        .pickerStyle(.segmented)
+        .onChange(of: selectedPeriod) { _, newValue in
+            let label = newValue < periodLabels.count ? periodLabels[newValue] : "unknown"
+            analytics.logHomeBodyCompPeriodChanged(period: label)
+        }
+        .accessibilityLabel("Time range selector")
+    }
+
+    // MARK: - Weight chart section
+
+    private var weightChartSection: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            // Section header
+            HStack(spacing: AppSpacing.xxSmall) {
+                Image(systemName: AppIcon.weight)
+                    .font(AppText.callout)
+                    .foregroundStyle(AppColor.Chart.weight)
+                Text("Weight")
+                    .font(AppText.sectionTitle)
+                    .foregroundStyle(AppColor.Text.primary)
+            }
+
+            // Chart
+            if weightDataPoints.isEmpty {
+                chartEmptyState(metric: "weight")
+            } else {
+                Chart {
+                    ForEach(weightDataPoints, id: \.date) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("Weight", settings.unitSystem == .metric ? point.value : point.value * 2.20462)
+                        )
+                        .foregroundStyle(AppColor.Chart.weight)
+                        .interpolationMethod(.catmullRom)
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+
+                        PointMark(
+                            x: .value("Date", point.date),
+                            y: .value("Weight", settings.unitSystem == .metric ? point.value : point.value * 2.20462)
+                        )
+                        .foregroundStyle(AppColor.Chart.weight)
+                        .symbolSize(30)
+                    }
+
+                    // Goal range rule marks
+                    let targetMin = settings.unitSystem == .metric
+                        ? profile.targetWeightMin
+                        : profile.targetWeightMin * 2.20462
+                    let targetMax = settings.unitSystem == .metric
+                        ? profile.targetWeightMax
+                        : profile.targetWeightMax * 2.20462
+
+                    RuleMark(y: .value("Goal Min", targetMin))
+                        .foregroundStyle(AppColor.Status.success.opacity(0.6))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 3]))
+
+                    RuleMark(y: .value("Goal Max", targetMax))
+                        .foregroundStyle(AppColor.Status.success.opacity(0.6))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 3]))
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(AppColor.Border.hairline)
+                        AxisValueLabel()
+                            .font(AppText.caption)
+                            .foregroundStyle(AppColor.Text.tertiary)
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(AppColor.Border.hairline)
+                        AxisValueLabel()
+                            .font(AppText.caption)
+                            .foregroundStyle(AppColor.Text.tertiary)
+                    }
+                }
+                .frame(height: 200)
+            }
+
+            // Current vs goal summary
+            weightSummaryLine
+        }
+        .padding(AppSpacing.small)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.card, style: .continuous)
+                .fill(AppColor.Surface.elevated)
+        )
+        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
+    }
+
+    private var weightSummaryLine: some View {
+        HStack(spacing: AppSpacing.xxSmall) {
+            Text("Current:")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.secondary)
+            Text(currentWeight.map { settings.unitSystem.displayWeightValue($0) } ?? "--")
+                .font(AppText.captionStrong)
+                .foregroundStyle(AppColor.Text.primary)
+                .monospacedDigit()
+            Text(settings.unitSystem.weightLabel())
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.tertiary)
+
+            Spacer()
+
+            Text("Goal:")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.secondary)
+            Text("\(settings.unitSystem.displayWeightValue(profile.targetWeightMin))–\(settings.unitSystem.displayWeightValue(profile.targetWeightMax))")
+                .font(AppText.captionStrong)
+                .foregroundStyle(AppColor.Status.success)
+                .monospacedDigit()
+            Text(settings.unitSystem.weightLabel())
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.tertiary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Current weight \(currentWeight.map { settings.unitSystem.displayWeightValue($0) } ?? "unknown") \(settings.unitSystem.weightLabel()), " +
+            "goal \(settings.unitSystem.displayWeightValue(profile.targetWeightMin)) to \(settings.unitSystem.displayWeightValue(profile.targetWeightMax)) \(settings.unitSystem.weightLabel())"
+        )
+    }
+
+    // MARK: - Body fat chart section
+
+    private var bodyFatChartSection: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            // Section header
+            HStack(spacing: AppSpacing.xxSmall) {
+                Image(systemName: AppIcon.bodyFat)
+                    .font(AppText.callout)
+                    .foregroundStyle(AppColor.Chart.body)
+                Text("Body Fat")
+                    .font(AppText.sectionTitle)
+                    .foregroundStyle(AppColor.Text.primary)
+            }
+
+            // Chart
+            if bodyFatDataPoints.isEmpty {
+                chartEmptyState(metric: "body fat")
+            } else {
+                Chart {
+                    ForEach(bodyFatDataPoints, id: \.date) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("Body Fat", point.value)
+                        )
+                        .foregroundStyle(AppColor.Chart.body)
+                        .interpolationMethod(.catmullRom)
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+
+                        PointMark(
+                            x: .value("Date", point.date),
+                            y: .value("Body Fat", point.value)
+                        )
+                        .foregroundStyle(AppColor.Chart.body)
+                        .symbolSize(30)
+                    }
+
+                    // Goal range rule marks
+                    RuleMark(y: .value("Goal Min", profile.targetBFMin))
+                        .foregroundStyle(AppColor.Status.success.opacity(0.6))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 3]))
+
+                    RuleMark(y: .value("Goal Max", profile.targetBFMax))
+                        .foregroundStyle(AppColor.Status.success.opacity(0.6))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 3]))
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(AppColor.Border.hairline)
+                        AxisValueLabel()
+                            .font(AppText.caption)
+                            .foregroundStyle(AppColor.Text.tertiary)
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(AppColor.Border.hairline)
+                        AxisValueLabel()
+                            .font(AppText.caption)
+                            .foregroundStyle(AppColor.Text.tertiary)
+                    }
+                }
+                .frame(height: 200)
+            }
+
+            // Current vs goal summary
+            bodyFatSummaryLine
+        }
+        .padding(AppSpacing.small)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.card, style: .continuous)
+                .fill(AppColor.Surface.elevated)
+        )
+        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
+    }
+
+    private var bodyFatSummaryLine: some View {
+        HStack(spacing: AppSpacing.xxSmall) {
+            Text("Current:")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.secondary)
+            Text(currentBF.map { String(format: "%.1f", $0) } ?? "--")
+                .font(AppText.captionStrong)
+                .foregroundStyle(AppColor.Text.primary)
+                .monospacedDigit()
+            Text("%")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.tertiary)
+
+            Spacer()
+
+            Text("Goal:")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.secondary)
+            Text("\(Int(profile.targetBFMin))–\(Int(profile.targetBFMax))")
+                .font(AppText.captionStrong)
+                .foregroundStyle(AppColor.Status.success)
+                .monospacedDigit()
+            Text("%")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.tertiary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Current body fat \(currentBF.map { String(format: "%.1f", $0) } ?? "unknown") percent, " +
+            "goal \(Int(profile.targetBFMin)) to \(Int(profile.targetBFMax)) percent"
+        )
+    }
+
+    // MARK: - Chart empty state
+
+    private func chartEmptyState(metric: String) -> some View {
+        VStack(spacing: AppSpacing.xSmall) {
+            Image(systemName: AppIcon.chart)
+                .font(AppText.iconLarge)
+                .foregroundStyle(AppColor.Text.tertiary.opacity(0.5))
+            Text("No \(metric) data yet")
+                .font(AppText.callout)
+                .foregroundStyle(AppColor.Text.tertiary)
+            Text("Log your first measurement to see trends")
+                .font(AppText.caption)
+                .foregroundStyle(AppColor.Text.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 200)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No \(metric) data available. Log a measurement to see trends.")
+    }
+
+    // MARK: - Progress bars section
+
+    private var progressBarsSection: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            Text("PROGRESS")
+                .font(AppText.eyebrow)
+                .tracking(2.1)
+                .foregroundStyle(AppColor.Text.tertiary)
+                .textCase(.uppercase)
+                .accessibilityAddTraits(.isHeader)
+
+            progressBar(
+                title: "Weight",
+                progress: weightProgress,
+                tint: AppColor.Chart.weight
+            )
+
+            progressBar(
+                title: "Body Fat",
+                progress: bfProgress,
+                tint: AppColor.Chart.body
+            )
+        }
+        .padding(AppSpacing.small)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.card, style: .continuous)
+                .fill(AppColor.Surface.elevated)
+        )
+        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
+    }
+
+    private func progressBar(title: String, progress: Double, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
+            HStack {
+                Text(title)
+                    .font(AppText.callout)
+                    .foregroundStyle(AppColor.Text.secondary)
+                Spacer()
+                Text("\(Int(progress * 100))%")
+                    .font(AppText.callout)
+                    .monospacedDigit()
+                    .foregroundStyle(tint)
+            }
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: AppRadius.micro, style: .continuous)
+                        .fill(AppColor.Surface.tertiary)
+                    RoundedRectangle(cornerRadius: AppRadius.micro, style: .continuous)
+                        .fill(tint)
+                        .frame(width: max(AppSize.progressBarHeight, proxy.size.width * CGFloat(progress)))
+                }
+            }
+            .frame(height: AppSize.progressBarHeight)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title) progress")
+        .accessibilityValue("\(Int(progress * 100)) percent")
+    }
+
+    // MARK: - Log Metrics CTA
+
+    private var logMetricsCTA: some View {
+        Button {
+            analytics.logHomeBodyCompLogTap()
+            showManualEntry = true
+        } label: {
+            Text("Log Metrics")
+                .font(AppText.button)
+                .foregroundStyle(AppColor.Text.inversePrimary)
+                .frame(maxWidth: .infinity)
+                .frame(height: AppSize.ctaHeight)
+                .background(
+                    AppColor.Accent.primary,
+                    in: RoundedRectangle(cornerRadius: AppRadius.button, style: .continuous)
+                )
+                .shadow(color: AppShadow.ctaColor, radius: AppShadow.ctaRadius, y: AppShadow.ctaYOffset)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Log body composition metrics")
+        .accessibilityHint("Opens the manual entry form for weight and body fat")
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Body Composition Detail") {
+    BodyCompositionDetailView()
+        .environmentObject(EncryptedDataStore())
+        .environmentObject(HealthKitService())
+        .environmentObject(AppSettings())
+        .environmentObject(AnalyticsService.makeDefault())
+}
+#endif

--- a/FitTracker/Views/Main/v2/MainScreenView.swift
+++ b/FitTracker/Views/Main/v2/MainScreenView.swift
@@ -20,6 +20,7 @@ struct MainScreenView: View {
 
     @State private var showExerciseSheet  = false
     @State private var manualEntry        = false
+    @State private var showBodyCompDetail = false
     @State private var selectedRecoveryRoutine: RecoveryRoutine?
     @State private var selectedDayType: DayType? = nil
 
@@ -186,6 +187,13 @@ struct MainScreenView: View {
             ManualBiometricEntry()
                 .presentationDetents([.medium])
         }
+        .sheet(isPresented: $showBodyCompDetail) {
+            NavigationStack {
+                BodyCompositionDetailView()
+            }
+            .presentationDetents([.medium, .large])
+            .presentationCornerRadius(AppRadius.large)
+        }
         .sheet(item: $selectedRecoveryRoutine) { routine in
             NavigationStack {
                 RecoveryRoutineSheet(
@@ -213,8 +221,7 @@ struct MainScreenView: View {
                 greetingSection
                 readinessSection
                 trainingNutritionCard
-                statusCard
-                goalCard
+                bodyCompositionCard
                 metricsRow
             }
             .padding(.horizontal, AppSpacing.medium)
@@ -385,7 +392,36 @@ struct MainScreenView: View {
     }
 
     // ─────────────────────────────────────────────────────
-    // MARK: - Status card (Weight + Body Fat)
+    // MARK: - Body Composition Card (replaces statusCard + goalCard)
+    // ─────────────────────────────────────────────────────
+
+    private var bodyCompositionCard: some View {
+        BodyCompositionCard(
+            currentWeight: currentWeight,
+            currentBF: currentBF,
+            weightTarget: (min: profile.targetWeightMin, max: profile.targetWeightMax),
+            bfTarget: (min: profile.targetBFMin, max: profile.targetBFMax),
+            overallProgress: goalProgress,
+            proteinConsumed: nil, // TODO: wire protein from NutritionProfile when macro strip ships
+            proteinTarget: nil,
+            recommendation: HomeRecommendationProvider.recommendation(
+                readinessScore: readinessScore,
+                isRestDay: activeDayType == .restDay,
+                streakDays: dataStore.supplementStreak
+            ),
+            onTap: {
+                analytics.logHomeBodyCompTap(
+                    hasWeight: currentWeight != nil,
+                    hasBodyFat: currentBF != nil,
+                    progressPercent: Int(goalProgress * 100)
+                )
+                showBodyCompDetail = true
+            },
+            onLogTap: { manualEntry = true }
+        )
+    }
+
+    // MARK: - Status card (REPLACED by bodyCompositionCard — kept for reference)
     // ─────────────────────────────────────────────────────
 
     private var statusCard: some View {

--- a/FitTracker/Views/Main/v2/MainScreenView.swift
+++ b/FitTracker/Views/Main/v2/MainScreenView.swift
@@ -421,133 +421,7 @@ struct MainScreenView: View {
         )
     }
 
-    // MARK: - Status card (REPLACED by bodyCompositionCard — kept for reference)
-    // ─────────────────────────────────────────────────────
-
-    private var statusCard: some View {
-        HStack(alignment: .top, spacing: AppSpacing.small) {
-            AppMetricColumn(
-                icon: AppIcon.weight,
-                title: "WEIGHT",
-                value: currentWeight.map { settings.unitSystem.displayWeightValue($0) },
-                unit: settings.unitSystem.weightLabel(),
-                target: "Goal \(settings.unitSystem.displayWeightValue(profile.targetWeightMin))–\(settings.unitSystem.displayWeightValue(profile.targetWeightMax)) \(settings.unitSystem.weightLabel())",
-                tintColor: AppColor.Chart.weight,
-                onLogTap: { manualEntry = true }
-            )
-
-            Divider()
-                .overlay(AppColor.Surface.tertiary)
-                .padding(.vertical, AppSpacing.xxSmall)
-
-            AppMetricColumn(
-                icon: AppIcon.bodyFat,
-                title: "BODY FAT",
-                value: currentBF.map { String(format: "%.1f", $0) },
-                unit: "%",
-                target: "Goal \(Int(profile.targetBFMin))–\(Int(profile.targetBFMax))%",
-                tintColor: AppColor.Chart.body,
-                onLogTap: { manualEntry = true }
-            )
-        }
-        .padding(AppSpacing.small)
-        .background(
-            RoundedRectangle(cornerRadius: AppRadius.card, style: .continuous)
-                .fill(AppColor.Surface.elevated)
-        )
-        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
-        .scaleEffect(statusPulse ? 1.01 : 1)
-        .motionSafe(AppSpring.snappy, value: statusPulse)
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: - Goal card
-    // ─────────────────────────────────────────────────────
-
-    private var goalCard: some View {
-        HStack(alignment: .center, spacing: AppSpacing.medium) {
-            // Progress ring
-            VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
-                Text("GOAL")
-                    .font(AppText.eyebrow)
-                    .tracking(2.1)
-                    .foregroundStyle(AppColor.Text.tertiary)
-                    .textCase(.uppercase)
-                    .accessibilityAddTraits(.isHeader)
-
-                AppProgressRing(
-                    value: goalProgress,
-                    color: AppColor.Accent.primary,
-                    label: "\(Int(goalProgress * 100))%",
-                    lineWidth: 10
-                )
-                .frame(width: 96, height: 96)
-                .accessibilityLabel("Overall goal progress")
-                .accessibilityValue("\(Int(goalProgress * 100)) percent")
-            }
-
-            // Goal breakdown
-            VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
-                Text("GOAL PROGRESS")
-                    .font(AppText.eyebrow)
-                    .tracking(2.1)
-                    .foregroundStyle(AppColor.Text.tertiary)
-                    .textCase(.uppercase)
-                    .accessibilityAddTraits(.isHeader)
-
-                progressLine(
-                    title: "Weight",
-                    progress: profile.weightProgress(current: currentWeight),
-                    tint: AppColor.Chart.weight
-                )
-                progressLine(
-                    title: "Body Fat",
-                    progress: profile.bfProgress(current: currentBF),
-                    tint: AppColor.Chart.body
-                )
-
-                Text(essentialsSummary)
-                    .font(AppText.caption)
-                    .foregroundStyle(AppColor.Text.tertiary)
-                    .lineLimit(2)
-                    .accessibilityLabel(essentialsSummary)
-            }
-        }
-        .padding(AppSpacing.small)
-        .background(
-            RoundedRectangle(cornerRadius: AppRadius.card, style: .continuous)
-                .fill(AppColor.Surface.elevated)
-        )
-        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
-    }
-
-    private func progressLine(title: String, progress: Double, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
-            HStack {
-                Text(title)
-                    .font(AppText.callout)
-                    .foregroundStyle(AppColor.Text.secondary)
-                Spacer()
-                Text("\(Int(progress * 100))%")
-                    .font(AppText.callout)
-                    .monospacedDigit()
-                    .foregroundStyle(tint)
-            }
-            GeometryReader { proxy in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(AppColor.Surface.tertiary)
-                    Capsule()
-                        .fill(tint.opacity(0.95))
-                        .frame(width: max(8, proxy.size.width * CGFloat(progress)))
-                }
-            }
-            .frame(height: AppSize.progressBarHeight * 2)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(title) progress")
-        .accessibilityValue("\(Int(progress * 100)) percent")
-    }
+    // statusCard + goalCard + progressLine removed — replaced by bodyCompositionCard (PR #65)
 
     // ─────────────────────────────────────────────────────
     // MARK: - Metrics row
@@ -631,13 +505,6 @@ struct MainScreenView: View {
         if loggedMealCount == 0 { count += 1 }
         if completedSupplementStacks < 2 { count += 1 }
         return count
-    }
-
-    private var essentialsSummary: String {
-        if essentialMissingCount == 0 {
-            return "Status is on track for today."
-        }
-        return "\(essentialMissingCount) core \(essentialMissingCount == 1 ? "item still needs" : "items still need") attention."
     }
 
     // ─────────────────────────────────────────────────────

--- a/docs/product/analytics-taxonomy.csv
+++ b/docs/product/analytics-taxonomy.csv
@@ -34,6 +34,9 @@ Onboarding,permission_result,Custom,HealthKit auth response,permission_type (hea
 Home,home_action_tap,Custom,Home Screen,action_type (start_workout/log_meal),day_type (push/pull/legs/etc),has_recommendation (true/false),,,No,event,Primary engagement signal
 Home,home_action_completed,Custom,Home Screen,action_type (start_workout/log_meal),duration_seconds (int),source (home),,,Yes,event,Mark as conversion. Measures follow-through.
 Home,home_empty_state_shown,Custom,Home Screen,empty_reason (no_healthkit/no_data/first_launch),cta_shown (connect_health/log_manually/both),,,,No,event,Monitors data availability
+Home,home_body_comp_tap,Custom,Home Screen,has_weight (true/false),has_body_fat (true/false),progress_percent (0-100),,,No,event,Body comp card drill-down signal
+Home,home_body_comp_period_changed,Custom,Home Screen,period (week/month/quarter/year),,,,,,No,event,Tracks preferred time-range
+Home,home_body_comp_log_tap,Custom,Home Screen,,,,,,,No,event,Log CTA engagement on body comp card
 ,,,,,,,,,,
 Screen Name,View Name,SwiftUI View,Category,,,,,,,,
 Home / Today,home,MainScreenView,core,,,,,,,,
@@ -58,6 +61,7 @@ Sign In,sign_in,SignInView,auth,,,,,,,,
 Sign Up,sign_up,SignUpView,auth,,,,,,,,
 Profile,profile,ProfileView,core,,,,,,,,
 Readiness,readiness,ReadinessCard,core,,,,,,,,
+Body Comp Detail,body_comp_detail,BodyCompDetailView,core,,,,,,,,
 Consent,consent,ConsentView,consent,,,,,,,,
 Onboarding,onboarding,OnboardingView,onboarding,,,,,,,,
 Onboarding Welcome,onboarding_welcome,OnboardingWelcomeView,onboarding,,,,,,,,


### PR DESCRIPTION
## Summary

- Merge separate Status + Goal cards into unified **Body Composition Card** on Home v2
- New **BodyCompositionDetailView** drill-down sheet with trend charts, goal overlays, time range picker
- 3 new `home_body_comp_*` analytics events
- Saves ~70pt vertical space on Home, adds data exploration that didn't exist before

### Changes
| File | Action |
|---|---|
| `BodyCompositionCard.swift` | **New** — unified card: hero values, progress bar, recommendation |
| `BodyCompositionDetailView.swift` | **New** — drill-down: SwiftUI Charts trends, goal overlays, Log CTA |
| `v2/MainScreenView.swift` | **Modified** — replaced statusCard + goalCard with bodyCompositionCard |
| `AnalyticsProvider.swift` | **Modified** — 3 events + 4 params + 1 screen |
| `AnalyticsService.swift` | **Modified** — 3 convenience methods |
| `analytics-taxonomy.csv` | **Modified** — 3 event rows + 1 screen |
| `project.pbxproj` | **Modified** — 2 new file refs |

Sub-feature of home-today-screen v2 (PR #61). Closes #64.

## Test plan

- [x] `xcodebuild build` — BUILD SUCCEEDED
- [ ] Analytics tests for 3 new events
- [ ] Manual: card tap → detail sheet opens
- [ ] Manual: time range switching in detail view
- [ ] Manual: Log CTA → manual biometric entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)