### PR TITLE
chore(audit): Sprint K-8 — UI-003 + UI-005 historical closures (2 findings)

### DIFF
--- a/FitTracker/Views/Nutrition/NutritionView.swift
+++ b/FitTracker/Views/Nutrition/NutritionView.swift
@@ -3,6 +3,13 @@
 // .claude/features/nutrition-v2/v2-audit-report.md for the gap analysis.
 // This file is no longer in the build target; it stays in the repo
 // as a reviewable reference for the v1 → v2 diff.
+//
+// Audit UI-003 closure (2026-04-19): file is correctly excluded from the
+// Sources build phase in FitTracker.xcodeproj. The Sources entry references
+// v2/NutritionView.swift; the v1 file has only a PBXFileReference (visible
+// in git history + navigator) without a PBXBuildFile entry. No code change
+// required — the audit's "1112-line file" concern is moot because the file
+// is dead weight in the repo, not in the binary.
 
 import SwiftUI
 

--- a/FitTracker/Views/Settings/SettingsView.swift
+++ b/FitTracker/Views/Settings/SettingsView.swift
@@ -3,6 +3,13 @@
 // .claude/features/settings-v2/v2-audit-report.md for the gap analysis.
 // This file is no longer in the build target; it stays in the repo
 // as a reviewable reference for the v1 → v2 diff.
+//
+// Audit UI-005 closure (2026-04-19): file is correctly excluded from the
+// Sources build phase in FitTracker.xcodeproj. The Sources entry references
+// v2/SettingsView.swift; the v1 file has only a PBXFileReference (visible
+// in git history + navigator) without a PBXBuildFile entry. No code change
+// required — the audit's "1189-line file" concern is moot because the file
+// is dead weight in the repo, not in the binary.
 
 import SwiftUI
 import LocalAuthentication


### PR DESCRIPTION
## Summary

Two HIGH-severity audit findings (UI-003 NutritionView v1 1112L, UI-005 SettingsView v1 1189L) closed by verifying the v1 files are correctly excluded from the build target and adding explicit audit-ID closure markers.

## Verification

\`FitTracker.xcodeproj/project.pbxproj\` already had the right structure:
- v1 files (\`Views/Nutrition/NutritionView.swift\`, \`Views/Settings/SettingsView.swift\`) have only \`PBXFileReference\` entries — visible in git history + file navigator, but no \`PBXBuildFile\` entry → not compiled into the binary
- Sources build phase references the v2 file refs (\`Views/Nutrition/v2/NutritionView.swift\`, \`Views/Settings/v2/SettingsView.swift\`)

The audit's "1112-line file" / "1189-line file" concerns are moot because these are dead weight in the repo, not in the binary.

## Changes

Header-comment only — added explicit "Audit UI-003 closure" / "Audit UI-005 closure" notes to the existing HISTORICAL headers documenting the 2026-04-19 pbxproj verification.

## Test plan

- [x] \`xcodebuild build\` green (no behavior change)
- [ ] CI green

## Audit progress after K-8

After merge + sync re-run: ~14 → ~12 open. Per the completion plan, next is **K-9** (DEEP-AUTH-015 jailbreak hardening, ~30 min — move three-way merge checksums from UserDefaults to Keychain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)