### PR TITLE
fix(encryption+tests): Sprint B — HMAC validation + test dedup (3 findings)

### DIFF
--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -148,6 +148,14 @@ actor EncryptionService {
         let expected   = HMAC<SHA512>.authenticationCode(for: toVerify, using: hmacKey)
         guard Data(expected) == mac else { throw FTCryptoError.integrityCheckFailed }
 
+        // Validate timestamp — reject data older than 2 years (stale/replayed)
+        let timestampBits = ts.withUnsafeBytes { $0.load(as: UInt64.self) }
+        let timestamp = Date(timeIntervalSince1970: TimeInterval(bitPattern: timestampBits))
+        let maxAge: TimeInterval = 2 * 365.25 * 24 * 3600  // ~2 years
+        if abs(Date().timeIntervalSince(timestamp)) > maxAge {
+            throw FTCryptoError.decryptFailed("HMAC timestamp outside valid window")
+        }
+
         // Layer 2 decrypt: ChaCha20
         guard let chachaBox = try? ChaChaPoly.SealedBox(combined: Data(ciphertext)),
               let layer1 = try? ChaChaPoly.open(chachaBox, using: chachaKey) else {

--- a/FitTracker/Views/AI/AIInsightCard.swift
+++ b/FitTracker/Views/AI/AIInsightCard.swift
@@ -97,7 +97,7 @@ struct AIInsightCard: View {
             return "Analyzing your data..."
         }
         // Map internal signals to human-readable copy
-        return rec.signals.first.map(humanReadableSignal) ?? "Check your latest insights"
+        return rec.signals.first.map(Self.humanReadableSignal) ?? "Check your latest insights"
     }
 
     private var insightSubtitle: String {
@@ -185,7 +185,8 @@ struct AIInsightCard: View {
 
     /// Maps internal signal keys to user-facing copy.
     /// Follows "Celebration Not Guilt" principle — encouraging, never judgmental.
-    private func humanReadableSignal(_ signal: String) -> String {
+    /// Maps raw AI signal keys to user-facing copy. `internal static` for testability.
+    static func humanReadableSignal(_ signal: String) -> String {
         switch signal {
         case let s where s.contains("sleep_deprivation") || s.contains("sleep_debt"):
             return "Your sleep quality could use a boost"

--- a/FitTrackerTests/EvalTests/AIOutputQualityEvals.swift
+++ b/FitTrackerTests/EvalTests/AIOutputQualityEvals.swift
@@ -9,31 +9,9 @@ final class AIOutputQualityEvals: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Replicates the humanReadableSignal mapping from AIInsightCard.
-    /// The original is a private SwiftUI view method, so we reproduce the
-    /// switch logic here as the testable surface. If the production mapping
-    /// changes, this must stay in sync.
+    /// Calls the production humanReadableSignal from AIInsightCard (now internal static).
     private func humanReadableSignal(_ signal: String) -> String {
-        switch signal {
-        case let s where s.contains("sleep_deprivation") || s.contains("sleep_debt"):
-            return "Your sleep quality could use a boost"
-        case let s where s.contains("elevated_resting_hr") || s.contains("elevated_hr"):
-            return "Your heart rate is a bit elevated today"
-        case let s where s.contains("recovery_phase") || s.contains("keep_intensity"):
-            return "Your body is in recovery mode"
-        case let s where s.contains("protein_below"):
-            return "You might want to up your protein today"
-        case let s where s.contains("high_frequency") || s.contains("overreaching"):
-            return "Consider dialing back intensity"
-        case let s where s.contains("readiness_critical"):
-            return "Your body needs rest today"
-        case let s where s.contains("hydration"):
-            return "Watch your hydration levels"
-        case let s where s.contains("consistency") || s.contains("streak"):
-            return "Great consistency — keep it up!"
-        default:
-            return "New insight available"
-        }
+        AIInsightCard.humanReadableSignal(signal)
     }
 
     /// Builds a minimal ReadinessResult with the given overall score and recommendation.

--- a/docs/case-studies/meta-analysis-audit-and-remediation-case-study.md
+++ b/docs/case-studies/meta-analysis-audit-and-remediation-case-study.md
@@ -13,11 +13,11 @@
 | Work Type | Chore (audit) → Fix (remediation) |
 | Total Findings | 185 (12 critical · 49 high · 90 medium · 25 low · 9 info) |
 | Actionable Findings | 170 |
-| Findings Resolved | **95** across Phases 1–8 + Sprint A |
-| Findings Deferred | 75 (Phase 6 new test files + Phase 9 large-effort) |
+| Findings Resolved | **98** across Phases 1–8 + Sprints A–B |
+| Findings Deferred | 72 (Phase 6 new test files + Phase 9 large-effort) |
 | Domains Covered | 6 (UI, Backend, AI, Design System, Tests, Framework) |
-| Files Changed | 26 app + 4 test |
-| Commits | 11 (7 in PR #84, 2 in PR #85, 1 in PR #86, 1 in PR #87) |
+| Files Changed | 28 app + 5 test |
+| Commits | 12 (7 in PR #84, 2 in PR #85, 1 in PR #86, 2 in PR #87, 1 in PR #88) |
 | Build | SUCCEEDED (pre-audit, post-audit, post-remediation) |
 | Test Suite | 231 pass / 0 fail at every stage |
 | Self-Referential | Yes — same AI system that built the code also audited and fixed it |
@@ -202,7 +202,7 @@ Supporting fixes:
 
 | Metric | Pre-Audit | Post-Remediation | Delta |
 |---|---|---|---|
-| Known findings | 0 | 185 identified, 95 resolved | +185 identified |
+| Known findings | 0 | 185 identified, 98 resolved | +185 identified |
 | Build | SUCCEEDED | SUCCEEDED | No regression |
 | Tests passing | 231 / 0 fail | 231 / 0 fail | No regression |
 | Deprecated Color calls (compiled) | 23 | 0 | -23 (100%) |
@@ -259,7 +259,8 @@ This system finds what it knows how to look for (code patterns, token compliance
 | PR #84 (Phases 1–4, 8) | `fix/audit-remediation` — merged 2026-04-17 |
 | PR #85 (Phases 5, 7) | `fix/audit-remediation-phase-5-7` — merged 2026-04-17 |
 | PR #86 (Phase 6 partial) | `fix/audit-remediation-phase-6` — merged 2026-04-17 |
-| PR #87 (Sprint A) | `fix/audit-sprint-a` — pending |
+| PR #87 (Sprint A) | `fix/audit-sprint-a` — merged 2026-04-17 |
+| PR #88 (Sprint B) | `fix/audit-sprint-b` — pending |
 
 ---
 


### PR DESCRIPTION
## Summary
- **HMAC timestamp validation** (DEEP-AUTH-009, BE-013): Decrypt now rejects encrypted data older than 2 years — prevents replay of stale/rotated-key blobs
- **Extract humanReadableSignal** (TEST-029): Promoted from private instance method to `internal static` on AIInsightCard — test now calls production code instead of maintaining a duplicated switch statement
- **rotateKeys atomicity** (DEEP-AUTH-008): Verified already addressed by actor serialization — no code change needed
- **Case study updated**: 98 of 170 findings now resolved (58%)

## Test plan
- [x] \`xcodebuild build\` — BUILD SUCCEEDED
- [x] \`xcodebuild test\` — All tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)