### PR TITLE
fix(ui): Sprint K-10 — UI-006 + UI-018 — extract MilestoneDetector service

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		111A5E022F64641D006E7013 /* WatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E012F64641D006E7013 /* WatchConnectivityService.swift */; };
 		111A5E042F64641D006E7013 /* TrainingProgramStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E032F64641D006E7013 /* TrainingProgramStore.swift */; };
+		MD000001000000000000AA01 /* MilestoneDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD000002000000000000AA01 /* MilestoneDetector.swift */; };
 		111A5E062F64641D006E7013 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E052F64641D006E7013 /* AppTheme.swift */; };
 		11B09D2B2F852AEF00DCB9A0 /* FitMeBrandIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B09D2A2F852AEF00DCB9A0 /* FitMeBrandIcon.swift */; };
 		OB100000000000000000AA01 /* OnboardingConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB200000000000000000AA01 /* OnboardingConsentView.swift */; };
@@ -226,6 +227,7 @@
 		IM200000000000000000AA05 /* ImportPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPreviewView.swift; sourceTree = "<group>"; };
 		111A5E012F64641D006E7013 /* WatchConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityService.swift; sourceTree = "<group>"; };
 		111A5E032F64641D006E7013 /* TrainingProgramStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingProgramStore.swift; sourceTree = "<group>"; };
+		MD000002000000000000AA01 /* MilestoneDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneDetector.swift; sourceTree = "<group>"; };
 		111A5E052F64641D006E7013 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		11B09D2A2F852AEF00DCB9A0 /* FitMeBrandIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitMeBrandIcon.swift; sourceTree = "<group>"; };
 		11B09D2C2F852BF900DCB9A0 /* OnboardingConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConsentView.swift; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 			children = (
 				111A5E012F64641D006E7013 /* WatchConnectivityService.swift */,
 				111A5E032F64641D006E7013 /* TrainingProgramStore.swift */,
+				MD000002000000000000AA01 /* MilestoneDetector.swift */,
 				111A5E052F64641D006E7013 /* AppTheme.swift */,
 				AC3000000000000000000001 /* Analytics */,
 				A40000010000000000000007 /* Auth */,
@@ -1006,6 +1009,7 @@
 				A10000010000000000000008 /* AppSettings.swift in Sources */,
 				111A5E022F64641D006E7013 /* WatchConnectivityService.swift in Sources */,
 				111A5E042F64641D006E7013 /* TrainingProgramStore.swift in Sources */,
+				MD000001000000000000AA01 /* MilestoneDetector.swift in Sources */,
 				111A5E062F64641D006E7013 /* AppTheme.swift in Sources */,
 				AC1000000000000000000001 /* AnalyticsProvider.swift in Sources */,
 				AC1000000000000000000002 /* AnalyticsScreenModifier.swift in Sources */,

--- a/FitTracker/Services/MilestoneDetector.swift
+++ b/FitTracker/Services/MilestoneDetector.swift
@@ -1,0 +1,79 @@
+// Services/MilestoneDetector.swift
+// Audit UI-018 + UI-006: business logic + state previously held inline as
+// @State in MainScreenView (v2). Extracted to an ObservableObject so the
+// view layer stays focused on presentation; the detector owns the
+// "have-we-shown-this-milestone-yet" memory and the milestone-presentation
+// state (title/message + dismissal). Keeps the view's @State count below
+// the 500-line / 12-var refactor threshold.
+//
+// Pure Swift, no UIKit imports — testable in isolation.
+
+import SwiftUI
+
+/// Owns milestone detection + presentation state for the home screen.
+/// The view binds to `presentedMilestone` for modal presentation; calls
+/// `evaluate(streakMilestone:currentPhase:)` once per data refresh; and
+/// calls `dismissPresented()` when the user taps through the modal.
+@MainActor
+final class MilestoneDetector: ObservableObject {
+
+    /// Currently-presented milestone (nil = nothing to show). The view
+    /// observes this for `.fullScreenCover` presentation.
+    @Published var presentedMilestone: Milestone?
+
+    /// Last streak milestone we've already shown — prevents re-showing the
+    /// same number on every data refresh.
+    private var lastShownStreak: Int = 0
+
+    /// Last program phase we've recorded — set on first evaluate, then a
+    /// transition triggers a phase milestone.
+    private var lastShownPhase: ProgramPhase?
+
+    struct Milestone: Equatable {
+        let title: String
+        let message: String
+    }
+
+    /// Evaluate whether a new milestone should be presented.
+    /// - Parameters:
+    ///   - streakMilestone: the next streak threshold reached (e.g. 7, 30, 100), or nil
+    ///   - currentPhase: the user's current program phase (used to detect phase transitions)
+    /// - Returns: true if a new milestone was set on `presentedMilestone`
+    @discardableResult
+    func evaluate(streakMilestone: Int?, currentPhase: ProgramPhase) -> Bool {
+        // Don't double-present
+        guard presentedMilestone == nil else { return false }
+
+        // Streak milestone takes precedence
+        if let milestone = streakMilestone, milestone != lastShownStreak {
+            lastShownStreak = milestone
+            presentedMilestone = Milestone(
+                title: "\(milestone)-Day Streak!",
+                message: "\(milestone) days straight. Consistency beats intensity every time."
+            )
+            return true
+        }
+
+        // Phase transition (skip the very first evaluate — that's just baseline capture)
+        guard let lastPhase = lastShownPhase else {
+            lastShownPhase = currentPhase
+            return false
+        }
+        if currentPhase != lastPhase {
+            lastShownPhase = currentPhase
+            presentedMilestone = Milestone(
+                title: "Phase Complete!",
+                message: "Welcome to \(currentPhase.rawValue). A new chapter begins."
+            )
+            return true
+        }
+        return false
+    }
+
+    /// Clear the presented milestone (called when the modal is dismissed).
+    /// Memory of `lastShownStreak` and `lastShownPhase` persists so the
+    /// same milestone won't re-trigger.
+    func dismissPresented() {
+        presentedMilestone = nil
+    }
+}

--- a/FitTracker/Views/Main/v2/MainScreenView.swift
+++ b/FitTracker/Views/Main/v2/MainScreenView.swift
@@ -32,10 +32,11 @@ struct MainScreenView: View {
 
     @State private var readinessHapticDay: Date? = nil
     @State private var statusPulse = false
-    @State private var shownMilestoneStreak: Int = 0
-    @State private var shownMilestonePhase: ProgramPhase? = nil
-    @State private var milestoneTitle: String? = nil
-    @State private var milestoneMessage: String? = nil
+    // Audit UI-006 + UI-018: milestone state + detection logic moved to
+    // MilestoneDetector (in Services/). The view holds only the @StateObject;
+    // the detector owns the "have we shown this milestone yet" memory and
+    // the presentation state. Removes 4 @State vars from this view (12 → 8).
+    @StateObject private var milestoneDetector = MilestoneDetector()
 
     // MARK: - Derived data
 
@@ -134,13 +135,12 @@ struct MainScreenView: View {
             }
         }
         .fullScreenCover(isPresented: Binding(
-            get: { milestoneTitle != nil },
-            set: { if !$0 { milestoneTitle = nil; milestoneMessage = nil } }
+            get: { milestoneDetector.presentedMilestone != nil },
+            set: { if !$0 { milestoneDetector.dismissPresented() } }
         )) {
-            if let title = milestoneTitle, let msg = milestoneMessage {
-                MilestoneModal(title: title, message: msg) {
-                    milestoneTitle = nil
-                    milestoneMessage = nil
+            if let m = milestoneDetector.presentedMilestone {
+                MilestoneModal(title: m.title, message: m.message) {
+                    milestoneDetector.dismissPresented()
                 }
             }
         }
@@ -545,24 +545,17 @@ struct MainScreenView: View {
     // MARK: - Milestones
     // ─────────────────────────────────────────────────────
 
+    /// Audit UI-006 + UI-018: thin shim over MilestoneDetector.evaluate().
+    /// Detection + state memory now live in the service; the view only
+    /// triggers haptic feedback for phase transitions (UI concern).
     private func checkMilestones() {
-        // Supplement streak
-        if let milestone = streakMilestone, milestone != shownMilestoneStreak {
-            shownMilestoneStreak = milestone
-            milestoneTitle = "\(milestone)-Day Streak!"
-            milestoneMessage = "\(milestone) days straight. Consistency beats intensity every time."
-            return
-        }
-        // Phase transition
-        let phase = dataStore.userProfile.currentPhase
-        if shownMilestonePhase == nil {
-            shownMilestonePhase = phase
-            return
-        }
-        if phase != shownMilestonePhase {
-            shownMilestonePhase = phase
-            milestoneTitle = "Phase Complete!"
-            milestoneMessage = "Welcome to \(phase.rawValue). A new chapter begins."
+        let phaseBefore = dataStore.userProfile.currentPhase
+        let presented = milestoneDetector.evaluate(
+            streakMilestone: streakMilestone,
+            currentPhase: phaseBefore
+        )
+        // Phase-transition haptic stays in the view (UI concern, not business logic)
+        if presented, let m = milestoneDetector.presentedMilestone, m.title == "Phase Complete!" {
             let ng = UINotificationFeedbackGenerator()
             ng.prepare()
             ng.notificationOccurred(.success)


### PR DESCRIPTION
## Summary

Two UI findings closed by extracting milestone detection logic + presentation state from \`MainScreenView\` (v2) into a dedicated \`MilestoneDetector\` service.

## Changes

### New: \`FitTracker/Services/MilestoneDetector.swift\`
- \`@MainActor ObservableObject\` with \`@Published presentedMilestone\`
- \`evaluate(streakMilestone:currentPhase:) -> Bool\` — single entry point that handles "have we shown this yet" memory + presentation
- \`dismissPresented()\` — tap-through clear
- Pure-Swift, no UIKit imports → unit-testable in isolation

### \`MainScreenView.swift\` (v2)
- 4 \`@State\` vars removed (\`shownMilestoneStreak\`, \`shownMilestonePhase\`, \`milestoneTitle\`, \`milestoneMessage\`) → 1 \`@StateObject milestoneDetector\`
- View \`@State\` count: **12 → 8** (now below the threshold UI-006 flagged)
- \`.fullScreenCover\` binding reads/writes via the detector
- \`checkMilestones()\` shrank from ~22 lines of business logic to a thin shim that delegates and only retains haptic feedback (legitimate UI concern)

The remaining 8 \`@State\` are deliberately view-layer (sheet flags, animation triggers).

### \`project.pbxproj\`
PBXBuildFile + PBXFileReference + Sources + Services group entry for the new file.

## Test plan

- [x] \`xcodebuild build\` green
- [x] \`xcodebuild test\` green (full suite)
- [ ] CI green

## Audit progress after K-10

After merge + sync re-run: ~11 → ~9 open. Per the completion plan, next is **K-11** (UI-017 — same VM-extraction pattern in another view, ~60 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)