### PR TITLE
refactor(nutrition): M-2 final — ViewModel + per-tab views (UI-004) [resubmit to main]

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -146,6 +146,11 @@
 		MS100000000000000000AA03 /* NutritionCameraSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA03 /* NutritionCameraSheet.swift */; };
 		MS100000000000000000AA04 /* BarcodeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA04 /* BarcodeScanner.swift */; };
 		MS100000000000000000AA05 /* MealEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA05 /* MealEntryViewModel.swift */; };
+		MS100000000000000000AA06 /* MealEntrySharedComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA06 /* MealEntrySharedComponents.swift */; };
+		MS100000000000000000AA07 /* SmartTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA07 /* SmartTabView.swift */; };
+		MS100000000000000000AA08 /* ManualTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA08 /* ManualTabView.swift */; };
+		MS100000000000000000AA09 /* TemplateTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA09 /* TemplateTabView.swift */; };
+		MS100000000000000000AA0A /* SearchTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA0A /* SearchTabView.swift */; };
 		CC000001000000000000AA0C /* RecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0C /* RecoverySupport.swift */; };
 		SE100000000000000000AA01 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA01 /* SettingsView.swift */; };
 		SE100000000000000000AA02 /* AccountSecuritySettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA02 /* AccountSecuritySettingsScreen.swift */; };
@@ -343,6 +348,11 @@
 		MS200000000000000000AA03 /* NutritionCameraSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionCameraSheet.swift; sourceTree = "<group>"; };
 		MS200000000000000000AA04 /* BarcodeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScanner.swift; sourceTree = "<group>"; };
 		MS200000000000000000AA05 /* MealEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealEntryViewModel.swift; sourceTree = "<group>"; };
+		MS200000000000000000AA06 /* MealEntrySharedComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealEntrySharedComponents.swift; sourceTree = "<group>"; };
+		MS200000000000000000AA07 /* SmartTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartTabView.swift; sourceTree = "<group>"; };
+		MS200000000000000000AA08 /* ManualTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualTabView.swift; sourceTree = "<group>"; };
+		MS200000000000000000AA09 /* TemplateTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateTabView.swift; sourceTree = "<group>"; };
+		MS200000000000000000AA0A /* SearchTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTabView.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA0C /* RecoverySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverySupport.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA0D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DD000002000000000000AA01 /* AppDesignSystemComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDesignSystemComponents.swift; sourceTree = "<group>"; };
@@ -712,8 +722,21 @@
 				MS400000000000000000AA01 /* Models */,
 				MS400000000000000000AA02 /* Parsing */,
 				MS400000000000000000AA03 /* Camera */,
+				MS400000000000000000AA04 /* Tabs */,
 			);
 			path = Nutrition;
+			sourceTree = "<group>";
+		};
+		MS400000000000000000AA04 /* Tabs */ = {
+			isa = PBXGroup;
+			children = (
+				MS200000000000000000AA06 /* MealEntrySharedComponents.swift */,
+				MS200000000000000000AA07 /* SmartTabView.swift */,
+				MS200000000000000000AA08 /* ManualTabView.swift */,
+				MS200000000000000000AA09 /* TemplateTabView.swift */,
+				MS200000000000000000AA0A /* SearchTabView.swift */,
+			);
+			path = Tabs;
 			sourceTree = "<group>";
 		};
 		MS400000000000000000AA01 /* Models */ = {
@@ -1167,6 +1190,11 @@
 				MS100000000000000000AA03 /* NutritionCameraSheet.swift in Sources */,
 				MS100000000000000000AA04 /* BarcodeScanner.swift in Sources */,
 				MS100000000000000000AA05 /* MealEntryViewModel.swift in Sources */,
+				MS100000000000000000AA06 /* MealEntrySharedComponents.swift in Sources */,
+				MS100000000000000000AA07 /* SmartTabView.swift in Sources */,
+				MS100000000000000000AA08 /* ManualTabView.swift in Sources */,
+				MS100000000000000000AA09 /* TemplateTabView.swift in Sources */,
+				MS100000000000000000AA0A /* SearchTabView.swift in Sources */,
 				CC000001000000000000AA0C /* RecoverySupport.swift in Sources */,
 				AC1000000000000000000010 /* DeleteAccountView.swift in Sources */,
 				AC1000000000000000000011 /* ExportDataView.swift in Sources */,

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		MS100000000000000000AA02 /* NutritionLabelParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA02 /* NutritionLabelParser.swift */; };
 		MS100000000000000000AA03 /* NutritionCameraSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA03 /* NutritionCameraSheet.swift */; };
 		MS100000000000000000AA04 /* BarcodeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA04 /* BarcodeScanner.swift */; };
+		MS100000000000000000AA05 /* MealEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MS200000000000000000AA05 /* MealEntryViewModel.swift */; };
 		CC000001000000000000AA0C /* RecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA0C /* RecoverySupport.swift */; };
 		SE100000000000000000AA01 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA01 /* SettingsView.swift */; };
 		SE100000000000000000AA02 /* AccountSecuritySettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE200000000000000000AA02 /* AccountSecuritySettingsScreen.swift */; };
@@ -341,6 +342,7 @@
 		MS200000000000000000AA02 /* NutritionLabelParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionLabelParser.swift; sourceTree = "<group>"; };
 		MS200000000000000000AA03 /* NutritionCameraSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionCameraSheet.swift; sourceTree = "<group>"; };
 		MS200000000000000000AA04 /* BarcodeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeScanner.swift; sourceTree = "<group>"; };
+		MS200000000000000000AA05 /* MealEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealEntryViewModel.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA0C /* RecoverySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverySupport.swift; sourceTree = "<group>"; };
 		CC000002000000000000AA0D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DD000002000000000000AA01 /* AppDesignSystemComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDesignSystemComponents.swift; sourceTree = "<group>"; };
@@ -704,6 +706,7 @@
 				CC000002000000000000AA09 /* MacroTargetBar.swift */,
 				CC000002000000000000AA0A /* MealSectionView.swift */,
 				CC000002000000000000AA0B /* MealEntrySheet.swift */,
+				MS200000000000000000AA05 /* MealEntryViewModel.swift */,
 				NV400000000000000000AA01 /* v2 */,
 				NV400000000000000000AA02 /* Components */,
 				MS400000000000000000AA01 /* Models */,
@@ -1163,6 +1166,7 @@
 				MS100000000000000000AA02 /* NutritionLabelParser.swift in Sources */,
 				MS100000000000000000AA03 /* NutritionCameraSheet.swift in Sources */,
 				MS100000000000000000AA04 /* BarcodeScanner.swift in Sources */,
+				MS100000000000000000AA05 /* MealEntryViewModel.swift in Sources */,
 				CC000001000000000000AA0C /* RecoverySupport.swift in Sources */,
 				AC1000000000000000000010 /* DeleteAccountView.swift in Sources */,
 				AC1000000000000000000011 /* ExportDataView.swift in Sources */,

--- a/FitTracker/Views/Nutrition/MealEntrySheet.swift
+++ b/FitTracker/Views/Nutrition/MealEntrySheet.swift
@@ -1,9 +1,9 @@
 // Views/Nutrition/MealEntrySheet.swift
 // Sheet presented when the user taps a meal slot.
-// Three tabs: Manual entry, Template picker, Food search (text + barcode).
+// Four tabs: Smart capture, Manual entry, Template picker, Food search (text + barcode).
+// State + business logic live in MealEntryViewModel (Audit M-2c).
 
 import SwiftUI
-import Vision
 #if canImport(PhotosUI)
 import PhotosUI
 #endif
@@ -32,50 +32,13 @@ struct MealEntrySheet: View {
     let onSave: (MealEntry) -> Void
     @Environment(\.dismiss) var dismiss
 
-    @State private var activeTab: MealEntryTab = .smart
-
-    // Manual tab fields
-    @State private var name:     String = ""
-    @State private var calories: String = ""
-    @State private var proteinG: String = ""
-    @State private var carbsG:   String = ""
-    @State private var fatG:     String = ""
-    @State private var servingGrams: String = ""
-    @State private var referenceGrams: String = "100"
-    @State private var sourceDetails: String = ""
-
-    // Smart label parsing
-    @State private var rawLabelText: String = ""
-    @State private var parsedLabel: ParsedNutritionLabel?
-    @State private var smartStatus: String?
-    @State private var smartError: String?
-
-    // Template save confirmation
-    @State private var savedTemplate = false
-
-    // Search tab
-    // Audit UI-017: search state + async network logic moved to
-    // FoodSearchService (in Services/). Only the user-input text binding
-    // (searchQuery) stays in the view — that's pure UI state.
-    @State private var searchQuery: String = ""
+    @StateObject private var vm = MealEntryViewModel()
     @StateObject private var foodSearch = FoodSearchService()
 
-    // Barcode scanner
-    @State private var showScanner: Bool = false
-    #if canImport(UIKit)
-    @State private var showCameraCapture = false
-    @State private var selectedImagePreview: UIImage?
-    #endif
-    #if canImport(PhotosUI)
-    @State private var selectedPhotoItem: PhotosPickerItem?
-    #endif
-
-    // ── Initialise fields from the binding on appear ──────
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                // Tab picker
-                Picker("Meal entry method", selection: $activeTab) {
+                Picker("Meal entry method", selection: $vm.activeTab) {
                     ForEach(MealEntryTab.allCases, id: \.self) { tab in
                         Text(tab.rawValue).tag(tab)
                     }
@@ -88,9 +51,8 @@ struct MealEntrySheet: View {
 
                 Divider()
 
-                // Tab content
                 Group {
-                    switch activeTab {
+                    switch vm.activeTab {
                     case .smart:    smartTab
                     case .manual:   manualTab
                     case .template: templateTab
@@ -107,34 +69,27 @@ struct MealEntrySheet: View {
                 }
             }
             .onAppear {
-                name     = entry.name
-                calories = entry.calories.map { String($0) } ?? ""
-                proteinG = entry.proteinG.map  { String($0) } ?? ""
-                carbsG   = entry.carbsG.map    { String($0) } ?? ""
-                fatG     = entry.fatG.map      { String($0) } ?? ""
-                servingGrams = entry.servingGrams.map { formatNum($0) } ?? ""
-                referenceGrams = entry.labelReferenceGrams.map { formatNum($0) } ?? "100"
-                sourceDetails = entry.sourceDetails
-                rawLabelText = entry.source == .photoLabel ? entry.sourceDetails : ""
+                vm.onSourceChange = { newSource in entry.source = newSource }
+                vm.loadFromEntry(entry)
             }
         }
         #if os(iOS)
-        .sheet(isPresented: $showScanner) {
+        .sheet(isPresented: $vm.showScanner) {
             BarcodeScannerSheet { barcode in
-                showScanner = false
+                vm.showScanner = false
                 fetchProduct(barcode: barcode)
             }
         }
-        .sheet(isPresented: $showCameraCapture) {
+        .sheet(isPresented: $vm.showCameraCapture) {
             NutritionCameraSheet { image in
-                showCameraCapture = false
-                processNutritionImage(image)
+                vm.showCameraCapture = false
+                vm.processNutritionImage(image)
             }
         }
         #if canImport(PhotosUI)
-        .onChange(of: selectedPhotoItem) { _, newItem in
+        .onChange(of: vm.selectedPhotoItem) { _, newItem in
             guard let newItem else { return }
-            Task { await loadSelectedPhoto(newItem) }
+            Task { await vm.loadSelectedPhoto(newItem) }
         }
         #endif
         #endif
@@ -156,7 +111,7 @@ struct MealEntrySheet: View {
                 }
 
                 #if canImport(UIKit)
-                if let selectedImagePreview {
+                if let selectedImagePreview = vm.selectedImagePreview {
                     Image(uiImage: selectedImagePreview)
                         .resizable()
                         .scaledToFill()
@@ -173,7 +128,7 @@ struct MealEntrySheet: View {
                 HStack(spacing: AppSpacing.xxSmall) {
                     #if canImport(UIKit)
                     Button {
-                        showCameraCapture = true
+                        vm.showCameraCapture = true
                     } label: {
                         smartActionLabel("Take Label Photo", systemImage: "camera.fill", tint: AppColor.Accent.recovery)
                     }
@@ -181,7 +136,7 @@ struct MealEntrySheet: View {
                     #endif
 
                     #if canImport(PhotosUI)
-                    PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                    PhotosPicker(selection: $vm.selectedPhotoItem, matching: .images) {
                         smartActionLabel("Choose Photo", systemImage: "photo.fill", tint: AppColor.Brand.warm)
                     }
                     .buttonStyle(.plain)
@@ -192,7 +147,7 @@ struct MealEntrySheet: View {
                     Text("Nutrition Text")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(AppColor.Text.secondary)
-                    TextEditor(text: $rawLabelText)
+                    TextEditor(text: $vm.rawLabelText)
                         .frame(minHeight: 140)
                         .padding(AppSpacing.xxSmall)
                         .background(AppColor.Text.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: AppRadius.small))
@@ -202,24 +157,24 @@ struct MealEntrySheet: View {
                 }
 
                 HStack(spacing: AppSpacing.xSmall) {
-                    manualField(label: "Consumed weight (g)", placeholder: "e.g. 100", text: $servingGrams, isNumeric: true)
-                    manualField(label: "Label reference (g)", placeholder: "100", text: $referenceGrams, isNumeric: true)
+                    manualField(label: "Consumed weight (g)", placeholder: "e.g. 100", text: $vm.servingGrams, isNumeric: true)
+                    manualField(label: "Label reference (g)", placeholder: "100", text: $vm.referenceGrams, isNumeric: true)
                 }
 
-                if let smartStatus {
+                if let smartStatus = vm.smartStatus {
                     Label(smartStatus, systemImage: "checkmark.circle.fill")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(AppColor.Status.success)
                 }
 
-                if let smartError {
+                if let smartError = vm.smartError {
                     Label(smartError, systemImage: "exclamationmark.triangle.fill")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(AppColor.Status.error)
                 }
 
                 Button {
-                    parseSmartLabel()
+                    vm.parseSmartLabel()
                 } label: {
                     Text("Parse and Apply")
                         .font(AppText.button)
@@ -231,7 +186,7 @@ struct MealEntrySheet: View {
                 }
                 .buttonStyle(.plain)
 
-                if let parsedLabel {
+                if let parsedLabel = vm.parsedLabel {
                     VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
                         Text("Parsed Per \(Int(parsedLabel.referenceGrams))g")
                             .font(.caption.weight(.semibold))
@@ -261,22 +216,20 @@ struct MealEntrySheet: View {
         ScrollView {
             VStack(spacing: AppSpacing.small) {
                 Group {
-                    manualField(label: "Meal name",       placeholder: "e.g. Chicken & Rice", text: $name)
-                    manualField(label: "Calories (kcal)", placeholder: "e.g. 500",            text: $calories, isNumeric: true)
-                    manualField(label: "Protein (g)",     placeholder: "e.g. 40",             text: $proteinG, isNumeric: true)
-                    manualField(label: "Carbs (g)",       placeholder: "e.g. 60",             text: $carbsG,   isNumeric: true)
-                    manualField(label: "Fat (g)",         placeholder: "e.g. 15",             text: $fatG,     isNumeric: true)
+                    manualField(label: "Meal name",       placeholder: "e.g. Chicken & Rice", text: $vm.name)
+                    manualField(label: "Calories (kcal)", placeholder: "e.g. 500",            text: $vm.calories, isNumeric: true)
+                    manualField(label: "Protein (g)",     placeholder: "e.g. 40",             text: $vm.proteinG, isNumeric: true)
+                    manualField(label: "Carbs (g)",       placeholder: "e.g. 60",             text: $vm.carbsG,   isNumeric: true)
+                    manualField(label: "Fat (g)",         placeholder: "e.g. 15",             text: $vm.fatG,     isNumeric: true)
                 }
                 .padding(.horizontal, AppSpacing.small)
 
-                // Buttons
                 VStack(spacing: AppSpacing.xSmall) {
-                    // Save as Template
                     Button {
                         saveAsTemplate()
                     } label: {
                         HStack {
-                            if savedTemplate {
+                            if vm.savedTemplate {
                                 Image(systemName: "checkmark")
                                     .foregroundStyle(AppColor.Status.success)
                                 Text("Saved!")
@@ -295,7 +248,7 @@ struct MealEntrySheet: View {
                                 .stroke(AppColor.Border.subtle, lineWidth: 1)
                         )
                     }
-                    .disabled(name.isEmpty)
+                    .disabled(vm.name.isEmpty)
 
                     AppButton(
                         title: "Log",
@@ -303,7 +256,7 @@ struct MealEntrySheet: View {
                     ) {
                         logMeal()
                     }
-                    .disabled(name.isEmpty)
+                    .disabled(vm.name.isEmpty)
                 }
                 .padding(.horizontal, AppSpacing.small)
                 .padding(.top, AppSpacing.xxSmall)
@@ -345,7 +298,7 @@ struct MealEntrySheet: View {
                 List {
                     ForEach(dataStore.mealTemplates) { template in
                         Button {
-                            fillFromTemplate(template)
+                            vm.fillFromTemplate(template)
                         } label: {
                             VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
                                 Text(template.name)
@@ -381,11 +334,10 @@ struct MealEntrySheet: View {
 
     private var searchTab: some View {
         VStack(spacing: 0) {
-            // Search bar
             VStack(spacing: AppSpacing.xxSmall) {
                 HStack(spacing: AppSpacing.xxSmall) {
                     AppInputShell {
-                        TextField("Search food…", text: $searchQuery)
+                        TextField("Search food…", text: $vm.searchQuery)
                             .font(AppText.body)
                             .foregroundStyle(AppColor.Text.primary)
                             .submitLabel(.search)
@@ -400,7 +352,7 @@ struct MealEntrySheet: View {
                     ) {
                         runTextSearch()
                     }
-                    .disabled(searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || foodSearch.isSearching)
+                    .disabled(vm.searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || foodSearch.isSearching)
                 }
 
                 #if os(iOS)
@@ -409,7 +361,7 @@ struct MealEntrySheet: View {
                     systemImage: "barcode.viewfinder",
                     tint: AppColor.Accent.sleep
                 ) {
-                    showScanner = true
+                    vm.showScanner = true
                 }
                 #endif
 
@@ -430,7 +382,6 @@ struct MealEntrySheet: View {
 
             Divider()
 
-            // Results
             if foodSearch.searchResults.isEmpty && !foodSearch.isSearching {
                 Spacer()
                 EmptyStateView(
@@ -447,7 +398,7 @@ struct MealEntrySheet: View {
             } else {
                 List(foodSearch.searchResults) { product in
                     Button {
-                        fillFromProduct(product)
+                        vm.fillFromProduct(product)
                     } label: {
                         VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
                             Text(product.name.isEmpty ? "Unknown product" : product.name)
@@ -479,175 +430,8 @@ struct MealEntrySheet: View {
     }
 
     // ─────────────────────────────────────────────────────
-    // MARK: – Actions
+    // MARK: – View helpers
     // ─────────────────────────────────────────────────────
-
-    private func saveAsTemplate() {
-        let template = MealTemplate(
-            name:     name,
-            calories: Double(calories),
-            proteinG: Double(proteinG),
-            carbsG:   Double(carbsG),
-            fatG:     Double(fatG)
-        )
-        dataStore.mealTemplates.append(template)
-        Task { await dataStore.persistToDisk() }
-
-        savedTemplate = true
-        Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
-            await MainActor.run { savedTemplate = false }
-        }
-    }
-
-    private func logMeal() {
-        entry.name     = name
-        entry.calories = Double(calories)
-        entry.proteinG = Double(proteinG)
-        entry.carbsG   = Double(carbsG)
-        entry.fatG     = Double(fatG)
-        entry.servingGrams = Double(servingGrams)
-        entry.labelReferenceGrams = Double(referenceGrams)
-        entry.sourceDetails = sourceDetails
-        entry.eatenAt  = Date()
-        entry.status   = .completed
-        onSave(entry)
-        dismiss()
-    }
-
-    private func fillFromTemplate(_ template: MealTemplate) {
-        name     = template.name
-        calories = template.calories.map { formatNum($0) } ?? ""
-        proteinG = template.proteinG.map  { formatNum($0) } ?? ""
-        carbsG   = template.carbsG.map    { formatNum($0) } ?? ""
-        fatG     = template.fatG.map      { formatNum($0) } ?? ""
-        entry.source = .template
-        sourceDetails = "Saved template"
-        activeTab = .manual
-    }
-
-    private func fillFromProduct(_ product: FoodProduct) {
-        name     = product.name.isEmpty ? searchQuery : product.name
-        calories = product.caloriesPer100g.map { formatNum($0) } ?? ""
-        proteinG = product.proteinPer100g.map   { formatNum($0) } ?? ""
-        carbsG   = product.carbsPer100g.map     { formatNum($0) } ?? ""
-        fatG     = product.fatPer100g.map       { formatNum($0) } ?? ""
-        referenceGrams = formatNum(product.referenceGrams)
-        servingGrams = servingGrams.isEmpty ? formatNum(product.referenceGrams) : servingGrams
-        entry.source = product.source
-        sourceDetails = product.sourceDescription
-        activeTab = .manual
-    }
-
-    private func deleteTemplates(at offsets: IndexSet) {
-        dataStore.mealTemplates.remove(atOffsets: offsets)
-        Task { await dataStore.persistToDisk() }
-    }
-
-    private func formatNum(_ v: Double) -> String {
-        v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
-    }
-
-    private func parseSmartLabel() {
-        smartError = nil
-        smartStatus = nil
-
-        guard let parsed = NutritionLabelParser.parse(rawLabelText, fallbackReferenceGrams: Double(referenceGrams) ?? 100) else {
-            smartError = "I couldn’t parse the label yet. Try a clearer photo or paste the nutrition lines."
-            return
-        }
-
-        parsedLabel = parsed
-        referenceGrams = formatNum(parsed.referenceGrams)
-        applyParsedLabel(parsed)
-        entry.source = .photoLabel
-        sourceDetails = rawLabelText
-        smartStatus = parsed.detectedLanguageHint == .hebrew
-            ? "Hebrew nutrition text parsed successfully."
-            : "Nutrition label applied successfully."
-        activeTab = .manual
-    }
-
-    private func applyParsedLabel(_ parsed: ParsedNutritionLabel) {
-        let consumedGrams = Double(servingGrams) ?? parsed.referenceGrams
-        servingGrams = formatNum(consumedGrams)
-        let scale = max(consumedGrams, 1) / max(parsed.referenceGrams, 1)
-
-        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            name = parsed.nameHint ?? name
-        }
-
-        calories = parsed.calories.map { formatNum($0 * scale) } ?? calories
-        proteinG = parsed.proteinG.map { formatNum($0 * scale) } ?? proteinG
-        carbsG = parsed.carbsG.map { formatNum($0 * scale) } ?? carbsG
-        fatG = parsed.fatG.map { formatNum($0 * scale) } ?? fatG
-    }
-
-    #if canImport(UIKit)
-    private func processNutritionImage(_ image: UIImage) {
-        selectedImagePreview = image
-        smartError = nil
-        smartStatus = "Reading nutrition label…"
-
-        guard let cgImage = image.cgImage else {
-            smartStatus = nil
-            smartError = "That image could not be processed."
-            return
-        }
-
-        let request = VNRecognizeTextRequest { request, error in
-            DispatchQueue.main.async {
-                if let error {
-                    smartStatus = nil
-                    smartError = "Photo scan failed: \(error.localizedDescription)"
-                    return
-                }
-
-                let lines = (request.results as? [VNRecognizedTextObservation])?
-                    .compactMap { $0.topCandidates(1).first?.string }
-                    .joined(separator: "\n") ?? ""
-
-                rawLabelText = lines
-                parseSmartLabel()
-            }
-        }
-        request.recognitionLevel = .accurate
-        request.usesLanguageCorrection = true
-        if #available(iOS 16.0, macOS 13.0, *) {
-            request.automaticallyDetectsLanguage = true
-        }
-        if let languages = try? request.supportedRecognitionLanguages() {
-            let preferred = ["en-US", "he-IL", "ar-SA"]
-            request.recognitionLanguages = preferred.filter { languages.contains($0) }
-        }
-
-        Task.detached(priority: .userInitiated) {
-            do {
-                try VNImageRequestHandler(cgImage: cgImage, options: [:]).perform([request])
-            } catch {
-                await MainActor.run {
-                    smartStatus = nil
-                    smartError = "Photo scan failed: \(error.localizedDescription)"
-                }
-            }
-        }
-    }
-
-    #if canImport(PhotosUI)
-    private func loadSelectedPhoto(_ item: PhotosPickerItem) async {
-        do {
-            guard let data = try await item.loadTransferable(type: Data.self),
-                  let image = UIImage(data: data) else {
-                await MainActor.run { smartError = "That photo could not be opened." }
-                return
-            }
-            await MainActor.run { processNutritionImage(image) }
-        } catch {
-            await MainActor.run { smartError = "Photo import failed: \(error.localizedDescription)" }
-        }
-    }
-    #endif
-    #endif
 
     private func smartActionLabel(_ title: String, systemImage: String, tint: Color) -> some View {
         HStack(spacing: AppSpacing.xxSmall) {
@@ -666,11 +450,39 @@ struct MealEntrySheet: View {
             Text(title)
                 .font(.caption2)
                 .foregroundStyle(AppColor.Text.secondary)
-            Text(value.map { formatNum($0) } ?? "—")
+            Text(value.map { vm.formatNum($0) } ?? "—")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(tint)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Bridge actions (entry / dataStore / dismiss)
+    // ─────────────────────────────────────────────────────
+
+    private func saveAsTemplate() {
+        let template = MealTemplate(
+            name:     vm.name,
+            calories: Double(vm.calories),
+            proteinG: Double(vm.proteinG),
+            carbsG:   Double(vm.carbsG),
+            fatG:     Double(vm.fatG)
+        )
+        dataStore.mealTemplates.append(template)
+        Task { await dataStore.persistToDisk() }
+        vm.confirmTemplateSaved()
+    }
+
+    private func logMeal() {
+        vm.writeBack(into: &entry)
+        onSave(entry)
+        dismiss()
+    }
+
+    private func deleteTemplates(at offsets: IndexSet) {
+        dataStore.mealTemplates.remove(atOffsets: offsets)
+        Task { await dataStore.persistToDisk() }
     }
 
     // ─────────────────────────────────────────────────────
@@ -680,14 +492,14 @@ struct MealEntrySheet: View {
     // ─────────────────────────────────────────────────────
 
     private func runTextSearch() {
-        Task { await foodSearch.search(query: searchQuery) }
+        Task { await foodSearch.search(query: vm.searchQuery) }
     }
 
     private func fetchProduct(barcode: String) {
-        activeTab = .search
+        vm.activeTab = .search
         Task {
             if let product = await foodSearch.fetchProduct(barcode: barcode) {
-                fillFromProduct(product)
+                vm.fillFromProduct(product)
             }
         }
     }

--- a/FitTracker/Views/Nutrition/MealEntrySheet.swift
+++ b/FitTracker/Views/Nutrition/MealEntrySheet.swift
@@ -1,15 +1,10 @@
 // Views/Nutrition/MealEntrySheet.swift
 // Sheet presented when the user taps a meal slot.
-// Four tabs: Smart capture, Manual entry, Template picker, Food search (text + barcode).
-// State + business logic live in MealEntryViewModel (Audit M-2c).
+// Four tabs (each its own View struct under Tabs/): Smart, Manual, Template, Search.
+// State + business logic in MealEntryViewModel (M-2c). This file is the
+// coordinator: tab switch + sheets + bridge actions to dataStore / onSave / dismiss.
 
 import SwiftUI
-#if canImport(PhotosUI)
-import PhotosUI
-#endif
-#if canImport(UIKit)
-import UIKit
-#endif
 
 // ─────────────────────────────────────────────────────────
 // MARK: – Tab enum
@@ -53,10 +48,14 @@ struct MealEntrySheet: View {
 
                 Group {
                     switch vm.activeTab {
-                    case .smart:    smartTab
-                    case .manual:   manualTab
-                    case .template: templateTab
-                    case .search:   searchTab
+                    case .smart:
+                        SmartTabView(vm: vm)
+                    case .manual:
+                        ManualTabView(vm: vm, onSaveAsTemplate: saveAsTemplate, onLog: logMeal)
+                    case .template:
+                        TemplateTabView(vm: vm, onDelete: deleteTemplates)
+                    case .search:
+                        SearchTabView(vm: vm, foodSearch: foodSearch, onTextSearch: runTextSearch)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -96,369 +95,7 @@ struct MealEntrySheet: View {
     }
 
     // ─────────────────────────────────────────────────────
-    // MARK: – Smart Tab
-    // ─────────────────────────────────────────────────────
-
-    private var smartTab: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: AppSpacing.large) {
-                VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-                    Text("Smart Nutrition Capture")
-                        .font(AppText.sectionTitle)
-                    Text("Scan a nutrition label, paste English or Hebrew nutrition text, then scale it to the weight you actually ate.")
-                        .font(AppText.caption)
-                        .foregroundStyle(AppColor.Text.secondary)
-                }
-
-                #if canImport(UIKit)
-                if let selectedImagePreview = vm.selectedImagePreview {
-                    Image(uiImage: selectedImagePreview)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(height: 150)
-                        .frame(maxWidth: .infinity)
-                        .clipShape(RoundedRectangle(cornerRadius: AppRadius.medium))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppRadius.medium)
-                                .stroke(AppColor.Border.subtle, lineWidth: 1)
-                        )
-                }
-                #endif
-
-                HStack(spacing: AppSpacing.xxSmall) {
-                    #if canImport(UIKit)
-                    Button {
-                        vm.showCameraCapture = true
-                    } label: {
-                        smartActionLabel("Take Label Photo", systemImage: "camera.fill", tint: AppColor.Accent.recovery)
-                    }
-                    .buttonStyle(.plain)
-                    #endif
-
-                    #if canImport(PhotosUI)
-                    PhotosPicker(selection: $vm.selectedPhotoItem, matching: .images) {
-                        smartActionLabel("Choose Photo", systemImage: "photo.fill", tint: AppColor.Brand.warm)
-                    }
-                    .buttonStyle(.plain)
-                    #endif
-                }
-
-                VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-                    Text("Nutrition Text")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(AppColor.Text.secondary)
-                    TextEditor(text: $vm.rawLabelText)
-                        .frame(minHeight: 140)
-                        .padding(AppSpacing.xxSmall)
-                        .background(AppColor.Text.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: AppRadius.small))
-                    Text("Hebrew and English keywords are parsed here. Photos use Apple Vision OCR first, then this parser scales the label to your consumed weight. If a Hebrew label photo doesn’t scan cleanly, paste the label text here and the parser still works.")
-                        .font(.caption2)
-                        .foregroundStyle(AppColor.Text.secondary)
-                }
-
-                HStack(spacing: AppSpacing.xSmall) {
-                    manualField(label: "Consumed weight (g)", placeholder: "e.g. 100", text: $vm.servingGrams, isNumeric: true)
-                    manualField(label: "Label reference (g)", placeholder: "100", text: $vm.referenceGrams, isNumeric: true)
-                }
-
-                if let smartStatus = vm.smartStatus {
-                    Label(smartStatus, systemImage: "checkmark.circle.fill")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(AppColor.Status.success)
-                }
-
-                if let smartError = vm.smartError {
-                    Label(smartError, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(AppColor.Status.error)
-                }
-
-                Button {
-                    vm.parseSmartLabel()
-                } label: {
-                    Text("Parse and Apply")
-                        .font(AppText.button)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, AppSpacing.xSmall)
-                        .background(AppColor.Accent.recovery, in: RoundedRectangle(cornerRadius: AppRadius.small))
-                        // Audit UI-012: token instead of raw .white literal
-                        .foregroundStyle(AppColor.Text.inversePrimary)
-                }
-                .buttonStyle(.plain)
-
-                if let parsedLabel = vm.parsedLabel {
-                    VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-                        Text("Parsed Per \(Int(parsedLabel.referenceGrams))g")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(AppColor.Text.secondary)
-                        HStack(spacing: AppSpacing.xSmall) {
-                            parsedMetric("kcal", parsedLabel.calories, tint: AppColor.Brand.warm)
-                            parsedMetric("Protein", parsedLabel.proteinG, tint: AppColor.Accent.recovery)
-                            parsedMetric("Carbs", parsedLabel.carbsG, tint: AppColor.Brand.warmSoft)
-                            parsedMetric("Fat", parsedLabel.fatG, tint: AppColor.Chart.nutritionFat)
-                        }
-                    }
-                    .padding(AppSpacing.xSmall)
-                    .background(AppColor.Surface.materialStrong, in: RoundedRectangle(cornerRadius: AppRadius.medium))
-                }
-            }
-            .padding(.horizontal, AppSpacing.small)
-            .padding(.top, AppSpacing.small)
-            .padding(.bottom, AppSpacing.xLarge)
-        }
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Manual Tab
-    // ─────────────────────────────────────────────────────
-
-    private var manualTab: some View {
-        ScrollView {
-            VStack(spacing: AppSpacing.small) {
-                Group {
-                    manualField(label: "Meal name",       placeholder: "e.g. Chicken & Rice", text: $vm.name)
-                    manualField(label: "Calories (kcal)", placeholder: "e.g. 500",            text: $vm.calories, isNumeric: true)
-                    manualField(label: "Protein (g)",     placeholder: "e.g. 40",             text: $vm.proteinG, isNumeric: true)
-                    manualField(label: "Carbs (g)",       placeholder: "e.g. 60",             text: $vm.carbsG,   isNumeric: true)
-                    manualField(label: "Fat (g)",         placeholder: "e.g. 15",             text: $vm.fatG,     isNumeric: true)
-                }
-                .padding(.horizontal, AppSpacing.small)
-
-                VStack(spacing: AppSpacing.xSmall) {
-                    Button {
-                        saveAsTemplate()
-                    } label: {
-                        HStack {
-                            if vm.savedTemplate {
-                                Image(systemName: "checkmark")
-                                    .foregroundStyle(AppColor.Status.success)
-                                Text("Saved!")
-                                    .foregroundStyle(AppColor.Status.success)
-                            } else {
-                                Image(systemName: "square.and.arrow.down")
-                                Text("Save as Template")
-                            }
-                        }
-                        .font(AppText.body)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, AppSpacing.xSmall)
-                        .background(AppColor.Surface.elevated, in: RoundedRectangle(cornerRadius: AppRadius.medium, style: .continuous))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: AppRadius.medium, style: .continuous)
-                                .stroke(AppColor.Border.subtle, lineWidth: 1)
-                        )
-                    }
-                    .disabled(vm.name.isEmpty)
-
-                    AppButton(
-                        title: "Log",
-                        hierarchy: .primary
-                    ) {
-                        logMeal()
-                    }
-                    .disabled(vm.name.isEmpty)
-                }
-                .padding(.horizontal, AppSpacing.small)
-                .padding(.top, AppSpacing.xxSmall)
-            }
-            .padding(.top, AppSpacing.small)
-            .padding(.bottom, AppSpacing.xLarge)
-        }
-    }
-
-    @ViewBuilder
-    private func manualField(label: String, placeholder: String, text: Binding<String>, isNumeric: Bool = false) -> some View {
-        VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
-            AppFieldLabel(title: label)
-            AppInputShell {
-                TextField(placeholder, text: text)
-                    .font(AppText.body)
-                    .foregroundStyle(AppColor.Text.primary)
-                    #if canImport(UIKit)
-                    .keyboardType(isNumeric ? .decimalPad : .default)
-                    #endif
-            }
-        }
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Template Tab
-    // ─────────────────────────────────────────────────────
-
-    private var templateTab: some View {
-        Group {
-            if dataStore.mealTemplates.isEmpty {
-                EmptyStateView(
-                    icon: "doc.text",
-                    title: "No Templates Yet",
-                    subtitle: "Save a meal from the Manual tab to reuse it here."
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                List {
-                    ForEach(dataStore.mealTemplates) { template in
-                        Button {
-                            vm.fillFromTemplate(template)
-                        } label: {
-                            VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
-                                Text(template.name)
-                                    .font(AppText.body)
-                                    .foregroundStyle(AppColor.Text.primary)
-                                HStack(spacing: AppSpacing.xxSmall) {
-                                    if let cal = template.calories {
-                                        Text("\(Int(cal)) kcal")
-                                            .font(AppText.caption)
-                                            .foregroundStyle(AppColor.Accent.achievement)
-                                    }
-                                    if let pro = template.proteinG {
-                                        Text("\(Int(pro))g protein")
-                                            .font(AppText.caption)
-                                            .foregroundStyle(AppColor.Accent.recovery)
-                                    }
-                                }
-                            }
-                            .padding(.vertical, AppSpacing.xxxSmall)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    .onDelete { offsets in deleteTemplates(at: offsets) }
-                }
-                .listStyle(.plain)
-            }
-        }
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Search Tab
-    // ─────────────────────────────────────────────────────
-
-    private var searchTab: some View {
-        VStack(spacing: 0) {
-            VStack(spacing: AppSpacing.xxSmall) {
-                HStack(spacing: AppSpacing.xxSmall) {
-                    AppInputShell {
-                        TextField("Search food…", text: $vm.searchQuery)
-                            .font(AppText.body)
-                            .foregroundStyle(AppColor.Text.primary)
-                            .submitLabel(.search)
-                            .onSubmit { runTextSearch() }
-                    }
-
-                    AppButton(
-                        title: "",
-                        systemImage: foodSearch.isSearching ? "clock" : "magnifyingglass",
-                        hierarchy: .primary,
-                        isFullWidth: false
-                    ) {
-                        runTextSearch()
-                    }
-                    .disabled(vm.searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || foodSearch.isSearching)
-                }
-
-                #if os(iOS)
-                AppQuietButton(
-                    title: "Scan Barcode",
-                    systemImage: "barcode.viewfinder",
-                    tint: AppColor.Accent.sleep
-                ) {
-                    vm.showScanner = true
-                }
-                #endif
-
-                if let error = foodSearch.searchError {
-                    HStack(spacing: AppSpacing.xxSmall) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(AppColor.Status.error)
-                        Text(error)
-                            .font(AppText.caption)
-                            .foregroundStyle(AppColor.Status.error)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
-            .padding(.horizontal, AppSpacing.small)
-            .padding(.top, AppSpacing.xSmall)
-            .padding(.bottom, AppSpacing.xxSmall)
-
-            Divider()
-
-            if foodSearch.searchResults.isEmpty && !foodSearch.isSearching {
-                Spacer()
-                EmptyStateView(
-                    icon: "magnifyingglass",
-                    title: "Search for food",
-                    subtitle: "Type a food name above or scan a barcode to find nutrition data."
-                )
-                Spacer()
-            } else if foodSearch.isSearching {
-                Spacer()
-                ProgressView("Searching…")
-                    .font(AppText.subheading)
-                Spacer()
-            } else {
-                List(foodSearch.searchResults) { product in
-                    Button {
-                        vm.fillFromProduct(product)
-                    } label: {
-                        VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
-                            Text(product.name.isEmpty ? "Unknown product" : product.name)
-                                .font(AppText.body)
-                                .foregroundStyle(AppColor.Text.primary)
-                            HStack(spacing: AppSpacing.xxSmall) {
-                                if let cal = product.caloriesPer100g {
-                                    Text("\(Int(cal)) kcal/100g")
-                                        .font(AppText.caption)
-                                        .foregroundStyle(AppColor.Accent.achievement)
-                                }
-                                if let pro = product.proteinPer100g {
-                                    Text("\(Int(pro))g prot")
-                                        .font(AppText.caption)
-                                        .foregroundColor(AppColor.Accent.recovery)
-                                }
-                            }
-                            Text(product.sourceDescription)
-                                .font(.caption2)
-                                .foregroundStyle(AppColor.Text.secondary)
-                        }
-                        .padding(.vertical, AppSpacing.xxxSmall)
-                    }
-                    .buttonStyle(.plain)
-                }
-                .listStyle(.plain)
-            }
-        }
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – View helpers
-    // ─────────────────────────────────────────────────────
-
-    private func smartActionLabel(_ title: String, systemImage: String, tint: Color) -> some View {
-        HStack(spacing: AppSpacing.xxSmall) {
-            Image(systemName: systemImage)
-            Text(title)
-        }
-        .font(.caption.weight(.semibold))
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, AppSpacing.xSmall)
-        .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: AppRadius.small))
-        .foregroundStyle(tint)
-    }
-
-    private func parsedMetric(_ title: String, _ value: Double?, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: AppSpacing.micro) {
-            Text(title)
-                .font(.caption2)
-                .foregroundStyle(AppColor.Text.secondary)
-            Text(value.map { vm.formatNum($0) } ?? "—")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(tint)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // ─────────────────────────────────────────────────────
-    // MARK: – Bridge actions (entry / dataStore / dismiss)
+    // MARK: – Bridge actions (entry / dataStore / dismiss / foodSearch)
     // ─────────────────────────────────────────────────────
 
     private func saveAsTemplate() {
@@ -485,11 +122,8 @@ struct MealEntrySheet: View {
         Task { await dataStore.persistToDisk() }
     }
 
-    // ─────────────────────────────────────────────────────
-    // MARK: – Networking — thin shims over FoodSearchService
     // Audit UI-017: actual implementation lives in
     // Services/FoodSearchService.swift. The view only triggers + observes.
-    // ─────────────────────────────────────────────────────
 
     private func runTextSearch() {
         Task { await foodSearch.search(query: vm.searchQuery) }

--- a/FitTracker/Views/Nutrition/MealEntryViewModel.swift
+++ b/FitTracker/Views/Nutrition/MealEntryViewModel.swift
@@ -58,9 +58,8 @@ final class MealEntryViewModel: ObservableObject {
     // MARK: – Helpers
     // ─────────────────────────────────────────────────────
 
-    func formatNum(_ v: Double) -> String {
-        v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
-    }
+    // formatMealValue is a free helper in Tabs/MealEntrySharedComponents.swift —
+    // both the VM and the parsed-metric tile call the same function.
 
     func loadFromEntry(_ entry: MealEntry) {
         name     = entry.name
@@ -68,8 +67,8 @@ final class MealEntryViewModel: ObservableObject {
         proteinG = entry.proteinG.map  { String($0) } ?? ""
         carbsG   = entry.carbsG.map    { String($0) } ?? ""
         fatG     = entry.fatG.map      { String($0) } ?? ""
-        servingGrams = entry.servingGrams.map { formatNum($0) } ?? ""
-        referenceGrams = entry.labelReferenceGrams.map { formatNum($0) } ?? "100"
+        servingGrams = entry.servingGrams.map { formatMealValue($0) } ?? ""
+        referenceGrams = entry.labelReferenceGrams.map { formatMealValue($0) } ?? "100"
         sourceDetails = entry.sourceDetails
         rawLabelText = entry.source == .photoLabel ? entry.sourceDetails : ""
     }
@@ -101,10 +100,10 @@ final class MealEntryViewModel: ObservableObject {
 
     func fillFromTemplate(_ template: MealTemplate) {
         name     = template.name
-        calories = template.calories.map { formatNum($0) } ?? ""
-        proteinG = template.proteinG.map  { formatNum($0) } ?? ""
-        carbsG   = template.carbsG.map    { formatNum($0) } ?? ""
-        fatG     = template.fatG.map      { formatNum($0) } ?? ""
+        calories = template.calories.map { formatMealValue($0) } ?? ""
+        proteinG = template.proteinG.map  { formatMealValue($0) } ?? ""
+        carbsG   = template.carbsG.map    { formatMealValue($0) } ?? ""
+        fatG     = template.fatG.map      { formatMealValue($0) } ?? ""
         sourceDetails = "Saved template"
         activeTab = .manual
         onSourceChange(.template)
@@ -112,12 +111,12 @@ final class MealEntryViewModel: ObservableObject {
 
     func fillFromProduct(_ product: FoodProduct) {
         name     = product.name.isEmpty ? searchQuery : product.name
-        calories = product.caloriesPer100g.map { formatNum($0) } ?? ""
-        proteinG = product.proteinPer100g.map   { formatNum($0) } ?? ""
-        carbsG   = product.carbsPer100g.map     { formatNum($0) } ?? ""
-        fatG     = product.fatPer100g.map       { formatNum($0) } ?? ""
-        referenceGrams = formatNum(product.referenceGrams)
-        servingGrams = servingGrams.isEmpty ? formatNum(product.referenceGrams) : servingGrams
+        calories = product.caloriesPer100g.map { formatMealValue($0) } ?? ""
+        proteinG = product.proteinPer100g.map   { formatMealValue($0) } ?? ""
+        carbsG   = product.carbsPer100g.map     { formatMealValue($0) } ?? ""
+        fatG     = product.fatPer100g.map       { formatMealValue($0) } ?? ""
+        referenceGrams = formatMealValue(product.referenceGrams)
+        servingGrams = servingGrams.isEmpty ? formatMealValue(product.referenceGrams) : servingGrams
         sourceDetails = product.sourceDescription
         activeTab = .manual
         onSourceChange(product.source)
@@ -137,7 +136,7 @@ final class MealEntryViewModel: ObservableObject {
         }
 
         parsedLabel = parsed
-        referenceGrams = formatNum(parsed.referenceGrams)
+        referenceGrams = formatMealValue(parsed.referenceGrams)
         applyParsedLabel(parsed)
         sourceDetails = rawLabelText
         smartStatus = parsed.detectedLanguageHint == .hebrew
@@ -149,17 +148,17 @@ final class MealEntryViewModel: ObservableObject {
 
     private func applyParsedLabel(_ parsed: ParsedNutritionLabel) {
         let consumedGrams = Double(servingGrams) ?? parsed.referenceGrams
-        servingGrams = formatNum(consumedGrams)
+        servingGrams = formatMealValue(consumedGrams)
         let scale = max(consumedGrams, 1) / max(parsed.referenceGrams, 1)
 
         if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             name = parsed.nameHint ?? name
         }
 
-        calories = parsed.calories.map { formatNum($0 * scale) } ?? calories
-        proteinG = parsed.proteinG.map { formatNum($0 * scale) } ?? proteinG
-        carbsG = parsed.carbsG.map { formatNum($0 * scale) } ?? carbsG
-        fatG = parsed.fatG.map { formatNum($0 * scale) } ?? fatG
+        calories = parsed.calories.map { formatMealValue($0 * scale) } ?? calories
+        proteinG = parsed.proteinG.map { formatMealValue($0 * scale) } ?? proteinG
+        carbsG = parsed.carbsG.map { formatMealValue($0 * scale) } ?? carbsG
+        fatG = parsed.fatG.map { formatMealValue($0 * scale) } ?? fatG
     }
 
     // ─────────────────────────────────────────────────────

--- a/FitTracker/Views/Nutrition/MealEntryViewModel.swift
+++ b/FitTracker/Views/Nutrition/MealEntryViewModel.swift
@@ -1,0 +1,235 @@
+// FitTracker/Views/Nutrition/MealEntryViewModel.swift
+// State + business logic for MealEntrySheet. Holds the 16 mutable
+// fields the sheet exposes to its 4 tabs and owns the bilingual label
+// parser + Vision OCR + photo import flows.
+// Extracted from MealEntrySheet.swift in Audit M-2c (UI-004 decomposition).
+
+import SwiftUI
+import Vision
+#if canImport(PhotosUI)
+import PhotosUI
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@MainActor
+final class MealEntryViewModel: ObservableObject {
+    // ── Tab selection ─────────────────────────────────────
+    @Published var activeTab: MealEntryTab = .smart
+
+    // ── Manual tab fields ─────────────────────────────────
+    @Published var name: String = ""
+    @Published var calories: String = ""
+    @Published var proteinG: String = ""
+    @Published var carbsG: String = ""
+    @Published var fatG: String = ""
+    @Published var servingGrams: String = ""
+    @Published var referenceGrams: String = "100"
+    @Published var sourceDetails: String = ""
+
+    // ── Smart label parsing ───────────────────────────────
+    @Published var rawLabelText: String = ""
+    @Published var parsedLabel: ParsedNutritionLabel?
+    @Published var smartStatus: String?
+    @Published var smartError: String?
+
+    // ── Template save confirmation ────────────────────────
+    @Published var savedTemplate: Bool = false
+
+    // ── Search tab ────────────────────────────────────────
+    @Published var searchQuery: String = ""
+
+    // ── Barcode + camera state ────────────────────────────
+    @Published var showScanner: Bool = false
+    #if canImport(UIKit)
+    @Published var showCameraCapture: Bool = false
+    @Published var selectedImagePreview: UIImage?
+    #endif
+    #if canImport(PhotosUI)
+    @Published var selectedPhotoItem: PhotosPickerItem?
+    #endif
+
+    // The view injects this in onAppear so the VM can record the entry's
+    // input source without holding a Binding<MealEntry>. Default no-op.
+    var onSourceChange: (MealEntrySource) -> Void = { _ in }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Helpers
+    // ─────────────────────────────────────────────────────
+
+    func formatNum(_ v: Double) -> String {
+        v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
+    }
+
+    func loadFromEntry(_ entry: MealEntry) {
+        name     = entry.name
+        calories = entry.calories.map { String($0) } ?? ""
+        proteinG = entry.proteinG.map  { String($0) } ?? ""
+        carbsG   = entry.carbsG.map    { String($0) } ?? ""
+        fatG     = entry.fatG.map      { String($0) } ?? ""
+        servingGrams = entry.servingGrams.map { formatNum($0) } ?? ""
+        referenceGrams = entry.labelReferenceGrams.map { formatNum($0) } ?? "100"
+        sourceDetails = entry.sourceDetails
+        rawLabelText = entry.source == .photoLabel ? entry.sourceDetails : ""
+    }
+
+    func writeBack(into entry: inout MealEntry) {
+        entry.name     = name
+        entry.calories = Double(calories)
+        entry.proteinG = Double(proteinG)
+        entry.carbsG   = Double(carbsG)
+        entry.fatG     = Double(fatG)
+        entry.servingGrams = Double(servingGrams)
+        entry.labelReferenceGrams = Double(referenceGrams)
+        entry.sourceDetails = sourceDetails
+        entry.eatenAt  = Date()
+        entry.status   = .completed
+    }
+
+    func confirmTemplateSaved() {
+        savedTemplate = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            await MainActor.run { self.savedTemplate = false }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Template + product fill
+    // ─────────────────────────────────────────────────────
+
+    func fillFromTemplate(_ template: MealTemplate) {
+        name     = template.name
+        calories = template.calories.map { formatNum($0) } ?? ""
+        proteinG = template.proteinG.map  { formatNum($0) } ?? ""
+        carbsG   = template.carbsG.map    { formatNum($0) } ?? ""
+        fatG     = template.fatG.map      { formatNum($0) } ?? ""
+        sourceDetails = "Saved template"
+        activeTab = .manual
+        onSourceChange(.template)
+    }
+
+    func fillFromProduct(_ product: FoodProduct) {
+        name     = product.name.isEmpty ? searchQuery : product.name
+        calories = product.caloriesPer100g.map { formatNum($0) } ?? ""
+        proteinG = product.proteinPer100g.map   { formatNum($0) } ?? ""
+        carbsG   = product.carbsPer100g.map     { formatNum($0) } ?? ""
+        fatG     = product.fatPer100g.map       { formatNum($0) } ?? ""
+        referenceGrams = formatNum(product.referenceGrams)
+        servingGrams = servingGrams.isEmpty ? formatNum(product.referenceGrams) : servingGrams
+        sourceDetails = product.sourceDescription
+        activeTab = .manual
+        onSourceChange(product.source)
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Smart label parsing
+    // ─────────────────────────────────────────────────────
+
+    func parseSmartLabel() {
+        smartError = nil
+        smartStatus = nil
+
+        guard let parsed = NutritionLabelParser.parse(rawLabelText, fallbackReferenceGrams: Double(referenceGrams) ?? 100) else {
+            smartError = "I couldn’t parse the label yet. Try a clearer photo or paste the nutrition lines."
+            return
+        }
+
+        parsedLabel = parsed
+        referenceGrams = formatNum(parsed.referenceGrams)
+        applyParsedLabel(parsed)
+        sourceDetails = rawLabelText
+        smartStatus = parsed.detectedLanguageHint == .hebrew
+            ? "Hebrew nutrition text parsed successfully."
+            : "Nutrition label applied successfully."
+        activeTab = .manual
+        onSourceChange(.photoLabel)
+    }
+
+    private func applyParsedLabel(_ parsed: ParsedNutritionLabel) {
+        let consumedGrams = Double(servingGrams) ?? parsed.referenceGrams
+        servingGrams = formatNum(consumedGrams)
+        let scale = max(consumedGrams, 1) / max(parsed.referenceGrams, 1)
+
+        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            name = parsed.nameHint ?? name
+        }
+
+        calories = parsed.calories.map { formatNum($0 * scale) } ?? calories
+        proteinG = parsed.proteinG.map { formatNum($0 * scale) } ?? proteinG
+        carbsG = parsed.carbsG.map { formatNum($0 * scale) } ?? carbsG
+        fatG = parsed.fatG.map { formatNum($0 * scale) } ?? fatG
+    }
+
+    // ─────────────────────────────────────────────────────
+    // MARK: – Vision OCR + photo import (iOS only)
+    // ─────────────────────────────────────────────────────
+
+    #if canImport(UIKit)
+    func processNutritionImage(_ image: UIImage) {
+        selectedImagePreview = image
+        smartError = nil
+        smartStatus = "Reading nutrition label…"
+
+        guard let cgImage = image.cgImage else {
+            smartStatus = nil
+            smartError = "That image could not be processed."
+            return
+        }
+
+        let request = VNRecognizeTextRequest { [weak self] request, error in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if let error {
+                    self.smartStatus = nil
+                    self.smartError = "Photo scan failed: \(error.localizedDescription)"
+                    return
+                }
+
+                let lines = (request.results as? [VNRecognizedTextObservation])?
+                    .compactMap { $0.topCandidates(1).first?.string }
+                    .joined(separator: "\n") ?? ""
+
+                self.rawLabelText = lines
+                self.parseSmartLabel()
+            }
+        }
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        if #available(iOS 16.0, macOS 13.0, *) {
+            request.automaticallyDetectsLanguage = true
+        }
+        if let languages = try? request.supportedRecognitionLanguages() {
+            let preferred = ["en-US", "he-IL", "ar-SA"]
+            request.recognitionLanguages = preferred.filter { languages.contains($0) }
+        }
+
+        Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                try VNImageRequestHandler(cgImage: cgImage, options: [:]).perform([request])
+            } catch {
+                await MainActor.run {
+                    self?.smartStatus = nil
+                    self?.smartError = "Photo scan failed: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    #if canImport(PhotosUI)
+    func loadSelectedPhoto(_ item: PhotosPickerItem) async {
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self),
+                  let image = UIImage(data: data) else {
+                smartError = "That photo could not be opened."
+                return
+            }
+            processNutritionImage(image)
+        } catch {
+            smartError = "Photo import failed: \(error.localizedDescription)"
+        }
+    }
+    #endif
+    #endif
+}

--- a/FitTracker/Views/Nutrition/Tabs/ManualTabView.swift
+++ b/FitTracker/Views/Nutrition/Tabs/ManualTabView.swift
@@ -1,0 +1,65 @@
+// FitTracker/Views/Nutrition/Tabs/ManualTabView.swift
+// Manual tab — direct entry of meal name + macros, plus Save Template / Log actions.
+// Extracted from MealEntrySheet.swift in Audit M-2b (UI-004 decomposition).
+
+import SwiftUI
+
+struct ManualTabView: View {
+    @ObservedObject var vm: MealEntryViewModel
+    let onSaveAsTemplate: () -> Void
+    let onLog: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: AppSpacing.small) {
+                Group {
+                    MealEntryField(label: "Meal name",       placeholder: "e.g. Chicken & Rice", text: $vm.name)
+                    MealEntryField(label: "Calories (kcal)", placeholder: "e.g. 500",            text: $vm.calories, isNumeric: true)
+                    MealEntryField(label: "Protein (g)",     placeholder: "e.g. 40",             text: $vm.proteinG, isNumeric: true)
+                    MealEntryField(label: "Carbs (g)",       placeholder: "e.g. 60",             text: $vm.carbsG,   isNumeric: true)
+                    MealEntryField(label: "Fat (g)",         placeholder: "e.g. 15",             text: $vm.fatG,     isNumeric: true)
+                }
+                .padding(.horizontal, AppSpacing.small)
+
+                VStack(spacing: AppSpacing.xSmall) {
+                    Button {
+                        onSaveAsTemplate()
+                    } label: {
+                        HStack {
+                            if vm.savedTemplate {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(AppColor.Status.success)
+                                Text("Saved!")
+                                    .foregroundStyle(AppColor.Status.success)
+                            } else {
+                                Image(systemName: "square.and.arrow.down")
+                                Text("Save as Template")
+                            }
+                        }
+                        .font(AppText.body)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, AppSpacing.xSmall)
+                        .background(AppColor.Surface.elevated, in: RoundedRectangle(cornerRadius: AppRadius.medium, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppRadius.medium, style: .continuous)
+                                .stroke(AppColor.Border.subtle, lineWidth: 1)
+                        )
+                    }
+                    .disabled(vm.name.isEmpty)
+
+                    AppButton(
+                        title: "Log",
+                        hierarchy: .primary
+                    ) {
+                        onLog()
+                    }
+                    .disabled(vm.name.isEmpty)
+                }
+                .padding(.horizontal, AppSpacing.small)
+                .padding(.top, AppSpacing.xxSmall)
+            }
+            .padding(.top, AppSpacing.small)
+            .padding(.bottom, AppSpacing.xLarge)
+        }
+    }
+}

--- a/FitTracker/Views/Nutrition/Tabs/MealEntrySharedComponents.swift
+++ b/FitTracker/Views/Nutrition/Tabs/MealEntrySharedComponents.swift
@@ -1,0 +1,71 @@
+// FitTracker/Views/Nutrition/Tabs/MealEntrySharedComponents.swift
+// Shared view helpers used by 2+ Meal Entry tabs.
+// Extracted from MealEntrySheet.swift in Audit M-2b (UI-004 decomposition).
+
+import SwiftUI
+
+// Pretty-prints a numeric meal value: integers as Int, decimals to 1 fraction digit.
+// Free helper so both the VM and the parsed-metric tile can use the same logic.
+func formatMealValue(_ v: Double) -> String {
+    v == v.rounded() ? String(Int(v)) : String(format: "%.1f", v)
+}
+
+// Labelled text field used by the Smart and Manual tabs.
+struct MealEntryField: View {
+    let label: String
+    let placeholder: String
+    @Binding var text: String
+    var isNumeric: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+            AppFieldLabel(title: label)
+            AppInputShell {
+                TextField(placeholder, text: $text)
+                    .font(AppText.body)
+                    .foregroundStyle(AppColor.Text.primary)
+                    #if canImport(UIKit)
+                    .keyboardType(isNumeric ? .decimalPad : .default)
+                    #endif
+            }
+        }
+    }
+}
+
+// Tinted action button label used by the Smart tab (Take Photo / Choose Photo).
+struct SmartActionLabel: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: AppSpacing.xxSmall) {
+            Image(systemName: systemImage)
+            Text(title)
+        }
+        .font(.caption.weight(.semibold))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, AppSpacing.xSmall)
+        .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: AppRadius.small))
+        .foregroundStyle(tint)
+    }
+}
+
+// Single metric tile in the parsed-label result panel (Smart tab).
+struct ParsedMetricView: View {
+    let title: String
+    let value: Double?
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.micro) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(AppColor.Text.secondary)
+            Text(value.map { formatMealValue($0) } ?? "—")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(tint)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/FitTracker/Views/Nutrition/Tabs/SearchTabView.swift
+++ b/FitTracker/Views/Nutrition/Tabs/SearchTabView.swift
@@ -1,0 +1,108 @@
+// FitTracker/Views/Nutrition/Tabs/SearchTabView.swift
+// Search tab — Open Food Facts text search + iOS barcode scan.
+// Extracted from MealEntrySheet.swift in Audit M-2b (UI-004 decomposition).
+
+import SwiftUI
+
+struct SearchTabView: View {
+    @ObservedObject var vm: MealEntryViewModel
+    @ObservedObject var foodSearch: FoodSearchService
+    let onTextSearch: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: AppSpacing.xxSmall) {
+                HStack(spacing: AppSpacing.xxSmall) {
+                    AppInputShell {
+                        TextField("Search food…", text: $vm.searchQuery)
+                            .font(AppText.body)
+                            .foregroundStyle(AppColor.Text.primary)
+                            .submitLabel(.search)
+                            .onSubmit { onTextSearch() }
+                    }
+
+                    AppButton(
+                        title: "",
+                        systemImage: foodSearch.isSearching ? "clock" : "magnifyingglass",
+                        hierarchy: .primary,
+                        isFullWidth: false
+                    ) {
+                        onTextSearch()
+                    }
+                    .disabled(vm.searchQuery.trimmingCharacters(in: .whitespaces).isEmpty || foodSearch.isSearching)
+                }
+
+                #if os(iOS)
+                AppQuietButton(
+                    title: "Scan Barcode",
+                    systemImage: "barcode.viewfinder",
+                    tint: AppColor.Accent.sleep
+                ) {
+                    vm.showScanner = true
+                }
+                #endif
+
+                if let error = foodSearch.searchError {
+                    HStack(spacing: AppSpacing.xxSmall) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(AppColor.Status.error)
+                        Text(error)
+                            .font(AppText.caption)
+                            .foregroundStyle(AppColor.Status.error)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(.horizontal, AppSpacing.small)
+            .padding(.top, AppSpacing.xSmall)
+            .padding(.bottom, AppSpacing.xxSmall)
+
+            Divider()
+
+            if foodSearch.searchResults.isEmpty && !foodSearch.isSearching {
+                Spacer()
+                EmptyStateView(
+                    icon: "magnifyingglass",
+                    title: "Search for food",
+                    subtitle: "Type a food name above or scan a barcode to find nutrition data."
+                )
+                Spacer()
+            } else if foodSearch.isSearching {
+                Spacer()
+                ProgressView("Searching…")
+                    .font(AppText.subheading)
+                Spacer()
+            } else {
+                List(foodSearch.searchResults) { product in
+                    Button {
+                        vm.fillFromProduct(product)
+                    } label: {
+                        VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
+                            Text(product.name.isEmpty ? "Unknown product" : product.name)
+                                .font(AppText.body)
+                                .foregroundStyle(AppColor.Text.primary)
+                            HStack(spacing: AppSpacing.xxSmall) {
+                                if let cal = product.caloriesPer100g {
+                                    Text("\(Int(cal)) kcal/100g")
+                                        .font(AppText.caption)
+                                        .foregroundStyle(AppColor.Accent.achievement)
+                                }
+                                if let pro = product.proteinPer100g {
+                                    Text("\(Int(pro))g prot")
+                                        .font(AppText.caption)
+                                        .foregroundColor(AppColor.Accent.recovery)
+                                }
+                            }
+                            Text(product.sourceDescription)
+                                .font(.caption2)
+                                .foregroundStyle(AppColor.Text.secondary)
+                        }
+                        .padding(.vertical, AppSpacing.xxxSmall)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+}

--- a/FitTracker/Views/Nutrition/Tabs/SmartTabView.swift
+++ b/FitTracker/Views/Nutrition/Tabs/SmartTabView.swift
@@ -1,0 +1,121 @@
+// FitTracker/Views/Nutrition/Tabs/SmartTabView.swift
+// Smart tab — camera/photo capture + bilingual nutrition label parsing.
+// Extracted from MealEntrySheet.swift in Audit M-2b (UI-004 decomposition).
+
+import SwiftUI
+#if canImport(PhotosUI)
+import PhotosUI
+#endif
+
+struct SmartTabView: View {
+    @ObservedObject var vm: MealEntryViewModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.large) {
+                VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+                    Text("Smart Nutrition Capture")
+                        .font(AppText.sectionTitle)
+                    Text("Scan a nutrition label, paste English or Hebrew nutrition text, then scale it to the weight you actually ate.")
+                        .font(AppText.caption)
+                        .foregroundStyle(AppColor.Text.secondary)
+                }
+
+                #if canImport(UIKit)
+                if let selectedImagePreview = vm.selectedImagePreview {
+                    Image(uiImage: selectedImagePreview)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(height: 150)
+                        .frame(maxWidth: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: AppRadius.medium))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppRadius.medium)
+                                .stroke(AppColor.Border.subtle, lineWidth: 1)
+                        )
+                }
+                #endif
+
+                HStack(spacing: AppSpacing.xxSmall) {
+                    #if canImport(UIKit)
+                    Button {
+                        vm.showCameraCapture = true
+                    } label: {
+                        SmartActionLabel(title: "Take Label Photo", systemImage: "camera.fill", tint: AppColor.Accent.recovery)
+                    }
+                    .buttonStyle(.plain)
+                    #endif
+
+                    #if canImport(PhotosUI)
+                    PhotosPicker(selection: $vm.selectedPhotoItem, matching: .images) {
+                        SmartActionLabel(title: "Choose Photo", systemImage: "photo.fill", tint: AppColor.Brand.warm)
+                    }
+                    .buttonStyle(.plain)
+                    #endif
+                }
+
+                VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+                    Text("Nutrition Text")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppColor.Text.secondary)
+                    TextEditor(text: $vm.rawLabelText)
+                        .frame(minHeight: 140)
+                        .padding(AppSpacing.xxSmall)
+                        .background(AppColor.Text.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: AppRadius.small))
+                    Text("Hebrew and English keywords are parsed here. Photos use Apple Vision OCR first, then this parser scales the label to your consumed weight. If a Hebrew label photo doesn’t scan cleanly, paste the label text here and the parser still works.")
+                        .font(.caption2)
+                        .foregroundStyle(AppColor.Text.secondary)
+                }
+
+                HStack(spacing: AppSpacing.xSmall) {
+                    MealEntryField(label: "Consumed weight (g)", placeholder: "e.g. 100", text: $vm.servingGrams, isNumeric: true)
+                    MealEntryField(label: "Label reference (g)", placeholder: "100", text: $vm.referenceGrams, isNumeric: true)
+                }
+
+                if let smartStatus = vm.smartStatus {
+                    Label(smartStatus, systemImage: "checkmark.circle.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppColor.Status.success)
+                }
+
+                if let smartError = vm.smartError {
+                    Label(smartError, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppColor.Status.error)
+                }
+
+                Button {
+                    vm.parseSmartLabel()
+                } label: {
+                    Text("Parse and Apply")
+                        .font(AppText.button)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, AppSpacing.xSmall)
+                        .background(AppColor.Accent.recovery, in: RoundedRectangle(cornerRadius: AppRadius.small))
+                        // Audit UI-012: token instead of raw .white literal
+                        .foregroundStyle(AppColor.Text.inversePrimary)
+                }
+                .buttonStyle(.plain)
+
+                if let parsedLabel = vm.parsedLabel {
+                    VStack(alignment: .leading, spacing: AppSpacing.xxSmall) {
+                        Text("Parsed Per \(Int(parsedLabel.referenceGrams))g")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(AppColor.Text.secondary)
+                        HStack(spacing: AppSpacing.xSmall) {
+                            ParsedMetricView(title: "kcal", value: parsedLabel.calories, tint: AppColor.Brand.warm)
+                            ParsedMetricView(title: "Protein", value: parsedLabel.proteinG, tint: AppColor.Accent.recovery)
+                            ParsedMetricView(title: "Carbs", value: parsedLabel.carbsG, tint: AppColor.Brand.warmSoft)
+                            ParsedMetricView(title: "Fat", value: parsedLabel.fatG, tint: AppColor.Chart.nutritionFat)
+                        }
+                    }
+                    .padding(AppSpacing.xSmall)
+                    .background(AppColor.Surface.materialStrong, in: RoundedRectangle(cornerRadius: AppRadius.medium))
+                }
+            }
+            .padding(.horizontal, AppSpacing.small)
+            .padding(.top, AppSpacing.small)
+            .padding(.bottom, AppSpacing.xLarge)
+        }
+    }
+}

--- a/FitTracker/Views/Nutrition/Tabs/TemplateTabView.swift
+++ b/FitTracker/Views/Nutrition/Tabs/TemplateTabView.swift
@@ -1,0 +1,54 @@
+// FitTracker/Views/Nutrition/Tabs/TemplateTabView.swift
+// Template tab — pick a saved meal template to populate the manual form.
+// Extracted from MealEntrySheet.swift in Audit M-2b (UI-004 decomposition).
+
+import SwiftUI
+
+struct TemplateTabView: View {
+    @ObservedObject var vm: MealEntryViewModel
+    @EnvironmentObject var dataStore: EncryptedDataStore
+    let onDelete: (IndexSet) -> Void
+
+    var body: some View {
+        Group {
+            if dataStore.mealTemplates.isEmpty {
+                EmptyStateView(
+                    icon: "doc.text",
+                    title: "No Templates Yet",
+                    subtitle: "Save a meal from the Manual tab to reuse it here."
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(dataStore.mealTemplates) { template in
+                        Button {
+                            vm.fillFromTemplate(template)
+                        } label: {
+                            VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
+                                Text(template.name)
+                                    .font(AppText.body)
+                                    .foregroundStyle(AppColor.Text.primary)
+                                HStack(spacing: AppSpacing.xxSmall) {
+                                    if let cal = template.calories {
+                                        Text("\(Int(cal)) kcal")
+                                            .font(AppText.caption)
+                                            .foregroundStyle(AppColor.Accent.achievement)
+                                    }
+                                    if let pro = template.proteinG {
+                                        Text("\(Int(pro))g protein")
+                                            .font(AppText.caption)
+                                            .foregroundStyle(AppColor.Accent.recovery)
+                                    }
+                                }
+                            }
+                            .padding(.vertical, AppSpacing.xxxSmall)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onDelete { offsets in onDelete(offsets) }
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Resubmit to main**: PRs #127 (M-2c) and #128 (M-2b) merged into their stacked base branches instead of into main. Their commits live on this branch (\`feature/m2b-mealentry-tab-views\`). This PR brings them onto main as a single landing.

Two commits, both already reviewed in #127 and #128:
- \`6309e83\` — M-2c: extract MealEntryViewModel from MealEntrySheet
- \`54b0ee0\` — M-2b: extract per-tab views from MealEntrySheet

## Cumulative impact (M-2a + M-2c + M-2b on main)

- \`MealEntrySheet.swift\`: **1104 → 140 lines (~87% reduction)**
- 9 new files under \`Nutrition/Models\`, \`Parsing\`, \`Camera\`, \`Tabs\`
- @State vars in main view: 17 → 0
- Coordinator is now pure routing + bridge actions

## What's in this delta vs main

- \`FitTracker/Views/Nutrition/MealEntryViewModel.swift\` (235 lines) — VM with all 16 @Published state + business logic
- \`FitTracker/Views/Nutrition/Tabs/MealEntrySharedComponents.swift\` (71 lines) — \`formatMealValue\` free helper + \`MealEntryField\`, \`SmartActionLabel\`, \`ParsedMetricView\`
- \`FitTracker/Views/Nutrition/Tabs/SmartTabView.swift\` (121)
- \`FitTracker/Views/Nutrition/Tabs/ManualTabView.swift\` (65)
- \`FitTracker/Views/Nutrition/Tabs/TemplateTabView.swift\` (54)
- \`FitTracker/Views/Nutrition/Tabs/SearchTabView.swift\` (108)
- \`FitTracker/Views/Nutrition/MealEntrySheet.swift\` (140 lines, was 694) — pure coordinator
- \`FitTracker.xcodeproj/project.pbxproj\` — 6 file refs + Tabs PBXGroup

Reviewed reasoning: see #127 + #128 PR descriptions.

Plan: [docs/superpowers/plans/2026-04-19-m2-mealentrysheet-decomposition.md](docs/superpowers/plans/2026-04-19-m2-mealentrysheet-decomposition.md)

## Test plan

- [x] \`xcodebuild build\` green
- [ ] Manual: Smart parse / Manual save+log / Template pick / Search + Barcode all render and function
- [ ] Once merged, M-2d (case study + UI-004 closure) follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)