### PR TITLE
refactor(settings): M-1c — extract home-view sub-components (UI-002)

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		SE100000000000000000AA06 /* DataSyncSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA06 /* DataSyncSettingsScreen.swift */; };
 		SE100000000000000000AC01 /* SettingsScaffolds.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AC01 /* SettingsScaffolds.swift */; };
 		SE100000000000000000AC02 /* SettingsFormComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AC02 /* SettingsFormComponents.swift */; };
+		SE100000000000000000AC04 /* SettingsHomeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AC04 /* SettingsHomeViews.swift */; };
 		DD000001000000000000AA01 /* AppDesignSystemComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000002000000000000AA01 /* AppDesignSystemComponents.swift */; };
 		DD000001000000000000AA02 /* DesignSystemCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000002000000000000AA02 /* DesignSystemCatalogView.swift */; };
 		DS000001000000000000AA01 /* AppPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS000002000000000000AA01 /* AppPalette.swift */; };
@@ -319,6 +320,7 @@
 		SE200000000000000000AA06 /* DataSyncSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSyncSettingsScreen.swift; sourceTree = "<group>"; };
 		SE200000000000000000AC01 /* SettingsScaffolds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScaffolds.swift; sourceTree = "<group>"; };
 		SE200000000000000000AC02 /* SettingsFormComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFormComponents.swift; sourceTree = "<group>"; };
+		SE200000000000000000AC04 /* SettingsHomeViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHomeViews.swift; sourceTree = "<group>"; };
 		B20000010000000000000002 /* FitTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FitTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC000002000000000000AA01 /* ReadinessCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadinessCard.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA02 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
@@ -865,6 +867,7 @@
 			children = (
 				SE200000000000000000AC01 /* SettingsScaffolds.swift */,
 				SE200000000000000000AC02 /* SettingsFormComponents.swift */,
+				SE200000000000000000AC04 /* SettingsHomeViews.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1131,6 +1134,7 @@
 				SE100000000000000000AA06 /* DataSyncSettingsScreen.swift in Sources */,
 				SE100000000000000000AC01 /* SettingsScaffolds.swift in Sources */,
 				SE100000000000000000AC02 /* SettingsFormComponents.swift in Sources */,
+				SE100000000000000000AC04 /* SettingsHomeViews.swift in Sources */,
 				DD000001000000000000AA01 /* AppDesignSystemComponents.swift in Sources */,
 				DD000001000000000000AA02 /* DesignSystemCatalogView.swift in Sources */,
 				DS000001000000000000AA01 /* AppPalette.swift in Sources */,

--- a/FitTracker/Views/Settings/v2/Components/SettingsHomeViews.swift
+++ b/FitTracker/Views/Settings/v2/Components/SettingsHomeViews.swift
@@ -1,0 +1,113 @@
+// FitTracker/Views/Settings/v2/Components/SettingsHomeViews.swift
+// Settings v2 — home-screen sub-components (header, category card, badge row, badge view).
+// Extracted from SettingsView.swift in Audit M-1c (UI-002 decomposition).
+
+import SwiftUI
+
+struct SettingsHomeHeader: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+            Text(title)
+                .font(AppText.hero)
+                .foregroundStyle(AppColor.Text.primary)
+
+            Text(subtitle)
+                .font(AppText.body)
+                .foregroundStyle(AppColor.Text.secondary)
+        }
+    }
+}
+
+struct SettingsCategoryCard: View {
+    let category: SettingsCategory
+    let summary: String
+    let badges: [SettingsSummaryBadge]
+    let featured: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
+            HStack(alignment: .top) {
+                Image(systemName: category.icon)
+                    .font(featured ? AppText.sectionTitle : AppText.callout)
+                    .foregroundStyle(category.tint)
+                    .frame(width: 34, height: 34)
+                    .background(category.tint.opacity(0.14), in: RoundedRectangle(cornerRadius: AppRadius.small))
+
+                Spacer(minLength: 12)
+
+                Image(systemName: "chevron.right")
+                    .font(AppText.captionStrong)
+                    .foregroundStyle(AppColor.Text.tertiary)
+            }
+
+            VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+                Text(category.title)
+                    .font(featured ? AppText.sectionTitle : AppText.button)
+                    .foregroundStyle(AppColor.Text.primary)
+                    .multilineTextAlignment(.leading)
+
+                Text(summary)
+                    .font(AppText.subheading)
+                    .foregroundStyle(AppColor.Text.secondary)
+                    .lineLimit(featured ? 2 : 3)
+                    .multilineTextAlignment(.leading)
+            }
+
+            if !badges.isEmpty {
+                FlexibleBadgeRow(badges: badges)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(featured ? AppSpacing.small : AppSpacing.small)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.large)
+                .fill(AppColor.Surface.elevated.opacity(featured ? 0.96 : 0.92))
+                .overlay(
+                    RoundedRectangle(cornerRadius: AppRadius.large)
+                        .stroke(AppColor.Border.subtle, lineWidth: 1)
+                )
+        )
+        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
+    }
+}
+
+struct FlexibleBadgeRow: View {
+    let badges: [SettingsSummaryBadge]
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: AppSpacing.xxSmall) {
+                ForEach(badges) { badge in
+                    SettingsBadgeView(badge: badge)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+                ForEach(badges) { badge in
+                    SettingsBadgeView(badge: badge)
+                }
+            }
+        }
+    }
+}
+
+struct SettingsBadgeView: View {
+    let badge: SettingsSummaryBadge
+
+    var body: some View {
+        HStack(spacing: AppSpacing.xxSmall) {
+            Circle()
+                .fill(badge.tint)
+                .frame(width: 6, height: 6)
+            Text(badge.title)
+                .font(AppText.captionStrong)
+        }
+        .foregroundStyle(badge.tint)
+        .padding(.horizontal, AppSpacing.xxSmall)
+        .padding(.vertical, AppSpacing.xxSmall)
+        .background(badge.tint.opacity(0.12), in: Capsule())
+    }
+}

--- a/FitTracker/Views/Settings/v2/SettingsView.swift
+++ b/FitTracker/Views/Settings/v2/SettingsView.swift
@@ -55,7 +55,7 @@ enum SettingsCategory: String, CaseIterable, Hashable, Identifiable {
     }
 }
 
-private struct SettingsSummaryBadge: Identifiable {
+struct SettingsSummaryBadge: Identifiable {
     let title: String
     let tint: Color
 
@@ -291,111 +291,4 @@ struct SettingsView: View {
     }
 }
 
-struct SettingsHomeHeader: View {
-    let title: String
-    let subtitle: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-            Text(title)
-                .font(AppText.hero)
-                .foregroundStyle(AppColor.Text.primary)
-
-            Text(subtitle)
-                .font(AppText.body)
-                .foregroundStyle(AppColor.Text.secondary)
-        }
-    }
-}
-
-private struct SettingsCategoryCard: View {
-    let category: SettingsCategory
-    let summary: String
-    let badges: [SettingsSummaryBadge]
-    let featured: Bool
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: AppSpacing.xSmall) {
-            HStack(alignment: .top) {
-                Image(systemName: category.icon)
-                    .font(featured ? AppText.sectionTitle : AppText.callout)
-                    .foregroundStyle(category.tint)
-                    .frame(width: 34, height: 34)
-                    .background(category.tint.opacity(0.14), in: RoundedRectangle(cornerRadius: AppRadius.small))
-
-                Spacer(minLength: 12)
-
-                Image(systemName: "chevron.right")
-                    .font(AppText.captionStrong)
-                    .foregroundStyle(AppColor.Text.tertiary)
-            }
-
-            VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-                Text(category.title)
-                    .font(featured ? AppText.sectionTitle : AppText.button)
-                    .foregroundStyle(AppColor.Text.primary)
-                    .multilineTextAlignment(.leading)
-
-                Text(summary)
-                    .font(AppText.subheading)
-                    .foregroundStyle(AppColor.Text.secondary)
-                    .lineLimit(featured ? 2 : 3)
-                    .multilineTextAlignment(.leading)
-            }
-
-            if !badges.isEmpty {
-                FlexibleBadgeRow(badges: badges)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(featured ? AppSpacing.small : AppSpacing.small)
-        .background(
-            RoundedRectangle(cornerRadius: AppRadius.large)
-                .fill(AppColor.Surface.elevated.opacity(featured ? 0.96 : 0.92))
-                .overlay(
-                    RoundedRectangle(cornerRadius: AppRadius.large)
-                        .stroke(AppColor.Border.subtle, lineWidth: 1)
-                )
-        )
-        .shadow(color: AppShadow.cardColor, radius: AppShadow.cardRadius, y: AppShadow.cardYOffset)
-    }
-}
-
-private struct FlexibleBadgeRow: View {
-    let badges: [SettingsSummaryBadge]
-
-    var body: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: AppSpacing.xxSmall) {
-                ForEach(badges) { badge in
-                    SettingsBadgeView(badge: badge)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-                ForEach(badges) { badge in
-                    SettingsBadgeView(badge: badge)
-                }
-            }
-        }
-    }
-}
-
-private struct SettingsBadgeView: View {
-    let badge: SettingsSummaryBadge
-
-    var body: some View {
-        HStack(spacing: AppSpacing.xxSmall) {
-            Circle()
-                .fill(badge.tint)
-                .frame(width: 6, height: 6)
-            Text(badge.title)
-                .font(AppText.captionStrong)
-        }
-        .foregroundStyle(badge.tint)
-        .padding(.horizontal, AppSpacing.xxSmall)
-        .padding(.vertical, AppSpacing.xxSmall)
-        .background(badge.tint.opacity(0.12), in: Capsule())
-    }
-}
 


### PR DESCRIPTION
## Summary

Audit M-1c — final structural pass on SettingsView.swift. Moves the home-screen sub-components into `Components/SettingsHomeViews.swift`. SettingsView is now a pure coordinator.

- `SettingsView.swift`: **401 → 294 lines** (~27% drop)
- Total across M-1a + M-1b + M-1c: **1170 → 294 lines (~75% reduction)**
- 1 new file under `Components/`, ~110 lines moved

## What changed

`Components/SettingsHomeViews.swift` (110 lines): `SettingsHomeHeader`, `SettingsCategoryCard`, `FlexibleBadgeRow`, `SettingsBadgeView`. `SettingsHomeHeader` was kept in SettingsView through M-1b for the scaffold's reuse — now grouped logically with the rest of the home views.

`SettingsSummaryBadge` bumped private → internal so `SettingsCategoryCard` can reach it from the new file. `project.pbxproj` updated with one PBXFileReference + PBXBuildFile entry.

## What stays in SettingsView.swift (294 lines)

- `SettingsCategory` enum (lines 1-56) — semantic types for the screen
- `SettingsSummaryBadge` (now internal, used by home views)
- `SettingsReviewDestination` (private, deep-link routing)
- `SettingsView` coordinator + review-destination helpers

This is the right size for the coordinator — no further decomposition needed. M-1c officially closes the structural decomposition phase.

## Phase status (per [the plan](docs/superpowers/plans/2026-04-19-m1-settings-v3-decomposition.md))

- ✅ M-1a (#122): 5 detail screens → `Screens/`
- ✅ M-1b (#123): scaffolds + form components → `Components/`
- ✅ M-1c (this PR): home-view sub-components → `Components/SettingsHomeViews.swift`
- ⏳ M-1d: case study + monitoring entry per the rule

## Test plan

- [x] `xcodebuild build` green
- [ ] Manual: Settings home renders with all 5 category cards + badges
- [ ] Manual: deep links to deleteAccount + exportData destinations still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)