### PR TITLE
refactor(settings): M-1a — extract 5 detail screens (UI-002)

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -143,6 +143,11 @@
 		CC000001000000000000AA0B /* MealEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0B /* MealEntrySheet.swift */; };
 		CC000001000000000000AA0C /* RecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0C /* RecoverySupport.swift */; };
 		SE100000000000000000AA01 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA01 /* SettingsView.swift */; };
+		SE100000000000000000AA02 /* AccountSecuritySettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA02 /* AccountSecuritySettingsScreen.swift */; };
+		SE100000000000000000AA03 /* HealthDevicesSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA03 /* HealthDevicesSettingsScreen.swift */; };
+		SE100000000000000000AA04 /* GoalsPreferencesSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA04 /* GoalsPreferencesSettingsScreen.swift */; };
+		SE100000000000000000AA05 /* TrainingNutritionSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA05 /* TrainingNutritionSettingsScreen.swift */; };
+		SE100000000000000000AA06 /* DataSyncSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA06 /* DataSyncSettingsScreen.swift */; };
 		DD000001000000000000AA01 /* AppDesignSystemComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000002000000000000AA01 /* AppDesignSystemComponents.swift */; };
 		DD000001000000000000AA02 /* DesignSystemCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000002000000000000AA02 /* DesignSystemCatalogView.swift */; };
 		DS000001000000000000AA01 /* AppPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS000002000000000000AA01 /* AppPalette.swift */; };
@@ -305,6 +310,11 @@
 		EV300000000000000000GR01 /* EvalTests */ = {isa = PBXGroup; children = (EV200000000000000000ET01 /* ReadinessFormulaEvals.swift */, EV200000000000000000ET02 /* AIOutputQualityEvals.swift */, EV200000000000000000ET03 /* AITierBehaviorEvals.swift */, EV200000000000000000ET04 /* ProfileEvals.swift */); path = EvalTests; sourceTree = "<group>"; };
 		AI200000000000000000AT01 /* AIAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAnalyticsTests.swift; sourceTree = "<group>"; };
 		SE200000000000000000AA01 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		SE200000000000000000AA02 /* AccountSecuritySettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSecuritySettingsScreen.swift; sourceTree = "<group>"; };
+		SE200000000000000000AA03 /* HealthDevicesSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthDevicesSettingsScreen.swift; sourceTree = "<group>"; };
+		SE200000000000000000AA04 /* GoalsPreferencesSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalsPreferencesSettingsScreen.swift; sourceTree = "<group>"; };
+		SE200000000000000000AA05 /* TrainingNutritionSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingNutritionSettingsScreen.swift; sourceTree = "<group>"; };
+		SE200000000000000000AA06 /* DataSyncSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncSettingsScreen.swift; sourceTree = "<group>"; };
 		B20000010000000000000002 /* FitTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FitTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC000002000000000000AA01 /* ReadinessCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadinessCard.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA02 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
@@ -840,8 +850,21 @@
 			isa = PBXGroup;
 			children = (
 				SE200000000000000000AA01 /* SettingsView.swift */,
+				SE400000000000000000AA02 /* Screens */,
 			);
 			path = v2;
+			sourceTree = "<group>";
+		};
+		SE400000000000000000AA02 /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				SE200000000000000000AA02 /* AccountSecuritySettingsScreen.swift */,
+				SE200000000000000000AA03 /* HealthDevicesSettingsScreen.swift */,
+				SE200000000000000000AA04 /* GoalsPreferencesSettingsScreen.swift */,
+				SE200000000000000000AA05 /* TrainingNutritionSettingsScreen.swift */,
+				SE200000000000000000AA06 /* DataSyncSettingsScreen.swift */,
+			);
+			path = Screens;
 			sourceTree = "<group>";
 		};
 		DS000000000000000000AA00 /* DesignSystem */ = {
@@ -1087,6 +1110,11 @@
 				AC1000000000000000000010 /* DeleteAccountView.swift in Sources */,
 				AC1000000000000000000011 /* ExportDataView.swift in Sources */,
 				SE100000000000000000AA01 /* SettingsView.swift in Sources */,
+				SE100000000000000000AA02 /* AccountSecuritySettingsScreen.swift in Sources */,
+				SE100000000000000000AA03 /* HealthDevicesSettingsScreen.swift in Sources */,
+				SE100000000000000000AA04 /* GoalsPreferencesSettingsScreen.swift in Sources */,
+				SE100000000000000000AA05 /* TrainingNutritionSettingsScreen.swift in Sources */,
+				SE100000000000000000AA06 /* DataSyncSettingsScreen.swift in Sources */,
 				DD000001000000000000AA01 /* AppDesignSystemComponents.swift in Sources */,
 				DD000001000000000000AA02 /* DesignSystemCatalogView.swift in Sources */,
 				DS000001000000000000AA01 /* AppPalette.swift in Sources */,

--- a/FitTracker/Views/Settings/v2/Screens/AccountSecuritySettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/AccountSecuritySettingsScreen.swift
@@ -1,0 +1,113 @@
+// FitTracker/Views/Settings/v2/Screens/AccountSecuritySettingsScreen.swift
+// Settings v2 — Account & Security detail screen.
+// Extracted from SettingsView.swift in Audit M-1a (UI-002 decomposition).
+
+import SwiftUI
+import LocalAuthentication
+
+struct AccountSecuritySettingsScreen: View {
+    @EnvironmentObject private var signIn: SignInService
+    @EnvironmentObject private var dataStore: EncryptedDataStore
+    @EnvironmentObject private var cloudSync: CloudKitSyncService
+    @EnvironmentObject private var supabaseSync: SupabaseSyncService
+    @EnvironmentObject private var settings: AppSettings
+    @EnvironmentObject private var biometricAuth: AuthManager
+    @EnvironmentObject private var analytics: AnalyticsService
+
+    var body: some View {
+        SettingsDetailScaffold(
+            title: SettingsCategory.accountSecurity.title,
+            subtitle: "Manage how your account opens, how credentials are stored, and which protections are active on this device."
+        ) {
+            SettingsSectionCard(title: "Account Identity", eyebrow: "Account") {
+                SettingsValueRow(title: "Sign-In Method", value: signIn.currentSession?.provider.rawValue ?? "Unavailable")
+                SettingsValueRow(title: "Name", value: signIn.currentSession?.displayName ?? "—")
+                SettingsValueRow(title: "Email", value: signIn.currentSession?.email ?? "—")
+                SettingsValueRow(title: "Phone", value: signIn.currentSession?.phone ?? "—")
+            }
+
+            SettingsSectionCard(title: "Access on Reopen", eyebrow: "Security") {
+                Toggle(isOn: $settings.requireBiometricUnlockOnReopen) {
+                    VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
+                        Text("Require \(biometricUnlockLabel) on Reopen")
+                            .font(AppText.button)
+                            .foregroundStyle(AppColor.Text.primary)
+                        Text("When off, \(AppBrand.name) stays unlocked while the app remains in memory.")
+                            .font(AppText.subheading)
+                            .foregroundStyle(AppColor.Text.secondary)
+                    }
+                }
+                .tint(AppColor.Accent.primary)
+                .disabled(!biometricsAvailable)
+
+                if !biometricsAvailable {
+                    SettingsSupportingText("Biometric unlock is unavailable on this device. Set up Face ID or Touch ID to protect reopen access.")
+                }
+
+                Button {
+                    signIn.addPasskeyForCurrentUser()
+                } label: {
+                    SettingsActionLabel(
+                        title: signIn.currentSession?.provider == .passkey ? "Create Another Passkey" : "Add Passkey",
+                        subtitle: signIn.isPasskeyConfigured ? "Register a passkey for quick passwordless sign in." : "Passkey setup requires a valid relying party configuration.",
+                        icon: "key.fill",
+                        tint: AppColor.Accent.sleep,
+                        trailing: signIn.isLoading ? .progress : .chevron
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(signIn.isLoading || !signIn.isPasskeyConfigured)
+            }
+
+            SettingsSectionCard(title: "Protection Summary", eyebrow: "Security") {
+                SettingsValueRow(title: "Encryption", value: "AES-256-GCM + ChaCha20-Poly1305")
+                SettingsValueRow(title: "Key Storage", value: "Keychain with biometric protection")
+                SettingsValueRow(title: "Cloud Storage", value: "Encrypted locally before upload")
+                SettingsValueRow(title: "Data Protection", value: "NSFileProtectionCompleteUnlessOpen")
+            }
+
+            SettingsSectionCard(title: "Account", eyebrow: "GDPR") {
+                NavigationLink {
+                    DeleteAccountView()
+                        .environmentObject(AccountDeletionService(
+                            dataStore: dataStore,
+                            cloudSync: cloudSync,
+                            supabaseSync: supabaseSync,
+                            signIn: signIn,
+                            analytics: analytics
+                        ))
+                        .environmentObject(analytics)
+                } label: {
+                    SettingsActionLabel(
+                        title: "Delete Account",
+                        subtitle: "Schedule permanent deletion of your account and all data.",
+                        icon: "trash.fill",
+                        tint: AppColor.Status.error
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .navigationTitle(SettingsCategory.accountSecurity.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var biometricsAvailable: Bool {
+        let ctx = LAContext()
+        var error: NSError?
+        return ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+    }
+
+    private var biometricUnlockLabel: String {
+        let ctx = LAContext()
+        var error: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return biometricAuth.biometricName
+        }
+        switch ctx.biometryType {
+        case .faceID: return "Face ID"
+        case .touchID: return "Touch ID"
+        default: return "Biometric Unlock"
+        }
+    }
+}

--- a/FitTracker/Views/Settings/v2/Screens/DataSyncSettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/DataSyncSettingsScreen.swift
@@ -1,0 +1,132 @@
+// FitTracker/Views/Settings/v2/Screens/DataSyncSettingsScreen.swift
+// Settings v2 — Data & Sync detail screen.
+// Extracted from SettingsView.swift in Audit M-1a (UI-002 decomposition).
+
+import SwiftUI
+
+struct DataSyncSettingsScreen: View {
+    @EnvironmentObject private var dataStore: EncryptedDataStore
+    @EnvironmentObject private var cloudSync: CloudKitSyncService
+    @EnvironmentObject private var analytics: AnalyticsService
+    @Binding var showResetAlert: Bool
+
+    var body: some View {
+        SettingsDetailScaffold(
+            title: SettingsCategory.dataSync.title,
+            subtitle: "Monitor iCloud sync health, manually trigger transfers when needed, and manage local storage carefully."
+        ) {
+            SettingsSectionCard(title: "Sync Status", eyebrow: "Sync") {
+                SettingsValueRow(title: "Status", value: cloudSync.status.rawValue)
+                SettingsValueRow(title: "iCloud", value: cloudSync.iCloudAvailable ? "Available" : "Unavailable")
+                if let lastSyncDate = cloudSync.lastSyncDate {
+                    SettingsValueRow(title: "Last Sync", value: Self.lastSyncFormatter.string(from: lastSyncDate))
+                }
+
+                Button {
+                    Task { await cloudSync.pushPendingChanges(dataStore: dataStore) }
+                } label: {
+                    SettingsActionLabel(
+                        title: "Sync Now",
+                        subtitle: "Push local encrypted changes to your private iCloud database.",
+                        icon: "icloud.and.arrow.up.fill",
+                        tint: AppColor.Status.success
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Sync now")
+                .accessibilityHint("Push local changes to iCloud")
+
+                Button {
+                    Task { await cloudSync.fetchChanges(dataStore: dataStore) }
+                } label: {
+                    SettingsActionLabel(
+                        title: "Fetch from iCloud",
+                        subtitle: "Download the latest encrypted changes from your account.",
+                        icon: "icloud.and.arrow.down.fill",
+                        tint: AppColor.Accent.recovery
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Fetch from iCloud")
+                .accessibilityHint("Download latest data from your iCloud account")
+            }
+
+            SettingsSectionCard(title: "Local Storage", eyebrow: "Data") {
+                SettingsValueRow(title: "Daily Logs", value: "\(dataStore.dailyLogs.count) entries")
+                SettingsValueRow(title: "Weekly Snapshots", value: "\(dataStore.weeklySnapshots.count) entries")
+            }
+
+            SettingsSectionCard(title: "Analytics", eyebrow: "Privacy") {
+                Toggle(isOn: Binding(
+                    get: { analytics.consent.gdprConsent == .granted },
+                    set: { enabled in
+                        if enabled {
+                            analytics.consent.regrantConsent()
+                            analytics.syncConsentToProvider()
+                            analytics.logSettingsChanged(settingName: "analytics", newValue: "enabled")
+                        } else {
+                            analytics.consent.revokeConsent()
+                            analytics.syncConsentToProvider()
+                        }
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: AppSpacing.micro) {
+                        Text("App Analytics")
+                            .font(AppText.body)
+                            .foregroundStyle(AppColor.Text.primary)
+                        Text("Help improve FitMe by sharing anonymous usage data. No health data is ever shared.")
+                            .font(AppText.caption)
+                            .foregroundStyle(AppColor.Text.tertiary)
+                    }
+                }
+                .tint(AppColor.Brand.primary)
+            }
+
+            SettingsSectionCard(title: "Data Portability", eyebrow: "GDPR") {
+                NavigationLink {
+                    ExportDataView()
+                        .environmentObject(DataExportService(
+                            dataStore: dataStore,
+                            analytics: analytics
+                        ))
+                        .environmentObject(analytics)
+                } label: {
+                    SettingsActionLabel(
+                        title: "Export My Data",
+                        subtitle: "Download all your data as a JSON file.",
+                        icon: "square.and.arrow.up.fill",
+                        tint: AppColor.Accent.primary
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+
+            SettingsSectionCard(title: "Danger Zone", eyebrow: "Data") {
+                SettingsSupportingText("Delete local logs only if you understand they will repopulate from iCloud on the next fetch. Permanent deletion requires removing the data from your iCloud account as well.")
+
+                Button(role: .destructive) {
+                    showResetAlert = true
+                } label: {
+                    SettingsActionLabel(
+                        title: "Delete All Local Data",
+                        subtitle: "Remove all daily logs and snapshots from this device.",
+                        icon: "trash.fill",
+                        tint: AppColor.Status.error
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Delete all local data")
+                .accessibilityHint("Permanently removes all local logs and snapshots from this device. This action cannot be undone.")
+            }
+        }
+        .navigationTitle(SettingsCategory.dataSync.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private static let lastSyncFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}

--- a/FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
@@ -1,0 +1,160 @@
+// FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
+// Settings v2 — Goals & Preferences detail screen.
+// Extracted from SettingsView.swift in Audit M-1a (UI-002 decomposition).
+
+import SwiftUI
+
+struct GoalsPreferencesSettingsScreen: View {
+    @EnvironmentObject private var dataStore: EncryptedDataStore
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        SettingsDetailScaffold(
+            title: SettingsCategory.goalsPreferences.title,
+            subtitle: "Personalize the app’s presentation, choose how stats are surfaced, and keep body-composition targets in one place."
+        ) {
+            SettingsSectionCard(title: "Profile Snapshot", eyebrow: "Goals") {
+                SettingsValueRow(title: "Name", value: dataStore.userProfile.name)
+                SettingsValueRow(title: "Recovery Start", value: Self.recoveryStartFormatter.string(from: dataStore.userProfile.recoveryStart))
+                SettingsValueRow(title: "Phase", value: dataStore.userProfile.currentPhase.rawValue)
+                SettingsValueRow(title: "Recovery Day", value: "Day \(dataStore.userProfile.daysSinceStart)")
+            }
+
+            SettingsSectionCard(title: "Body Goals", eyebrow: "Goals") {
+                SettingsNumericFieldRow(title: "Goal Weight Min", suffix: settings.unitSystem.weightLabel(), value: goalWeightMinBinding)
+                SettingsNumericFieldRow(title: "Goal Weight Max", suffix: settings.unitSystem.weightLabel(), value: goalWeightMaxBinding)
+                SettingsNumericFieldRow(title: "Goal Body Fat Min", suffix: "%", value: goalBodyFatMinBinding)
+                SettingsNumericFieldRow(title: "Goal Body Fat Max", suffix: "%", value: goalBodyFatMaxBinding)
+            }
+
+            SettingsSectionCard(title: "Units", eyebrow: "Preferences") {
+                SettingsChoiceGrid(options: UnitSystem.allCases, selection: $settings.unitSystem) { system in
+                    SettingsSelectionTile(
+                        title: system.rawValue,
+                        subtitle: system == .metric ? "kg · cm · km" : "lbs · in · mi",
+                        isSelected: settings.unitSystem == system,
+                        tint: AppColor.Accent.achievement
+                    )
+                }
+            }
+
+            SettingsSectionCard(title: "Appearance", eyebrow: "Preferences") {
+                SettingsChoiceGrid(options: AppAppearance.allCases, selection: $settings.appearance) { mode in
+                    SettingsSelectionTile(
+                        title: mode.rawValue,
+                        subtitle: mode == .system ? "Follow the device setting" : "Force \(mode.rawValue.lowercased()) mode",
+                        isSelected: settings.appearance == mode,
+                        tint: AppColor.Accent.sleep
+                    )
+                }
+            }
+
+            SettingsSectionCard(title: "Stats Carousel", eyebrow: "Preferences") {
+                SettingsSupportingText("Weight and Body Fat stay pinned on the stats screen. Choose which extra metrics appear in Track More.")
+
+                ForEach(statsMetricOptions) { metric in
+                    Button {
+                        toggleStatsMetric(metric)
+                    } label: {
+                        HStack(spacing: AppSpacing.xSmall) {
+                            Image(systemName: metric.icon)
+                                .font(AppText.captionStrong)
+                                .foregroundStyle(metric.tint)
+                                .frame(width: 20)
+
+                            Text(metric.title)
+                                .font(AppText.body)
+                                .foregroundStyle(AppColor.Text.primary)
+
+                            Spacer()
+
+                            Image(systemName: isStatsMetricVisible(metric) ? "checkmark.circle.fill" : "circle")
+                                .font(AppText.sectionTitle)
+                                .foregroundStyle(isStatsMetricVisible(metric) ? metric.tint : AppColor.Text.tertiary)
+                        }
+                        .padding(.vertical, AppSpacing.xxxSmall)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Button("Reset Recommended Metrics") {
+                    dataStore.userPreferences.preferredStatsCarouselMetrics = UserPreferences.defaultStatsCarouselMetrics
+                    Task { await dataStore.persistToDisk() }
+                }
+                .font(AppText.chip)
+                .foregroundStyle(AppColor.Accent.primary)
+            }
+        }
+        .navigationTitle(SettingsCategory.goalsPreferences.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private static let recoveryStartFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    private var goalWeightMinBinding: Binding<Double> {
+        Binding(
+            get: { dataStore.userProfile.targetWeightMin },
+            set: {
+                dataStore.userProfile.targetWeightMin = $0
+                Task { await dataStore.persistToDisk() }
+            }
+        )
+    }
+
+    private var goalWeightMaxBinding: Binding<Double> {
+        Binding(
+            get: { dataStore.userProfile.targetWeightMax },
+            set: {
+                dataStore.userProfile.targetWeightMax = $0
+                Task { await dataStore.persistToDisk() }
+            }
+        )
+    }
+
+    private var goalBodyFatMinBinding: Binding<Double> {
+        Binding(
+            get: { dataStore.userProfile.targetBFMin },
+            set: {
+                dataStore.userProfile.targetBFMin = $0
+                Task { await dataStore.persistToDisk() }
+            }
+        )
+    }
+
+    private var goalBodyFatMaxBinding: Binding<Double> {
+        Binding(
+            get: { dataStore.userProfile.targetBFMax },
+            set: {
+                dataStore.userProfile.targetBFMax = $0
+                Task { await dataStore.persistToDisk() }
+            }
+        )
+    }
+
+    private var statsMetricOptions: [StatsFocusMetric] {
+        StatsFocusMetric.allCases.filter { !$0.isPermanent }
+    }
+
+    private func isStatsMetricVisible(_ metric: StatsFocusMetric) -> Bool {
+        dataStore.userPreferences.preferredStatsCarouselMetrics.contains(metric.rawValue)
+    }
+
+    private func toggleStatsMetric(_ metric: StatsFocusMetric) {
+        var metrics = dataStore.userPreferences.preferredStatsCarouselMetrics
+
+        if let index = metrics.firstIndex(of: metric.rawValue) {
+            guard metrics.count > 1 else { return }
+            metrics.remove(at: index)
+        } else {
+            metrics.append(metric.rawValue)
+        }
+
+        dataStore.userPreferences.preferredStatsCarouselMetrics = metrics
+        Task { await dataStore.persistToDisk() }
+    }
+}

--- a/FitTracker/Views/Settings/v2/Screens/HealthDevicesSettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/HealthDevicesSettingsScreen.swift
@@ -1,0 +1,59 @@
+// FitTracker/Views/Settings/v2/Screens/HealthDevicesSettingsScreen.swift
+// Settings v2 — Health & Devices detail screen.
+// Extracted from SettingsView.swift in Audit M-1a (UI-002 decomposition).
+
+import SwiftUI
+
+struct HealthDevicesSettingsScreen: View {
+    @EnvironmentObject private var healthService: HealthKitService
+    @EnvironmentObject private var watchService: WatchConnectivityService
+
+    var body: some View {
+        SettingsDetailScaffold(
+            title: SettingsCategory.healthDevices.title,
+            subtitle: "See whether health data access is active, whether your Apple Watch is reachable, and which connected sources are currently feeding the app."
+        ) {
+            SettingsSectionCard(title: "Connection Status", eyebrow: "Devices") {
+                SettingsValueRow(title: "HealthKit", value: healthService.isAuthorized ? "Authorized" : "Not Authorized")
+                SettingsValueRow(title: "Apple Watch", value: watchService.status.label)
+                SettingsSupportingText(healthSummary)
+                SettingsSupportingText(watchSummary)
+            }
+
+            SettingsSectionCard(title: "Actions", eyebrow: "Devices") {
+                Button {
+                    Task { try? await healthService.requestAuthorization() }
+                } label: {
+                    SettingsActionLabel(
+                        title: "Re-authorize HealthKit",
+                        subtitle: "Refresh the current HealthKit permissions and reconnect read access.",
+                        icon: "heart.text.square.fill",
+                        tint: AppColor.Accent.recovery
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .navigationTitle(SettingsCategory.healthDevices.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var healthSummary: String {
+        healthService.isAuthorized
+            ? "HealthKit is connected, so compatible body, recovery, and activity metrics can flow into \(AppBrand.name)."
+            : "HealthKit is not authorized yet, so recovery and body signals depend on manual entry and imported device data."
+    }
+
+    private var watchSummary: String {
+        switch watchService.status {
+        case .connected:
+            return "Your Apple Watch is reachable right now and can provide live workout-related context."
+        case .offline:
+            return "Your watch is paired, but it is not currently reachable. This is common when the watch app is not active."
+        case .notPaired:
+            return "No paired Apple Watch is detected for this iPhone."
+        case .appNotInstalled:
+            return "A paired watch was found, but the watch companion app is not installed."
+        }
+    }
+}

--- a/FitTracker/Views/Settings/v2/Screens/TrainingNutritionSettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/TrainingNutritionSettingsScreen.swift
@@ -1,0 +1,83 @@
+// FitTracker/Views/Settings/v2/Screens/TrainingNutritionSettingsScreen.swift
+// Settings v2 — Training & Nutrition detail screen.
+// Extracted from SettingsView.swift in Audit M-1a (UI-002 decomposition).
+
+import SwiftUI
+
+struct TrainingNutritionSettingsScreen: View {
+    @EnvironmentObject private var dataStore: EncryptedDataStore
+
+    var body: some View {
+        SettingsDetailScaffold(
+            title: SettingsCategory.trainingNutrition.title,
+            subtitle: "Tune the strategy that drives your nutrition recommendations and the thresholds used for training and readiness logic."
+        ) {
+            SettingsSectionCard(title: "HR & Intervals", eyebrow: "Training") {
+                SettingsSliderRow(
+                    title: "Zone 2 Lower HR",
+                    valueText: "\(dataStore.userPreferences.zone2LowerHR) bpm",
+                    value: Binding(
+                        get: { Double(dataStore.userPreferences.zone2LowerHR) },
+                        set: {
+                            let newValue = Int($0)
+                            dataStore.userPreferences.zone2LowerHR = min(newValue, dataStore.userPreferences.zone2UpperHR - 1)
+                        }
+                    ),
+                    range: 80...160
+                ) {
+                    Task { await dataStore.persistToDisk() }
+                }
+
+                SettingsSliderRow(
+                    title: "Zone 2 Upper HR",
+                    valueText: "\(dataStore.userPreferences.zone2UpperHR) bpm",
+                    value: Binding(
+                        get: { Double(dataStore.userPreferences.zone2UpperHR) },
+                        set: {
+                            let newValue = Int($0)
+                            dataStore.userPreferences.zone2UpperHR = max(newValue, dataStore.userPreferences.zone2LowerHR + 1)
+                        }
+                    ),
+                    range: 90...180
+                ) {
+                    Task { await dataStore.persistToDisk() }
+                }
+            }
+
+            SettingsSectionCard(title: "Readiness Thresholds", eyebrow: "Training") {
+                SettingsSliderRow(
+                    title: "Readiness HR Threshold",
+                    valueText: "\(dataStore.userPreferences.hrReadyThreshold) bpm",
+                    value: Binding(
+                        get: { Double(dataStore.userPreferences.hrReadyThreshold) },
+                        set: { dataStore.userPreferences.hrReadyThreshold = Int($0) }
+                    ),
+                    range: 40...80
+                ) {
+                    Task { await dataStore.persistToDisk() }
+                }
+
+                SettingsSliderRow(
+                    title: "Readiness HRV Threshold",
+                    valueText: "\(Int(dataStore.userPreferences.hrvReadyThreshold)) ms",
+                    value: $dataStore.userPreferences.hrvReadyThreshold,
+                    range: 10...80
+                ) {
+                    Task { await dataStore.persistToDisk() }
+                }
+            }
+        }
+        .navigationTitle(SettingsCategory.trainingNutrition.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var nutritionGoalModeBinding: Binding<NutritionGoalMode> {
+        Binding(
+            get: { dataStore.userPreferences.nutritionGoalMode },
+            set: {
+                dataStore.userPreferences.nutritionGoalMode = $0
+                Task { await dataStore.persistToDisk() }
+            }
+        )
+    }
+}

--- a/FitTracker/Views/Settings/v2/SettingsView.swift
+++ b/FitTracker/Views/Settings/v2/SettingsView.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import LocalAuthentication
 
-private enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
+enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
     case accountSecurity
     case healthDevices
     case goalsPreferences
@@ -291,527 +291,6 @@ struct SettingsView: View {
     }
 }
 
-private struct AccountSecuritySettingsScreen: View {
-    @EnvironmentObject private var signIn: SignInService
-    @EnvironmentObject private var dataStore: EncryptedDataStore
-    @EnvironmentObject private var cloudSync: CloudKitSyncService
-    @EnvironmentObject private var supabaseSync: SupabaseSyncService
-    @EnvironmentObject private var settings: AppSettings
-    @EnvironmentObject private var biometricAuth: AuthManager
-    @EnvironmentObject private var analytics: AnalyticsService
-
-    var body: some View {
-        SettingsDetailScaffold(
-            title: SettingsCategory.accountSecurity.title,
-            subtitle: "Manage how your account opens, how credentials are stored, and which protections are active on this device."
-        ) {
-            SettingsSectionCard(title: "Account Identity", eyebrow: "Account") {
-                SettingsValueRow(title: "Sign-In Method", value: signIn.currentSession?.provider.rawValue ?? "Unavailable")
-                SettingsValueRow(title: "Name", value: signIn.currentSession?.displayName ?? "—")
-                SettingsValueRow(title: "Email", value: signIn.currentSession?.email ?? "—")
-                SettingsValueRow(title: "Phone", value: signIn.currentSession?.phone ?? "—")
-            }
-
-            SettingsSectionCard(title: "Access on Reopen", eyebrow: "Security") {
-                Toggle(isOn: $settings.requireBiometricUnlockOnReopen) {
-                    VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
-                        Text("Require \(biometricUnlockLabel) on Reopen")
-                            .font(AppText.button)
-                            .foregroundStyle(AppColor.Text.primary)
-                        Text("When off, \(AppBrand.name) stays unlocked while the app remains in memory.")
-                            .font(AppText.subheading)
-                            .foregroundStyle(AppColor.Text.secondary)
-                    }
-                }
-                .tint(AppColor.Accent.primary)
-                .disabled(!biometricsAvailable)
-
-                if !biometricsAvailable {
-                    SettingsSupportingText("Biometric unlock is unavailable on this device. Set up Face ID or Touch ID to protect reopen access.")
-                }
-
-                Button {
-                    signIn.addPasskeyForCurrentUser()
-                } label: {
-                    SettingsActionLabel(
-                        title: signIn.currentSession?.provider == .passkey ? "Create Another Passkey" : "Add Passkey",
-                        subtitle: signIn.isPasskeyConfigured ? "Register a passkey for quick passwordless sign in." : "Passkey setup requires a valid relying party configuration.",
-                        icon: "key.fill",
-                        tint: AppColor.Accent.sleep,
-                        trailing: signIn.isLoading ? .progress : .chevron
-                    )
-                }
-                .buttonStyle(.plain)
-                .disabled(signIn.isLoading || !signIn.isPasskeyConfigured)
-            }
-
-            SettingsSectionCard(title: "Protection Summary", eyebrow: "Security") {
-                SettingsValueRow(title: "Encryption", value: "AES-256-GCM + ChaCha20-Poly1305")
-                SettingsValueRow(title: "Key Storage", value: "Keychain with biometric protection")
-                SettingsValueRow(title: "Cloud Storage", value: "Encrypted locally before upload")
-                SettingsValueRow(title: "Data Protection", value: "NSFileProtectionCompleteUnlessOpen")
-            }
-
-            SettingsSectionCard(title: "Account", eyebrow: "GDPR") {
-                NavigationLink {
-                    DeleteAccountView()
-                        .environmentObject(AccountDeletionService(
-                            dataStore: dataStore,
-                            cloudSync: cloudSync,
-                            supabaseSync: supabaseSync,
-                            signIn: signIn,
-                            analytics: analytics
-                        ))
-                        .environmentObject(analytics)
-                } label: {
-                    SettingsActionLabel(
-                        title: "Delete Account",
-                        subtitle: "Schedule permanent deletion of your account and all data.",
-                        icon: "trash.fill",
-                        tint: AppColor.Status.error
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .navigationTitle(SettingsCategory.accountSecurity.title)
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private var biometricsAvailable: Bool {
-        let ctx = LAContext()
-        var error: NSError?
-        return ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
-    }
-
-    private var biometricUnlockLabel: String {
-        let ctx = LAContext()
-        var error: NSError?
-        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
-            return biometricAuth.biometricName
-        }
-        switch ctx.biometryType {
-        case .faceID: return "Face ID"
-        case .touchID: return "Touch ID"
-        default: return "Biometric Unlock"
-        }
-    }
-}
-
-private struct HealthDevicesSettingsScreen: View {
-    @EnvironmentObject private var healthService: HealthKitService
-    @EnvironmentObject private var watchService: WatchConnectivityService
-
-    var body: some View {
-        SettingsDetailScaffold(
-            title: SettingsCategory.healthDevices.title,
-            subtitle: "See whether health data access is active, whether your Apple Watch is reachable, and which connected sources are currently feeding the app."
-        ) {
-            SettingsSectionCard(title: "Connection Status", eyebrow: "Devices") {
-                SettingsValueRow(title: "HealthKit", value: healthService.isAuthorized ? "Authorized" : "Not Authorized")
-                SettingsValueRow(title: "Apple Watch", value: watchService.status.label)
-                SettingsSupportingText(healthSummary)
-                SettingsSupportingText(watchSummary)
-            }
-
-            SettingsSectionCard(title: "Actions", eyebrow: "Devices") {
-                Button {
-                    Task { try? await healthService.requestAuthorization() }
-                } label: {
-                    SettingsActionLabel(
-                        title: "Re-authorize HealthKit",
-                        subtitle: "Refresh the current HealthKit permissions and reconnect read access.",
-                        icon: "heart.text.square.fill",
-                        tint: AppColor.Accent.recovery
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .navigationTitle(SettingsCategory.healthDevices.title)
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private var healthSummary: String {
-        healthService.isAuthorized
-            ? "HealthKit is connected, so compatible body, recovery, and activity metrics can flow into \(AppBrand.name)."
-            : "HealthKit is not authorized yet, so recovery and body signals depend on manual entry and imported device data."
-    }
-
-    private var watchSummary: String {
-        switch watchService.status {
-        case .connected:
-            return "Your Apple Watch is reachable right now and can provide live workout-related context."
-        case .offline:
-            return "Your watch is paired, but it is not currently reachable. This is common when the watch app is not active."
-        case .notPaired:
-            return "No paired Apple Watch is detected for this iPhone."
-        case .appNotInstalled:
-            return "A paired watch was found, but the watch companion app is not installed."
-        }
-    }
-}
-
-private struct GoalsPreferencesSettingsScreen: View {
-    @EnvironmentObject private var dataStore: EncryptedDataStore
-    @EnvironmentObject private var settings: AppSettings
-
-    var body: some View {
-        SettingsDetailScaffold(
-            title: SettingsCategory.goalsPreferences.title,
-            subtitle: "Personalize the app’s presentation, choose how stats are surfaced, and keep body-composition targets in one place."
-        ) {
-            SettingsSectionCard(title: "Profile Snapshot", eyebrow: "Goals") {
-                SettingsValueRow(title: "Name", value: dataStore.userProfile.name)
-                SettingsValueRow(title: "Recovery Start", value: Self.recoveryStartFormatter.string(from: dataStore.userProfile.recoveryStart))
-                SettingsValueRow(title: "Phase", value: dataStore.userProfile.currentPhase.rawValue)
-                SettingsValueRow(title: "Recovery Day", value: "Day \(dataStore.userProfile.daysSinceStart)")
-            }
-
-            SettingsSectionCard(title: "Body Goals", eyebrow: "Goals") {
-                SettingsNumericFieldRow(title: "Goal Weight Min", suffix: settings.unitSystem.weightLabel(), value: goalWeightMinBinding)
-                SettingsNumericFieldRow(title: "Goal Weight Max", suffix: settings.unitSystem.weightLabel(), value: goalWeightMaxBinding)
-                SettingsNumericFieldRow(title: "Goal Body Fat Min", suffix: "%", value: goalBodyFatMinBinding)
-                SettingsNumericFieldRow(title: "Goal Body Fat Max", suffix: "%", value: goalBodyFatMaxBinding)
-            }
-
-            SettingsSectionCard(title: "Units", eyebrow: "Preferences") {
-                SettingsChoiceGrid(options: UnitSystem.allCases, selection: $settings.unitSystem) { system in
-                    SettingsSelectionTile(
-                        title: system.rawValue,
-                        subtitle: system == .metric ? "kg · cm · km" : "lbs · in · mi",
-                        isSelected: settings.unitSystem == system,
-                        tint: AppColor.Accent.achievement
-                    )
-                }
-            }
-
-            SettingsSectionCard(title: "Appearance", eyebrow: "Preferences") {
-                SettingsChoiceGrid(options: AppAppearance.allCases, selection: $settings.appearance) { mode in
-                    SettingsSelectionTile(
-                        title: mode.rawValue,
-                        subtitle: mode == .system ? "Follow the device setting" : "Force \(mode.rawValue.lowercased()) mode",
-                        isSelected: settings.appearance == mode,
-                        tint: AppColor.Accent.sleep
-                    )
-                }
-            }
-
-            SettingsSectionCard(title: "Stats Carousel", eyebrow: "Preferences") {
-                SettingsSupportingText("Weight and Body Fat stay pinned on the stats screen. Choose which extra metrics appear in Track More.")
-
-                ForEach(statsMetricOptions) { metric in
-                    Button {
-                        toggleStatsMetric(metric)
-                    } label: {
-                        HStack(spacing: AppSpacing.xSmall) {
-                            Image(systemName: metric.icon)
-                                .font(AppText.captionStrong)
-                                .foregroundStyle(metric.tint)
-                                .frame(width: 20)
-
-                            Text(metric.title)
-                                .font(AppText.body)
-                                .foregroundStyle(AppColor.Text.primary)
-
-                            Spacer()
-
-                            Image(systemName: isStatsMetricVisible(metric) ? "checkmark.circle.fill" : "circle")
-                                .font(AppText.sectionTitle)
-                                .foregroundStyle(isStatsMetricVisible(metric) ? metric.tint : AppColor.Text.tertiary)
-                        }
-                        .padding(.vertical, AppSpacing.xxxSmall)
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                Button("Reset Recommended Metrics") {
-                    dataStore.userPreferences.preferredStatsCarouselMetrics = UserPreferences.defaultStatsCarouselMetrics
-                    Task { await dataStore.persistToDisk() }
-                }
-                .font(AppText.chip)
-                .foregroundStyle(AppColor.Accent.primary)
-            }
-        }
-        .navigationTitle(SettingsCategory.goalsPreferences.title)
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private static let recoveryStartFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter
-    }()
-
-    private var goalWeightMinBinding: Binding<Double> {
-        Binding(
-            get: { dataStore.userProfile.targetWeightMin },
-            set: {
-                dataStore.userProfile.targetWeightMin = $0
-                Task { await dataStore.persistToDisk() }
-            }
-        )
-    }
-
-    private var goalWeightMaxBinding: Binding<Double> {
-        Binding(
-            get: { dataStore.userProfile.targetWeightMax },
-            set: {
-                dataStore.userProfile.targetWeightMax = $0
-                Task { await dataStore.persistToDisk() }
-            }
-        )
-    }
-
-    private var goalBodyFatMinBinding: Binding<Double> {
-        Binding(
-            get: { dataStore.userProfile.targetBFMin },
-            set: {
-                dataStore.userProfile.targetBFMin = $0
-                Task { await dataStore.persistToDisk() }
-            }
-        )
-    }
-
-    private var goalBodyFatMaxBinding: Binding<Double> {
-        Binding(
-            get: { dataStore.userProfile.targetBFMax },
-            set: {
-                dataStore.userProfile.targetBFMax = $0
-                Task { await dataStore.persistToDisk() }
-            }
-        )
-    }
-
-    private var statsMetricOptions: [StatsFocusMetric] {
-        StatsFocusMetric.allCases.filter { !$0.isPermanent }
-    }
-
-    private func isStatsMetricVisible(_ metric: StatsFocusMetric) -> Bool {
-        dataStore.userPreferences.preferredStatsCarouselMetrics.contains(metric.rawValue)
-    }
-
-    private func toggleStatsMetric(_ metric: StatsFocusMetric) {
-        var metrics = dataStore.userPreferences.preferredStatsCarouselMetrics
-
-        if let index = metrics.firstIndex(of: metric.rawValue) {
-            guard metrics.count > 1 else { return }
-            metrics.remove(at: index)
-        } else {
-            metrics.append(metric.rawValue)
-        }
-
-        dataStore.userPreferences.preferredStatsCarouselMetrics = metrics
-        Task { await dataStore.persistToDisk() }
-    }
-}
-
-private struct TrainingNutritionSettingsScreen: View {
-    @EnvironmentObject private var dataStore: EncryptedDataStore
-
-    var body: some View {
-        SettingsDetailScaffold(
-            title: SettingsCategory.trainingNutrition.title,
-            subtitle: "Tune the strategy that drives your nutrition recommendations and the thresholds used for training and readiness logic."
-        ) {
-            SettingsSectionCard(title: "HR & Intervals", eyebrow: "Training") {
-                SettingsSliderRow(
-                    title: "Zone 2 Lower HR",
-                    valueText: "\(dataStore.userPreferences.zone2LowerHR) bpm",
-                    value: Binding(
-                        get: { Double(dataStore.userPreferences.zone2LowerHR) },
-                        set: {
-                            let newValue = Int($0)
-                            dataStore.userPreferences.zone2LowerHR = min(newValue, dataStore.userPreferences.zone2UpperHR - 1)
-                        }
-                    ),
-                    range: 80...160
-                ) {
-                    Task { await dataStore.persistToDisk() }
-                }
-
-                SettingsSliderRow(
-                    title: "Zone 2 Upper HR",
-                    valueText: "\(dataStore.userPreferences.zone2UpperHR) bpm",
-                    value: Binding(
-                        get: { Double(dataStore.userPreferences.zone2UpperHR) },
-                        set: {
-                            let newValue = Int($0)
-                            dataStore.userPreferences.zone2UpperHR = max(newValue, dataStore.userPreferences.zone2LowerHR + 1)
-                        }
-                    ),
-                    range: 90...180
-                ) {
-                    Task { await dataStore.persistToDisk() }
-                }
-            }
-
-            SettingsSectionCard(title: "Readiness Thresholds", eyebrow: "Training") {
-                SettingsSliderRow(
-                    title: "Readiness HR Threshold",
-                    valueText: "\(dataStore.userPreferences.hrReadyThreshold) bpm",
-                    value: Binding(
-                        get: { Double(dataStore.userPreferences.hrReadyThreshold) },
-                        set: { dataStore.userPreferences.hrReadyThreshold = Int($0) }
-                    ),
-                    range: 40...80
-                ) {
-                    Task { await dataStore.persistToDisk() }
-                }
-
-                SettingsSliderRow(
-                    title: "Readiness HRV Threshold",
-                    valueText: "\(Int(dataStore.userPreferences.hrvReadyThreshold)) ms",
-                    value: $dataStore.userPreferences.hrvReadyThreshold,
-                    range: 10...80
-                ) {
-                    Task { await dataStore.persistToDisk() }
-                }
-            }
-        }
-        .navigationTitle(SettingsCategory.trainingNutrition.title)
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private var nutritionGoalModeBinding: Binding<NutritionGoalMode> {
-        Binding(
-            get: { dataStore.userPreferences.nutritionGoalMode },
-            set: {
-                dataStore.userPreferences.nutritionGoalMode = $0
-                Task { await dataStore.persistToDisk() }
-            }
-        )
-    }
-}
-
-private struct DataSyncSettingsScreen: View {
-    @EnvironmentObject private var dataStore: EncryptedDataStore
-    @EnvironmentObject private var cloudSync: CloudKitSyncService
-    @EnvironmentObject private var analytics: AnalyticsService
-    @Binding var showResetAlert: Bool
-
-    var body: some View {
-        SettingsDetailScaffold(
-            title: SettingsCategory.dataSync.title,
-            subtitle: "Monitor iCloud sync health, manually trigger transfers when needed, and manage local storage carefully."
-        ) {
-            SettingsSectionCard(title: "Sync Status", eyebrow: "Sync") {
-                SettingsValueRow(title: "Status", value: cloudSync.status.rawValue)
-                SettingsValueRow(title: "iCloud", value: cloudSync.iCloudAvailable ? "Available" : "Unavailable")
-                if let lastSyncDate = cloudSync.lastSyncDate {
-                    SettingsValueRow(title: "Last Sync", value: Self.lastSyncFormatter.string(from: lastSyncDate))
-                }
-
-                Button {
-                    Task { await cloudSync.pushPendingChanges(dataStore: dataStore) }
-                } label: {
-                    SettingsActionLabel(
-                        title: "Sync Now",
-                        subtitle: "Push local encrypted changes to your private iCloud database.",
-                        icon: "icloud.and.arrow.up.fill",
-                        tint: AppColor.Status.success
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Sync now")
-                .accessibilityHint("Push local changes to iCloud")
-
-                Button {
-                    Task { await cloudSync.fetchChanges(dataStore: dataStore) }
-                } label: {
-                    SettingsActionLabel(
-                        title: "Fetch from iCloud",
-                        subtitle: "Download the latest encrypted changes from your account.",
-                        icon: "icloud.and.arrow.down.fill",
-                        tint: AppColor.Accent.recovery
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Fetch from iCloud")
-                .accessibilityHint("Download latest data from your iCloud account")
-            }
-
-            SettingsSectionCard(title: "Local Storage", eyebrow: "Data") {
-                SettingsValueRow(title: "Daily Logs", value: "\(dataStore.dailyLogs.count) entries")
-                SettingsValueRow(title: "Weekly Snapshots", value: "\(dataStore.weeklySnapshots.count) entries")
-            }
-
-            SettingsSectionCard(title: "Analytics", eyebrow: "Privacy") {
-                Toggle(isOn: Binding(
-                    get: { analytics.consent.gdprConsent == .granted },
-                    set: { enabled in
-                        if enabled {
-                            analytics.consent.regrantConsent()
-                            analytics.syncConsentToProvider()
-                            analytics.logSettingsChanged(settingName: "analytics", newValue: "enabled")
-                        } else {
-                            analytics.consent.revokeConsent()
-                            analytics.syncConsentToProvider()
-                        }
-                    }
-                )) {
-                    VStack(alignment: .leading, spacing: AppSpacing.micro) {
-                        Text("App Analytics")
-                            .font(AppText.body)
-                            .foregroundStyle(AppColor.Text.primary)
-                        Text("Help improve FitMe by sharing anonymous usage data. No health data is ever shared.")
-                            .font(AppText.caption)
-                            .foregroundStyle(AppColor.Text.tertiary)
-                    }
-                }
-                .tint(AppColor.Brand.primary)
-            }
-
-            SettingsSectionCard(title: "Data Portability", eyebrow: "GDPR") {
-                NavigationLink {
-                    ExportDataView()
-                        .environmentObject(DataExportService(
-                            dataStore: dataStore,
-                            analytics: analytics
-                        ))
-                        .environmentObject(analytics)
-                } label: {
-                    SettingsActionLabel(
-                        title: "Export My Data",
-                        subtitle: "Download all your data as a JSON file.",
-                        icon: "square.and.arrow.up.fill",
-                        tint: AppColor.Accent.primary
-                    )
-                }
-                .buttonStyle(.plain)
-            }
-
-            SettingsSectionCard(title: "Danger Zone", eyebrow: "Data") {
-                SettingsSupportingText("Delete local logs only if you understand they will repopulate from iCloud on the next fetch. Permanent deletion requires removing the data from your iCloud account as well.")
-
-                Button(role: .destructive) {
-                    showResetAlert = true
-                } label: {
-                    SettingsActionLabel(
-                        title: "Delete All Local Data",
-                        subtitle: "Remove all daily logs and snapshots from this device.",
-                        icon: "trash.fill",
-                        tint: AppColor.Status.error
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Delete all local data")
-                .accessibilityHint("Permanently removes all local logs and snapshots from this device. This action cannot be undone.")
-            }
-        }
-        .navigationTitle(SettingsCategory.dataSync.title)
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private static let lastSyncFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-        return formatter
-    }()
-}
-
 private struct SettingsHomeHeader: View {
     let title: String
     let subtitle: String
@@ -1009,12 +488,12 @@ struct SettingsSupportingText: View {
     }
 }
 
-private enum SettingsActionTrailing {
+enum SettingsActionTrailing {
     case chevron
     case progress
 }
 
-private struct SettingsActionLabel: View {
+struct SettingsActionLabel: View {
     let title: String
     let subtitle: String
     let icon: String
@@ -1054,7 +533,7 @@ private struct SettingsActionLabel: View {
     }
 }
 
-private struct SettingsSelectionTile: View {
+struct SettingsSelectionTile: View {
     let title: String
     let subtitle: String
     let isSelected: Bool
@@ -1084,7 +563,7 @@ private struct SettingsSelectionTile: View {
     }
 }
 
-private struct SettingsChoiceGrid<Option: Hashable, Tile: View>: View {
+struct SettingsChoiceGrid<Option: Hashable, Tile: View>: View {
     let options: [Option]
     @Binding var selection: Option
     let tile: (Option) -> Tile
@@ -1111,7 +590,7 @@ private struct SettingsChoiceGrid<Option: Hashable, Tile: View>: View {
     }
 }
 
-private struct SettingsNumericFieldRow: View {
+struct SettingsNumericFieldRow: View {
     let title: String
     let suffix: String
     @Binding var value: Double
@@ -1138,7 +617,7 @@ private struct SettingsNumericFieldRow: View {
     }
 }
 
-private struct SettingsSliderRow: View {
+struct SettingsSliderRow: View {
     let title: String
     let valueText: String
     @Binding var value: Double

--- a/docs/superpowers/plans/2026-04-19-m1-settings-v3-decomposition.md
+++ b/docs/superpowers/plans/2026-04-19-m1-settings-v3-decomposition.md
@@ -1,0 +1,98 @@
+# M-1 — SettingsView (v2) Decomposition
+
+> **Audit finding**: UI-002 — SettingsView.swift (v2) is 1170 lines, actively compiled
+> **Type**: Multi-session feature — case study tracking ON from start (per the rule + M-3 precedent)
+> **Predecessor plan**: `docs/superpowers/plans/2026-04-19-audit-completion-plan.md` (M-1 row)
+> **Date**: 2026-04-19
+
+## Goal
+
+Decompose `FitTracker/Views/Settings/v2/SettingsView.swift` (1170 lines) into focused per-screen files. After M-1, `SettingsView.swift` becomes a thin coordinator (~225 lines) and each detail screen lives in its own file alongside the shared component library.
+
+## Source structure (read-only inventory)
+
+The file is already well-organized into clearly-bounded sections:
+
+| Lines | Section | Type | Decomposition target |
+|---|---|---|---|
+| 1-69 | Enums + types (SettingsCategory, SettingsSummaryBadge, SettingsReviewDestination) | private | Stay (small, view-internal) |
+| 70-293 | `SettingsView` (main coordinator) | struct | Stay (this IS the entry point) |
+| 294-400 | `AccountSecuritySettingsScreen` | private struct | **Extract → AccountSecuritySettingsScreen.swift** |
+| 401-454 | `HealthDevicesSettingsScreen` | private struct | **Extract → HealthDevicesSettingsScreen.swift** |
+| 455-609 | `GoalsPreferencesSettingsScreen` | private struct | **Extract → GoalsPreferencesSettingsScreen.swift** |
+| 610-687 | `TrainingNutritionSettingsScreen` | private struct | **Extract → TrainingNutritionSettingsScreen.swift** |
+| 688-814 | `DataSyncSettingsScreen` | private struct | **Extract → DataSyncSettingsScreen.swift** |
+| 815-922 | Home header + category card + badge views | private struct | Stay (used by main coordinator only) |
+| 923-1011 | Shared scaffolds (SettingsDetailScaffold, SettingsSectionCard, SettingsValueRow, SettingsSupportingText) | struct (already internal) | **Extract → SettingsScaffolds.swift** |
+| 1012-1170 | Shared form components (SettingsActionLabel, SettingsSelectionTile, SettingsChoiceGrid, SettingsNumericFieldRow, SettingsSliderRow) | private struct | **Extract → SettingsFormComponents.swift** |
+
+After full M-1: SettingsView.swift = ~225 lines (main coordinator + home view sub-components only).
+
+## Phases
+
+### Phase M-1a — Extract 5 detail screens (this sprint)
+
+Move each of the 5 `*SettingsScreen` private structs to its own file under `FitTracker/Views/Settings/v2/Screens/`. Bump visibility from `private` to `internal` (file-private to module-internal) so the main coordinator can reference them. Detail screens currently take their dependencies via `@EnvironmentObject` so no init signature changes needed.
+
+| New file | Lines moved | Original location |
+|---|---|---|
+| `Screens/AccountSecuritySettingsScreen.swift` | ~107 | 294-400 |
+| `Screens/HealthDevicesSettingsScreen.swift` | ~54 | 401-454 |
+| `Screens/GoalsPreferencesSettingsScreen.swift` | ~155 | 455-609 |
+| `Screens/TrainingNutritionSettingsScreen.swift` | ~78 | 610-687 |
+| `Screens/DataSyncSettingsScreen.swift` | ~127 | 688-814 |
+| **Total moved** | **~521 lines** | |
+
+After M-1a: SettingsView.swift = ~649 lines.
+
+**Risk**: medium. Each screen has its own dependencies (services via `@EnvironmentObject`, helper components via direct call). All references stay module-internal so compilation should succeed once visibility is bumped.
+
+**Pbxproj updates**: 5 new file references + Sources entries + a new "Screens" PBXGroup under `Settings/v2/`.
+
+### Phase M-1b — Extract shared components (next sprint)
+
+Move the shared scaffolds + form components to their own files under `FitTracker/Views/Settings/v2/Components/`. These are used by the main coordinator AND the 5 detail screens.
+
+| New file | Lines moved | Original location |
+|---|---|---|
+| `Components/SettingsScaffolds.swift` | ~89 | 923-1011 (SettingsDetailScaffold, SettingsSectionCard, SettingsValueRow, SettingsSupportingText) |
+| `Components/SettingsFormComponents.swift` | ~158 | 1012-1170 (SettingsActionLabel, SettingsSelectionTile, SettingsChoiceGrid, SettingsNumericFieldRow, SettingsSliderRow + SettingsActionTrailing enum) |
+| **Total moved** | **~247 lines** | |
+
+After M-1b: SettingsView.swift = ~402 lines.
+
+### Phase M-1c — Final SettingsView trim (if needed)
+
+If SettingsView.swift is still > 400 lines after M-1b, evaluate whether the home view sub-components (lines 815-922 — SettingsHomeHeader, SettingsCategoryCard, FlexibleBadgeRow, SettingsBadgeView) deserve their own `Components/SettingsHomeViews.swift`. May or may not be needed depending on actual line count after the prior phases.
+
+### Phase M-1d — Case study + monitoring entry
+
+Per the rule, M-1 gets its own case study. Following M-3's "concurrent tracking" pattern, this happens in the same session as M-1a/b/c (not retroactive).
+
+## Out of scope
+
+- **Behavior changes** — pure structural decomposition. Every screen renders identically before and after.
+- **Renaming or API changes** — keep all type names (`AccountSecuritySettingsScreen`, etc.) so call sites in SettingsView don't change.
+- **New tests** — settings view doesn't have unit tests; XCUITest infrastructure (M-4) is the right vehicle for coverage here.
+- **Visual changes** — no spacing/color/font changes.
+
+## Success criteria
+
+- After Phase M-1a: SettingsView.swift drops from 1170 → ~649 lines, build green, all 5 detail screens render correctly
+- After Phase M-1b: SettingsView.swift drops to ~402 lines
+- After Phase M-1c: SettingsView.swift ≤ 400 lines OR explicitly documented as "this is the right size for the coordinator"
+- After Phase M-1d: case study + monitoring entry shipped per the rule
+
+## Estimated effort
+
+| Phase | Effort | Risk |
+|---|---|---|
+| M-1a (this PR) | 60-90 min | medium (5 file extractions + pbxproj updates) |
+| M-1b | 45-60 min | low (component library extraction) |
+| M-1c | 15-30 min if needed | low |
+| M-1d | 60-90 min | low |
+| **Total** | **~3-4 hours** | |
+
+## Rollback plan
+
+Each phase ships as its own PR. If a phase introduces a regression (visual or behavioral), revert the PR. The shared component library + screen files were carved out of the same module, so undoing is git-revert-clean.


### PR DESCRIPTION
## Summary

Audit M-1a — first phase of decomposing the 1170-line `SettingsView.swift` (UI-002 audit finding). Moves 5 detail screens to their own files under `FitTracker/Views/Settings/v2/Screens/`. Pure structural refactor, no behaviour change.

- `SettingsView.swift`: **1170 → 649 lines** (~44% reduction)
- 5 new files under `Screens/`, total ~521 lines moved
- Visibility bumped from `private` → internal on `SettingsCategory` + 5 form components + `SettingsActionTrailing` so extracted screens can reference them

## What changed

| New file | Lines moved |
|---|---|
| `Screens/AccountSecuritySettingsScreen.swift` | ~107 |
| `Screens/HealthDevicesSettingsScreen.swift` | ~54 |
| `Screens/GoalsPreferencesSettingsScreen.swift` | ~155 |
| `Screens/TrainingNutritionSettingsScreen.swift` | ~78 |
| `Screens/DataSyncSettingsScreen.swift` | ~127 |

`project.pbxproj` updated with 5 PBXFileReference + PBXBuildFile entries and a new `Screens` PBXGroup under `Settings/v2/`.

## Out of scope (M-1b/c/d)

- M-1b: extract shared scaffolds + form components into `Components/`
- M-1c: final SettingsView trim if still > 400 lines after M-1b
- M-1d: case study + monitoring entry per the rule

Plan: [docs/superpowers/plans/2026-04-19-m1-settings-v3-decomposition.md](docs/superpowers/plans/2026-04-19-m1-settings-v3-decomposition.md)

## Test plan

- [x] `xcodebuild build` green
- [x] Test suite green for all Settings-related tests (pre-existing EncryptionService/Keychain failures are environmental, present on clean main)
- [ ] Manual: tap each of the 5 categories from Settings home — each detail screen renders identically
- [ ] Manual: deep-link `settings_review_destination` → DeleteAccount + ExportData routes still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)