### PR TITLE
fix(backend): Sprint K-1 — BE-016 + BE-021 + BE-029 (3 deferred Sprint G items)

### DIFF
--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -134,6 +134,9 @@ struct FitTrackerApp: App {
                                 await EncryptionService.shared.clearSessionContext()
                             }
                             guard signIn.isAuthenticated else { return }
+                            // Audit BE-016: if a previous persistToDisk failed, retry on foreground
+                            // before any further reads/writes — recovers transient disk-pressure cases.
+                            await dataStore.retryPersistIfFailed()
                             await dataStore.loadFromDisk()
                             // Update AI engine with actual user goal (was default .fatLoss at init)
                             aiOrchestrator.goalMode = { [weak dataStore] in

--- a/FitTracker/Models/DomainModels.swift
+++ b/FitTracker/Models/DomainModels.swift
@@ -507,6 +507,11 @@ struct UserPreferences: Codable, Equatable, Sendable {
     var nutritionGoalMode: NutritionGoalMode
     var preferredStatsCarouselMetrics: [String]
 
+    /// User's nightly sleep target. Audit BE-029 — was hardcoded 8.0 throughout.
+    /// 6.0–10.0h range covers reasonable physiology; reads from this default
+    /// for legacy users (decode init below uses 8.0 fallback).
+    var sleepGoalHours: Double
+
     // Conflict resolution timestamp — set on every mutation, nil for legacy data
     var lastModified: Date?
 
@@ -516,7 +521,8 @@ struct UserPreferences: Codable, Equatable, Sendable {
         hrReadyThreshold: Int = 60,
         hrvReadyThreshold: Double = 28.0,
         nutritionGoalMode: NutritionGoalMode = .fatLoss,
-        preferredStatsCarouselMetrics: [String] = UserPreferences.defaultStatsCarouselMetrics
+        preferredStatsCarouselMetrics: [String] = UserPreferences.defaultStatsCarouselMetrics,
+        sleepGoalHours: Double = 8.0
     ) {
         self.zone2LowerHR = zone2LowerHR
         self.zone2UpperHR = zone2UpperHR
@@ -524,6 +530,7 @@ struct UserPreferences: Codable, Equatable, Sendable {
         self.hrvReadyThreshold = hrvReadyThreshold
         self.nutritionGoalMode = nutritionGoalMode
         self.preferredStatsCarouselMetrics = preferredStatsCarouselMetrics
+        self.sleepGoalHours = sleepGoalHours
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -533,6 +540,7 @@ struct UserPreferences: Codable, Equatable, Sendable {
         case hrvReadyThreshold
         case nutritionGoalMode
         case preferredStatsCarouselMetrics
+        case sleepGoalHours
         case lastModified
     }
 
@@ -544,6 +552,7 @@ struct UserPreferences: Codable, Equatable, Sendable {
         hrvReadyThreshold = try container.decodeIfPresent(Double.self, forKey: .hrvReadyThreshold) ?? 28.0
         nutritionGoalMode = try container.decodeIfPresent(NutritionGoalMode.self, forKey: .nutritionGoalMode) ?? .fatLoss
         preferredStatsCarouselMetrics = try container.decodeIfPresent([String].self, forKey: .preferredStatsCarouselMetrics) ?? Self.defaultStatsCarouselMetrics
+        sleepGoalHours = try container.decodeIfPresent(Double.self, forKey: .sleepGoalHours) ?? 8.0
         lastModified = try container.decodeIfPresent(Date.self, forKey: .lastModified)
     }
 }

--- a/FitTracker/Services/Auth/SignInService.swift
+++ b/FitTracker/Services/Auth/SignInService.swift
@@ -366,6 +366,11 @@ final class SignInService: NSObject, ObservableObject {
     }
 
     static let sessionKey = "ft.session"
+    /// Audit BE-021: live Supabase JWT lives in its own Keychain item with a
+    /// stricter ACL (`kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly`) so it
+    /// won't restore via iCloud Keychain or backup, requires the user have a
+    /// passcode set, and is separable from the session metadata.
+    static let jwtKey = "ft.session.jwt"
     private static let passkeyRegisteredKey = "ft.passkeyRegistered"
     private static let reviewAuthKey = "FITTRACKER_REVIEW_AUTH"
 
@@ -395,6 +400,7 @@ final class SignInService: NSObject, ObservableObject {
         guard activeSession == nil else { return }
         guard SupabaseRuntimeConfiguration.isConfigured else {
             KeychainHelper.delete(key: Self.sessionKey)
+            KeychainHelper.delete(key: Self.jwtKey)
             self.storedSession = nil
             return
         }
@@ -424,7 +430,11 @@ final class SignInService: NSObject, ObservableObject {
         }
 
         if let accessToken = sessionResult {
-            // 2. Load UserSession metadata from Keychain and refresh the backend JWT
+            // 2. Load UserSession metadata from Keychain and apply the live JWT.
+            // BE-021: metadata and JWT live in separate Keychain items now.
+            // For legacy single-item sessions, the embedded JWT (if any) was
+            // already cleared by the next saveSession call after this fix
+            // landed; the live `accessToken` from Supabase is authoritative.
             if let data = KeychainHelper.load(key: Self.sessionKey),
                var stored = try? JSONDecoder().decode(UserSession.self, from: data) {
                 stored.backendAccessToken = accessToken
@@ -432,12 +442,16 @@ final class SignInService: NSObject, ObservableObject {
                 if activateStoredSession {
                     self.activeSession = stored
                 }
+                // Re-persist so the JWT is kicked into its dedicated tighter-ACL item
+                // even for legacy sessions where it was embedded in the metadata.
+                saveSession(stored)
                 return
             }
         }
 
-        // 3. No valid Supabase session or timeout → clear Keychain
+        // 3. No valid Supabase session or timeout → clear Keychain (both items)
         KeychainHelper.delete(key: Self.sessionKey)
+        KeychainHelper.delete(key: Self.jwtKey)
         self.storedSession = nil
     }
 
@@ -499,8 +513,10 @@ final class SignInService: NSObject, ObservableObject {
     }
 
     func signOut() {
-        // Clear local state first to prevent stale session usage
+        // Clear local state first to prevent stale session usage.
+        // BE-021: clear both the metadata and the JWT items.
         KeychainHelper.delete(key: Self.sessionKey)
+        KeychainHelper.delete(key: Self.jwtKey)
         let wasActive = activeSession != nil
         activeSession = nil       // triggers FitTrackerApp.onChange to clear dataStore + AI
         storedSession = nil
@@ -825,9 +841,31 @@ final class SignInService: NSObject, ObservableObject {
         }
     }
 
+    /// Persist the session split into two Keychain items (audit BE-021):
+    ///   - `sessionKey` holds the metadata (provider, email, IDs, etc.) with
+    ///     the standard `WhenUnlockedThisDeviceOnly` ACL.
+    ///   - `jwtKey` holds *only* the live `backendAccessToken` JWT with the
+    ///     stricter `WhenPasscodeSetThisDeviceOnly` ACL — won't restore from
+    ///     backup, requires a passcode be set on the device.
+    /// The metadata payload has its `backendAccessToken` field cleared before
+    /// encoding so a single Keychain compromise of the metadata item alone
+    /// can't yield a usable JWT.
     private func saveSession(_ session: UserSession) {
-        if let encoded = try? JSONEncoder().encode(session) {
+        var metadata = session
+        metadata.backendAccessToken = nil
+        if let encoded = try? JSONEncoder().encode(metadata) {
             KeychainHelper.save(key: Self.sessionKey, data: encoded)
+        }
+        if let jwt = session.backendAccessToken,
+           let jwtData = jwt.data(using: .utf8) {
+            KeychainHelper.save(
+                key: Self.jwtKey,
+                data: jwtData,
+                accessible: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
+            )
+        } else {
+            // No JWT to save (e.g. anonymous review session) — clear any stale value
+            KeychainHelper.delete(key: Self.jwtKey)
         }
     }
 
@@ -1001,14 +1039,25 @@ enum KeychainHelper {
     /// Save data to the Keychain. Returns true on success, false if SecItemAdd
     /// failed (e.g., out of disk space, permissions denied). Per audit BE-020 —
     /// the return status was previously ignored, masking silent save failures.
+    ///
+    /// `accessible` defaults to `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
+    /// for backward compatibility. Audit BE-021: callers storing live JWTs or
+    /// other sensitive credentials should pass
+    /// `kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly` to require a passcode
+    /// be configured and prevent the item from migrating via iCloud Keychain
+    /// or backup restore.
     @discardableResult
-    static func save(key: String, data: Data) -> Bool {
+    static func save(
+        key: String,
+        data: Data,
+        accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> Bool {
         let q: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: key,
             kSecValueData: data,
-            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecAttrAccessible: accessible,
         ]
         SecItemDelete(q as CFDictionary)
         let status = SecItemAdd(q as CFDictionary, nil)

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -421,6 +421,11 @@ final class EncryptedDataStore: ObservableObject {
     @Published var lastError:        String?
     /// Set when `loadFromDisk` fails; observed by the UI to show an alert.
     @Published var loadError:       String?
+    /// Audit BE-016: set when `persistToDisk` fails after retry. UI / scenePhase
+    /// observers can call `retryPersistIfFailed()` to attempt recovery, otherwise
+    /// data may be lost on next launch. Distinct from `lastError` (which is
+    /// transient) so consumers can show a persistent "save failed" indicator.
+    @Published var persistenceFailed: Bool = false
 
     private let fm  = FileManager.default
     private var dir: URL { fm.urls(for: .documentDirectory, in: .userDomainMask)[0] }
@@ -535,7 +540,7 @@ final class EncryptedDataStore: ObservableObject {
             dailyLogs: dailyLogs,
             goalMode: userPreferences.nutritionGoalMode,
             date: date,
-            sleepGoalHours: 8.0,  // TODO: add sleepGoalHours to UserPreferences
+            sleepGoalHours: userPreferences.sleepGoalHours,
             userAge: userProfile.age
         )
     }
@@ -547,7 +552,43 @@ final class EncryptedDataStore: ObservableObject {
 
     // ── Persist / Load ───────────────────────────────────
 
+    /// Persist the in-memory store to disk. Audit BE-016: a single transient
+    /// failure (encryption hiccup, momentary disk pressure) used to silently
+    /// strand data in memory until the next launch. Now: one retry on failure,
+    /// then `persistenceFailed = true` so the UI / scenePhase observers can
+    /// surface or attempt recovery via `retryPersistIfFailed()`.
+    ///
+    /// Existing call sites (30+) use fire-and-forget `Task { await persistToDisk() }`
+    /// — that pattern is preserved by keeping the function `async -> Void` and
+    /// signalling failure via published state instead of return value.
     func persistToDisk() async {
+        if await attemptPersist() {
+            await MainActor.run { persistenceFailed = false }
+            return
+        }
+        // First write failed — try once more after a short backoff. Disk-full
+        // and transient encryption errors often recover on the second attempt.
+        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5s
+        if await attemptPersist() {
+            await MainActor.run { persistenceFailed = false }
+            return
+        }
+        await MainActor.run { persistenceFailed = true }
+    }
+
+    /// Re-attempt persistence if the last `persistToDisk` call left the
+    /// store in a failed state. Safe no-op when there's nothing to retry.
+    /// Call this from `scenePhase == .active` and after surfacing a
+    /// "save failed" UI affordance.
+    func retryPersistIfFailed() async {
+        guard persistenceFailed else { return }
+        await persistToDisk()
+    }
+
+    /// Single persistence attempt. Returns true on success, false on any
+    /// thrown error (encryption or disk). Updates `lastError` on failure
+    /// so callers can inspect what went wrong.
+    private func attemptPersist() async -> Bool {
         do {
             let logsEnc      = try await EncryptionService.shared.encrypt(dailyLogs)
             let snapsEnc     = try await EncryptionService.shared.encrypt(weeklySnapshots)
@@ -569,8 +610,10 @@ final class EncryptedDataStore: ObservableObject {
             try templatesEnc.write(to: url("mealTemplates"))
             try prefsEnc.write(to:     url("userPreferences"))
             #endif
+            return true
         } catch {
             await MainActor.run { lastError = error.localizedDescription }
+            return false
         }
     }
 


### PR DESCRIPTION
## Summary

First sub-batch of Path A (deferred Sprint G items) from the audit-cleanup plan. Three small-to-medium backend findings shipped together because they don't share files.

| Finding | Sev | Change |
|---|---|---|
| **BE-029** | low | New `UserPreferences.sleepGoalHours: Double` (default 8.0). `EncryptionService.readinessResult` now reads from preferences instead of the hardcoded constant + TODO. Codable back-compat for legacy data. |
| **BE-016** | medium | `persistToDisk` now retries once on failure (500ms backoff) and surfaces a new `@Published persistenceFailed: Bool` flag on persistent failure. `retryPersistIfFailed()` wired into `FitTrackerApp` scenePhase=`.active` for auto-recovery. **Function signature unchanged** — all 30+ fire-and-forget call sites continue working. |
| **BE-021** | medium | Split the single Keychain item into two: `sessionKey` (metadata, JWT field cleared) and `jwtKey` (the live JWT alone, with stricter `WhenPasscodeSetThisDeviceOnly` ACL — won't restore from backup). KeychainHelper gains an `accessible:` parameter (default unchanged). Legacy single-item sessions migrated on next `restoreSession`. |

## Test plan

- [x] `xcodebuild build` green on iOS 26.4 simulator
- [x] `xcodebuild test` green for all suites (the keychain-entitlement issues from prior CIs no longer apply since PR #101's ad-hoc signing fix)
- [ ] CI green

## What's next in Path A

After K-1 merges, the remaining deferred Sprint G items will ship as K-2/K-3:
- DEEP-AUTH-011 — atomic 5-file write
- BE-023 — Supabase deletion grace period
- BE-024 — delete Supabase Auth user record (Edge Function)
- DEEP-SYNC-010 — CK cardio image → Supabase forwarding
- DEEP-SYNC-014 — cloudRecordID atomic persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)