### PR TITLE
fix(ai): Sprint K-5 — AI Adapter Cleanup (12 findings)

### DIFF
--- a/FitTracker/AI/AIOrchestrator.swift
+++ b/FitTracker/AI/AIOrchestrator.swift
@@ -121,7 +121,16 @@ public final class AIOrchestrator: ObservableObject {
 
         latestRecommendations[segment] = finalRecommendation
 
-        // Validate and attach goal context
+        // Validate and attach goal context.
+        // Audit AI-011: if `setAdapters` hasn't been called yet (e.g., a test
+        // path that calls `process` directly without going through the
+        // app-wide `buildSnapshot` wrapper), bootstrap an empty-data adapter
+        // list so the freshness/evidence chain doesn't crash on an empty
+        // input. The empty adapters report `lastUpdated: nil`, which the
+        // freshness computation already handles as a "no data" signal.
+        if lastAdapters.isEmpty {
+            lastAdapters = Self.bootstrapEmptyAdapters()
+        }
         let validated = ValidatedRecommendation.validate(
             recommendation: finalRecommendation,
             snapshot: userSnapshot,
@@ -129,6 +138,32 @@ public final class AIOrchestrator: ObservableObject {
             goalProfile: goalProfile
         )
         validatedRecommendations[segment] = validated
+    }
+
+    /// Build a default-state adapter list for the AI-011 bootstrap path.
+    /// Each adapter is constructed with empty/default inputs and reports
+    /// `lastUpdated: nil` so the validation evidence chain has at least one
+    /// node per source even before the app wires the real adapter list via
+    /// `setAdapters`.
+    private static func bootstrapEmptyAdapters() -> [any AIInputAdapter] {
+        let emptyProfile = UserProfile()
+        let emptyPreferences = UserPreferences()
+        return [
+            ProfileAdapter(profile: emptyProfile, preferences: emptyPreferences, todayDayType: .restDay),
+            HealthKitAdapter(liveMetrics: LiveMetrics(), recentLogs: [], profile: emptyProfile, readiness: nil),
+            TrainingAdapter(recentLogs: [], todayDayType: .restDay),
+            NutritionAdapter(
+                latestLog: nil,
+                goalPlan: emptyProfile.nutritionPlan(
+                    currentWeightKg: emptyProfile.startWeightKg,
+                    currentBodyFatPercent: emptyProfile.startBodyFatPct,
+                    isTrainingDay: false,
+                    preferences: emptyPreferences
+                ),
+                liveMetrics: LiveMetrics(),
+                profile: emptyProfile
+            ),
+        ]
     }
 
     /// Process all segments sequentially for a full refresh.

--- a/FitTracker/AI/Adapters/HealthKitAdapter.swift
+++ b/FitTracker/AI/Adapters/HealthKitAdapter.swift
@@ -23,7 +23,9 @@ struct HealthKitAdapter: AIInputAdapter {
     func contribute(to snapshot: inout LocalUserSnapshot) {
         let recent7 = Array(recentLogs.prefix(7))
 
-        // BMI — only from measured weight, never from startWeightKg (which may be stale)
+        // BMI — only from measured weight, never from startWeightKg (which may be stale).
+        // Audit AI-008 / DEEP-AI-003: source order is liveMetrics → most-recent log → nil.
+        // No fallback to profile.startWeightKg.
         let currentWeight = liveMetrics.weightKg
             ?? recentLogs.first?.biometrics.weightKg
         snapshot.bmiValue = Self.bmi(weightKg: currentWeight, heightCm: profile.heightCm)
@@ -56,6 +58,9 @@ struct HealthKitAdapter: AIInputAdapter {
 
     // MARK: - Private helpers (extracted from AISnapshotBuilder)
 
+    /// Audit AI-009 / DEEP-AI-003: enforce plausibility bounds before computing
+    /// BMI. Heights outside 100-250cm and weights outside 30-300kg return nil
+    /// instead of producing nonsense bands ("underweight" for a 1cm subject).
     private static func bmi(weightKg: Double?, heightCm: Double) -> Double? {
         guard let weightKg, heightCm >= 100, heightCm <= 250,
               weightKg >= 30, weightKg <= 300 else { return nil }
@@ -81,13 +86,21 @@ struct HealthKitAdapter: AIInputAdapter {
 
     private static func stressLevel(from log: DailyLog?) -> String? {
         guard let log else { return nil }
-        // Only infer stress when we have at least one subjective signal
+        // At least one subjective signal must be present.
         guard log.mood != nil || log.energyLevel != nil || log.cravingLevel != nil else { return nil }
+        // Audit AI-007: only emit a classification when there's STRONG evidence.
+        // Previously we returned "moderate" as a default whenever any signal
+        // was present — that fabricated a confidence level (and suppressed the
+        // orchestrator's `insufficientData` UX path) from one weak data point.
+        // New rule:
+        //   - Any extreme signal (mood ≤2, energy ≤2, craving ≥4) → "high"
+        //   - Both mood AND energy ≥4 → "low" (need two corroborating signals)
+        //   - Otherwise → nil (do not fabricate "moderate" from weak data)
         if let mood = log.mood, mood <= 2 { return "high" }
         if let energy = log.energyLevel, energy <= 2 { return "high" }
         if let craving = log.cravingLevel, craving >= 4 { return "high" }
         if let mood = log.mood, mood >= 4, let energy = log.energyLevel, energy >= 4 { return "low" }
-        return "moderate"
+        return nil
     }
 
     private static func sleepQuality(for hours: Double?) -> String? {

--- a/FitTracker/AI/Adapters/NutritionAdapter.swift
+++ b/FitTracker/AI/Adapters/NutritionAdapter.swift
@@ -29,6 +29,9 @@ struct NutritionAdapter: AIInputAdapter {
         )
         snapshot.dailyProteinGrams = latestNutrition?.resolvedProteinG
         snapshot.proteinTargetGrams = goalPlan.proteinG
+        // Audit AI-010: count only `.completed` meal entries — never planned-
+        // but-uneaten meals. Returns nil rather than 0 so the orchestrator
+        // surfaces "no meals logged today" instead of "user ate 0 meals".
         let completedMealCount = latestNutrition?.meals.filter { $0.status == .completed }.count
         snapshot.mealsPerDay = (completedMealCount ?? 0) > 0 ? completedMealCount : nil
     }

--- a/FitTracker/AI/Adapters/ProfileAdapter.swift
+++ b/FitTracker/AI/Adapters/ProfileAdapter.swift
@@ -20,12 +20,18 @@ struct ProfileAdapter: AIInputAdapter {
 
     func contribute(to snapshot: inout LocalUserSnapshot) {
         snapshot.ageYears = profile.age
-        snapshot.genderIdentity = nil // no gender field in UserProfile — leave nil rather than fabricate
+        // Audit AI-004: gender stays nil until UserProfile gains a `gender` field.
+        // Better to surface insufficientData than fabricate "prefer_not_to_say".
+        snapshot.genderIdentity = nil
         snapshot.activeWeeks = max(0, Int(ceil(Double(profile.daysSinceStart) / 7.0)))
         snapshot.programPhase = todayDayType.aiProgramPhase
+        // Audit AI-005: pass the real user value (Int? — nil if not configured).
+        // No compile-time constant fallback; the snapshot honestly reports "not set".
         snapshot.trainingDaysPerWeek = profile.trainingDaysPerWeek
         snapshot.primaryGoal = Self.primaryGoal(for: preferences)
-        snapshot.dietPattern = nil // no diet pattern field in UserPreferences — leave nil rather than fabricate
+        // Audit AI-006: dietPattern stays nil until UserPreferences gains a
+        // `dietPattern` field. Same reasoning as AI-004.
+        snapshot.dietPattern = nil
     }
 
     private static func primaryGoal(for preferences: UserPreferences) -> String {

--- a/FitTracker/AI/Adapters/TrainingAdapter.swift
+++ b/FitTracker/AI/Adapters/TrainingAdapter.swift
@@ -33,15 +33,18 @@ struct TrainingAdapter: AIInputAdapter {
 
     // MARK: - Private helpers (extracted from AISnapshotBuilder)
 
+    /// Audit AI-017: improved from the original 10min/exercise heuristic to
+    /// 15min/exercise with a 20min floor (covers rest between sets). True
+    /// session duration would require a `sessionMinutes` field on DailyLog
+    /// (model change, deferred). When no workout data exists at all, returns
+    /// nil — don't fabricate a fallback.
     private static func averageSessionMinutes(from logs: [DailyLog], fallbackDayType: DayType) -> Int? {
         let durations = logs.compactMap { log -> Int? in
             let cardioMinutes = Int(log.cardioLogs.values.compactMap(\.durationMinutes).reduce(0, +).rounded())
-            // ~15 min per exercise is a better heuristic than 10 (includes rest between sets)
             let strengthMinutes = log.exerciseLogs.isEmpty ? 0 : max(20, log.exerciseLogs.count * 15)
             let estimated = cardioMinutes + strengthMinutes
             return estimated > 0 ? estimated : nil
         }
-        // Return nil when no workout data exists — don't fabricate a fallback
         return durations.averageRounded
     }
 
@@ -59,6 +62,11 @@ struct TrainingAdapter: AIInputAdapter {
         return Int(total.rounded())
     }
 
+    /// Audit DEEP-AI-014: `scheduledSessions` is now sourced from
+    /// `snapshot.trainingDaysPerWeek` (set by ProfileAdapter from the user's
+    /// real `UserProfile.trainingDaysPerWeek` value — see AI-005), not a
+    /// hardcoded constant. When the user hasn't configured a target, returns
+    /// nil rather than fabricating a "high"/"low"/"moderate" classification.
     private static func workoutConsistency(completedSessions: Int, scheduledSessions: Int) -> String? {
         guard scheduledSessions > 0 else { return nil }
         let ratio = Double(completedSessions) / Double(scheduledSessions)

--- a/FitTracker/AI/ValidatedRecommendation.swift
+++ b/FitTracker/AI/ValidatedRecommendation.swift
@@ -110,16 +110,34 @@ struct ValidatedRecommendation: Sendable {
 
     // MARK: - Freshness
 
+    /// Audit DEEP-AI-011: average each adapter's freshness score instead of
+    /// computing a single score from the newest adapter date. Previously one
+    /// fresh adapter (e.g., a synced ProfileAdapter) masked stale others
+    /// (e.g., a HealthKitAdapter that hadn't fetched in 48h). Now: each
+    /// adapter contributes its own freshness score, and the result is the
+    /// mean. Adapters with no `lastUpdated` (always-fresh sources like
+    /// ProfileAdapter) are excluded so they don't pull the mean up.
     private static func computeFreshness(adapters: [any AIInputAdapter]) -> Double {
-        let dates = adapters.compactMap(\.lastUpdated)
-        guard let newest = dates.max() else { return 0 }
-        let ageHours = Date().timeIntervalSince(newest) / 3600
+        let scores = adapters.compactMap { adapter -> Double? in
+            guard let lastUpdated = adapter.lastUpdated else { return nil }
+            return scoreFor(date: lastUpdated)
+        }
+        guard !scores.isEmpty else { return 0 }
+        return scores.reduce(0, +) / Double(scores.count)
+    }
+
+    /// Bucketed freshness score (0.0 – 1.0) for a single adapter's
+    /// `lastUpdated` timestamp. Same buckets as the previous implementation
+    /// to preserve the absolute scale; the change is per-adapter scoring
+    /// rather than per-fleet-newest scoring.
+    private static func scoreFor(date: Date) -> Double {
+        let ageHours = Date().timeIntervalSince(date) / 3600
         switch ageHours {
-        case ..<1:   return 1.0   // < 1 hour old
-        case ..<6:   return 0.9   // < 6 hours
-        case ..<24:  return 0.7   // < 1 day
-        case ..<72:  return 0.4   // < 3 days
-        default:     return 0.1   // stale
+        case ..<1:   return 1.0
+        case ..<6:   return 0.9
+        case ..<24:  return 0.7
+        case ..<72:  return 0.4
+        default:     return 0.1
         }
     }
 }

--- a/FitTrackerTests/ValidatedRecommendationTests.swift
+++ b/FitTrackerTests/ValidatedRecommendationTests.swift
@@ -211,8 +211,11 @@ final class ValidatedRecommendationTests: XCTestCase {
         XCTAssertEqual(result.sourceFreshness, 0.1, "200h-old adapter → stale floor 0.1")
     }
 
-    func testValidate_picksNewestAdapterForFreshness() {
-        // Mix of stale + fresh — must use the newest
+    func testValidate_averagesPerAdapterFreshness() {
+        // Audit DEEP-AI-011: freshness now averages per-adapter scores instead
+        // of taking the newest adapter's score. One fresh adapter (1.0) and one
+        // stale adapter (0.1, 200h old → "stale" band) → mean = 0.55.
+        // Previous behavior (newest-only) returned 1.0, masking the stale source.
         let stale = TestAdapter(sourceID: "old", lastUpdated: Date().addingTimeInterval(-200 * 3600))
         let fresh = TestAdapter(sourceID: "new", lastUpdated: Date())
 
@@ -222,8 +225,8 @@ final class ValidatedRecommendationTests: XCTestCase {
             adapters: [stale, fresh],
             goalProfile: .muscleGain
         )
-        XCTAssertEqual(result.sourceFreshness, 1.0,
-                       "Freshness must use the newest adapter, not the average or oldest")
+        XCTAssertEqual(result.sourceFreshness, 0.55, accuracy: 0.001,
+                       "Freshness must be the mean of per-adapter scores, not just the newest (DEEP-AI-011)")
     }
 
     // ── Combined confidence ──────────────────────────────


### PR DESCRIPTION
## Summary

12 findings closed across the AI pipeline — 3 new behavioral fixes + 9 already-fixed verifications.

## New behavioral fixes

| ID | Sev | Change |
|---|---|---|
| **AI-007** | medium | \`HealthKitAdapter.stressLevel\`: stops fabricating "moderate" from a single weak signal. New rule: extreme signal (mood ≤2, energy ≤2, craving ≥4) → "high"; mood AND energy ≥4 → "low"; otherwise nil. |
| **AI-011** | medium | \`AIOrchestrator.process\`: bootstraps an empty-data adapter list if \`setAdapters\` hasn't been called yet (test paths). Bootstrap adapters report \`lastUpdated: nil\`, which the freshness logic already treats as "no data". |
| **DEEP-AI-011** | medium | \`ValidatedRecommendation.computeFreshness\`: averages per-adapter scores instead of taking newest-only. One fresh adapter no longer masks stale others. |

## Verified already-fixed

| ID | Sev | Already correct because |
|---|---|---|
| AI-004 | medium | ProfileAdapter.genderIdentity = nil (no fabrication) |
| AI-005 | medium | ProfileAdapter passes real \`UserProfile.trainingDaysPerWeek\` |
| AI-006 | medium | ProfileAdapter.dietPattern = nil |
| AI-008 / DEEP-AI-003 | high/medium | BMI uses live → log → nil; no startWeightKg fallback |
| AI-009 / DEEP-AI-003 | medium | bmi() has 100-250cm + 30-300kg plausibility bounds |
| AI-010 | medium | NutritionAdapter filters to \`.completed\` meals |
| AI-017 | low | avgSessionMinutes already uses 15min/exercise + 20min floor |
| DEEP-AI-014 | low | workoutConsistency uses real \`trainingDaysPerWeek\` from snapshot |

## Test plan

- [x] \`xcodebuild build\` green
- [x] \`xcodebuild test\` green (full suite)
- [x] Updated \`ValidatedRecommendationTests.testValidate_averagesPerAdapterFreshness\` to assert new mean-based behavior
- [x] \`AIAdapterTests.testHealthKitAdapter_stressInferredFromMoodEnergy\` still passes under the new rule
- [ ] CI green

## Audit progress after K-5

After merge + sync re-run: 36 → 24 open. Per the completion plan, next is **K-6** (FW Cleanup, ~8 findings, ~30 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)