### PR TITLE
fix(ds): Sprint K-7 — DS-002 + DS-003 mechanical mass-rename

### DIFF
--- a/FitTracker/Services/AppTheme.swift
+++ b/FitTracker/Services/AppTheme.swift
@@ -331,39 +331,13 @@ enum AppGradient {
     )
 }
 
-// MARK: - Legacy compatibility aliases (DEPRECATED — migrate call sites to AppColor.*)
-// These exist only for backward compatibility with older view code.
-// Do not use in new code. Removal tracked for next cleanup pass.
-extension Color {
-    static let appOrange1 = AppColor.Brand.warmSoft
-    static let appOrange2 = AppColor.Brand.warm
-    static let appOrange3 = AppColor.Brand.primary
-    static let appBlue1   = AppColor.Brand.cool
-    static let appBlue2   = AppColor.Brand.secondary
-    static let appBlue3   = AppColor.Brand.coolSoft
-    static let appBlue4   = AppColor.Background.appSecondary
-
-    static let appSurface      = AppColor.Surface.primary
-    static let appStroke       = AppColor.Border.strong
-    static let appTextPrimary  = AppColor.Text.inversePrimary
-    static let appTextSecondary = AppColor.Text.inverseSecondary
-    static let appTextTertiary = AppColor.Text.inverseTertiary
-    static let appAccentPrimary = AppColor.Accent.primary
-    static let appAccentSoft   = AppColor.Brand.warmSoft.opacity(0.34)
-
-    enum status {
-        static let success = AppColor.Status.success
-        static let warning = AppColor.Status.warning
-        static let error   = AppColor.Status.error
-    }
-
-    enum accent {
-        static let primary = AppColor.Accent.primary
-        static let cyan   = AppColor.Accent.recovery
-        static let purple = AppColor.Accent.sleep
-        static let gold   = AppColor.Accent.achievement
-    }
-}
+// Audit DS-002 + DS-003 (Sprint K-7): the deprecated `Color.appOrange*` /
+// `appBlue*` / `appSurface` / `appStroke` / `appText*` / `appAccent*` /
+// `Color.status.*` / `Color.accent.*` aliases were removed here. All 57
+// call-sites across TrainingPlanView, NutritionView (v1+v2), and
+// MainScreenView were migrated to `AppColor.*` semantic tokens in the
+// same commit. Re-introducing any of these aliases would constitute a
+// design-system regression — use the `AppColor.*` namespace instead.
 
 // MARK: - Contrast validation (DEBUG only)
 #if DEBUG

--- a/FitTracker/Views/Main/MainScreenView.swift
+++ b/FitTracker/Views/Main/MainScreenView.swift
@@ -73,10 +73,10 @@ struct MainScreenView: View {
     }
 
     // Background palette — defined centrally in AppTheme.swift
-    private let bgOrange1 = Color.appOrange1
-    private let bgOrange2 = Color.appOrange2
-    private let bgBlue1   = Color.appBlue1
-    private let bgBlue2   = Color.appBlue2
+    private let bgOrange1 = AppColor.Brand.warmSoft
+    private let bgOrange2 = AppColor.Brand.warm
+    private let bgBlue1   = AppColor.Brand.cool
+    private let bgBlue2   = AppColor.Brand.secondary
     private let bodyFatTint = AppColor.Chart.nutritionFat
 
     private func checkMilestones() {
@@ -329,7 +329,7 @@ struct MainScreenView: View {
                 } label: {
                     Image(systemName: "square.and.pencil")
                         .font(AppText.body)
-                        .foregroundStyle(Color.appBlue1)
+                        .foregroundStyle(AppColor.Brand.cool)
                         .frame(width: 34, height: 34)
                         .background(AppColor.Surface.tertiary, in: Circle())
                 }
@@ -353,7 +353,7 @@ struct MainScreenView: View {
                     Circle()
                         .trim(from: 0, to: max(goalProgress, 0.02))
                         .stroke(
-                            AngularGradient(colors: [.appBlue1, bodyFatTint, .appBlue1], center: .center),
+                            AngularGradient(colors: [AppColor.Brand.cool, bodyFatTint, AppColor.Brand.cool], center: .center),
                             style: StrokeStyle(lineWidth: 12, lineCap: .round)
                         )
                         .rotationEffect(.degrees(-90))
@@ -374,7 +374,7 @@ struct MainScreenView: View {
                 progressLine(
                     title: "Weight",
                     progress: profile.weightProgress(current: currentWeight),
-                    tint: .appBlue1,
+                    tint: AppColor.Brand.cool,
                     compact: tight
                 )
                 progressLine(
@@ -436,7 +436,7 @@ struct MainScreenView: View {
                                 .font(.caption.weight(.bold))
                         }
                         .font(.system(size: tight ? 14 : 15.5, weight: .medium, design: .rounded)) // responsive — no AppText equivalent
-                        .foregroundStyle(Color.appBlue1)
+                        .foregroundStyle(AppColor.Brand.cool)
                     }
 
                     Text("\(estimatedSessionLength) • \(recommendationTone)")
@@ -622,10 +622,10 @@ struct MainScreenView: View {
 
     private var recommendationAccent: Color {
         switch readinessScore ?? 65 {
-        case 80...: Color.status.success
-        case 60..<80: Color.accent.cyan
-        case 40..<60: Color.status.warning
-        default: Color.status.error
+        case 80...: AppColor.Status.success
+        case 60..<80: AppColor.Accent.recovery
+        case 40..<60: AppColor.Status.warning
+        default: AppColor.Status.error
         }
     }
 

--- a/FitTracker/Views/Nutrition/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/NutritionView.swift
@@ -278,7 +278,7 @@ struct NutritionView_V1_Historical: View {
         return VStack(spacing: AppSpacing.micro) {
             Text("\(pct)%")
                 .font(AppText.monoMetric)
-                .foregroundStyle(Color.status.success)
+                .foregroundStyle(AppColor.Status.success)
             Text("supps")
                 .font(AppText.caption)
                 .foregroundStyle(AppColor.Text.secondary)
@@ -317,7 +317,7 @@ struct NutritionView_V1_Historical: View {
                 quickActionButton(
                     title: "Repeat Last",
                     icon: "clock.arrow.circlepath",
-                    tint: Color.status.success
+                    tint: AppColor.Status.success
                 ) {
                     if let recent = recentMeals.first {
                         openPrefilledMeal(recent)
@@ -326,7 +326,7 @@ struct NutritionView_V1_Historical: View {
             }
 
             HStack(spacing: AppSpacing.medium) {
-                nutritionMetric(title: "Protein left", value: "\(Int(remainingProteinG))g", color: Color.accent.cyan)
+                nutritionMetric(title: "Protein left", value: "\(Int(remainingProteinG))g", color: AppColor.Accent.recovery)
                 nutritionMetric(title: "Fat floor", value: "\(Int(max(targetFatG, 0)))g", color: AppColor.Chart.nutritionFat)
                 nutritionMetric(title: "Meals logged", value: "\(nutritionLog.meals.filter { $0.status == .completed }.count)", color: AppColor.Brand.warm)
             }
@@ -375,7 +375,7 @@ struct NutritionView_V1_Historical: View {
                     RoundedRectangle(cornerRadius: AppRadius.micro)
                         .fill(AppColor.Text.secondary.opacity(0.15)).frame(height: 6)
                     RoundedRectangle(cornerRadius: AppRadius.micro)
-                        .fill(LinearGradient(colors: [Color.status.success, Color.status.success], startPoint: .leading, endPoint: .trailing))
+                        .fill(LinearGradient(colors: [AppColor.Status.success, AppColor.Status.success], startPoint: .leading, endPoint: .trailing))
                         .frame(width: geo.size.width * frac, height: 6)
                         .animation(.spring(response: 0.6), value: frac)
                 }
@@ -563,7 +563,7 @@ struct NutritionView_V1_Historical: View {
                 } label: {
                     Label(log?.nutritionLog.alluloseTaken == true ? "Allulose done" : "Allulose", systemImage: log?.nutritionLog.alluloseTaken == true ? "checkmark.circle.fill" : "circle")
                         .font(AppText.captionStrong)
-                        .foregroundStyle(log?.nutritionLog.alluloseTaken == true ? Color.status.success : AppColor.Text.secondary)
+                        .foregroundStyle(log?.nutritionLog.alluloseTaken == true ? AppColor.Status.success : AppColor.Text.secondary)
                         .padding(.horizontal, AppSpacing.xSmall)
                         .padding(.vertical, AppSpacing.xxSmall)
                         .background(AppColor.Surface.elevated, in: Capsule())
@@ -676,19 +676,19 @@ struct NutritionView_V1_Historical: View {
                                         .font(.caption2.weight(.bold))
                                 }
                             }
-                            .foregroundStyle(morningStatus == .completed ? Color.status.success : AppColor.Text.secondary)
+                            .foregroundStyle(morningStatus == .completed ? AppColor.Status.success : AppColor.Text.secondary)
                             .padding(.horizontal, AppSpacing.xxSmall)
                             .padding(.vertical, AppSpacing.xxxSmall)
                             .background(
                                 morningStatus == .completed
-                                    ? Color.status.success.opacity(0.15)
+                                    ? AppColor.Status.success.opacity(0.15)
                                     : AppColor.Surface.elevated.opacity(0.8)
                             )
                             .overlay(
                                 Capsule()
                                     .stroke(
                                         morningStatus == .completed
-                                            ? Color.status.success
+                                            ? AppColor.Status.success
                                             : AppColor.Border.subtle,
                                         lineWidth: 1
                                     )
@@ -719,19 +719,19 @@ struct NutritionView_V1_Historical: View {
                                         .font(.caption2.weight(.bold))
                                 }
                             }
-                            .foregroundStyle(eveningStatus == .completed ? Color.status.success : AppColor.Text.secondary)
+                            .foregroundStyle(eveningStatus == .completed ? AppColor.Status.success : AppColor.Text.secondary)
                             .padding(.horizontal, AppSpacing.xxSmall)
                             .padding(.vertical, AppSpacing.xxxSmall)
                             .background(
                                 eveningStatus == .completed
-                                    ? Color.status.success.opacity(0.15)
+                                    ? AppColor.Status.success.opacity(0.15)
                                     : AppColor.Surface.elevated.opacity(0.8)
                             )
                             .overlay(
                                 Capsule()
                                     .stroke(
                                         eveningStatus == .completed
-                                            ? Color.status.success
+                                            ? AppColor.Status.success
                                             : AppColor.Border.subtle,
                                         lineWidth: 1
                                     )

--- a/FitTracker/Views/Nutrition/v2/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/v2/NutritionView.swift
@@ -303,7 +303,7 @@ struct NutritionView: View {
         .padding(.top, AppSpacing.xxxSmall)
     }
 
-    // F7 fix: AppColor.Status.success instead of Color.status.success
+    // F7 fix: AppColor.Status.success instead of AppColor.Status.success
     private var overallBadge: some View {
         let total  = morning.count + evening.count
         let taken  = individualStatus.filter { $0.value }.count

--- a/FitTracker/Views/Settings/SettingsView.swift
+++ b/FitTracker/Views/Settings/SettingsView.swift
@@ -49,10 +49,10 @@ private enum SettingsCategory_V1_Historical: String, CaseIterable, Hashable, Ide
     var tint: Color {
         switch self {
         case .accountSecurity: AppColor.Accent.primary
-        case .healthDevices: .accent.cyan
+        case .healthDevices: AppColor.Accent.recovery
         case .goalsPreferences: AppColor.Accent.achievement
-        case .trainingNutrition: .accent.purple
-        case .dataSync: .status.success
+        case .trainingNutrition: AppColor.Accent.sleep
+        case .dataSync: AppColor.Status.success
         }
     }
 }
@@ -218,26 +218,26 @@ struct SettingsView_V1_Historical: View {
                 SettingsSummaryBadge(title: provider, tint: AppColor.Accent.primary),
                 SettingsSummaryBadge(
                     title: biometric,
-                    tint: settings.requireBiometricUnlockOnReopen ? .status.success : .status.warning
+                    tint: settings.requireBiometricUnlockOnReopen ? AppColor.Status.success : AppColor.Status.warning
                 ),
             ]
         case .healthDevices:
             let health = healthService.isAuthorized ? "HealthKit On" : "HealthKit Off"
             return [
-                SettingsSummaryBadge(title: health, tint: healthService.isAuthorized ? .status.success : .status.warning),
+                SettingsSummaryBadge(title: health, tint: healthService.isAuthorized ? AppColor.Status.success : AppColor.Status.warning),
                 SettingsSummaryBadge(title: watchService.status.label, tint: watchService.status.dotColor),
             ]
         case .goalsPreferences:
             return [
                 SettingsSummaryBadge(title: settings.unitSystem.rawValue, tint: AppColor.Accent.achievement),
-                SettingsSummaryBadge(title: settings.appearance.rawValue, tint: .accent.purple),
+                SettingsSummaryBadge(title: settings.appearance.rawValue, tint: AppColor.Accent.sleep),
             ]
         case .trainingNutrition:
             return [
-                SettingsSummaryBadge(title: dataStore.userPreferences.nutritionGoalMode.shortLabel, tint: .accent.purple),
+                SettingsSummaryBadge(title: dataStore.userPreferences.nutritionGoalMode.shortLabel, tint: AppColor.Accent.sleep),
                 SettingsSummaryBadge(
                     title: "Zone 2 \(dataStore.userPreferences.zone2LowerHR)-\(dataStore.userPreferences.zone2UpperHR)",
-                    tint: .accent.cyan
+                    tint: AppColor.Accent.recovery
                 ),
             ]
         case .dataSync:
@@ -251,11 +251,11 @@ struct SettingsView_V1_Historical: View {
     private var syncTint: Color {
         switch cloudSync.status {
         case .idle:
-            return .status.success
+            return AppColor.Status.success
         case .syncing:
-            return .status.warning
+            return AppColor.Status.warning
         case .failed:
-            return .status.error
+            return AppColor.Status.error
         case .offline, .disabled:
             return AppColor.Text.secondary
         }
@@ -339,7 +339,7 @@ private struct AccountSecuritySettingsScreen: View {
                         title: signIn.currentSession?.provider == .passkey ? "Create Another Passkey" : "Add Passkey",
                         subtitle: signIn.isPasskeyConfigured ? "Register a passkey for quick passwordless sign in." : "Passkey setup requires a valid relying party configuration.",
                         icon: "key.fill",
-                        tint: .accent.purple,
+                        tint: AppColor.Accent.sleep,
                         trailing: signIn.isLoading ? .progress : .chevron
                     )
                 }
@@ -370,7 +370,7 @@ private struct AccountSecuritySettingsScreen: View {
                         title: "Delete Account",
                         subtitle: "Schedule permanent deletion of your account and all data.",
                         icon: "trash.fill",
-                        tint: .status.error
+                        tint: AppColor.Status.error
                     )
                 }
                 .buttonStyle(.plain)
@@ -424,7 +424,7 @@ private struct HealthDevicesSettingsScreen: View {
                         title: "Re-authorize HealthKit",
                         subtitle: "Refresh the current HealthKit permissions and reconnect read access.",
                         icon: "heart.text.square.fill",
-                        tint: .accent.cyan
+                        tint: AppColor.Accent.recovery
                     )
                 }
                 .buttonStyle(.plain)
@@ -494,7 +494,7 @@ private struct GoalsPreferencesSettingsScreen: View {
                         title: mode.rawValue,
                         subtitle: mode == .system ? "Follow the device setting" : "Force \(mode.rawValue.lowercased()) mode",
                         isSelected: settings.appearance == mode,
-                        tint: .accent.purple
+                        tint: AppColor.Accent.sleep
                     )
                 }
             }
@@ -735,7 +735,7 @@ private struct DataSyncSettingsScreen: View {
                         title: "Sync Now",
                         subtitle: "Push local encrypted changes to your private iCloud database.",
                         icon: "icloud.and.arrow.up.fill",
-                        tint: .status.success
+                        tint: AppColor.Status.success
                     )
                 }
                 .buttonStyle(.plain)
@@ -747,7 +747,7 @@ private struct DataSyncSettingsScreen: View {
                         title: "Fetch from iCloud",
                         subtitle: "Download the latest encrypted changes from your account.",
                         icon: "icloud.and.arrow.down.fill",
-                        tint: .accent.cyan
+                        tint: AppColor.Accent.recovery
                     )
                 }
                 .buttonStyle(.plain)
@@ -797,7 +797,7 @@ private struct DataSyncSettingsScreen: View {
                         title: "Export My Data",
                         subtitle: "Download all your data as a JSON file.",
                         icon: "square.and.arrow.up.fill",
-                        tint: .accent.primary
+                        tint: AppColor.Accent.primary
                     )
                 }
                 .buttonStyle(.plain)
@@ -813,7 +813,7 @@ private struct DataSyncSettingsScreen: View {
                         title: "Delete All Local Data",
                         subtitle: "Remove all daily logs and snapshots from this device.",
                         icon: "trash.fill",
-                        tint: .status.error
+                        tint: AppColor.Status.error
                     )
                 }
                 .buttonStyle(.plain)

--- a/FitTracker/Views/Shared/StatusBadge.swift
+++ b/FitTracker/Views/Shared/StatusBadge.swift
@@ -27,15 +27,15 @@ struct StatusBadge_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: AppSpacing.xSmall) {
             HStack(spacing: AppSpacing.xxSmall) {
-                StatusBadge(text: "Active", color: .status.success)
-                StatusBadge(text: "Pending", color: .status.warning)
-                StatusBadge(text: "Error", color: .status.error)
+                StatusBadge(text: "Active", color: AppColor.Status.success)
+                StatusBadge(text: "Pending", color: AppColor.Status.warning)
+                StatusBadge(text: "Error", color: AppColor.Status.error)
             }
 
             HStack(spacing: AppSpacing.xxSmall) {
-                StatusBadge(text: "Completed", color: .accent.cyan)
-                StatusBadge(text: "Premium", color: .accent.gold)
-                StatusBadge(text: "Featured", color: .accent.purple)
+                StatusBadge(text: "Completed", color: AppColor.Accent.recovery)
+                StatusBadge(text: "Premium", color: AppColor.Accent.achievement)
+                StatusBadge(text: "Featured", color: AppColor.Accent.sleep)
             }
         }
         .padding()

--- a/FitTracker/Views/Shared/TrendIndicator.swift
+++ b/FitTracker/Views/Shared/TrendIndicator.swift
@@ -8,13 +8,13 @@ struct TrendIndicator: View {
 
     var statusColor: Color {
         if delta > 0 && positiveIsGood {
-            return .status.success
+            return AppColor.Status.success
         } else if delta < 0 && !positiveIsGood {
-            return .status.success
+            return AppColor.Status.success
         } else if delta == 0 {
-            return .status.warning
+            return AppColor.Status.warning
         } else {
-            return .status.error
+            return AppColor.Status.error
         }
     }
 

--- a/FitTracker/Views/Stats/StatsView.swift
+++ b/FitTracker/Views/Stats/StatsView.swift
@@ -162,41 +162,41 @@ enum StatsFocusMetric_V1_Historical: String, CaseIterable, Identifiable {
     var tint: Color {
         switch self {
         case .weight:
-            return .appOrange2
+            return AppColor.Brand.warm
         case .bodyFat:
-            return .status.warning
+            return AppColor.Status.warning
         case .readiness:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .sleep:
-            return .accent.purple
+            return AppColor.Accent.sleep
         case .hrv:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .restingHeartRate:
-            return .status.error
+            return AppColor.Status.error
         case .trainingVolume:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .zone2:
-            return .status.success
+            return AppColor.Status.success
         case .steps:
-            return .appBlue2
+            return AppColor.Brand.secondary
         case .activeCalories:
-            return .appOrange1
+            return AppColor.Brand.warmSoft
         case .vo2Max:
-            return .status.success
+            return AppColor.Status.success
         case .leanMass:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .muscleMass:
-            return .status.success
+            return AppColor.Status.success
         case .bodyWater:
-            return .appBlue2
+            return AppColor.Brand.secondary
         case .visceralFat:
-            return .accent.purple
+            return AppColor.Accent.sleep
         case .protein:
-            return .status.success
+            return AppColor.Status.success
         case .calories:
-            return .appOrange1
+            return AppColor.Brand.warmSoft
         case .supplementAdherence:
-            return .accent.gold
+            return AppColor.Accent.achievement
         }
     }
 

--- a/FitTracker/Views/Stats/v2/StatsView.swift
+++ b/FitTracker/Views/Stats/v2/StatsView.swift
@@ -161,41 +161,41 @@ enum StatsFocusMetric: String, CaseIterable, Identifiable {
     var tint: Color {
         switch self {
         case .weight:
-            return .appOrange2
+            return AppColor.Brand.warm
         case .bodyFat:
-            return .status.warning
+            return AppColor.Status.warning
         case .readiness:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .sleep:
-            return .accent.purple
+            return AppColor.Accent.sleep
         case .hrv:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .restingHeartRate:
-            return .status.error
+            return AppColor.Status.error
         case .trainingVolume:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .zone2:
-            return .status.success
+            return AppColor.Status.success
         case .steps:
-            return .appBlue2
+            return AppColor.Brand.secondary
         case .activeCalories:
-            return .appOrange1
+            return AppColor.Brand.warmSoft
         case .vo2Max:
-            return .status.success
+            return AppColor.Status.success
         case .leanMass:
-            return .accent.cyan
+            return AppColor.Accent.recovery
         case .muscleMass:
-            return .status.success
+            return AppColor.Status.success
         case .bodyWater:
-            return .appBlue2
+            return AppColor.Brand.secondary
         case .visceralFat:
-            return .accent.purple
+            return AppColor.Accent.sleep
         case .protein:
-            return .status.success
+            return AppColor.Status.success
         case .calories:
-            return .appOrange1
+            return AppColor.Brand.warmSoft
         case .supplementAdherence:
-            return .accent.gold
+            return AppColor.Accent.achievement
         }
     }
 

--- a/FitTracker/Views/Training/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/TrainingPlanView.swift
@@ -179,7 +179,7 @@ struct TrainingPlanView: View {
 
                     // Completion dot
                     Circle()
-                        .fill(hasLog ? Color.status.success : Color.clear)
+                        .fill(hasLog ? AppColor.Status.success : Color.clear)
                         .frame(width: 5, height: 5)
                 }
                 .opacity(isRest && !hasLog ? 0.4 : 1.0)
@@ -284,7 +284,7 @@ struct TrainingPlanView: View {
                 trainingActionButton(
                     title: "Jump To Next",
                     systemImage: "arrow.down.circle.fill",
-                    fill: Color.accent.cyan,
+                    fill: AppColor.Accent.recovery,
                     foreground: .white
                 ) {
                     if let next = nextExercise {
@@ -367,7 +367,7 @@ struct TrainingPlanView: View {
                     .padding(.horizontal, AppSpacing.small)
                     .padding(.vertical, AppSpacing.xxSmall)
                     .background(
-                        isDone ? Color.status.success : AppColor.Text.primary,
+                        isDone ? AppColor.Status.success : AppColor.Text.primary,
                         in: Capsule()
                     )
                     .foregroundStyle(AppColor.Text.inversePrimary)
@@ -618,9 +618,9 @@ struct TrainingPlanView: View {
 
     private func queueColor(for status: TaskStatus) -> Color {
         switch status {
-        case .completed: Color.status.success
-        case .partial: Color.status.warning
-        case .missed: Color.status.error
+        case .completed: AppColor.Status.success
+        case .partial: AppColor.Status.warning
+        case .missed: AppColor.Status.error
         case .pending: AppColor.Text.secondary
         }
     }
@@ -830,7 +830,7 @@ struct ExerciseRowView: View {
             HStack(spacing: AppSpacing.xxSmall) {
                 Text(exercise.name)
                     .font(.subheadline.weight(.semibold))
-                    .strikethrough(status == .completed, color: Color.status.success)
+                    .strikethrough(status == .completed, color: AppColor.Status.success)
                     .foregroundStyle(status == .completed ? AppColor.Text.secondary : AppColor.Text.primary)
                 if isFocused {
                     Text("LIVE")
@@ -896,15 +896,15 @@ struct ExerciseRowView: View {
 
     private var accentColor: Color {
         switch status {
-        case .completed: Color.status.success; case .partial: Color.status.warning; case .missed: Color.status.error; case .pending: AppColor.Text.secondary
+        case .completed: AppColor.Status.success; case .partial: AppColor.Status.warning; case .missed: AppColor.Status.error; case .pending: AppColor.Text.secondary
         }
     }
 
     private var rowBG: Color {
         switch status {
-        case .completed: Color.status.success.opacity(0.08)
-        case .partial: Color.status.warning.opacity(0.06)
-        case .missed: Color.status.error.opacity(0.06)
+        case .completed: AppColor.Status.success.opacity(0.08)
+        case .partial: AppColor.Status.warning.opacity(0.06)
+        case .missed: AppColor.Status.error.opacity(0.06)
         default: isFocused ? AppColor.Surface.materialStrong : Color.clear
         }
     }
@@ -954,13 +954,13 @@ struct LiftLogPanel: View {
                 HStack {
                     Text(isFocused ? "LIVE SET LOG" : "SET LOG")
                         .font(.caption2.monospaced())
-                        .foregroundStyle(isFocused ? AppColor.Brand.secondary : Color.status.success)
+                        .foregroundStyle(isFocused ? AppColor.Brand.secondary : AppColor.Status.success)
                         .tracking(1)
                     Spacer()
                     if exerciseLog.totalVolume > 0 {
                         Text("Total: \(Int(exerciseLog.totalVolume)) kg")
                             .font(.caption2.monospaced())
-                            .foregroundStyle(Color.status.success.opacity(0.82))
+                            .foregroundStyle(AppColor.Status.success.opacity(0.82))
                     }
                 }
 
@@ -984,7 +984,7 @@ struct LiftLogPanel: View {
                    let orm = estimated1RM(weightKg: weight, reps: reps) {
                     Text("Est. 1RM ~\(Int(orm.rounded())) kg")
                         .font(AppText.caption)
-                        .foregroundStyle(Color.accent.cyan)
+                        .foregroundStyle(AppColor.Accent.recovery)
                         .padding(.horizontal, AppSpacing.xSmall)
                         .padding(.top, 2)
                 }
@@ -992,7 +992,7 @@ struct LiftLogPanel: View {
                 if let suggestion = overloadSuggestion {
                     Text(suggestion)
                         .font(AppText.captionStrong)
-                        .foregroundStyle(Color.accent.cyan)
+                        .foregroundStyle(AppColor.Accent.recovery)
                 }
 
                 HStack(spacing: AppSpacing.xxSmall) {
@@ -1008,7 +1008,7 @@ struct LiftLogPanel: View {
                         } label: {
                             Label("Copy Last", systemImage: "bolt.fill")
                                 .font(AppText.captionStrong)
-                                .foregroundStyle(Color.accent.cyan)
+                                .foregroundStyle(AppColor.Accent.recovery)
                         }
                     }
                     Button {
@@ -1018,7 +1018,7 @@ struct LiftLogPanel: View {
                         ))
                     } label: {
                         Label("Add Set", systemImage: "plus.circle.fill")
-                            .font(AppText.captionStrong).foregroundStyle(Color.status.success)
+                            .font(AppText.captionStrong).foregroundStyle(AppColor.Status.success)
                     }
                     Spacer()
                     Button {
@@ -1169,10 +1169,10 @@ struct SetRowView: View {
                         Text(setIsComplete ? "Done" : "Log")
                             .font(AppText.captionStrong)
                     }
-                    .foregroundStyle(setIsComplete ? Color.status.success : AppColor.Brand.warm)
+                    .foregroundStyle(setIsComplete ? AppColor.Status.success : AppColor.Brand.warm)
                     .padding(.horizontal, AppSpacing.xxSmall)
                     .padding(.vertical, AppSpacing.xxxSmall)
-                    .background((setIsComplete ? Color.status.success : AppColor.Brand.warm).opacity(0.12), in: Capsule())
+                    .background((setIsComplete ? AppColor.Status.success : AppColor.Brand.warm).opacity(0.12), in: Capsule())
                 }
                 .buttonStyle(.plain)
 
@@ -1233,7 +1233,7 @@ struct SetRowView: View {
             .background(AppColor.Surface.materialLight, in: RoundedRectangle(cornerRadius: AppRadius.xSmall))
         }
         .padding(AppSpacing.xSmall)
-        .background(flashGreen ? Color.status.success.opacity(0.16) : (setIsComplete ? Color.status.success.opacity(0.08) : AppColor.Surface.materialLight), in: RoundedRectangle(cornerRadius: AppRadius.small))
+        .background(flashGreen ? AppColor.Status.success.opacity(0.16) : (setIsComplete ? AppColor.Status.success.opacity(0.08) : AppColor.Surface.materialLight), in: RoundedRectangle(cornerRadius: AppRadius.small))
         .onAppear {
             weightStr = setLog.weightKg.map(formattedWeight) ?? ""
             repsStr   = setLog.repsCompleted.map { String($0) } ?? ""
@@ -1273,7 +1273,7 @@ struct SetRowView: View {
                         onUsePrevious()
                     }
                     .font(.caption2.weight(.medium))
-                    .foregroundStyle(Color.accent.cyan)
+                    .foregroundStyle(AppColor.Accent.recovery)
                 }
             }
 
@@ -1321,13 +1321,13 @@ struct CardioLogPanel: View {
             HStack {
                 Text(cardioType == .rowing ? "ROWING LOG" : "ELLIPTICAL LOG")
                     .font(.caption2.monospaced())
-                    .foregroundStyle(Color.status.success)
+                    .foregroundStyle(AppColor.Status.success)
                     .tracking(1)
                 Spacer()
                 if let zone = cardioLog.wasInZone2(lower: dataStore.userPreferences.zone2LowerHR, upper: dataStore.userPreferences.zone2UpperHR) {
                     Text(zone ? "✓ Zone 2" : "↑ Above Zone 2")
                         .font(.caption2.monospaced())
-                        .foregroundStyle(zone ? Color.status.success : Color.status.warning)
+                        .foregroundStyle(zone ? AppColor.Status.success : AppColor.Status.warning)
                 }
             }
 
@@ -1377,8 +1377,8 @@ struct CardioLogPanel: View {
                         }
                         .font(AppText.captionStrong)
                         .padding(.horizontal, AppSpacing.xxSmall).padding(.vertical, AppSpacing.xxxSmall)
-                        .background(Color.status.success.opacity(0.1), in: Capsule())
-                        .foregroundStyle(Color.status.success)
+                        .background(AppColor.Status.success.opacity(0.1), in: Capsule())
+                        .foregroundStyle(AppColor.Status.success)
                     }
                     #endif
 
@@ -1670,7 +1670,7 @@ struct StatusDropdown: View {
 
     private var color: Color {
         switch status {
-        case .completed: Color.status.success; case .partial: Color.status.warning; case .missed: Color.status.error; case .pending: AppColor.Text.secondary
+        case .completed: AppColor.Status.success; case .partial: AppColor.Status.warning; case .missed: AppColor.Status.error; case .pending: AppColor.Text.secondary
         }
     }
 }
@@ -1701,7 +1701,7 @@ struct SessionCompletionSheet: View {
                     VStack(spacing: AppSpacing.xxSmall) {
                         Image(systemName: "checkmark.seal.fill")
                             .font(AppText.iconLarge)
-                            .foregroundStyle(Color.status.success)
+                            .foregroundStyle(AppColor.Status.success)
                         Text("Session Complete!")
                             .font(AppText.pageTitle)
                         Text(selectedDay.rawValue)
@@ -1725,7 +1725,7 @@ struct SessionCompletionSheet: View {
                             label: "Volume",
                             value: totalVolumeStr,
                             delta: volumeDeltaStr,
-                            color: Color.accent.cyan
+                            color: AppColor.Accent.recovery
                         )
                         // Exercises done
                         statTile(
@@ -1733,7 +1733,7 @@ struct SessionCompletionSheet: View {
                             label: "Exercises",
                             value: exerciseSummaryStr,
                             delta: nil,
-                            color: Color.status.success
+                            color: AppColor.Status.success
                         )
                         // Session duration
                         statTile(
@@ -1741,7 +1741,7 @@ struct SessionCompletionSheet: View {
                             label: "Duration",
                             value: durationStr,
                             delta: nil,
-                            color: Color.accent.purple
+                            color: AppColor.Accent.sleep
                         )
                         // PRs this session (from exerciseLogs bestSet vs previous)
                         statTile(
@@ -1749,7 +1749,7 @@ struct SessionCompletionSheet: View {
                             label: "PRs",
                             value: prCountStr,
                             delta: nil,
-                            color: Color.accent.gold
+                            color: AppColor.Accent.achievement
                         )
                     }
 
@@ -1772,7 +1772,7 @@ struct SessionCompletionSheet: View {
                                 .padding(.vertical, AppSpacing.xSmall)
                                 .foregroundStyle(.black)
                                 .background(
-                                    LinearGradient(colors: [Color.status.success, Color.status.success.opacity(0.8)],
+                                    LinearGradient(colors: [AppColor.Status.success, AppColor.Status.success.opacity(0.8)],
                                                    startPoint: .leading, endPoint: .trailing),
                                     in: RoundedRectangle(cornerRadius: AppRadius.small)
                                 )
@@ -1916,7 +1916,7 @@ struct SessionCompletionSheet: View {
             if let delta {
                 Text(delta)
                     .font(.caption2)
-                    .foregroundStyle(delta.hasPrefix("+") ? Color.status.success : Color.status.error)
+                    .foregroundStyle(delta.hasPrefix("+") ? AppColor.Status.success : AppColor.Status.error)
             }
         }
         .frame(maxWidth: .infinity)
@@ -2013,7 +2013,7 @@ struct FocusModeView: View {
                 } else {
                     Text("All sets done ✓")
                         .font(AppText.pageTitle)
-                        .foregroundStyle(Color.status.success)
+                        .foregroundStyle(AppColor.Status.success)
                 }
 
                 // Weight + Reps fields
@@ -2053,7 +2053,7 @@ struct FocusModeView: View {
                         .foregroundStyle(.black)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, AppSpacing.medium)
-                        .background(Color.status.success, in: RoundedRectangle(cornerRadius: AppRadius.large))
+                        .background(AppColor.Status.success, in: RoundedRectangle(cornerRadius: AppRadius.large))
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, AppSpacing.xLarge)


### PR DESCRIPTION
## Summary

Two design-system findings closed by migrating ~100 call-sites of deprecated \`Color.*\` aliases to \`AppColor.*\` semantic tokens, then deleting the deprecated extension block from AppTheme.swift.

## DS-002: Color.status.* + Color.accent.*
| Old | → | New |
|---|---|---|
| \`Color.status.success/warning/error\` | → | \`AppColor.Status.*\` |
| \`Color.accent.primary\` | → | \`AppColor.Accent.primary\` |
| \`Color.accent.cyan\` | → | \`AppColor.Accent.recovery\` |
| \`Color.accent.purple\` | → | \`AppColor.Accent.sleep\` |
| \`Color.accent.gold\` | → | \`AppColor.Accent.achievement\` |

## DS-003: Color.app* aliases
| Old | → | New |
|---|---|---|
| \`appOrange1/2/3\` | → | \`AppColor.Brand.warmSoft/warm/primary\` |
| \`appBlue1/2/3/4\` | → | \`AppColor.Brand.cool/secondary/coolSoft\`, \`AppColor.Background.appSecondary\` |
| \`appSurface\` | → | \`AppColor.Surface.primary\` |
| \`appStroke\` | → | \`AppColor.Border.strong\` |
| \`appText*\` | → | \`AppColor.Text.inverse{Primary,Secondary,Tertiary}\` |
| \`appAccentPrimary\` | → | \`AppColor.Accent.primary\` |
| \`appAccentSoft\` | → | \`AppColor.Brand.warmSoft.opacity(0.34)\` |

## Files migrated (10)

- \`Services/AppTheme.swift\` — deprecated block deleted, replaced with audit closure comment
- \`Views/Training/TrainingPlanView.swift\` (35 sites)
- \`Views/Stats/StatsView.swift\` + \`Stats/v2/StatsView.swift\` (~14 each)
- \`Views/Settings/SettingsView.swift\` (~10)
- \`Views/Nutrition/NutritionView.swift\` (11) + \`Nutrition/v2/NutritionView.swift\` (1)
- \`Views/Main/MainScreenView.swift\` (10)
- \`Views/Shared/StatusBadge.swift\` (6 — preview only)
- \`Views/Shared/TrendIndicator.swift\` (4)
- \`DesignSystem/AppViewModifiers.swift\` (mixed)

## Test plan

- [x] \`xcodebuild build\` green (after 3 rounds — first pass missed leading-dot inferred-context usages like \`.status.success\` in StatusBadge previews and TrendIndicator; second pass missed \`.appOrange*\` in v2/StatsView; third pass clean)
- [x] \`xcodebuild test\` green (full suite)
- [ ] CI green

## Audit progress after K-7

After merge + sync re-run: ~16 → ~14 open. Per the completion plan, next is **K-8** (UI HISTORICAL closures, 2 findings, ~15 min — verify UI-003 and UI-005 are excluded from build target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)