### PR TITLE
fix(ai): Sprint H — AI pipeline correctness (8 findings)

### DIFF
--- a/FitTracker/AI/AIEngineClient.swift
+++ b/FitTracker/AI/AIEngineClient.swift
@@ -40,6 +40,14 @@ public final class AIEngineClient: AIEngineClientProtocol {
         payload: [String: String],
         jwt: String
     ) async throws -> AIRecommendation {
+        // Audit AI-013 / DEEP-AI-006: lightweight JWT expiry pre-check. The
+        // server still validates signature + expiry — this just avoids a
+        // round-trip when the token is locally provably expired. A token
+        // we can't decode is treated as valid (server is the source of truth).
+        if Self.isExpired(jwt: jwt) {
+            throw AIEngineError.unauthorised
+        }
+
         let url = baseURL
             .appendingPathComponent("v1")
             .appendingPathComponent(segment.rawValue)
@@ -68,6 +76,33 @@ public final class AIEngineClient: AIEngineClientProtocol {
         default:
             throw AIEngineError.serverError(statusCode: http.statusCode)
         }
+    }
+}
+
+// MARK: - JWT helpers
+
+extension AIEngineClient {
+    /// Decode the unsigned middle segment of a JWT and return true if the
+    /// `exp` claim is in the past. Tokens we can't parse are treated as
+    /// non-expired (the server is the source of truth for signature + expiry).
+    static func isExpired(jwt: String, now: Date = Date()) -> Bool {
+        let parts = jwt.split(separator: ".")
+        guard parts.count == 3 else { return false }
+        let payloadSegment = String(parts[1])
+        // JWT uses base64url; pad to a multiple of 4 and translate URL-safe chars.
+        var padded = payloadSegment
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = padded.count % 4
+        if remainder > 0 { padded += String(repeating: "=", count: 4 - remainder) }
+        guard
+            let data = Data(base64Encoded: padded),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let exp = (json["exp"] as? NSNumber)?.doubleValue ?? (json["exp"] as? Double)
+        else {
+            return false
+        }
+        return Date(timeIntervalSince1970: exp) <= now
     }
 }
 

--- a/FitTracker/AI/AIOrchestrator.swift
+++ b/FitTracker/AI/AIOrchestrator.swift
@@ -62,9 +62,13 @@ public final class AIOrchestrator: ObservableObject {
     }
 
     public func process(segment: AISegment, jwt: String?, overrideSnapshot: LocalUserSnapshot? = nil) async {
-        isProcessing = true
+        // Audit AI-012 / DEEP-AI-008: when called standalone, manage the
+        // isProcessing flag here. When called from `processAll`, that wrapper
+        // owns the flag so the UI doesn't flicker per-segment.
+        let owns = !isProcessing
+        if owns { isProcessing = true }
         lastError = nil
-        defer { isProcessing = false }
+        defer { if owns { isProcessing = false } }
 
         let userSnapshot = overrideSnapshot ?? snapshot()
         let goalProfile = GoalProfile.forGoal(goalMode())
@@ -95,14 +99,23 @@ public final class AIOrchestrator: ObservableObject {
             }
         }
 
+        // Audit AI-001 + DEEP-AI-009: defensively check `isAvailable` before
+        // invoking the Foundation Model. The protocol abstracts iOS 26+
+        // gating (see FoundationModelService), but a runtime guard ensures
+        // we never attempt inference if the implementation reports it isn't
+        // ready — for example a future iOS where the model is downloading.
         let finalRecommendation: AIRecommendation
-        do {
-            let (adapted, confidence) = try await foundationModel.adapt(
-                recommendation: baseRecommendation,
-                snapshot: userSnapshot
-            )
-            finalRecommendation = confidence >= personalisationThreshold ? adapted : baseRecommendation
-        } catch {
+        if foundationModel.isAvailable {
+            do {
+                let (adapted, confidence) = try await foundationModel.adapt(
+                    recommendation: baseRecommendation,
+                    snapshot: userSnapshot
+                )
+                finalRecommendation = confidence >= personalisationThreshold ? adapted : baseRecommendation
+            } catch {
+                finalRecommendation = baseRecommendation
+            }
+        } else {
             finalRecommendation = baseRecommendation
         }
 
@@ -121,7 +134,13 @@ public final class AIOrchestrator: ObservableObject {
     /// Process all segments sequentially for a full refresh.
     /// - Parameter snapshot: Live snapshot built from stores (HealthKit, profile, training).
     ///   When nil, falls back to the closure provided at init time.
+    ///
+    /// Audit AI-012 / DEEP-AI-008: hold `isProcessing` for the full batch so
+    /// the UI shows a single in-flight indicator instead of flickering
+    /// between segments as each `process(...)` call toggles the flag.
     public func processAll(jwt: String?, snapshot: LocalUserSnapshot? = nil) async {
+        isProcessing = true
+        defer { isProcessing = false }
         for segment in AISegment.allCases {
             await process(segment: segment, jwt: jwt, overrideSnapshot: snapshot)
         }

--- a/FitTracker/AI/AISnapshotBuilder.swift
+++ b/FitTracker/AI/AISnapshotBuilder.swift
@@ -2,16 +2,14 @@ import Foundation
 
 enum AISnapshotBuilder {
 
-    /// Build a LocalUserSnapshot using the adapter registry.
-    /// Each adapter contributes its disjoint set of fields to the snapshot.
+    /// Build a LocalUserSnapshot using the adapter registry. Each adapter
+    /// contributes its disjoint set of fields to the snapshot.
     ///
-    /// Note (audit AI-020): The adapter array constructed here is intentionally
-    /// discarded after `contribute(to:)` runs. Callers that need post-build
-    /// access to the adapters (e.g. `AIOrchestrator.lastAdapters`) must invoke
-    /// `orchestrator.setAdapters(...)` separately. A future refactor could
-    /// return `(snapshot, adapters)` as a tuple, but is deferred — see
-    /// AI-011 / DEEP-AI-007 for the related "lastAdapters never populated"
-    /// finding which tracks the full lifecycle issue.
+    /// Returns both the snapshot AND the adapter list so callers can wire the
+    /// adapters into `AIOrchestrator.setAdapters(_:)` for downstream
+    /// validation/evidence-chain use (audit DEEP-AI-007). Previously the
+    /// adapter array was constructed here and silently discarded, leaving
+    /// `AIOrchestrator.lastAdapters` permanently empty.
     static func build(
         profile: UserProfile,
         preferences: UserPreferences,
@@ -20,7 +18,7 @@ enum AISnapshotBuilder {
         todayDayType: DayType,
         now: Date = Date(),
         readiness: ReadinessResult? = nil
-    ) -> LocalUserSnapshot {
+    ) -> (snapshot: LocalUserSnapshot, adapters: [any AIInputAdapter]) {
         let sortedLogs = dailyLogs
             .filter { $0.date <= now }
             .sorted { $0.date > $1.date }
@@ -45,10 +43,19 @@ enum AISnapshotBuilder {
             NutritionAdapter(latestLog: sortedLogs.first, goalPlan: goalPlan, liveMetrics: liveMetrics, profile: profile),
         ]
 
+        // DEEP-AI-010: assert adapter sourceID disjointness in debug builds.
+        // Two adapters writing the same source ID would silently overwrite each
+        // other's contributions and corrupt validation evidence chains.
+        #if DEBUG
+        let ids = adapters.map(\.sourceID)
+        assert(Set(ids).count == ids.count,
+               "AIInputAdapter sourceIDs must be unique, got: \(ids)")
+        #endif
+
         var snapshot = LocalUserSnapshot()
         for adapter in adapters {
             adapter.contribute(to: &snapshot)
         }
-        return snapshot
+        return (snapshot, adapters)
     }
 }

--- a/FitTracker/AI/AITypes.swift
+++ b/FitTracker/AI/AITypes.swift
@@ -382,9 +382,13 @@ extension LocalUserSnapshot {
     // ── Private band helpers ───────────────────────────────
 
     private func ageBand() -> String? {
+        // Audit DEEP-AI-013: distinguish "user is under 18 (excluded)" from
+        // "no age data on file" — the cohort backend can then opt to drop
+        // the under_18_excluded segment from its rollups instead of
+        // silently lumping it with missing-age users.
         guard let age = ageYears else { return nil }
         switch age {
-        case ..<18:  return nil          // under-18 excluded
+        case ..<18:  return "under_18_excluded"
         case 18...24: return "18-24"
         case 25...34: return "25-34"
         case 35...44: return "35-44"

--- a/FitTracker/AI/FoundationModelService.swift
+++ b/FitTracker/AI/FoundationModelService.swift
@@ -93,12 +93,17 @@ public final class FoundationModelService: FoundationModelProtocol {
 
     // ── Private helpers ────────────────────────────────────
 
+    /// Build the on-device prompt context. The full biometric payload is
+    /// inlined into the prompt for the inference engine — but if the caller
+    /// wants a string suitable for *logging* (audit DEEP-AI-012), it must use
+    /// `redactedForLogging: true` to scrub raw RHR/sleep/stress values.
+    /// Production code paths that touch the inference engine pass `false`;
+    /// any debug/diagnostic emission must pass `true`.
     private func buildPrivateContext(
         snapshot: LocalUserSnapshot,
-        recommendation: AIRecommendation
+        recommendation: AIRecommendation,
+        redactedForLogging: Bool = false
     ) -> String {
-        // Assembles a structured prompt from the user's private data.
-        // Not transmitted to any external service.
         var lines: [String] = ["[FitTracker on-device personalisation context]"]
         lines.append("Segment: \(recommendation.segment)")
         lines.append("Cloud signals: \(recommendation.signals.joined(separator: ", "))")
@@ -117,13 +122,26 @@ public final class FoundationModelService: FoundationModelProtocol {
             lines.append("Primary drivers: \(drivers.joined(separator: "; "))")
         }
         if let phase = snapshot.programPhase     { lines.append("Phase: \(phase)") }
-        if let sleep = snapshot.avgSleepHours    { lines.append("Sleep: \(sleep)h avg") }
-        if let stress = snapshot.stressLevel     { lines.append("Stress: \(stress)") }
-        if let hr = snapshot.restingHeartRate    { lines.append("RHR: \(hr)bpm") }
+
+        // Audit DEEP-AI-012: when this string is destined for a log sink,
+        // scrub raw biometric values — keep only a presence indicator.
+        if redactedForLogging {
+            if snapshot.avgSleepHours    != nil { lines.append("Sleep: <redacted>") }
+            if snapshot.stressLevel      != nil { lines.append("Stress: <redacted>") }
+            if snapshot.restingHeartRate != nil { lines.append("RHR: <redacted>") }
+        } else {
+            if let sleep = snapshot.avgSleepHours    { lines.append("Sleep: \(sleep)h avg") }
+            if let stress = snapshot.stressLevel     { lines.append("Stress: \(stress)") }
+            if let hr = snapshot.restingHeartRate    { lines.append("RHR: \(hr)bpm") }
+        }
 
         if let score = snapshot.readinessScore {
-            lines.append("Readiness score: \(score)/100 (confidence: \(snapshot.readinessConfidence ?? "unknown"))")
-            lines.append("Recommended intensity: \(snapshot.readinessRecommendation ?? "unknown")")
+            if redactedForLogging {
+                lines.append("Readiness score: <redacted>/100")
+            } else {
+                lines.append("Readiness score: \(score)/100 (confidence: \(snapshot.readinessConfidence ?? "unknown"))")
+                lines.append("Recommended intensity: \(snapshot.readinessRecommendation ?? "unknown")")
+            }
             if let flags = snapshot.fatigueFlags, !flags.isEmpty {
                 lines.append("Fatigue warnings: \(flags.joined(separator: ", "))")
             }

--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -192,9 +192,12 @@ struct FitTrackerApp: App {
     }
 
     private func buildSnapshot() -> LocalUserSnapshot {
-        // Build snapshot with readiness data
+        // Build snapshot with readiness data. Audit DEEP-AI-007: also wire the
+        // adapter list into AIOrchestrator so `lastAdapters` is populated for
+        // the validation evidence chain — previously the adapters were built
+        // here and silently discarded.
         let readiness = dataStore.readinessResult(for: Date(), fallbackMetrics: healthService.latest)
-        return AISnapshotBuilder.build(
+        let (snapshot, adapters) = AISnapshotBuilder.build(
             profile: dataStore.userProfile,
             preferences: dataStore.userPreferences,
             liveMetrics: healthService.latest,
@@ -202,6 +205,8 @@ struct FitTrackerApp: App {
             todayDayType: programStore.todayDayType,
             readiness: readiness
         )
+        aiOrchestrator.setAdapters(adapters)
+        return snapshot
     }
 
     // ── Onboarding guard ─────────────────────────────────

--- a/FitTrackerTests/EvalTests/AITierBehaviorEvals.swift
+++ b/FitTrackerTests/EvalTests/AITierBehaviorEvals.swift
@@ -140,7 +140,7 @@ final class AITierBehaviorEvals: XCTestCase {
             recommendation: .fullIntensity
         )
 
-        let snapshot = AISnapshotBuilder.build(
+        let (snapshot, _) = AISnapshotBuilder.build(
             profile: UserProfile(),
             preferences: UserPreferences(),
             liveMetrics: LiveMetrics(),

--- a/FitTrackerTests/FitTrackerCoreTests.swift
+++ b/FitTrackerTests/FitTrackerCoreTests.swift
@@ -288,7 +288,7 @@ final class FitTrackerCoreTests: XCTestCase {
         today.mood = 4
         today.energyLevel = 4
 
-        let snapshot = AISnapshotBuilder.build(
+        let (snapshot, _) = AISnapshotBuilder.build(
             profile: profile,
             preferences: preferences,
             liveMetrics: liveMetrics,


### PR DESCRIPTION
## Summary

Sprint H of the post-stress-test audit remediation. Eight AI-pipeline findings — one critical (DEEP-AI-007 broke the validation evidence chain), the rest defensive hardening.

| Finding | Area | Change |
|---|---|---|
| DEEP-AI-007 | AISnapshotBuilder + FitTrackerApp | `build()` returns `(snapshot, adapters)`; wrapper wires adapters into `AIOrchestrator.setAdapters()` so `lastAdapters` populates |
| DEEP-AI-010 | AISnapshotBuilder | Debug-only `assert` that adapter `sourceID`s are disjoint |
| AI-001 + DEEP-AI-009 | AIOrchestrator | Defensive `isAvailable` check before `foundationModel.adapt()` |
| AI-012 / DEEP-AI-008 | AIOrchestrator | Lift `isProcessing` lifecycle to `processAll()`, suppress per-segment flicker |
| AI-013 / DEEP-AI-006 | AIEngineClient | Lightweight JWT `exp` pre-check; throws `.unauthorised` before round-trip when locally provably expired |
| DEEP-AI-012 | FoundationModelService | `buildPrivateContext(redactedForLogging:)` scrubs raw biometrics from any future log-emitting caller |
| DEEP-AI-013 | AITypes | `ageBand()` returns `"under_18_excluded"` for under-18 to distinguish from missing age |

**Already-fixed (verified, no change):** DEEP-AI-011 (`computeFreshness` uses `dates.max()`), DEEP-AI-014 (`trainingDaysPerWeek` uses real value), DEEP-AI-015 (no fabrication-over-nil pattern in any adapter).

## Test plan

- [x] `xcodebuild build` green on iOS 26.4 simulator
- [x] `xcodebuild test` green for all suites except pre-existing keychain-entitlement failures (`EncryptionServiceTests`, `KeychainHelperTests`) — environmental, unrelated to this sprint
- [x] `AISnapshotBuilder.build()` callers in tests updated to destructure the new tuple
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)