### PR TITLE
test: Sprint C3 — EncryptionService/Auth/HealthKit tests + Sprint B crash fix

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -91,6 +91,12 @@
 		AB200000000000000000AT01 /* AccessibilityBasicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityBasicsTests.swift; sourceTree = "<group>"; };
 		AC100000000000000000AT01 /* AccountDeletionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC200000000000000000AT01 /* AccountDeletionServiceTests.swift */; };
 		AC200000000000000000AT01 /* AccountDeletionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletionServiceTests.swift; sourceTree = "<group>"; };
+		EC100000000000000000AT01 /* EncryptionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC200000000000000000AT01 /* EncryptionServiceTests.swift */; };
+		EC200000000000000000AT01 /* EncryptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptionServiceTests.swift; sourceTree = "<group>"; };
+		AM100000000000000000AT01 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AM200000000000000000AT01 /* AuthManagerTests.swift */; };
+		AM200000000000000000AT01 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
+		HK100000000000000000AT01 /* HealthKitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HK200000000000000000AT01 /* HealthKitServiceTests.swift */; };
+		HK200000000000000000AT01 /* HealthKitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitServiceTests.swift; sourceTree = "<group>"; };
 		EV100000000000000000ET01 /* ReadinessFormulaEvals.swift in Sources */ = {isa = PBXBuildFile; fileRef = EV200000000000000000ET01 /* ReadinessFormulaEvals.swift */; };
 		EV100000000000000000ET02 /* AIOutputQualityEvals.swift in Sources */ = {isa = PBXBuildFile; fileRef = EV200000000000000000ET02 /* AIOutputQualityEvals.swift */; };
 		EV100000000000000000ET03 /* AITierBehaviorEvals.swift in Sources */ = {isa = PBXBuildFile; fileRef = EV200000000000000000ET03 /* AITierBehaviorEvals.swift */; };
@@ -742,6 +748,9 @@
 				PB200000000000000000AT01 /* PerformanceBenchmarkTests.swift */,
 				AB200000000000000000AT01 /* AccessibilityBasicsTests.swift */,
 				AC200000000000000000AT01 /* AccountDeletionServiceTests.swift */,
+				EC200000000000000000AT01 /* EncryptionServiceTests.swift */,
+				AM200000000000000000AT01 /* AuthManagerTests.swift */,
+				HK200000000000000000AT01 /* HealthKitServiceTests.swift */,
 				EV300000000000000000GR01 /* EvalTests */,
 				FT4000001000000000000001 /* SupabaseTests */,
 				NT200000000000000000T001 /* NotificationTests.swift */,
@@ -1099,6 +1108,9 @@
 				PB100000000000000000AT01 /* PerformanceBenchmarkTests.swift in Sources */,
 				AB100000000000000000AT01 /* AccessibilityBasicsTests.swift in Sources */,
 				AC100000000000000000AT01 /* AccountDeletionServiceTests.swift in Sources */,
+				EC100000000000000000AT01 /* EncryptionServiceTests.swift in Sources */,
+				AM100000000000000000AT01 /* AuthManagerTests.swift in Sources */,
+				HK100000000000000000AT01 /* HealthKitServiceTests.swift in Sources */,
 				EV100000000000000000ET01 /* ReadinessFormulaEvals.swift in Sources */,
 				EV100000000000000000ET02 /* AIOutputQualityEvals.swift in Sources */,
 				EV100000000000000000ET03 /* AITierBehaviorEvals.swift in Sources */,

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -148,8 +148,12 @@ actor EncryptionService {
         let expected   = HMAC<SHA512>.authenticationCode(for: toVerify, using: hmacKey)
         guard Data(expected) == mac else { throw FTCryptoError.integrityCheckFailed }
 
-        // Validate timestamp — reject data older than 2 years (stale/replayed)
-        let timestampBits = ts.withUnsafeBytes { $0.load(as: UInt64.self) }
+        // Validate timestamp — reject data older than 2 years (stale/replayed).
+        // Copy into aligned storage before reading — the Data slice may be unaligned.
+        var timestampBits: UInt64 = 0
+        withUnsafeMutableBytes(of: &timestampBits) { dst in
+            ts.copyBytes(to: dst)
+        }
         let timestamp = Date(timeIntervalSince1970: TimeInterval(bitPattern: timestampBits))
         let maxAge: TimeInterval = 2 * 365.25 * 24 * 3600  // ~2 years
         if abs(Date().timeIntervalSince(timestamp)) > maxAge {

--- a/FitTrackerTests/AuthManagerTests.swift
+++ b/FitTrackerTests/AuthManagerTests.swift
@@ -1,0 +1,96 @@
+// FitTrackerTests/AuthManagerTests.swift
+// TEST-002: AuthManager — simulator bypass + state transitions.
+//
+// iOS Simulator bypass makes biometric auth deterministic: isAvailable
+// always returns true and authenticateForQuickUnlock() succeeds unconditionally.
+// Tests cover this deterministic path; real-device biometric paths require
+// a physical device and are not covered here.
+
+import XCTest
+import LocalAuthentication
+@testable import FitTracker
+
+@MainActor
+final class AuthManagerTests: XCTestCase {
+
+    // MARK: - Initial state
+
+    func testInit_startsUnauthenticated() {
+        let auth = AuthManager()
+        XCTAssertFalse(auth.isAuthenticated)
+        XCTAssertNil(auth.authError)
+    }
+
+    // MARK: - Simulator bypass
+
+    func testAuthenticateForQuickUnlock_simulator_succeeds() async {
+        let auth = AuthManager()
+        let result = await auth.authenticateForQuickUnlock()
+
+        #if targetEnvironment(simulator)
+        XCTAssertTrue(result, "Simulator bypass must return true")
+        XCTAssertTrue(auth.isAuthenticated)
+        XCTAssertNil(auth.authError)
+        #endif
+    }
+
+    func testIsAvailable_simulator_returnsTrue() {
+        let auth = AuthManager()
+        #if targetEnvironment(simulator)
+        XCTAssertTrue(auth.isAvailable, "Simulator reports biometric as available")
+        #endif
+    }
+
+    func testBiometricType_simulator_reportsFaceID() {
+        let auth = AuthManager()
+        #if targetEnvironment(simulator)
+        XCTAssertEqual(auth.biometricType, .faceID, "Simulator reports Face ID by default")
+        #endif
+    }
+
+    // MARK: - Lock cycle
+
+    func testLockOnBackground_clearsAuthenticatedState() async {
+        let auth = AuthManager()
+        _ = await auth.authenticateForQuickUnlock()
+        XCTAssertTrue(auth.isAuthenticated)
+
+        auth.lockOnBackground()
+        XCTAssertFalse(auth.isAuthenticated)
+        XCTAssertNil(auth.authError)
+    }
+
+    func testLockOnBackground_withoutClearingSession_keepsCryptoContext() async {
+        let auth = AuthManager()
+        _ = await auth.authenticateForQuickUnlock()
+
+        // lockOnBackground(clearCryptoSession: false) — used for brief background events
+        auth.lockOnBackground(clearCryptoSession: false)
+        XCTAssertFalse(auth.isAuthenticated,
+                       "UI state must still flip to locked even when crypto session is kept")
+    }
+
+    // MARK: - Error clearing
+
+    func testAuthenticate_clearsPreviousError() async {
+        let auth = AuthManager()
+        auth.authError = "stale error from previous attempt"
+
+        _ = await auth.authenticateForQuickUnlock()
+
+        #if targetEnvironment(simulator)
+        XCTAssertNil(auth.authError, "Successful auth must clear prior error")
+        #endif
+    }
+
+    // MARK: - Biometric labels
+
+    func testBiometricLabels_faceIDOnSimulator() {
+        let auth = AuthManager()
+        #if targetEnvironment(simulator)
+        XCTAssertEqual(auth.biometricLabel, "Use Face ID")
+        XCTAssertEqual(auth.biometricName, "Face ID")
+        XCTAssertEqual(auth.biometricIcon, "faceid")
+        #endif
+    }
+}

--- a/FitTrackerTests/EncryptionServiceTests.swift
+++ b/FitTrackerTests/EncryptionServiceTests.swift
@@ -1,0 +1,139 @@
+// FitTrackerTests/EncryptionServiceTests.swift
+// TEST-001: EncryptionService — encrypt/decrypt round-trip, HMAC verification,
+// container format, empty data edge case, wrong-ciphertext rejection.
+//
+// Strategy: Uses the real EncryptionService actor and the real Keychain on iOS
+// Simulator, where biometric auth is bypassed. No mock infrastructure needed.
+
+import XCTest
+import LocalAuthentication
+@testable import FitTracker
+
+final class EncryptionServiceTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Ensure session context is set so crypto ops don't require biometric prompt
+        await EncryptionService.shared.setSessionContext(LAContext())
+    }
+
+    // MARK: - Round-trip
+
+    func testEncryptDecrypt_roundTripPreservesData() async throws {
+        let original = "FitMe secret health data".data(using: .utf8)!
+        let encrypted = try await EncryptionService.shared.encryptRaw(original)
+        let decrypted = try await EncryptionService.shared.decryptRaw(encrypted)
+        XCTAssertEqual(decrypted, original, "Round-trip must preserve bytes exactly")
+    }
+
+    func testEncryptDecrypt_differentCiphertextForSamePlaintext() async throws {
+        // AES-GCM uses a random IV → same plaintext should produce different ciphertext
+        let plaintext = "same data".data(using: .utf8)!
+        let blob1 = try await EncryptionService.shared.encryptRaw(plaintext)
+        let blob2 = try await EncryptionService.shared.encryptRaw(plaintext)
+        XCTAssertNotEqual(blob1, blob2,
+                          "AES-GCM random IV must produce different ciphertexts for same plaintext")
+    }
+
+    func testEncryptDecrypt_CodableValue() async throws {
+        struct Sample: Codable, Equatable {
+            let name: String
+            let count: Int
+            let values: [Double]
+        }
+        let original = Sample(name: "test", count: 42, values: [1.1, 2.2, 3.3])
+        let encrypted = try await EncryptionService.shared.encrypt(original)
+        let decrypted = try await EncryptionService.shared.decrypt(encrypted, as: Sample.self)
+        XCTAssertEqual(decrypted, original)
+    }
+
+    // MARK: - Container format
+
+    func testEncryptedBlob_hasCorrectHeader() async throws {
+        let plaintext = Data([0xFF, 0xEE, 0xDD])
+        let blob = try await EncryptionService.shared.encryptRaw(plaintext)
+
+        // Container layout: [version 1B][timestamp 8B][hmac 64B][ciphertext]
+        XCTAssertGreaterThan(blob.count, 73, "Blob must be larger than header (73 bytes)")
+        XCTAssertEqual(blob[0], 0x02, "Version byte must be 0x02")
+    }
+
+    // MARK: - Tamper detection
+
+    func testDecrypt_tamperedCiphertext_throws() async throws {
+        let plaintext = "authentic data".data(using: .utf8)!
+        var blob = try await EncryptionService.shared.encryptRaw(plaintext)
+
+        // Flip a bit in the ciphertext region (past the 73-byte header)
+        let tamperIndex = blob.count - 1
+        blob[tamperIndex] = blob[tamperIndex] ^ 0x01
+
+        do {
+            _ = try await EncryptionService.shared.decryptRaw(blob)
+            XCTFail("Tampered ciphertext should fail HMAC verification")
+        } catch {
+            // Expected — HMAC or AEAD should reject tampered data
+        }
+    }
+
+    func testDecrypt_tamperedHMAC_throws() async throws {
+        let plaintext = "protected".data(using: .utf8)!
+        var blob = try await EncryptionService.shared.encryptRaw(plaintext)
+
+        // Flip a bit in the HMAC region (bytes 9..72)
+        blob[10] = blob[10] ^ 0x01
+
+        do {
+            _ = try await EncryptionService.shared.decryptRaw(blob)
+            XCTFail("Tampered HMAC should fail verification")
+        } catch {
+            // Expected
+        }
+    }
+
+    func testDecrypt_wrongVersionByte_throws() async throws {
+        let plaintext = "versioned".data(using: .utf8)!
+        var blob = try await EncryptionService.shared.encryptRaw(plaintext)
+
+        // Change version from 0x02 to 0x99
+        blob[0] = 0x99
+
+        do {
+            _ = try await EncryptionService.shared.decryptRaw(blob)
+            XCTFail("Unknown version byte must be rejected")
+        } catch {
+            // Expected
+        }
+    }
+
+    // MARK: - Edge cases
+
+    func testEncrypt_emptyData() async throws {
+        let empty = Data()
+        let blob = try await EncryptionService.shared.encryptRaw(empty)
+        let decrypted = try await EncryptionService.shared.decryptRaw(blob)
+        XCTAssertEqual(decrypted, empty)
+    }
+
+    func testDecrypt_truncatedBlob_throws() async {
+        // A blob shorter than the 73-byte header must be rejected
+        let tooShort = Data(repeating: 0, count: 50)
+
+        do {
+            _ = try await EncryptionService.shared.decryptRaw(tooShort)
+            XCTFail("Truncated blob must be rejected")
+        } catch {
+            // Expected — integrityCheckFailed
+        }
+    }
+
+    // MARK: - HMAC timestamp validation (added in Sprint B)
+
+    func testDecrypt_freshBlob_passesTimestampCheck() async throws {
+        // A freshly-encrypted blob must decrypt successfully (timestamp within 2-year window)
+        let plaintext = "fresh".data(using: .utf8)!
+        let blob = try await EncryptionService.shared.encryptRaw(plaintext)
+        let decrypted = try await EncryptionService.shared.decryptRaw(blob)
+        XCTAssertEqual(decrypted, plaintext)
+    }
+}

--- a/FitTrackerTests/HealthKitServiceTests.swift
+++ b/FitTrackerTests/HealthKitServiceTests.swift
@@ -1,0 +1,115 @@
+// FitTrackerTests/HealthKitServiceTests.swift
+// TEST-005: HealthKit data mapping — tests LiveMetrics computed properties
+// and MetricStatus enum. HKHealthStore interaction requires a physical device
+// and is covered by integration tests (deferred).
+
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class HealthKitServiceTests: XCTestCase {
+
+    // MARK: - LiveMetrics.restingHRStatus
+
+    func testRestingHRStatus_excellent_below60() {
+        var m = LiveMetrics()
+        m.restingHR = 55
+        XCTAssertEqual(m.restingHRStatus, .excellent)
+    }
+
+    func testRestingHRStatus_good_60to74() {
+        var m = LiveMetrics()
+        m.restingHR = 65
+        XCTAssertEqual(m.restingHRStatus, .good)
+    }
+
+    func testRestingHRStatus_caution_75to84() {
+        var m = LiveMetrics()
+        m.restingHR = 80
+        XCTAssertEqual(m.restingHRStatus, .caution)
+    }
+
+    func testRestingHRStatus_alert_85plus() {
+        var m = LiveMetrics()
+        m.restingHR = 90
+        XCTAssertEqual(m.restingHRStatus, .alert)
+    }
+
+    func testRestingHRStatus_unknown_whenNil() {
+        let m = LiveMetrics()
+        XCTAssertEqual(m.restingHRStatus, .unknown)
+    }
+
+    // MARK: - LiveMetrics.hrvStatus
+
+    func testHRVStatus_excellent_above45() {
+        var m = LiveMetrics()
+        m.hrv = 50
+        XCTAssertEqual(m.hrvStatus, .excellent)
+    }
+
+    func testHRVStatus_good_35to44() {
+        var m = LiveMetrics()
+        m.hrv = 40
+        XCTAssertEqual(m.hrvStatus, .good)
+    }
+
+    func testHRVStatus_caution_28to34() {
+        var m = LiveMetrics()
+        m.hrv = 30
+        XCTAssertEqual(m.hrvStatus, .caution)
+    }
+
+    func testHRVStatus_alert_below28() {
+        var m = LiveMetrics()
+        m.hrv = 20
+        XCTAssertEqual(m.hrvStatus, .alert)
+    }
+
+    func testHRVStatus_unknown_whenNil() {
+        let m = LiveMetrics()
+        XCTAssertEqual(m.hrvStatus, .unknown)
+    }
+
+    // MARK: - isReadyForTraining gate
+
+    func testIsReadyForTraining_highHRVLowRHR_ready() {
+        var m = LiveMetrics()
+        m.restingHR = 58
+        m.hrv = 50
+        XCTAssertTrue(m.isReadyForTraining)
+    }
+
+    func testIsReadyForTraining_lowHRV_notReady() {
+        var m = LiveMetrics()
+        m.restingHR = 58
+        m.hrv = 20
+        XCTAssertFalse(m.isReadyForTraining, "HRV below 28 should block training readiness")
+    }
+
+    func testIsReadyForTraining_highRHR_notReady() {
+        var m = LiveMetrics()
+        m.restingHR = 80
+        m.hrv = 50
+        XCTAssertFalse(m.isReadyForTraining, "RHR ≥ 75 should block training readiness")
+    }
+
+    func testIsReadyForTraining_missingData_notReady() {
+        let m = LiveMetrics()
+        XCTAssertFalse(m.isReadyForTraining, "Missing biometrics must default to not-ready")
+    }
+
+    // MARK: - Boundary values (documents thresholds)
+
+    func testRestingHRStatus_boundaryAt60() {
+        var m = LiveMetrics()
+        m.restingHR = 60
+        XCTAssertEqual(m.restingHRStatus, .good, "RHR = 60 is good (boundary, not excellent)")
+    }
+
+    func testHRVStatus_boundaryAt45() {
+        var m = LiveMetrics()
+        m.hrv = 45
+        XCTAssertEqual(m.hrvStatus, .excellent, "HRV = 45 is excellent (boundary inclusive)")
+    }
+}

--- a/docs/case-studies/meta-analysis-audit-and-remediation-case-study.md
+++ b/docs/case-studies/meta-analysis-audit-and-remediation-case-study.md
@@ -13,12 +13,13 @@
 | Work Type | Chore (audit) → Fix (remediation) |
 | Total Findings | 185 (12 critical · 49 high · 90 medium · 25 low · 9 info) |
 | Actionable Findings | 170 |
-| Findings Resolved | **109** across Phases 1–8 + Sprints A–C2 |
-| Findings Deferred | 61 (Phase 6 mock-infra + Phase 9 large-effort) |
+| Findings Resolved | **112** across Phases 1–8 + Sprints A–C3 |
+| Findings Deferred | 58 (Sprint C4 CloudKit/Supabase mocks + Phase 9 large-effort) |
 | Domains Covered | 6 (UI, Backend, AI, Design System, Tests, Framework) |
-| Files Changed | 29 app + 13 test |
-| Commits | 14 (cumulative across PRs #84–90) |
-| New Test Suites | 9 suites, 57 test cases covering AI adapters, recommendation memory, app settings, goal profile, training program, import edge cases, performance, accessibility, account deletion |
+| Files Changed | 29 app + 16 test |
+| Commits | 15 (cumulative across PRs #84–91) |
+| New Test Suites | 12 suites, 90 test cases covering AI adapters, recommendation memory, app settings, goal profile, training program, import edge cases, performance, accessibility, account deletion, encryption service, auth manager, HealthKit metrics |
+| Regression Caught | Sprint B HMAC timestamp validation crashed on unaligned Data slice — caught and fixed by new EncryptionService round-trip test |
 | Build | SUCCEEDED (pre-audit, post-audit, post-remediation) |
 | Test Suite | 231 pass / 0 fail at every stage |
 | Self-Referential | Yes — same AI system that built the code also audited and fixed it |
@@ -203,7 +204,7 @@ Supporting fixes:
 
 | Metric | Pre-Audit | Post-Remediation | Delta |
 |---|---|---|---|
-| Known findings | 0 | 185 identified, 109 resolved | +185 identified |
+| Known findings | 0 | 185 identified, 112 resolved | +185 identified |
 | Build | SUCCEEDED | SUCCEEDED | No regression |
 | Tests passing | 231 / 0 fail | 231 / 0 fail | No regression |
 | Deprecated Color calls (compiled) | 23 | 0 | -23 (100%) |
@@ -268,7 +269,8 @@ This system finds what it knows how to look for (code patterns, token compliance
 | PR #87 (Sprint A) | `fix/audit-sprint-a` — merged 2026-04-17 |
 | PR #88 (Sprint B) | `fix/audit-sprint-b` — merged 2026-04-17 |
 | PR #89 (Sprint C1) | `fix/audit-sprint-c1` — merged 2026-04-17 |
-| PR #90 (Sprint C2) | `fix/audit-sprint-c2` — pending |
+| PR #90 (Sprint C2) | `fix/audit-sprint-c2` — merged 2026-04-17 |
+| PR #91 (Sprint C3) | `fix/audit-sprint-c3` — pending |
 
 ---
 
@@ -290,6 +292,7 @@ This system finds what it knows how to look for (code patterns, token compliance
 | HMAC timestamp validation, test deduplication | DEEP-AUTH-008/009, BE-013, TEST-029 | #88 |
 | AI adapter golden I/O tests (27 new test cases) | TEST-006/008/015/017/019/022 | #89 |
 | Service tests: AccountDeletion, TrainingProgram, Import, Perf, a11y (30 cases) | TEST-011/016/024/027/028 | #90 |
+| Encryption/Auth/HealthKit tests (33 cases, caught Sprint B alignment bug) | TEST-001/002/005 | #91 |
 
 ### Pending: 72 findings (3 categories)
 


### PR DESCRIPTION
## Summary

Sprint C3 adds 33 new test cases across 3 high-risk services and **caught + fixed a real production crash** that Sprint B introduced.

### The crash
Sprint B added HMAC timestamp validation using \`UnsafeRawBufferPointer.load(as: UInt64.self)\` on a Data slice (\`data[1..<9]\`). Data slices are not guaranteed 8-byte aligned, so this crashed with a Swift fatal error at runtime. Every \`decryptRaw()\` call would have crashed in production.

Fixed by copying the slice into aligned storage before reading:
\`\`\`swift
var timestampBits: UInt64 = 0
withUnsafeMutableBytes(of: &timestampBits) { dst in
    ts.copyBytes(to: dst)
}
\`\`\`

### New test suites

- **EncryptionServiceTests** (10) — TEST-001: round-trip, tamper detection (ciphertext + HMAC), version handling, truncation, empty data, fresh timestamp
- **AuthManagerTests** (8) — TEST-002: simulator bypass, state transitions, lock cycle
- **HealthKitServiceTests** (15) — TEST-005: restingHRStatus/hrvStatus thresholds, isReadyForTraining gate

### Strategy
These 3 services can be tested without new mock infrastructure:
- EncryptionService: uses real Keychain on simulator (works deterministically)
- AuthManager: simulator bypass makes biometric auth deterministic
- HealthKitService: \`LiveMetrics\` computed properties are pure functions

The remaining 2 services (CloudKitSyncService, SupabaseSyncService) genuinely need URLProtocol / mock CKDatabase and are deferred to Sprint C4.

## Test plan
- [x] \`xcodebuild test\` — TEST SUCCEEDED, all 33 new tests pass
- [x] Sprint B alignment crash confirmed fixed (all 10 EncryptionService tests green)
- [x] No regressions in existing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)