### PR TITLE
feat(home): metric tile deep linking to Stats

### DIFF
--- a/.claude/features/metric-tile-deep-linking/state.json
+++ b/.claude/features/metric-tile-deep-linking/state.json
@@ -1,0 +1,34 @@
+{
+  "feature": "metric-tile-deep-linking",
+  "created": "2026-04-09T23:30:00Z",
+  "updated": "2026-04-09T23:30:00Z",
+  "branch": "feature/metric-tile-deep-linking",
+  "current_phase": "tasks",
+  "work_type": "enhancement",
+  "parent_feature": "home-today-screen",
+  "has_ui": true,
+  "requires_analytics": true,
+  "github_issue_number": 66,
+  "description": "Tap metric tiles (HRV, RHR, Sleep, Steps) on Home → navigate to Stats filtered to that metric. Deferred from Home v2 per OQ-13.",
+  "transitions": [
+    {
+      "from": "init",
+      "to": "tasks",
+      "timestamp": "2026-04-09T23:30:00Z",
+      "approved_by": "user",
+      "note": "Enhancement — skipped Research, PRD, UX. Parent: home-today-screen (PR #61). Deferred item: OQ-13, F11-partial, F25-partial (home_metric_tile_tap event)."
+    }
+  ],
+  "phases": {
+    "research": { "status": "skipped", "reason": "work_type:enhancement" },
+    "prd": { "status": "skipped", "reason": "work_type:enhancement" },
+    "tasks": { "status": "in_progress", "started_at": "2026-04-09T23:30:00Z" },
+    "ux_or_integration": { "status": "skipped", "reason": "work_type:enhancement" },
+    "implementation": { "status": "pending", "commits": [] },
+    "testing": { "status": "pending", "ci_passed": false },
+    "review": { "status": "pending" },
+    "merge": { "status": "pending", "pr_number": null },
+    "documentation": { "status": "pending" }
+  },
+  "tasks": []
+}

--- a/FitTracker/DesignSystem/AppComponents.swift
+++ b/FitTracker/DesignSystem/AppComponents.swift
@@ -343,9 +343,10 @@ struct AppMetricTile: View {
     let label: String          // e.g. "RHR", "HRV", "Sleep"
     let tintColor: Color
     var onLogTap: (() -> Void)?
+    var onTileTap: (() -> Void)?
 
     var body: some View {
-        VStack(spacing: AppSpacing.xxSmall) {
+        let tileContent = VStack(spacing: AppSpacing.xxSmall) {
             Image(systemName: icon)
                 .font(AppText.iconMedium)
                 .foregroundStyle(tintColor)
@@ -378,10 +379,23 @@ struct AppMetricTile: View {
             tintColor.opacity(0.12),
             in: RoundedRectangle(cornerRadius: AppRadius.small, style: .continuous)
         )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(label)
-        .accessibilityValue(value ?? "Empty")
-        .accessibilityHint(value == nil ? "Tap to log" : "")
+
+        if value != nil, let onTileTap {
+            Button(action: onTileTap) {
+                tileContent
+            }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(label)
+            .accessibilityValue(value ?? "Empty")
+            .accessibilityHint("Tap to view \(label) trends in Stats")
+        } else {
+            tileContent
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(label)
+                .accessibilityValue(value ?? "Empty")
+                .accessibilityHint(value == nil ? "Tap to log" : "")
+        }
     }
 }
 

--- a/FitTracker/Services/Analytics/AnalyticsProvider.swift
+++ b/FitTracker/Services/Analytics/AnalyticsProvider.swift
@@ -128,6 +128,8 @@ enum AnalyticsEvent {
     static let homeBodyCompPeriodChanged = "home_body_comp_period_changed"
     /// User taps the log CTA on the body composition card
     static let homeBodyCompLogTap = "home_body_comp_log_tap"
+    /// User taps a metric tile on the Home screen to deep-link into Stats
+    static let homeMetricTileTap = "home_metric_tile_tap"
 }
 
 // MARK: - Parameter Constants
@@ -190,6 +192,8 @@ enum AnalyticsParam {
     static let hasRecommendation  = "has_recommendation" // true/false
     static let emptyReason        = "empty_reason"     // no_healthkit/no_data/first_launch
     static let ctaShown           = "cta_shown"        // connect_health/log_manually/both
+
+    static let hasValue           = "has_value"           // true/false — metric tile has data
 
     // Body composition parameters
     static let hasWeight          = "has_weight"         // true/false

--- a/FitTracker/Services/Analytics/AnalyticsService.swift
+++ b/FitTracker/Services/Analytics/AnalyticsService.swift
@@ -350,6 +350,14 @@ final class AnalyticsService: ObservableObject {
         logEvent(AnalyticsEvent.homeBodyCompLogTap, parameters: nil)
     }
 
+    /// User taps a metric tile on the Home screen to deep-link into Stats
+    func logHomeMetricTileTap(metricType: String, hasValue: Bool) {
+        logEvent(AnalyticsEvent.homeMetricTileTap, parameters: [
+            AnalyticsParam.metricType: metricType,
+            AnalyticsParam.hasValue: hasValue ? "true" : "false",
+        ])
+    }
+
     // MARK: - Settings Events
 
     func logSettingsChanged(settingName: String, newValue: String) {

--- a/FitTracker/Views/Main/v2/MainScreenView.swift
+++ b/FitTracker/Views/Main/v2/MainScreenView.swift
@@ -9,6 +9,7 @@ struct MainScreenView: View {
     // MARK: - External dependencies
 
     @Binding var selectedTab: AppTab
+    @Binding var statsMetric: StatsFocusMetric?
 
     @EnvironmentObject var dataStore:     EncryptedDataStore
     @EnvironmentObject var healthService: HealthKitService
@@ -434,29 +435,47 @@ struct MainScreenView: View {
                 value: displayMetricNumber(hrvValue),
                 label: "HRV",
                 tintColor: AppColor.Chart.hrv,
-                onLogTap: { manualEntry = true }
+                onLogTap: { manualEntry = true },
+                onTileTap: { navigateToStats(metric: .hrv, label: "hrv") }
             )
             AppMetricTile(
                 icon: AppIcon.heart,
                 value: displayMetricNumber(restingHRValue),
                 label: "RHR",
                 tintColor: AppColor.Chart.heartRate,
-                onLogTap: { manualEntry = true }
+                onLogTap: { manualEntry = true },
+                onTileTap: { navigateToStats(metric: .restingHeartRate, label: "resting_heart_rate") }
             )
             AppMetricTile(
                 icon: AppIcon.sleep,
                 value: displaySleepValue,
                 label: "Sleep",
                 tintColor: AppColor.Chart.sleep,
-                onLogTap: { manualEntry = true }
+                onLogTap: { manualEntry = true },
+                onTileTap: { navigateToStats(metric: .sleep, label: "sleep") }
             )
             AppMetricTile(
                 icon: AppIcon.steps,
                 value: displayStepsValue,
                 label: "Steps",
-                tintColor: AppColor.Chart.activity
+                tintColor: AppColor.Chart.activity,
+                onTileTap: { navigateToStats(metric: .steps, label: "steps") }
             )
         }
+    }
+
+    private func navigateToStats(metric: StatsFocusMetric, label: String) {
+        let g = UIImpactFeedbackGenerator(style: .light)
+        g.prepare()
+        g.impactOccurred()
+
+        analytics.logHomeMetricTileTap(
+            metricType: label,
+            hasValue: true
+        )
+
+        statsMetric = metric
+        selectedTab = .stats
     }
 
     // ─────────────────────────────────────────────────────
@@ -613,7 +632,7 @@ private extension EmptyReason {
 #if DEBUG
 #Preview("Home v2 — Filled") {
     NavigationStack {
-        MainScreenView(selectedTab: .constant(.main))
+        MainScreenView(selectedTab: .constant(.main), statsMetric: .constant(nil))
             .environmentObject(EncryptedDataStore())
             .environmentObject(HealthKitService())
             .environmentObject(TrainingProgramStore())

--- a/FitTracker/Views/RootTabView.swift
+++ b/FitTracker/Views/RootTabView.swift
@@ -36,6 +36,7 @@ struct RootTabView: View {
 
     @State private var selectedTab:    AppTab
     @State private var showAccount             = false
+    @State private var pendingStatsMetric: StatsFocusMetric?
 
     init() {
         _selectedTab = State(initialValue: Self.reviewSelectedTab)
@@ -207,10 +208,12 @@ struct RootTabView: View {
     @ViewBuilder
     private func tabContent(_ tab: AppTab) -> some View {
         switch tab {
-        case .main:      MainScreenView(selectedTab: $selectedTab)
+        case .main:      MainScreenView(selectedTab: $selectedTab, statsMetric: $pendingStatsMetric)
         case .training:  TrainingPlanView().analyticsScreen(AnalyticsScreen.trainingPlan)
         case .nutrition: NutritionView().analyticsScreen(AnalyticsScreen.nutrition)
-        case .stats:     StatsView().analyticsScreen(AnalyticsScreen.stats)
+        case .stats:     StatsView(initialMetric: pendingStatsMetric)
+                            .analyticsScreen(AnalyticsScreen.stats)
+                            .onDisappear { pendingStatsMetric = nil }
         }
     }
 

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -246,6 +246,8 @@ private struct MetricSeriesPoint: Identifiable {
 }
 
 struct StatsView: View {
+    var initialMetric: StatsFocusMetric?
+
     @EnvironmentObject var dataStore: EncryptedDataStore
     @EnvironmentObject var healthService: HealthKitService
 
@@ -329,7 +331,11 @@ struct StatsView: View {
         .navigationTitle("Stats")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            syncSelectedMetric()
+            if let initialMetric {
+                selectedMetric = initialMetric
+            } else {
+                syncSelectedMetric()
+            }
         }
         .onChange(of: period) { _, _ in
             chartSelection = nil

--- a/docs/product/analytics-taxonomy.csv
+++ b/docs/product/analytics-taxonomy.csv
@@ -37,6 +37,7 @@ Home,home_empty_state_shown,Custom,Home Screen,empty_reason (no_healthkit/no_dat
 Home,home_body_comp_tap,Custom,Home Screen,has_weight (true/false),has_body_fat (true/false),progress_percent (0-100),,,No,event,Body comp card drill-down signal
 Home,home_body_comp_period_changed,Custom,Home Screen,period (week/month/quarter/year),,,,,,No,event,Tracks preferred time-range
 Home,home_body_comp_log_tap,Custom,Home Screen,,,,,,,No,event,Log CTA engagement on body comp card
+Home,home_metric_tile_tap,Custom,Home Screen,metric_type (hrv/resting_heart_rate/sleep/steps),has_value (true/false),,,,No,event,Metric tile deep-link to Stats tab
 ,,,,,,,,,,
 Screen Name,View Name,SwiftUI View,Category,,,,,,,,
 Home / Today,home,MainScreenView,core,,,,,,,,


### PR DESCRIPTION
## Summary

- Tap metric tiles (HRV, RHR, Sleep, Steps) on Home → navigate to Stats tab with that metric pre-selected
- Deferred from Home v2 (OQ-13, F25-partial). Closes #66.
- Enhancement: 7 files changed, zero new views, backward compatible

### Changes
- `AppMetricTile`: added `onTileTap` callback (nil default, backward compat)
- `StatsView`: added `initialMetric: StatsFocusMetric?` param
- `RootTabView`: `pendingStatsMetric` binding threaded through
- `v2/MainScreenView`: tiles wired with haptic + analytics + tab switch
- Analytics: `home_metric_tile_tap` event + `has_value` param + taxonomy row

## Test plan
- [x] BUILD SUCCEEDED
- [x] TEST SUCCEEDED (all suites)
- [ ] Manual: tap HRV tile → Stats opens with HRV selected
- [ ] Manual: tap Sleep tile → Stats opens with Sleep selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)