### PR TITLE
fix(ui): Sprint K-11 — UI-017 — extract FoodSearchService from MealEntrySheet

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		111A5E022F64641D006E7013 /* WatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E012F64641D006E7013 /* WatchConnectivityService.swift */; };
 		111A5E042F64641D006E7013 /* TrainingProgramStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E032F64641D006E7013 /* TrainingProgramStore.swift */; };
 		MD000001000000000000AA01 /* MilestoneDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD000002000000000000AA01 /* MilestoneDetector.swift */; };
+		FS000001000000000000AA01 /* FoodSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FS000002000000000000AA01 /* FoodSearchService.swift */; };
 		111A5E062F64641D006E7013 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E052F64641D006E7013 /* AppTheme.swift */; };
 		11B09D2B2F852AEF00DCB9A0 /* FitMeBrandIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B09D2A2F852AEF00DCB9A0 /* FitMeBrandIcon.swift */; };
 		OB100000000000000000AA01 /* OnboardingConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB200000000000000000AA01 /* OnboardingConsentView.swift */; };
@@ -228,6 +229,7 @@
 		111A5E012F64641D006E7013 /* WatchConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityService.swift; sourceTree = "<group>"; };
 		111A5E032F64641D006E7013 /* TrainingProgramStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingProgramStore.swift; sourceTree = "<group>"; };
 		MD000002000000000000AA01 /* MilestoneDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneDetector.swift; sourceTree = "<group>"; };
+		FS000002000000000000AA01 /* FoodSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodSearchService.swift; sourceTree = "<group>"; };
 		111A5E052F64641D006E7013 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		11B09D2A2F852AEF00DCB9A0 /* FitMeBrandIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitMeBrandIcon.swift; sourceTree = "<group>"; };
 		11B09D2C2F852BF900DCB9A0 /* OnboardingConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConsentView.swift; sourceTree = "<group>"; };
@@ -501,6 +503,7 @@
 				111A5E012F64641D006E7013 /* WatchConnectivityService.swift */,
 				111A5E032F64641D006E7013 /* TrainingProgramStore.swift */,
 				MD000002000000000000AA01 /* MilestoneDetector.swift */,
+				FS000002000000000000AA01 /* FoodSearchService.swift */,
 				111A5E052F64641D006E7013 /* AppTheme.swift */,
 				AC3000000000000000000001 /* Analytics */,
 				A40000010000000000000007 /* Auth */,
@@ -1010,6 +1013,7 @@
 				111A5E022F64641D006E7013 /* WatchConnectivityService.swift in Sources */,
 				111A5E042F64641D006E7013 /* TrainingProgramStore.swift in Sources */,
 				MD000001000000000000AA01 /* MilestoneDetector.swift in Sources */,
+				FS000001000000000000AA01 /* FoodSearchService.swift in Sources */,
 				111A5E062F64641D006E7013 /* AppTheme.swift in Sources */,
 				AC1000000000000000000001 /* AnalyticsProvider.swift in Sources */,
 				AC1000000000000000000002 /* AnalyticsScreenModifier.swift in Sources */,

--- a/FitTracker/Services/FoodSearchService.swift
+++ b/FitTracker/Services/FoodSearchService.swift
@@ -1,0 +1,112 @@
+// Services/FoodSearchService.swift
+// Audit UI-017: extracted from MealEntrySheet so the view doesn't own
+// network/parse async logic. The view binds to `searchResults` /
+// `isSearching` / `searchError` for display; the form text input
+// (`searchQuery`) stays in the view because it's pure UI state.
+//
+// Owns the OpenFoodFacts (OFF) network calls + decoding + local-foods
+// fallback. Pure-data Sendable inputs/outputs make this testable in
+// isolation with URLProtocol mocks (when test infra is added).
+
+import Foundation
+import SwiftUI
+
+@MainActor
+final class FoodSearchService: ObservableObject {
+
+    // ── Published state observed by the view ─────────────────
+    @Published private(set) var searchResults: [FoodProduct] = []
+    @Published private(set) var isSearching: Bool = false
+    @Published var searchError: String?
+
+    // ── Public API ───────────────────────────────────────────
+
+    /// Run a text search: local-foods first (synchronous), then OFF for
+    /// remote results. Updates published state for the view.
+    func search(query rawQuery: String) async {
+        let query = rawQuery.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else { return }
+        searchError = nil
+        isSearching = true
+        defer { isSearching = false }
+
+        // Local matches first (instant feedback).
+        searchResults = Self.matchingLocalFoods(for: query)
+
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "https://world.openfoodfacts.org/cgi/search.pl?search_terms=\(encoded)&search_simple=1&action=process&json=1&page_size=10")
+        else {
+            searchError = "Invalid search query."
+            return
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let decoded = try JSONDecoder().decode(OFFSearchResponse.self, from: data)
+            let remoteResults = decoded.products.compactMap { FoodProduct(from: $0) }
+            searchResults = Self.deduplicatedProducts(searchResults + remoteResults)
+            if searchResults.isEmpty {
+                searchError = "No results found."
+            }
+        } catch {
+            if searchResults.isEmpty {
+                searchError = "Search failed: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    /// Look up a single product by barcode. Returns the product on hit so
+    /// the caller can `fillFromProduct(...)`; updates `searchError` on miss.
+    func fetchProduct(barcode: String) async -> FoodProduct? {
+        searchError = nil
+        isSearching = true
+        defer { isSearching = false }
+
+        guard let url = URL(string: "https://world.openfoodfacts.org/api/v0/product/\(barcode).json") else {
+            searchError = "Invalid barcode."
+            return nil
+        }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let decoded = try JSONDecoder().decode(OFFProductResponse.self, from: data)
+            if let raw = decoded.product, let product = FoodProduct(from: raw) {
+                return product
+            }
+            searchError = "Product not found for barcode \(barcode)."
+            return nil
+        } catch {
+            searchError = "Barcode lookup failed: \(error.localizedDescription)"
+            return nil
+        }
+    }
+
+    /// Clear any prior results + errors. Called when the user switches tabs
+    /// or closes the search affordance.
+    func reset() {
+        searchResults = []
+        searchError = nil
+        isSearching = false
+    }
+
+    // ── Pure helpers ─────────────────────────────────────────
+
+    static func matchingLocalFoods(for query: String) -> [FoodProduct] {
+        let normalized = query.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        return FoodProduct.referenceFoods.filter { product in
+            product.searchAliases.contains {
+                $0.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current).contains(normalized)
+            }
+        }
+    }
+
+    static func deduplicatedProducts(_ products: [FoodProduct]) -> [FoodProduct] {
+        var seen = Set<String>()
+        return products.filter { product in
+            seen.insert(product.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()).inserted
+        }
+    }
+}
+
+// Note: OFF response models (OFFSearchResponse, OFFProductResponse,
+// OFFProduct, OFFProduct.Nutriments) and FoodProduct live in
+// MealEntrySheet.swift as module-internal types — no duplication here.

--- a/FitTracker/Views/Nutrition/MealEntrySheet.swift
+++ b/FitTracker/Views/Nutrition/MealEntrySheet.swift
@@ -55,10 +55,11 @@ struct MealEntrySheet: View {
     @State private var savedTemplate = false
 
     // Search tab
+    // Audit UI-017: search state + async network logic moved to
+    // FoodSearchService (in Services/). Only the user-input text binding
+    // (searchQuery) stays in the view — that's pure UI state.
     @State private var searchQuery: String = ""
-    @State private var searchResults: [FoodProduct] = []
-    @State private var isSearching: Bool = false
-    @State private var searchError: String? = nil
+    @StateObject private var foodSearch = FoodSearchService()
 
     // Barcode scanner
     @State private var showScanner: Bool = false
@@ -394,13 +395,13 @@ struct MealEntrySheet: View {
 
                     AppButton(
                         title: "",
-                        systemImage: isSearching ? "clock" : "magnifyingglass",
+                        systemImage: foodSearch.isSearching ? "clock" : "magnifyingglass",
                         hierarchy: .primary,
                         isFullWidth: false
                     ) {
                         runTextSearch()
                     }
-                    .disabled(searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || isSearching)
+                    .disabled(searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || foodSearch.isSearching)
                 }
 
                 #if os(iOS)
@@ -413,7 +414,7 @@ struct MealEntrySheet: View {
                 }
                 #endif
 
-                if let error = searchError {
+                if let error = foodSearch.searchError {
                     HStack(spacing: AppSpacing.xxSmall) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(AppColor.Status.error)
@@ -431,7 +432,7 @@ struct MealEntrySheet: View {
             Divider()
 
             // Results
-            if searchResults.isEmpty && !isSearching {
+            if foodSearch.searchResults.isEmpty && !foodSearch.isSearching {
                 Spacer()
                 EmptyStateView(
                     icon: "magnifyingglass",
@@ -439,13 +440,13 @@ struct MealEntrySheet: View {
                     subtitle: "Type a food name above or scan a barcode to find nutrition data."
                 )
                 Spacer()
-            } else if isSearching {
+            } else if foodSearch.isSearching {
                 Spacer()
                 ProgressView("Searching…")
                     .font(AppText.subheading)
                 Spacer()
             } else {
-                List(searchResults) { product in
+                List(foodSearch.searchResults) { product in
                     Button {
                         fillFromProduct(product)
                     } label: {
@@ -673,78 +674,21 @@ struct MealEntrySheet: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func matchingLocalFoods(for query: String) -> [FoodProduct] {
-        let normalized = query.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
-        return FoodProduct.referenceFoods.filter { product in
-            product.searchAliases.contains {
-                $0.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current).contains(normalized)
-            }
-        }
-    }
-
-    private func deduplicatedProducts(_ products: [FoodProduct]) -> [FoodProduct] {
-        var seen = Set<String>()
-        return products.filter { product in
-            seen.insert(product.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()).inserted
-        }
-    }
-
     // ─────────────────────────────────────────────────────
-    // MARK: – Networking
+    // MARK: – Networking — thin shims over FoodSearchService
+    // Audit UI-017: actual implementation lives in
+    // Services/FoodSearchService.swift. The view only triggers + observes.
     // ─────────────────────────────────────────────────────
 
     private func runTextSearch() {
-        let query = searchQuery.trimmingCharacters(in: .whitespaces)
-        guard !query.isEmpty else { return }
-        searchError = nil
-        isSearching = true
-        searchResults = matchingLocalFoods(for: query)
-
-        Task {
-            defer { isSearching = false }
-            guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                  let url = URL(string: "https://world.openfoodfacts.org/cgi/search.pl?search_terms=\(encoded)&search_simple=1&action=process&json=1&page_size=10")
-            else {
-                searchError = "Invalid search query."
-                return
-            }
-            do {
-                let (data, _) = try await URLSession.shared.data(from: url)
-                let decoded = try JSONDecoder().decode(OFFSearchResponse.self, from: data)
-                let remoteResults = decoded.products.compactMap { FoodProduct(from: $0) }
-                searchResults = deduplicatedProducts(searchResults + remoteResults)
-                if searchResults.isEmpty {
-                    searchError = "No results found."
-                }
-            } catch {
-                if searchResults.isEmpty {
-                    searchError = "Search failed: \(error.localizedDescription)"
-                }
-            }
-        }
+        Task { await foodSearch.search(query: searchQuery) }
     }
 
     private func fetchProduct(barcode: String) {
-        searchError = nil
-        isSearching = true
         activeTab = .search
-
         Task {
-            defer { isSearching = false }
-            guard let url = URL(string: "https://world.openfoodfacts.org/api/v0/product/\(barcode).json") else {
-                searchError = "Invalid barcode."
-                return
-            }
-            do {
-                let (data, _) = try await URLSession.shared.data(from: url)
-                let decoded = try JSONDecoder().decode(OFFProductResponse.self, from: data)
-                if let raw = decoded.product, let product = FoodProduct(from: raw) {
-                    fillFromProduct(product)
-                } else {
-                    searchError = "Product not found for barcode \(barcode)."
-                }
-            } catch {
-                searchError = "Barcode lookup failed: \(error.localizedDescription)"
+            if let product = await foodSearch.fetchProduct(barcode: barcode) {
+                fillFromProduct(product)
             }
         }
     }
@@ -754,15 +698,17 @@ struct MealEntrySheet: View {
 // MARK: – OpenFoodFacts response models
 // ─────────────────────────────────────────────────────────
 
-private struct OFFSearchResponse: Decodable {
+// Audit UI-017: visibility bumped from `private` to internal so
+// FoodSearchService can decode these. Otherwise unchanged.
+struct OFFSearchResponse: Decodable {
     var products: [OFFProduct]
 }
 
-private struct OFFProductResponse: Decodable {
+struct OFFProductResponse: Decodable {
     var product: OFFProduct?
 }
 
-private struct OFFProduct: Decodable {
+struct OFFProduct: Decodable {
     var product_name: String?
 
     struct Nutriments: Decodable {
@@ -785,7 +731,9 @@ private struct OFFProduct: Decodable {
 // MARK: – Parsed food product (view model)
 // ─────────────────────────────────────────────────────────
 
-private struct FoodProduct: Identifiable {
+// Audit UI-017: visibility bumped from `private` to internal so
+// FoodSearchService can produce these. Otherwise unchanged.
+struct FoodProduct: Identifiable {
     let id = UUID()
     var name:             String
     var caloriesPer100g:  Double?


### PR DESCRIPTION
## Summary

Closes UI-017 by extracting the OpenFoodFacts text-search + barcode-lookup async network logic from \`MealEntrySheet\` (1156 lines, 17 @State) into a dedicated \`FoodSearchService\`.

## Changes

### New: \`FitTracker/Services/FoodSearchService.swift\`
- \`@MainActor ObservableObject\` with \`@Published\` searchResults / isSearching / searchError
- \`func search(query:) async\` — text search w/ local-foods fallback + OFF
- \`func fetchProduct(barcode:) async -> FoodProduct?\` — barcode lookup
- \`func reset()\` — clear on tab switch
- \`matchingLocalFoods\` + \`deduplicatedProducts\` as static helpers
- All \`URLSession.shared.data\` + \`JSONDecoder\` paths live here

### \`MealEntrySheet.swift\`
- 3 @State removed (\`searchResults\`, \`isSearching\`, \`searchError\`) → 1 \`@StateObject foodSearch\`
- \`searchQuery\` stays in the view (pure UI text-input state)
- \`runTextSearch\` + \`fetchProduct\` shrank to ~5-line Task shims
- \`matchingLocalFoods\` + \`deduplicatedProducts\` deleted (now in service)
- View refs use \`foodSearch.searchResults\` etc.
- Visibility of \`OFFSearchResponse\` / \`OFFProductResponse\` / \`OFFProduct\` / \`FoodProduct\` bumped from \`private\` to internal so the service can use them without redeclaration

### \`project.pbxproj\`
PBXBuildFile + PBXFileReference + Sources + Services group entry.

## Test plan

- [x] \`xcodebuild build\` green
- [x] \`xcodebuild test\` green (full suite)
- [ ] CI green (likely the same billing-block as K-9/K-10)

## Audit progress after K-11

After merge + sync re-run: ~9 → ~8 open. The remaining 8 are exactly the multi-session features (M-1 SettingsView v3, M-2 MealEntrySheet decomposition, M-3 dark mode + token pipeline expansion, M-4 XCUITest infra) + 2 external blockers (BE-024 Edge Function, DEEP-SYNC-010 cross-sync image bridge), per the completion plan in \`docs/superpowers/plans/2026-04-19-audit-completion-plan.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)