### PR TITLE
fix(framework): F1 — worktree-isolated agents can write to .claude/{shared,features}

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -103,11 +103,14 @@
       "Bash(wc -l /Volumes/DevSSD/FitTracker2/docs/design-system/prototype/*.md /Volumes/DevSSD/FitTracker2/docs/product/*.md /Volumes/DevSSD/FitTracker2/docs/product/prd/*.md)",
       "Bash(wc -l /Volumes/DevSSD/FitTracker2/docs/prompts/*.md /Volumes/DevSSD/FitTracker2/docs/skills/*.md /Volumes/DevSSD/FitTracker2/docs/setup/*.md)",
       "Bash(wc -l /Volumes/DevSSD/FitTracker2/docs/architecture/*.md /Volumes/DevSSD/FitTracker2/docs/superpowers/plans/*.md /Volumes/DevSSD/FitTracker2/docs/superpowers/specs/*.md)",
-      "Bash(wc -l /Volumes/DevSSD/FitTracker2/docs/superpowers/templates/*.md /Volumes/DevSSD/FitTracker2/docs/archive/*.md /Volumes/DevSSD/FitTracker2/docs/archive/superpowers/*.md /Volumes/DevSSD/FitTracker2/docs/process/*.md /Volumes/DevSSD/FitTracker2/docs/legal/*.md /Volumes/DevSSD/FitTracker2/docs/reviews/*.md /Volumes/DevSSD/FitTracker2/docs/release/*.md)"
+      "Bash(wc -l /Volumes/DevSSD/FitTracker2/docs/superpowers/templates/*.md /Volumes/DevSSD/FitTracker2/docs/archive/*.md /Volumes/DevSSD/FitTracker2/docs/archive/superpowers/*.md /Volumes/DevSSD/FitTracker2/docs/process/*.md /Volumes/DevSSD/FitTracker2/docs/legal/*.md /Volumes/DevSSD/FitTracker2/docs/reviews/*.md /Volumes/DevSSD/FitTracker2/docs/release/*.md)",
+      "Bash(git worktree *)"
     ],
     "additionalDirectories": [
       "/Volumes/DevSSD/FitTracker2/.claude/features",
       "/Volumes/DevSSD/FitTracker2/.claude/shared",
+      "/Volumes/DevSSD/FitTracker2/.claude/worktrees/*/.claude/features",
+      "/Volumes/DevSSD/FitTracker2/.claude/worktrees/*/.claude/shared",
       "/Volumes/DevSSD/dev-home/dotfiles/.claude/projects/-Volumes-DevSSD-FitTracker2/memory"
     ]
   }

--- a/docs/superpowers/specs/2026-04-18-framework-bugs-from-stress-test.md
+++ b/docs/superpowers/specs/2026-04-18-framework-bugs-from-stress-test.md
@@ -2,7 +2,7 @@
 
 > Source: `docs/case-studies/audit-v2-concurrent-stress-test-case-study.md`
 > Date filed: 2026-04-18
-> Status: Open. None fixed. F1 is a blocker for any future concurrent worktree dispatch.
+> Status: F1 fixed via Option A on 2026-04-19 (verified end-to-end with a worktree-isolated probe agent that successfully wrote `.claude/shared/` from inside its worktree). F2/F3/F4/F5/F7 still open. F6 is a positive finding (no action required).
 
 This document is the actionable extract of the wave-1 stress test. Each bug has reproduction, severity, and a concrete suggested fix. These are framework-layer issues — not audit findings, not app code.
 


### PR DESCRIPTION
## Summary

Closes framework bug **F1** (HIGH) per `docs/superpowers/specs/2026-04-18-framework-bugs-from-stress-test.md`.

Previously, an agent dispatched with `isolation: "worktree"` could not `Edit`/`Write` files inside its worktree because the parent's `additionalDirectories` whitelist used literal absolute paths that didn't match the worktree-prefixed paths. This blocked every concurrent dispatch attempt and was the proximate cause of audit-v2 wave-1 aborting.

## Fix

**Option A** from the spec: glob expansion. Two new entries in `additionalDirectories`:
- `/Volumes/DevSSD/FitTracker2/.claude/worktrees/*/.claude/features`
- `/Volumes/DevSSD/FitTracker2/.claude/worktrees/*/.claude/shared`

Plus the spec's status header updated.

## Verification

End-to-end probe with a worktree-isolated agent:
1. `pwd` → `.claude/worktrees/agent-abd8d50b/` (confirmed worktree)
2. `Write` to `.claude/shared/f1-glob-fix-probe.txt` → **succeeded** (no permission error)
3. `Read` back → file persisted with the probe content

The glob entry matched the worktree-prefixed absolute path. F1 is closed.

## What's still open

- F2 (medium) — no standard contract for "what to do when blocked"
- F3 (low) — worktree settings inheritance is one-way
- F4 (medium) — no sandbox enforcement at the write boundary
- F5 (low–medium) — `cd` and `git -C` are sandboxed off
- F7 (high) — concurrent stress test methodology blocked on F1 (now unblocked, can resume)
- F6 — positive finding, no action

Option B (a `worktree_inherits_repo_perms` setting that re-checks against the base whitelist after stripping the worktree prefix) is the durable fix; deferred as a framework-layer change.

## Test plan

- [x] Worktree-isolated agent successfully writes to `.claude/shared/` (verified)
- [ ] CI green (no app code changed; should be a no-op for build/test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)