### PR TITLE
test: Sprint C1 — AI adapter + service tests (6 findings, 27 new test cases)

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -75,6 +75,12 @@
 		PF200000000000000000AT01 /* ProfileAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAnalyticsTests.swift; sourceTree = "<group>"; };
 		RM100000000000000000AT01 /* ReminderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM200000000000000000AT01 /* ReminderTests.swift */; };
 		RM200000000000000000AT01 /* ReminderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderTests.swift; sourceTree = "<group>"; };
+		AD100000000000000000AT01 /* AIAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD200000000000000000AT01 /* AIAdapterTests.swift */; };
+		AD200000000000000000AT01 /* AIAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAdapterTests.swift; sourceTree = "<group>"; };
+		RC100000000000000000AT01 /* RecommendationMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC200000000000000000AT01 /* RecommendationMemoryTests.swift */; };
+		RC200000000000000000AT01 /* RecommendationMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationMemoryTests.swift; sourceTree = "<group>"; };
+		AS100000000000000000AT01 /* AppSettingsAndGoalProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AS200000000000000000AT01 /* AppSettingsAndGoalProfileTests.swift */; };
+		AS200000000000000000AT01 /* AppSettingsAndGoalProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsAndGoalProfileTests.swift; sourceTree = "<group>"; };
 		EV100000000000000000ET01 /* ReadinessFormulaEvals.swift in Sources */ = {isa = PBXBuildFile; fileRef = EV200000000000000000ET01 /* ReadinessFormulaEvals.swift */; };
 		EV100000000000000000ET02 /* AIOutputQualityEvals.swift in Sources */ = {isa = PBXBuildFile; fileRef = EV200000000000000000ET02 /* AIOutputQualityEvals.swift */; };
 		EV100000000000000000ET03 /* AITierBehaviorEvals.swift in Sources */ = {isa = PBXBuildFile; fileRef = EV200000000000000000ET03 /* AITierBehaviorEvals.swift */; };
@@ -718,6 +724,9 @@
 				AI200000000000000000AT01 /* AIAnalyticsTests.swift */,
 				PF200000000000000000AT01 /* ProfileAnalyticsTests.swift */,
 				RM200000000000000000AT01 /* ReminderTests.swift */,
+				AD200000000000000000AT01 /* AIAdapterTests.swift */,
+				RC200000000000000000AT01 /* RecommendationMemoryTests.swift */,
+				AS200000000000000000AT01 /* AppSettingsAndGoalProfileTests.swift */,
 				EV300000000000000000GR01 /* EvalTests */,
 				FT4000001000000000000001 /* SupabaseTests */,
 				NT200000000000000000T001 /* NotificationTests.swift */,
@@ -1067,6 +1076,9 @@
 				AI100000000000000000AT01 /* AIAnalyticsTests.swift in Sources */,
 				PF100000000000000000AT01 /* ProfileAnalyticsTests.swift in Sources */,
 				RM100000000000000000AT01 /* ReminderTests.swift in Sources */,
+				AD100000000000000000AT01 /* AIAdapterTests.swift in Sources */,
+				RC100000000000000000AT01 /* RecommendationMemoryTests.swift in Sources */,
+				AS100000000000000000AT01 /* AppSettingsAndGoalProfileTests.swift in Sources */,
 				EV100000000000000000ET01 /* ReadinessFormulaEvals.swift in Sources */,
 				EV100000000000000000ET02 /* AIOutputQualityEvals.swift in Sources */,
 				EV100000000000000000ET03 /* AITierBehaviorEvals.swift in Sources */,

--- a/FitTracker/Services/AppTheme.swift
+++ b/FitTracker/Services/AppTheme.swift
@@ -108,6 +108,14 @@ enum AppSpacing {
     static let xxLarge:  CGFloat = 40
     /// Supplement detail row indent — checkbox (26) + surrounding padding. Nutrition v2 specific.
     static let supplementDetailIndent: CGFloat = 54
+
+    /// All spacing values that MUST be on the 4pt grid.
+    /// Exposed for compliance tests — add new tokens here when they belong to the grid.
+    /// Sub-grid (`micro`, 2pt) and feature-specific values (`supplementDetailIndent`, 54pt)
+    /// are intentionally excluded.
+    static let gridValues: [CGFloat] = [
+        xxxSmall, xxSmall, xSmall, small, medium, large, xLarge, xxLarge
+    ]
 }
 
 // MARK: - Opacity

--- a/FitTrackerTests/AIAdapterTests.swift
+++ b/FitTrackerTests/AIAdapterTests.swift
@@ -1,0 +1,181 @@
+// FitTrackerTests/AIAdapterTests.swift
+// Golden I/O tests for the AI adapter layer (TEST-006).
+// Asserts that every adapter returns nil for missing data instead of fabricating,
+// and that present data produces the expected snapshot fields.
+
+import XCTest
+@testable import FitTracker
+
+final class AIAdapterTests: XCTestCase {
+
+    // MARK: - ProfileAdapter
+
+    func testProfileAdapter_populatesFieldsFromProfile() {
+        var profile = UserProfile()
+        profile.age = 32
+        profile.trainingDaysPerWeek = 4
+        let preferences = UserPreferences(nutritionGoalMode: .fatLoss)
+
+        var snapshot = LocalUserSnapshot()
+        let adapter = ProfileAdapter(profile: profile, preferences: preferences, todayDayType: .upperPush)
+        adapter.contribute(to: &snapshot)
+
+        XCTAssertEqual(snapshot.ageYears, 32)
+        XCTAssertEqual(snapshot.trainingDaysPerWeek, 4)
+        XCTAssertEqual(snapshot.primaryGoal, "weight_loss")
+    }
+
+    func testProfileAdapter_nilFieldsWhenAbsent() {
+        // No gender/diet fields exist on UserProfile/UserPreferences — must be nil, not fabricated
+        let profile = UserProfile()  // trainingDaysPerWeek defaults to nil
+        let preferences = UserPreferences(nutritionGoalMode: .maintain)
+
+        var snapshot = LocalUserSnapshot()
+        ProfileAdapter(profile: profile, preferences: preferences, todayDayType: .restDay)
+            .contribute(to: &snapshot)
+
+        XCTAssertNil(snapshot.genderIdentity, "Must not fabricate gender")
+        XCTAssertNil(snapshot.dietPattern, "Must not fabricate diet pattern")
+        XCTAssertNil(snapshot.trainingDaysPerWeek, "Must not fabricate training days")
+        XCTAssertEqual(snapshot.primaryGoal, "maintenance")
+    }
+
+    func testProfileAdapter_primaryGoalMapping() {
+        let scenarios: [(NutritionGoalMode, String)] = [
+            (.fatLoss, "weight_loss"),
+            (.maintain, "maintenance"),
+            (.gain, "muscle_gain"),
+        ]
+
+        for (mode, expected) in scenarios {
+            var snapshot = LocalUserSnapshot()
+            let prefs = UserPreferences(nutritionGoalMode: mode)
+            ProfileAdapter(profile: UserProfile(), preferences: prefs, todayDayType: .upperPush)
+                .contribute(to: &snapshot)
+            XCTAssertEqual(snapshot.primaryGoal, expected, "\(mode) should map to \(expected)")
+        }
+    }
+
+    // MARK: - NutritionAdapter
+
+    func testNutritionAdapter_zeroCompletedMeals_returnsNil() {
+        // Even if meals exist but none are completed, mealsPerDay must be nil
+        var log = DailyLog(date: Date(), phase: .recovery, dayType: .restDay, recoveryDay: 0)
+        log.nutritionLog.meals = [
+            MealEntry(mealNumber: 1, name: "Planned", calories: 500, proteinG: 30, carbsG: 50, fatG: 15, status: .pending),
+            MealEntry(mealNumber: 2, name: "Planned2", calories: 600, proteinG: 40, carbsG: 60, fatG: 20, status: .pending),
+        ]
+
+        var snapshot = LocalUserSnapshot()
+        let adapter = NutritionAdapter(
+            latestLog: log,
+            goalPlan: NutritionGoalPlan(calories: 2000, proteinG: 150, carbsG: 200, fatG: 60, title: "", summary: "", emphasis: ""),
+            liveMetrics: LiveMetrics(),
+            profile: UserProfile()
+        )
+        adapter.contribute(to: &snapshot)
+
+        XCTAssertNil(snapshot.mealsPerDay, "Zero completed meals must return nil, not inflate from planned count")
+    }
+
+    func testNutritionAdapter_completedMealsCounted() {
+        var log = DailyLog(date: Date(), phase: .recovery, dayType: .restDay, recoveryDay: 0)
+        log.nutritionLog.meals = [
+            MealEntry(mealNumber: 1, name: "Breakfast", calories: 500, proteinG: 30, carbsG: 50, fatG: 15, status: .completed),
+            MealEntry(mealNumber: 2, name: "Lunch", calories: 600, proteinG: 40, carbsG: 60, fatG: 20, status: .completed),
+            MealEntry(mealNumber: 3, name: "Planned", calories: 700, proteinG: 50, carbsG: 70, fatG: 25, status: .pending),
+        ]
+
+        var snapshot = LocalUserSnapshot()
+        NutritionAdapter(
+            latestLog: log,
+            goalPlan: NutritionGoalPlan(calories: 2000, proteinG: 150, carbsG: 200, fatG: 60, title: "", summary: "", emphasis: ""),
+            liveMetrics: LiveMetrics(),
+            profile: UserProfile()
+        ).contribute(to: &snapshot)
+
+        XCTAssertEqual(snapshot.mealsPerDay, 2, "Only completed meals should count, not planned")
+    }
+
+    // MARK: - TrainingAdapter
+
+    func testTrainingAdapter_noWorkoutData_returnsNilNotFallback() {
+        // No exercises, no cardio — avgSessionMinutes must be nil, not fabricated 30/45
+        let logs: [DailyLog] = []
+        var snapshot = LocalUserSnapshot()
+        TrainingAdapter(recentLogs: logs, todayDayType: .restDay).contribute(to: &snapshot)
+
+        XCTAssertNil(snapshot.avgSessionMinutes, "No workout data must produce nil, not fabricated fallback")
+        XCTAssertEqual(snapshot.weeklySessionCount, 0)
+    }
+
+    func testTrainingAdapter_usesExerciseCountForDuration() {
+        // 3 exercises → max(20, 3 * 15) = 45 min estimate
+        var log = DailyLog(date: Date(), phase: .recovery, dayType: .upperPush, recoveryDay: 0)
+        log.exerciseLogs = [
+            "e1": ExerciseLog(exerciseID: "e1", exerciseName: "Bench"),
+            "e2": ExerciseLog(exerciseID: "e2", exerciseName: "OHP"),
+            "e3": ExerciseLog(exerciseID: "e3", exerciseName: "Fly"),
+        ]
+
+        var snapshot = LocalUserSnapshot()
+        TrainingAdapter(recentLogs: [log], todayDayType: .upperPush).contribute(to: &snapshot)
+
+        XCTAssertEqual(snapshot.avgSessionMinutes, 45, "3 exercises × 15min = 45min")
+    }
+
+    // MARK: - HealthKitAdapter
+
+    func testHealthKitAdapter_bmiBoundsRejection() {
+        // Weight of 500kg is implausible — BMI must be nil
+        var live = LiveMetrics()
+        live.weightKg = 500
+        var profile = UserProfile()
+        profile.heightCm = 175
+
+        var snapshot = LocalUserSnapshot()
+        HealthKitAdapter(liveMetrics: live, recentLogs: [], profile: profile, readiness: nil)
+            .contribute(to: &snapshot)
+
+        XCTAssertNil(snapshot.bmiValue, "Implausible weight must produce nil BMI")
+    }
+
+    func testHealthKitAdapter_bmiPlausibleWeight() {
+        var live = LiveMetrics()
+        live.weightKg = 70
+        var profile = UserProfile()
+        profile.heightCm = 175
+
+        var snapshot = LocalUserSnapshot()
+        HealthKitAdapter(liveMetrics: live, recentLogs: [], profile: profile, readiness: nil)
+            .contribute(to: &snapshot)
+
+        XCTAssertNotNil(snapshot.bmiValue)
+        if let bmi = snapshot.bmiValue {
+            XCTAssertEqual(bmi, 70.0 / (1.75 * 1.75), accuracy: 0.01)
+        }
+    }
+
+    func testHealthKitAdapter_stressNilWhenNoSubjectiveSignals() {
+        // Log exists but no mood/energy/craving set — stress must be nil
+        let log = DailyLog(date: Date(), phase: .recovery, dayType: .restDay, recoveryDay: 0)
+
+        var snapshot = LocalUserSnapshot()
+        HealthKitAdapter(liveMetrics: LiveMetrics(), recentLogs: [log], profile: UserProfile(), readiness: nil)
+            .contribute(to: &snapshot)
+
+        XCTAssertNil(snapshot.stressLevel, "Must not fabricate 'moderate' stress when no subjective signals present")
+    }
+
+    func testHealthKitAdapter_stressInferredFromMoodEnergy() {
+        var log = DailyLog(date: Date(), phase: .recovery, dayType: .restDay, recoveryDay: 0)
+        log.mood = 5
+        log.energyLevel = 5
+
+        var snapshot = LocalUserSnapshot()
+        HealthKitAdapter(liveMetrics: LiveMetrics(), recentLogs: [log], profile: UserProfile(), readiness: nil)
+            .contribute(to: &snapshot)
+
+        XCTAssertEqual(snapshot.stressLevel, "low", "High mood + energy should infer low stress")
+    }
+}

--- a/FitTrackerTests/AppSettingsAndGoalProfileTests.swift
+++ b/FitTrackerTests/AppSettingsAndGoalProfileTests.swift
@@ -1,0 +1,97 @@
+// FitTrackerTests/AppSettingsAndGoalProfileTests.swift
+// TEST-015: AppSettings defaults + UserDefaults round-trip
+// TEST-017: GoalProfile.forGoal returns the correct profile for each mode
+
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class AppSettingsTests: XCTestCase {
+
+    private let unitKey = "ft.unitSystem"
+    private let appearanceKey = "ft.appearance"
+    private let biometricKey = "ft.requireBiometricUnlockOnReopen"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: unitKey)
+        UserDefaults.standard.removeObject(forKey: appearanceKey)
+        UserDefaults.standard.removeObject(forKey: biometricKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: unitKey)
+        UserDefaults.standard.removeObject(forKey: appearanceKey)
+        UserDefaults.standard.removeObject(forKey: biometricKey)
+        super.tearDown()
+    }
+
+    func testDefaults_freshLaunchHasExpectedValues() {
+        let settings = AppSettings()
+        XCTAssertEqual(settings.unitSystem, .metric, "Default unit system should be metric")
+        XCTAssertEqual(settings.appearance, .system, "Default appearance should be system")
+        XCTAssertFalse(settings.requireBiometricUnlockOnReopen, "Biometric unlock should be off by default")
+    }
+
+    func testUnitSystem_roundTripsThroughUserDefaults() {
+        let settings = AppSettings()
+        settings.unitSystem = .imperial
+
+        // Create a fresh instance — must pick up the persisted value
+        let restored = AppSettings()
+        XCTAssertEqual(restored.unitSystem, .imperial)
+    }
+
+    func testAppearance_roundTripsThroughUserDefaults() {
+        let settings = AppSettings()
+        settings.appearance = .dark
+
+        let restored = AppSettings()
+        XCTAssertEqual(restored.appearance, .dark)
+    }
+
+    func testBiometricFlag_roundTripsThroughUserDefaults() {
+        let settings = AppSettings()
+        settings.requireBiometricUnlockOnReopen = true
+
+        let restored = AppSettings()
+        XCTAssertTrue(restored.requireBiometricUnlockOnReopen)
+    }
+}
+
+final class GoalProfileTests: XCTestCase {
+
+    func testForGoal_fatLossMapsToFatLossProfile() {
+        let profile = GoalProfile.forGoal(.fatLoss)
+        XCTAssertEqual(profile.goal, .fatLoss)
+        XCTAssertFalse(profile.primaryDrivers.isEmpty)
+        XCTAssertFalse(profile.secondaryDrivers.isEmpty)
+    }
+
+    func testForGoal_gainMapsToMuscleGainProfile() {
+        let profile = GoalProfile.forGoal(.gain)
+        XCTAssertEqual(profile.goal, .gain)
+    }
+
+    func testForGoal_maintainMapsToMaintenanceProfile() {
+        let profile = GoalProfile.forGoal(.maintain)
+        XCTAssertEqual(profile.goal, .maintain)
+    }
+
+    func testFatLossProfile_hasCaloricDeficitAsPrimaryDriver() {
+        let profile = GoalProfile.forGoal(.fatLoss)
+        let primary = profile.primaryDrivers.first { $0.metric == "caloric_balance" }
+        XCTAssertNotNil(primary, "Fat loss profile must have caloric_balance as a primary driver")
+        XCTAssertEqual(primary?.direction, .lower, "Fat loss caloric direction must be lower")
+    }
+
+    func testAllProfiles_haveMessagingForAllSegments() {
+        // Every goal profile should have messaging for training, nutrition, recovery
+        for mode in NutritionGoalMode.allCases {
+            let profile = GoalProfile.forGoal(mode)
+            XCTAssertNotNil(profile.messagingEmphasis[.training], "\(mode) missing training messaging")
+            XCTAssertNotNil(profile.messagingEmphasis[.nutrition], "\(mode) missing nutrition messaging")
+            XCTAssertNotNil(profile.messagingEmphasis[.recovery], "\(mode) missing recovery messaging")
+        }
+    }
+}

--- a/FitTrackerTests/FitTrackerCoreTests.swift
+++ b/FitTrackerTests/FitTrackerCoreTests.swift
@@ -757,13 +757,10 @@ final class FitTrackerCoreTests: XCTestCase {
     }
 
     func testSpacingScaleIsStrictly4ptGrid() {
-        // Every AppSpacing value must be a multiple of 4
-        let spacingValues: [CGFloat] = [
-            AppSpacing.xxxSmall, AppSpacing.xxSmall, AppSpacing.xSmall,
-            AppSpacing.small, AppSpacing.medium, AppSpacing.large,
-            AppSpacing.xLarge, AppSpacing.xxLarge
-        ]
-        for value in spacingValues {
+        // Iterate over the production gridValues array — any new token added
+        // to AppSpacing.gridValues is automatically tested.
+        XCTAssertFalse(AppSpacing.gridValues.isEmpty, "AppSpacing.gridValues must not be empty")
+        for value in AppSpacing.gridValues {
             XCTAssertEqual(
                 value.truncatingRemainder(dividingBy: 4), 0,
                 "AppSpacing value \(value) is not on the 4pt grid"

--- a/FitTrackerTests/RecommendationMemoryTests.swift
+++ b/FitTrackerTests/RecommendationMemoryTests.swift
@@ -1,0 +1,170 @@
+// FitTrackerTests/RecommendationMemoryTests.swift
+// Tests for RecommendationMemory (TEST-008):
+// - Record/retrieve outcomes by segment
+// - Acceptance rate computation with minimum sample gate
+// - Frequently-dismissed signal detection
+// - GDPR clearAll
+// - LRU eviction (O(n) single-pass)
+
+import XCTest
+@testable import FitTracker
+
+final class RecommendationMemoryTests: XCTestCase {
+
+    private let uniqueKey = "fitme.ai.recommendation_memory"
+
+    override func setUp() {
+        super.setUp()
+        // Clear any existing state before each test
+        UserDefaults.standard.removeObject(forKey: uniqueKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: uniqueKey)
+        super.tearDown()
+    }
+
+    // MARK: - Record / retrieve
+
+    func testRecord_storesOutcomeForSegment() {
+        let memory = RecommendationMemory()
+        let outcome = RecommendationOutcome(
+            segment: AISegment.training.rawValue,
+            signals: ["local_sleep_debt"],
+            confidenceLevel: "high",
+            source: "cloud",
+            action: .accepted
+        )
+        memory.record(outcome: outcome)
+
+        let retrieved = memory.outcomes(for: .training)
+        XCTAssertEqual(retrieved.count, 1)
+        XCTAssertEqual(retrieved.first?.signals, ["local_sleep_debt"])
+    }
+
+    func testOutcomes_filtersBySegment() {
+        let memory = RecommendationMemory()
+        memory.record(outcome: outcome(segment: .training, action: .accepted))
+        memory.record(outcome: outcome(segment: .nutrition, action: .accepted))
+        memory.record(outcome: outcome(segment: .training, action: .dismissed))
+
+        XCTAssertEqual(memory.outcomes(for: .training).count, 2)
+        XCTAssertEqual(memory.outcomes(for: .nutrition).count, 1)
+        XCTAssertEqual(memory.outcomes(for: .recovery).count, 0)
+    }
+
+    // MARK: - Acceptance rate
+
+    func testAcceptanceRate_belowThresholdReturnsNil() {
+        let memory = RecommendationMemory()
+        // Record 4 — below the minimum of 5
+        for _ in 0..<4 {
+            memory.record(outcome: outcome(segment: .training, action: .accepted))
+        }
+        XCTAssertNil(memory.acceptanceRate(for: .training),
+                     "Acceptance rate below minimum sample gate must return nil")
+    }
+
+    func testAcceptanceRate_computesCorrectly() {
+        let memory = RecommendationMemory()
+        // 3 accepted + 2 dismissed = 60% acceptance
+        for _ in 0..<3 { memory.record(outcome: outcome(segment: .training, action: .accepted)) }
+        for _ in 0..<2 { memory.record(outcome: outcome(segment: .training, action: .dismissed)) }
+
+        let rate = memory.acceptanceRate(for: .training)
+        XCTAssertNotNil(rate)
+        XCTAssertEqual(rate ?? 0, 0.6, accuracy: 0.001)
+    }
+
+    func testAcceptanceRate_ignoresIgnored() {
+        let memory = RecommendationMemory()
+        // 5 accepted + 5 ignored — ignored should be excluded from denominator
+        for _ in 0..<5 { memory.record(outcome: outcome(segment: .training, action: .accepted)) }
+        for _ in 0..<5 { memory.record(outcome: outcome(segment: .training, action: .ignored)) }
+
+        XCTAssertEqual(memory.acceptanceRate(for: .training) ?? 0, 1.0, accuracy: 0.001,
+                       "Ignored outcomes must be excluded from acceptance rate denominator")
+    }
+
+    // MARK: - Frequently dismissed signals
+
+    func testFrequentlyDismissedSignals_returnsSignalsAboveThreshold() {
+        let memory = RecommendationMemory()
+        // Dismiss "low_sleep" 3 times, "low_protein" once
+        memory.record(outcome: outcome(segment: .nutrition, action: .dismissed, signals: ["low_sleep"]))
+        memory.record(outcome: outcome(segment: .nutrition, action: .dismissed, signals: ["low_sleep"]))
+        memory.record(outcome: outcome(segment: .nutrition, action: .dismissed, signals: ["low_sleep", "low_protein"]))
+
+        let frequent = memory.frequentlyDismissedSignals(for: .nutrition, threshold: 3)
+        XCTAssertTrue(frequent.contains("low_sleep"))
+        XCTAssertFalse(frequent.contains("low_protein"))
+    }
+
+    // MARK: - GDPR clearAll
+
+    func testClearAll_removesAllOutcomes() {
+        let memory = RecommendationMemory()
+        memory.record(outcome: outcome(segment: .training, action: .accepted))
+        memory.record(outcome: outcome(segment: .nutrition, action: .dismissed))
+
+        XCTAssertEqual(memory.totalCount, 2)
+        memory.clearAll()
+        XCTAssertEqual(memory.totalCount, 0)
+        XCTAssertTrue(memory.outcomes(for: .training).isEmpty)
+    }
+
+    // MARK: - LRU eviction
+
+    func testEnforceLimit_evictsOldestWhenExceeded() {
+        // Fill one segment past the limit and verify the oldest are evicted
+        let memory = RecommendationMemory()
+        let limit = 200
+
+        for i in 0..<(limit + 5) {
+            let o = RecommendationOutcome(
+                segment: AISegment.training.rawValue,
+                signals: ["signal_\(i)"],
+                confidenceLevel: "high",
+                source: "cloud",
+                action: .accepted
+            )
+            memory.record(outcome: o)
+        }
+
+        XCTAssertEqual(memory.outcomes(for: .training).count, limit,
+                       "Segment count must be capped at maxEntriesPerSegment")
+        // The last 5 (most recent) should be retained; signal_0..signal_4 evicted
+        let signals = memory.outcomes(for: .training).flatMap(\.signals)
+        XCTAssertFalse(signals.contains("signal_0"), "Oldest outcome must be evicted")
+        XCTAssertTrue(signals.contains("signal_\(limit + 4)"), "Newest outcome must be retained")
+    }
+
+    func testEnforceLimit_isolatesSegments() {
+        let memory = RecommendationMemory()
+        // Fill training past limit, nutrition untouched
+        for i in 0..<210 {
+            memory.record(outcome: outcome(segment: .training, action: .accepted, signals: ["t_\(i)"]))
+        }
+        memory.record(outcome: outcome(segment: .nutrition, action: .accepted, signals: ["n_0"]))
+
+        XCTAssertEqual(memory.outcomes(for: .training).count, 200)
+        XCTAssertEqual(memory.outcomes(for: .nutrition).count, 1,
+                       "Eviction in one segment must not touch other segments")
+    }
+
+    // MARK: - Helpers
+
+    private func outcome(
+        segment: AISegment,
+        action: UserAction,
+        signals: [String] = ["test_signal"]
+    ) -> RecommendationOutcome {
+        RecommendationOutcome(
+            segment: segment.rawValue,
+            signals: signals,
+            confidenceLevel: "high",
+            source: "cloud",
+            action: action
+        )
+    }
+}

--- a/FitTrackerTests/SupabaseTests/SyncMergeTests.swift
+++ b/FitTrackerTests/SupabaseTests/SyncMergeTests.swift
@@ -31,6 +31,20 @@ final class SyncMergeTests: XCTestCase {
         XCTAssertEqual(store.dailyLogs.first?.notes, "local")
     }
 
+    func testDailyLogMerge_sameTimestamp_keepsLocal() {
+        // Strict > comparison means equal timestamps don't replace local.
+        // This documents the tie-break contract: local wins on ties.
+        let store = EncryptedDataStore()
+        let logDate = Date()
+        let sharedTimestamp = Date()
+        let local  = makeDailyLog(date: logDate, notes: "local",  modifiedAt: sharedTimestamp)
+        let remote = makeDailyLog(date: logDate, notes: "remote", modifiedAt: sharedTimestamp)
+        store.dailyLogs = [local]
+        store.mergeDailyLog(remote)
+        XCTAssertEqual(store.dailyLogs.first?.notes, "local",
+                       "Same-timestamp tie-break: local wins (remote must be strictly newer)")
+    }
+
     func testDailyLogMerge_noLocal_insertsRemote() {
         let store = EncryptedDataStore()
         let remote = makeDailyLog(date: Date(), notes: "remote", modifiedAt: Date())

--- a/docs/case-studies/meta-analysis-audit-and-remediation-case-study.md
+++ b/docs/case-studies/meta-analysis-audit-and-remediation-case-study.md
@@ -13,11 +13,12 @@
 | Work Type | Chore (audit) → Fix (remediation) |
 | Total Findings | 185 (12 critical · 49 high · 90 medium · 25 low · 9 info) |
 | Actionable Findings | 170 |
-| Findings Resolved | **98** across Phases 1–8 + Sprints A–B |
-| Findings Deferred | 72 (Phase 6 new test files + Phase 9 large-effort) |
+| Findings Resolved | **104** across Phases 1–8 + Sprints A–C1 |
+| Findings Deferred | 66 (Phase 6 mock-infra test files + Phase 9 large-effort) |
 | Domains Covered | 6 (UI, Backend, AI, Design System, Tests, Framework) |
-| Files Changed | 28 app + 5 test |
-| Commits | 12 (7 in PR #84, 2 in PR #85, 1 in PR #86, 2 in PR #87, 1 in PR #88) |
+| Files Changed | 29 app + 8 test |
+| Commits | 13 (cumulative across PRs #84–89) |
+| New Test Suites | AIAdapterTests (10), RecommendationMemoryTests (9), AppSettingsTests (4), GoalProfileTests (5) |
 | Build | SUCCEEDED (pre-audit, post-audit, post-remediation) |
 | Test Suite | 231 pass / 0 fail at every stage |
 | Self-Referential | Yes — same AI system that built the code also audited and fixed it |
@@ -202,7 +203,7 @@ Supporting fixes:
 
 | Metric | Pre-Audit | Post-Remediation | Delta |
 |---|---|---|---|
-| Known findings | 0 | 185 identified, 98 resolved | +185 identified |
+| Known findings | 0 | 185 identified, 104 resolved | +185 identified |
 | Build | SUCCEEDED | SUCCEEDED | No regression |
 | Tests passing | 231 / 0 fail | 231 / 0 fail | No regression |
 | Deprecated Color calls (compiled) | 23 | 0 | -23 (100%) |
@@ -266,6 +267,7 @@ This system finds what it knows how to look for (code patterns, token compliance
 | PR #86 (Phase 6 partial) | `fix/audit-remediation-phase-6` — merged 2026-04-17 |
 | PR #87 (Sprint A) | `fix/audit-sprint-a` — merged 2026-04-17 |
 | PR #88 (Sprint B) | `fix/audit-sprint-b` — merged 2026-04-17 |
+| PR #89 (Sprint C1) | `fix/audit-sprint-c1` — pending |
 
 ---
 
@@ -285,6 +287,7 @@ This system finds what it knows how to look for (code patterns, token compliance
 | Phantom tests + deterministic helpers | TEST-018/020/021/030 | #86 |
 | UserDefaults namespacing, singleton timestamps, schema version | BE-004/009/012, DEEP-SYNC-006/009/012/013, DEEP-AUTH-012/014, BE-003 | #87 |
 | HMAC timestamp validation, test deduplication | DEEP-AUTH-008/009, BE-013, TEST-029 | #88 |
+| AI adapter golden I/O tests (27 new test cases) | TEST-006/008/015/017/019/022 | #89 |
 
 ### Pending: 72 findings (3 categories)
 


### PR DESCRIPTION
## Summary

Sprint C1 — test coverage that doesn't require mock infrastructure. 27 new test cases, 4 new test suites, 6 audit findings resolved.

**New test suites:**
- `AIAdapterTests` (10) — TEST-006 golden I/O for all 4 AI adapters
- `RecommendationMemoryTests` (9) — TEST-008 store/retrieve, acceptance rate, LRU eviction
- `AppSettingsTests` (4) — TEST-015 defaults + UserDefaults round-trip
- `GoalProfileTests` (5) — TEST-017 each mode maps to correct profile

**In-place fixes:**
- TEST-019: `AppSpacing.gridValues` array exposed so tests auto-validate new tokens
- TEST-022: Same-timestamp tie-break test documents local-wins contract

## Test plan
- [x] \`xcodebuild test\` — TEST SUCCEEDED, all 27 new tests pass
- [x] No regressions in existing 231-test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)