### PR TITLE
fix(security): Sprint K-9 — DEEP-AUTH-015 — three-way merge digests in Keychain

### DIFF
--- a/FitTracker/Services/CloudKit/CloudKitSyncService.swift
+++ b/FitTracker/Services/CloudKit/CloudKitSyncService.swift
@@ -366,6 +366,10 @@ final class CloudKitSyncService: ObservableObject {
             } while cursor != nil
         }
 
+        // Audit DEEP-AUTH-015: digests live in Keychain (with UserDefaults
+        // fallback for legacy data) — clear both backing stores on cleanup.
+        KeychainHelper.delete(key: SyncStateKey.userProfileDigest)
+        KeychainHelper.delete(key: SyncStateKey.userPreferencesDigest)
         defaults.removeObject(forKey: SyncStateKey.userProfileDigest)
         defaults.removeObject(forKey: SyncStateKey.userPreferencesDigest)
         lastSyncDate = nil
@@ -525,20 +529,20 @@ final class CloudKitSyncService: ObservableObject {
             let remoteDigest = digest(for: remote)
         else {
             apply(remote)
-            defaults.set(remoteDigestFallback(for: remote), forKey: digestKey)
+            storeDigest(remoteDigestFallback(for: remote), forKey: digestKey)
             return
         }
 
-        let lastSyncedDigest = defaults.string(forKey: digestKey)
+        let lastSyncedDigest = loadDigest(forKey: digestKey)
 
         if localDigest == remoteDigest {
-            defaults.set(remoteDigest, forKey: digestKey)
+            storeDigest(remoteDigest, forKey: digestKey)
             return
         }
 
         if lastSyncedDigest == nil || localDigest == lastSyncedDigest {
             apply(remote)
-            defaults.set(remoteDigest, forKey: digestKey)
+            storeDigest(remoteDigest, forKey: digestKey)
             return
         }
 
@@ -549,7 +553,7 @@ final class CloudKitSyncService: ObservableObject {
 
     private func storeSingletonDigest<T: Encodable>(_ value: T, forKey key: String) {
         guard let digest = digest(for: value) else { return }
-        defaults.set(digest, forKey: key)
+        storeDigest(digest, forKey: key)
     }
 
     private func digest<T: Encodable>(for value: T) -> String? {
@@ -561,6 +565,37 @@ final class CloudKitSyncService: ObservableObject {
 
     private func remoteDigestFallback<T: Encodable>(for value: T) -> String? {
         digest(for: value)
+    }
+
+    /// Audit DEEP-AUTH-015: store/load three-way merge digests in the Keychain
+    /// instead of UserDefaults so they're not tamperable on jailbroken devices
+    /// (an attacker who could write to Preferences could otherwise force the
+    /// merge to treat any remote payload as authoritative). Falls back to
+    /// UserDefaults for legacy data so a single migration window keeps existing
+    /// digests valid; reads write-through to Keychain on first hit.
+    private func storeDigest(_ digest: String?, forKey key: String) {
+        guard let digest, let data = digest.data(using: .utf8) else { return }
+        KeychainHelper.save(key: key, data: data)
+        // Cleanup: remove any legacy UserDefaults copy so future reads don't
+        // see a stale value if Keychain delete fails for some reason.
+        defaults.removeObject(forKey: key)
+    }
+
+    private func loadDigest(forKey key: String) -> String? {
+        if let data = KeychainHelper.load(key: key),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        // Legacy fallback: existing installs may still have the digest in
+        // UserDefaults. Promote to Keychain on first read.
+        if let legacy = defaults.string(forKey: key) {
+            if let data = legacy.data(using: .utf8) {
+                KeychainHelper.save(key: key, data: data)
+            }
+            defaults.removeObject(forKey: key)
+            return legacy
+        }
+        return nil
     }
 }
 


### PR DESCRIPTION
## Summary

Closes DEEP-AUTH-015 (low/security). Three-way merge digests for UserProfile + UserPreferences singleton sync now live in the Keychain instead of UserDefaults — not tamperable on jailbroken devices.

## Threat model

Previously: an attacker with Preferences write access on a jailbroken device could fake the "last-synced" digest to match the local digest, forcing the merge logic to treat any remote payload as authoritative (silent overwrite of local data).

Now: the digest lives behind \`KeychainHelper\` — same protection class as session metadata. A jailbreak attacker would need a separate Keychain compromise.

## Implementation

\`CloudKitSyncService\` gains two private helpers:
- \`storeDigest(_:forKey:)\` — \`KeychainHelper.save\` + cleanup of any legacy UserDefaults copy
- \`loadDigest(forKey:)\` — Keychain first, UserDefaults fallback with **write-through migration** for legacy installs (then the UserDefaults entry is removed)

Five call sites migrated:
- \`applyRemoteSingleton\` (3 reads/writes)
- \`storeSingletonDigest\` (1 write)
- \`deleteAllUserRecords\` cleanup (2 deletes — clears both Keychain AND UserDefaults to handle migration-in-progress installs)

## Migration

Existing installs work through one read cycle:
1. First read after upgrade: Keychain miss → UserDefaults hit → write to Keychain → remove UserDefaults entry → return value
2. Subsequent reads: Keychain hit (clean)

## Test plan

- [x] \`xcodebuild build\` green
- [x] \`xcodebuild test\` green (full suite)
- [ ] CI green

## Audit progress after K-9

After merge + sync re-run: ~12 → ~11 open. Per the completion plan, next is **K-10** (UI VM extraction round 1: UI-006 + UI-018, ~60 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)