### PR TITLE
UI-audit baseline burndown: P0 27→0, hard gate in verify-local, AppMotion tokens

### DIFF
--- a/.claude/features/ui-audit-baseline-burndown/case-study.md
+++ b/.claude/features/ui-audit-baseline-burndown/case-study.md
@@ -44,7 +44,36 @@ Three-layer safety model:
 
 ## Per-file burndown log
 
-_Populated during Phase 1 + Phase 2._
+### Phase 1 — color cluster (8 files, 21 P0 closed)
+
+| Commit | File | P0 | Key mappings |
+|---|---|---:|---|
+| `748de4c` | — | — | (Phase 0.1) 3 new AppSpring + AppEasing + AppLoadingAnimation tokens |
+| `82112b3` | OnboardingAuthView.swift | 8 | `.blue` → `Brand.secondary`; `Color.white` → `AppPalette.white` (Google brand); 5× `.foregroundStyle(.white)` → `Text.inversePrimary` |
+| `3b6102d` | AuthHubView.swift | 3 | `.fill(Color.white)` → `AppPalette.white`; 2× `.white` → `Text.inversePrimary` |
+| `41baab3` | SignInView.swift | 2 | `Color(.systemBackground)` → `Background.appPrimary`; Apple labelColor → `Text.inversePrimary` (fixes latent dark-mode contrast bug) |
+| `141b13c` | ConsentView.swift | 2 | `Color.white` → `AppPalette.white`; `.white` → `Text.inversePrimary` |
+| `9954381` | ProfileHeroSection.swift | 2 | 2× `.white` → `Text.inversePrimary` |
+| `80ab383` | MilestoneModal.swift | 2 | 2× `.white` → `Text.inversePrimary` |
+| `67fb3c8` | AccountPanelView.swift | 1 | `.white` → `Text.inversePrimary` |
+| `834d91b` | BodyCompositionCard.swift | 1 | `.white` → `Text.inversePrimary` |
+
+**Three distinct patterns emerged:**
+
+1. **Standard inverse-primary** (17 of 21 sites) — `.white` text on any colored/inverse surface → `AppColor.Text.inversePrimary`. No ambiguity.
+2. **Google-brand pure white** (4 sites) — `Color.white` discs/cards on Google auth buttons → `AppPalette.white`. Surface.elevated would shift to 20%-alpha in dark mode and break Google brand identity; palette-level pure white preserves brand compliance in both modes. Re-discovered a dormant token (`AppPalette.white` was declared but unused in views).
+3. **Semantic blue** (1 site — email icon) — `.blue` → `AppColor.Brand.secondary`. Shifts iOS system blue (#007AFF) to lighter brand blue (#8AC7FF); consistent with the Google "G" letter already using Brand.secondary. Visible change; flagged for mirror verification.
+
+**Phase 1 metrics:**
+- P0 closed: 21
+- P0 remaining: 6 (all animation, Phase 2)
+- Commits: 8 (one per file) + 1 baseline regeneration
+- Swift-parse: all clean
+- Mirror diffs: **PENDING user verification**
+
+### Phase 2 — animation cluster
+
+_Not yet started._
 
 ## Metrics
 

--- a/.claude/features/ui-audit-baseline-burndown/case-study.md
+++ b/.claude/features/ui-audit-baseline-burndown/case-study.md
@@ -71,9 +71,36 @@ Three-layer safety model:
 - Swift-parse: all clean
 - Mirror diffs: **PENDING user verification**
 
-### Phase 2 — animation cluster
+### Phase 2 — animation cluster (4 files, 6 P0 closed)
 
-_Not yet started._
+| Commit | File | P0 | Mapping |
+|---|---|---:|---|
+| `ee1c15b` | WelcomeView.swift | 3 | `AppSpring.hero`, `AppEasing.heroEntry` ×2 |
+| `14f7c10` | OnboardingFirstActionView.swift | 1 | `AppSpring.stepAdvance` |
+| `d70c00b` | ReadinessCard.swift | 1 | `AppSpring.dialPulse` |
+| `ab651ca` | TrainingPlanView.swift | 1 | `AppLoadingAnimation.fastShimmer` |
+
+**All six animation mappings are 1:1 semantic** — the new AppMotion tokens added in Phase 0.1 were deliberately declared with values identical to the raw call sites (hero = spring 0.80/0.70, stepAdvance = spring 0.50/0.70, dialPulse = interpolatingSpring 40/8, heroEntry = easeOut 0.60, fastShimmer = linear 1.2 repeatForever). No feel change expected.
+
+**Phase 2 metrics:**
+- P0 closed: 6
+- P0 remaining: **0**
+- Commits: 4 (one per file)
+- Swift-parse: all clean
+- Mirror diffs: **PENDING user verification**
+
+## Final baseline state (post-Phase 2)
+
+- **P0: 0** (was 27) — scanner exits 0 with no `--no-fail` flag; gate is ready for promotion
+- **P1: 103** (unchanged) — deferred to follow-on plan
+  - DS-MAGIC-FRAME: 71
+  - DS-RAW-FONT-SHORTHAND: 23
+  - DS-A11Y-BUTTON: 5
+  - DS-MAGIC-PADDING: 4
+
+Phase 3 (gate-the-gate) is unblocked.
+
+
 
 ## Metrics
 

--- a/.claude/features/ui-audit-baseline-burndown/case-study.md
+++ b/.claude/features/ui-audit-baseline-burndown/case-study.md
@@ -1,0 +1,61 @@
+# UI-Audit Baseline Burndown — Case Study
+
+**Status:** In progress
+**Started:** 2026-04-21
+**Parent feature:** design-system-v2
+**Plan:** [docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md](../../../docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md)
+**PRs:** TBD
+
+## Context
+
+The `make ui-audit` scanner shipped on branch `claude/review-ui-consistency-zSkvJ`
+(commits `cf3cf56` / `bc4ddfe` / `573fe8a`) established a per-view
+design-system compliance contract: raw Color literals, raw animations,
+raw fonts, magic numbers, missing a11y, and — crucially — the silent
+fallback bug where `Color("name")` references a non-existent colorset.
+At rest, 27 P0 + 103 P1 across 44 files. Because baseline P0 ≠ 0, the
+scanner could only run as an advisory step, not as a `verify-local`
+gate. This case study documents the burndown to P0=0 and the
+promotion to a hard gate.
+
+## The gap
+
+Verification layer without a gate is observation without enforcement.
+Any PR could introduce a new P0 and the scanner would report it — but
+nothing stopped the merge. Historical drift produced 27 findings that
+had never been rejected; the DS-MISSING-ASSET rule (the one that
+closed the chart-color Gap-A bug in commit `cf3cf56`) could not yet
+enforce because the baseline was not clean.
+
+## Approach
+
+Three-layer safety model:
+
+1. **Mirror layer** — every file-task captures before/after simulator
+   screenshots in `.build/mirrors/` (gitignored) and requires manual
+   diff before commit. Catches silent pixel changes from token swaps.
+2. **Rollback layer** — one file per commit + semantic-tagged baseline.
+   Any file can be reverted surgically; the whole burndown can be
+   reset to `573fe8a` without losing the verification layer.
+3. **Motion-tokens-first** — raw animations in P0 scope required new
+   AppMotion presets (`hero`, `stepAdvance`, `dialPulse`, `heroEntry`,
+   `fastShimmer`). These were added in Task 0.1 BEFORE any file was
+   migrated, so every mapping is 1:1 semantic, not approximation.
+
+## Per-file burndown log
+
+_Populated during Phase 1 + Phase 2._
+
+## Metrics
+
+- Baseline P0: 27 → 0 (target)
+- Baseline P1: 103 → ≤ 20 (stretch, deferred to follow-on plan)
+- Visual regressions post-merge: 0 (target; 7-day review)
+- Mirror diffs captured: 24 (2 modes × 12 files)
+- AppMotion tokens added: 5
+- Scanner rules added in Phase 4.1: TBD
+
+## Framework lessons
+
+_Populated at Phase 5 close-out._
+

--- a/.claude/features/ui-audit-baseline-burndown/state.json
+++ b/.claude/features/ui-audit-baseline-burndown/state.json
@@ -1,0 +1,49 @@
+{
+  "feature": "ui-audit-baseline-burndown",
+  "type": "enhancement",
+  "parent_feature": "design-system-v2",
+  "started": "2026-04-21",
+  "phase": "implement",
+  "branch": "claude/review-ui-consistency-zSkvJ",
+  "phases": {
+    "research": {
+      "skipped": true,
+      "reason": "covered by handoff + committed baseline at docs/design-system/ui-audit-baseline.md"
+    },
+    "prd": {
+      "skipped": true,
+      "reason": "work_type:enhancement; parent design-system-v2 PRD covers scope"
+    },
+    "tasks": {
+      "completed": true,
+      "plan": "docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md"
+    },
+    "ux_or_integration": {
+      "skipped": true,
+      "reason": "no new UI; token-migration only; v2-refactor-checklist not applicable"
+    },
+    "implement": {
+      "status": "in_progress",
+      "started": "2026-04-21"
+    },
+    "test": { "status": "pending" },
+    "review": { "status": "pending" },
+    "merge": { "status": "pending" },
+    "docs": { "status": "pending" }
+  },
+  "metrics": {
+    "primary": "baseline_p0_count",
+    "baseline": 27,
+    "target": 0,
+    "kill_criteria": "visual regressions reported post-merge > 2 within 7 days"
+  },
+  "case_study": ".claude/features/ui-audit-baseline-burndown/case-study.md",
+  "risks": {
+    "R1_visual_regression": "mitigated via mirror-diff per file",
+    "R2_animation_gaps": "mitigated via Phase 0.1 token additions",
+    "R3_advisory_gate": "closed by Phase 3.2",
+    "R4_scanner_gaps": "closed by Phase 4.1",
+    "R5_baseline_drift": "closed by Phase 4.2",
+    "R6_pbxproj_volatility": "isolated to separate PR in Phase 4.3"
+  }
+}

--- a/FitTracker/DesignSystem/AppMotion.swift
+++ b/FitTracker/DesignSystem/AppMotion.swift
@@ -32,6 +32,12 @@ enum AppSpring {
     static let stiff    = Animation.spring(response: 0.25, dampingFraction: 0.90)
     /// Progress: animated progress bars — softer, slower spring for visual indicators
     static let progress = Animation.spring(response: 0.55, dampingFraction: 0.80)
+    /// Hero entry: welcome screen title + brand icon (slow, gentle)
+    static let hero        = Animation.spring(response: 0.80, dampingFraction: 0.70)
+    /// Step advance: onboarding step transitions
+    static let stepAdvance = Animation.spring(response: 0.50, dampingFraction: 0.70)
+    /// Dial pulse: readiness physics — interpolating for continuous physics feel
+    static let dialPulse   = Animation.interpolatingSpring(stiffness: 40, damping: 8)
 }
 
 // MARK: - Easing
@@ -40,6 +46,8 @@ enum AppEasing {
     static let short     = Animation.easeInOut(duration: AppDuration.short)
     static let instant   = Animation.easeOut(duration: AppDuration.instant)
     static let linear    = Animation.linear(duration: AppDuration.standard)
+    /// Hero caption: slow easeOut for staggered hero text entry
+    static let heroEntry = Animation.easeOut(duration: AppDuration.xLong)
 }
 
 // MARK: - Reduce-motion helpers
@@ -89,4 +97,8 @@ enum AppLoadingAnimation {
     /// Shimmer: opacity oscillates 0.4→1.0, 0.8s cycle.
     /// Use for: waiting, background refresh.
     static let shimmer = Animation.easeInOut(duration: 0.8).repeatForever(autoreverses: true)
+
+    /// Fast shimmer: progress bar indeterminate gradient, 1.2s linear loop.
+    /// Use for: progress bar scrolling gradient, skeleton shimmer.
+    static let fastShimmer = Animation.linear(duration: 1.2).repeatForever(autoreverses: false)
 }

--- a/FitTracker/Views/Auth/AccountPanelView.swift
+++ b/FitTracker/Views/Auth/AccountPanelView.swift
@@ -200,7 +200,7 @@ struct AccountPanelView: View {
 
             Text(session?.initials ?? "—")
                 .font(AppText.pageTitle)
-                .foregroundStyle(.white)
+                .foregroundStyle(AppColor.Text.inversePrimary)
         }
     }
 

--- a/FitTracker/Views/Auth/AuthHubView.swift
+++ b/FitTracker/Views/Auth/AuthHubView.swift
@@ -513,7 +513,7 @@ private struct GoogleProviderRow: View {
         HStack(spacing: AppSpacing.xSmall) {
             ZStack {
                 Circle()
-                    .fill(Color.white)
+                    .fill(AppPalette.white)
                     .frame(width: 26, height: 26)
                 Text("G")
                     .font(AppText.callout)
@@ -550,7 +550,7 @@ private struct AppleProviderRow: View {
             VStack(alignment: .leading, spacing: AppSpacing.micro) {
                 Text(title)
                     .font(AppText.button)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(AppColor.Text.inversePrimary)
                 Text(subtitle)
                     .font(AppText.subheading)
                     .foregroundStyle(AppColor.Text.inverseSecondary)
@@ -661,7 +661,7 @@ private struct AuthPrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(AppText.button)
-            .foregroundStyle(.white)
+            .foregroundStyle(AppColor.Text.inversePrimary)
             .frame(maxWidth: .infinity)
             .padding(.vertical, AppSpacing.small)
             .background(

--- a/FitTracker/Views/Auth/SignInView.swift
+++ b/FitTracker/Views/Auth/SignInView.swift
@@ -18,7 +18,7 @@ struct SignInView: View {
             ZStack(alignment: .top) {
 
                 // Background
-                Color(.systemBackground).ignoresSafeArea()
+                AppColor.Background.appPrimary.ignoresSafeArea()
 
                 ScrollView(showsIndicators: false) {
                     VStack(spacing: AppSpacing.large) {
@@ -240,7 +240,7 @@ struct SocialSignInButton: View {
 
     private var labelColor: Color {
         switch provider {
-        case .apple:              return Color(.systemBackground)
+        case .apple:              return AppColor.Text.inversePrimary
         case .google, .facebook:  return AppColor.Brand.warm
         case .passkey:            return AppColor.Accent.sleep
         case .email:              return AppColor.Accent.secondary

--- a/FitTracker/Views/Auth/SignInView.swift
+++ b/FitTracker/Views/Auth/SignInView.swift
@@ -154,7 +154,7 @@ struct SignInView: View {
                     dismiss()
                 case .error(let msg):
                     errorBanner = msg
-                    withAnimation(.default.repeatCount(3, autoreverses: true)) {
+                    withAnimation(AppEasing.short.repeatCount(3, autoreverses: true)) {
                         shakeOffset = 6
                     }
                     Task { try? await Task.sleep(for: .milliseconds(300)); shakeOffset = 0 }

--- a/FitTracker/Views/Auth/WelcomeView.swift
+++ b/FitTracker/Views/Auth/WelcomeView.swift
@@ -134,13 +134,13 @@ struct WelcomeView: View {
         }
         // ── Entry animations ──────────────────────────────
         .onAppear {
-            withAnimation(.spring(response: 0.8, dampingFraction: 0.7).delay(0.1)) {
+            withAnimation(AppSpring.hero.delay(0.1)) {
                 logoScale = 1.0; logoOpacity = 1.0
             }
-            withAnimation(.easeOut(duration: 0.6).delay(0.4)) {
+            withAnimation(AppEasing.heroEntry.delay(0.4)) {
                 textOffset = 0; textOpacity = 1.0
             }
-            withAnimation(.easeOut(duration: 0.6).delay(0.7)) {
+            withAnimation(AppEasing.heroEntry.delay(0.7)) {
                 buttonsOffset = 0; buttonsOpacity = 1.0
             }
         }

--- a/FitTracker/Views/ConsentView.swift
+++ b/FitTracker/Views/ConsentView.swift
@@ -29,7 +29,7 @@ struct ConsentView: View {
                 Image(systemName: "checkmark.circle.fill")
                     .font(AppText.subheading)
                     .foregroundStyle(AppColor.Status.success)
-                    .background(Circle().fill(Color.white).frame(width: 26, height: 26))
+                    .background(Circle().fill(AppPalette.white).frame(width: 26, height: 26))
                     .offset(x: 44, y: -44)
             }
             .padding(.bottom, AppSpacing.large)
@@ -92,7 +92,7 @@ struct ConsentView: View {
             } label: {
                 Text("Accept & Continue")
                     .font(AppText.button)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(AppColor.Text.inversePrimary)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, AppSpacing.small)
             }

--- a/FitTracker/Views/Main/BodyCompositionCard.swift
+++ b/FitTracker/Views/Main/BodyCompositionCard.swift
@@ -111,7 +111,7 @@ struct BodyCompositionCard: View {
                 Button(action: onConnectHealthKit) {
                     Text("Connect HealthKit")
                         .font(AppText.button)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(AppColor.Text.inversePrimary)
                         .frame(maxWidth: .infinity)
                         .frame(height: AppSize.ctaHeight)
                         .background(AppColor.Accent.recovery, in: RoundedRectangle(cornerRadius: AppRadius.button, style: .continuous))

--- a/FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift
+++ b/FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift
@@ -146,7 +146,7 @@ struct OnboardingAuthView: View {
                 HStack(spacing: AppSpacing.xSmall) {
                     Image(systemName: "envelope.fill")
                         .font(AppText.sectionTitle)
-                        .foregroundStyle(.blue)
+                        .foregroundStyle(AppColor.Brand.secondary)
                         .frame(width: 26)
                     VStack(alignment: .leading, spacing: AppSpacing.micro) {
                         Text("Continue with Email")
@@ -176,7 +176,7 @@ struct OnboardingAuthView: View {
                 } label: {
                     HStack(spacing: AppSpacing.xSmall) {
                         ZStack {
-                            Circle().fill(Color.white).frame(width: 26, height: 26)
+                            Circle().fill(AppPalette.white).frame(width: 26, height: 26)
                             Text("G").font(AppText.callout).foregroundStyle(AppColor.Brand.secondary)
                         }
                         VStack(alignment: .leading, spacing: AppSpacing.micro) {
@@ -194,7 +194,7 @@ struct OnboardingAuthView: View {
                     }
                     .padding(.horizontal, AppSpacing.small)
                     .padding(.vertical, AppSpacing.small)
-                    .background(Color.white, in: RoundedRectangle(cornerRadius: AppRadius.medium))
+                    .background(AppPalette.white, in: RoundedRectangle(cornerRadius: AppRadius.medium))
                     .overlay(RoundedRectangle(cornerRadius: AppRadius.medium).stroke(AppColor.Border.hairline, lineWidth: 1))
                 }
                 .buttonStyle(.plain)
@@ -208,12 +208,12 @@ struct OnboardingAuthView: View {
                 HStack(spacing: AppSpacing.xSmall) {
                     Image(systemName: "apple.logo")
                         .font(AppText.sectionTitle)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(AppColor.Text.inversePrimary)
                         .frame(width: 26)
                     VStack(alignment: .leading, spacing: AppSpacing.micro) {
                         Text("Continue with Apple")
                             .font(AppText.button)
-                            .foregroundStyle(.white)
+                            .foregroundStyle(AppColor.Text.inversePrimary)
                         Text("Use your Apple Account")
                             .font(AppText.subheading)
                             .foregroundStyle(AppColor.Text.inverseSecondary)
@@ -306,7 +306,7 @@ struct OnboardingAuthView: View {
                 }
             }
             .font(AppText.button)
-            .foregroundStyle(.white)
+            .foregroundStyle(AppColor.Text.inversePrimary)
             .frame(maxWidth: .infinity)
             .frame(height: AppSize.ctaHeight)
             .background(AppColor.Surface.inverse.opacity(0.82), in: RoundedRectangle(cornerRadius: AppRadius.button))
@@ -347,7 +347,7 @@ struct OnboardingAuthView: View {
                 }
             }
             .font(AppText.button)
-            .foregroundStyle(.white)
+            .foregroundStyle(AppColor.Text.inversePrimary)
             .frame(maxWidth: .infinity)
             .frame(height: AppSize.ctaHeight)
             .background(AppColor.Surface.inverse.opacity(0.82), in: RoundedRectangle(cornerRadius: AppRadius.button))
@@ -406,7 +406,7 @@ struct OnboardingAuthView: View {
                 }
             }
             .font(AppText.button)
-            .foregroundStyle(.white)
+            .foregroundStyle(AppColor.Text.inversePrimary)
             .frame(maxWidth: .infinity)
             .frame(height: AppSize.ctaHeight)
             .background(AppColor.Surface.inverse.opacity(0.82), in: RoundedRectangle(cornerRadius: AppRadius.button))

--- a/FitTracker/Views/Onboarding/v2/OnboardingFirstActionView.swift
+++ b/FitTracker/Views/Onboarding/v2/OnboardingFirstActionView.swift
@@ -100,7 +100,7 @@ struct OnboardingFirstActionView: View {
                 if reduceMotion {
                     showContent = true
                 } else {
-                    withAnimation(.spring(response: 0.5, dampingFraction: 0.7).delay(0.2)) {
+                    withAnimation(AppSpring.stepAdvance.delay(0.2)) {
                         showContent = true
                     }
                 }

--- a/FitTracker/Views/Profile/ProfileHeroSection.swift
+++ b/FitTracker/Views/Profile/ProfileHeroSection.swift
@@ -30,7 +30,7 @@ struct ProfileHeroSection: View {
                         .frame(width: 72, height: 72)
                     Text(initials)
                         .font(AppText.titleStrong)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(AppColor.Text.inversePrimary)
                 }
             }
             .accessibilityLabel("Profile picture, \(displayName)")
@@ -51,7 +51,7 @@ struct ProfileHeroSection: View {
                     Button(action: onGoalTap) {
                         Text(goal.rawValue)
                             .font(AppText.caption)
-                            .foregroundStyle(.white)
+                            .foregroundStyle(AppColor.Text.inversePrimary)
                             .padding(.horizontal, AppSpacing.small)
                             .padding(.vertical, AppSpacing.xxxSmall)
                             .background(AppColor.Accent.primary, in: Capsule())

--- a/FitTracker/Views/Shared/MilestoneModal.swift
+++ b/FitTracker/Views/Shared/MilestoneModal.swift
@@ -21,7 +21,7 @@ struct MilestoneModal: View {
 
                 Text(title)
                     .font(AppText.metric)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(AppColor.Text.inversePrimary)
                     .multilineTextAlignment(.center)
 
                 Text(message)
@@ -38,7 +38,7 @@ struct MilestoneModal: View {
                 .padding(.horizontal, AppSpacing.xxLarge)
                 .padding(.vertical, AppSpacing.xSmall)
                 .background(AppColor.Surface.materialLight, in: RoundedRectangle(cornerRadius: AppRadius.large))
-                .foregroundStyle(.white)
+                .foregroundStyle(AppColor.Text.inversePrimary)
             }
             .padding(AppSpacing.xLarge)
         }

--- a/FitTracker/Views/Shared/ReadinessCard.swift
+++ b/FitTracker/Views/Shared/ReadinessCard.swift
@@ -156,7 +156,7 @@ struct ReadinessCard: View {
         .onAppear {
             guard let target = score else { return }
             displayedScore = 0
-            withAnimation(.interpolatingSpring(stiffness: 40, damping: 8)) {
+            withAnimation(AppSpring.dialPulse) {
                 displayedScore = target
             }
             if let result = readinessResult {

--- a/FitTracker/Views/Shared/ReadinessCard.swift
+++ b/FitTracker/Views/Shared/ReadinessCard.swift
@@ -19,7 +19,7 @@ struct ReadinessCard: View {
     private func startTimer() {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { _ in
-            withAnimation(.easeInOut) {
+            withAnimation(AppEasing.standard) {
                 currentPage = (currentPage + 1) % 6
             }
         }

--- a/FitTracker/Views/Training/v2/TrainingPlanView.swift
+++ b/FitTracker/Views/Training/v2/TrainingPlanView.swift
@@ -521,7 +521,7 @@ private struct ShimmerEffect: ViewModifier {
             .offset(x: phase).mask(content)
         )
         .onAppear {
-            withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) { phase = 300 }
+            withAnimation(AppLoadingAnimation.fastShimmer) { phase = 300 }
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,22 @@ ui-audit:
 ui-audit-baseline:
 	python3 scripts/ui-audit.py --baseline --no-fail
 
+# Drift check: fails if the committed ui-audit-baseline.md doesn't match
+# what the scanner would regenerate today. Backs up + restores the file so
+# the working tree is never left polluted (safe inside verify-local).
+# If this fails: run `make ui-audit-baseline` and commit the resulting diff.
+ui-audit-drift:
+	@_baseline=docs/design-system/ui-audit-baseline.md; \
+	 _tmp=$$(mktemp); cp $$_baseline $$_tmp; \
+	 python3 scripts/ui-audit.py --baseline --no-fail > /dev/null; \
+	 if diff -q $$_tmp $$_baseline > /dev/null 2>&1; then \
+	   rm -f $$_tmp; \
+	 else \
+	   cp $$_tmp $$_baseline; rm -f $$_tmp; \
+	   echo "ERROR: ui-audit-baseline.md is stale. Run 'make ui-audit-baseline' and commit."; \
+	   exit 1; \
+	 fi
+
 # Install npm dependencies (style-dictionary)
 install:
 	npm install
@@ -53,7 +69,7 @@ install:
 # either failing should abort before the heavier verify-ios build cost.
 # Any new P0 (raw Color literal, raw animation, raw font, missing colorset)
 # introduced by a PR fails the local + CI verify pass.
-verify-local: tokens-check ui-audit verify-web verify-ai verify-evals verify-ios verify-timing verify-framework
+verify-local: tokens-check ui-audit ui-audit-drift verify-web verify-ai verify-evals verify-ios verify-timing verify-framework
 
 verify-web:
 	cd dashboard && npm test

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,12 @@ ui-audit-baseline:
 install:
 	npm install
 
-# Note: ui-audit is intentionally NOT in verify-local yet — the existing
-# baseline has 27 P0 violations (see docs/design-system/ui-audit-baseline.md).
-# Run `make ui-audit` separately to see drift introduced by your branch.
-# Once the baseline reaches 0 P0, add ui-audit to this chain so it gates
-# every local + CI verify pass.
-verify-local: tokens-check verify-web verify-ai verify-evals verify-ios verify-timing verify-framework
+# ui-audit is a hard gate as of 2026-04-21 (baseline P0 driven from 27 → 0).
+# It runs right after tokens-check because both are fast source-level checks —
+# either failing should abort before the heavier verify-ios build cost.
+# Any new P0 (raw Color literal, raw animation, raw font, missing colorset)
+# introduced by a PR fails the local + CI verify pass.
+verify-local: tokens-check ui-audit verify-web verify-ai verify-evals verify-ios verify-timing verify-framework
 
 verify-web:
 	cd dashboard && npm test

--- a/docs/case-studies/ui-audit-baseline-burndown.md
+++ b/docs/case-studies/ui-audit-baseline-burndown.md
@@ -4,7 +4,7 @@
 **Started:** 2026-04-21
 **Code completed:** 2026-04-21
 **Parent feature:** design-system-v2
-**Plan:** [docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md](../../../docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md)
+**Plan:** [docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md](../superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md)
 **Branches:**
 - `claude/review-ui-consistency-zSkvJ` — 20 commits over pushed tip `573fe8a` (unpushed): AppMotion tokens, scanner `--file` flag, Phase 0 infra, 12 file migrations, baseline regenerations, gate promotion, scanner hardening, drift check
 - `chore/pbxproj-orphan-cleanup` — 1 commit over `origin/main` (unpushed): 2-line orphan deletion

--- a/docs/design-system/mirrors/README.md
+++ b/docs/design-system/mirrors/README.md
@@ -1,0 +1,63 @@
+# UI-Audit Mirror Workflow
+
+Before/after simulator screenshots captured during the UI-audit
+baseline burndown (Phases 1–2 of the burndown plan). Mirrors live at
+`.build/mirrors/` — gitignored — and are local verification artifacts
+only.
+
+## Naming
+
+`<FileStem>-<before|after>-<light|dark>.png`
+
+Examples:
+- `OnboardingAuthView-before-light.png`
+- `OnboardingAuthView-after-dark.png`
+
+## Tooling
+
+```bash
+./scripts/ui-mirror.sh <label>
+```
+
+Wraps `xcrun simctl io booted screenshot` with `.build/mirrors/`
+as the output directory. Boot the simulator and navigate to the
+target screen before running.
+
+For animations: capture a video instead:
+
+```bash
+xcrun simctl io booted recordVideo .build/mirrors/<label>.mov
+# trigger the animation in the simulator
+# Ctrl-C to stop
+```
+
+## Diff procedure
+
+Preview.app supports side-by-side comparison: open both files, then
+`Cmd+Option+Return` splits the window. Compare:
+
+- Text contrast on colored backgrounds (inverse-token swaps should
+  visually match `.white` on brand-orange; any shift is a regression).
+- Dark mode — v2 screens must flip surfaces correctly. Both modes
+  must be verified per file.
+- Animation timing and feel — if the file touched an animation, play
+  before/after videos side-by-side.
+
+If any unintended change, STOP, revert the file, re-examine the
+mapping. Do not commit until diffs are clean.
+
+## Retention
+
+Mirrors are retained for the duration of the burndown only. Once
+`ui-audit` is promoted to a hard gate in `verify-local` (Phase 3.2),
+clear `.build/mirrors/`. Long-term visual-regression safety is
+handled by snapshot tests (deferred — see
+`docs/design-system/figma-code-sync-status.md` Gap-C).
+
+## Why manual instead of snapshot tests
+
+Snapshot tests require a test target setup, a per-screen rendering
+harness, and a commit-tolerable pixel-diff threshold. The cost/
+benefit for this one-shot 27-finding burndown does not justify that
+infrastructure today. Snapshot tests are the long-term answer and
+are tracked as a separate item in the Figma-code sync status doc.

--- a/docs/design-system/ui-audit-baseline.md
+++ b/docs/design-system/ui-audit-baseline.md
@@ -7,7 +7,7 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 
 ## Summary
 
-- **P0 (blocking):** 6
+- **P0 (blocking):** 0
 - **P1 (warning):**  103
 - **Files with findings:** 42
 - **Files scanned:** 82
@@ -18,17 +18,17 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | Area | P0 | P1 | Files |
 |---|---:|---:|---:|
 | `AI` | 0 | 6 | 2 |
-| `Auth` | 3 | 14 | 4 |
+| `Auth` | 0 | 14 | 4 |
 | `ConsentView.swift` | 0 | 1 | 1 |
 | `Main` | 0 | 4 | 2 |
 | `Nutrition` | 0 | 15 | 6 |
-| `Onboarding` | 1 | 7 | 4 |
+| `Onboarding` | 0 | 7 | 4 |
 | `Profile` | 0 | 4 | 4 |
 | `RootTabView.swift` | 0 | 1 | 1 |
 | `Settings` | 0 | 4 | 3 |
-| `Shared` | 1 | 30 | 8 |
+| `Shared` | 0 | 30 | 8 |
 | `Stats` | 0 | 1 | 1 |
-| `Training` | 1 | 16 | 6 |
+| `Training` | 0 | 16 | 6 |
 
 ## Per-file findings
 
@@ -74,16 +74,13 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 183 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 28)` |
 | 287 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 28)` |
 
-### `FitTracker/Views/Auth/WelcomeView.swift` — P0=3, P1=3
+### `FitTracker/Views/Auth/WelcomeView.swift` — P0=0, P1=3
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 54 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 120, height: 120)` |
 | 69 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 96, height: 96)` |
 | 102 | P1 | `DS-MAGIC-FRAME` | `Spacer().frame(height: 36)` |
-| 137 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.spring(response: 0.8, dampingFraction: 0.7).delay(0.1)) {` |
-| 140 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.easeOut(duration: 0.6).delay(0.4)) {` |
-| 143 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.easeOut(duration: 0.6).delay(0.7)) {` |
 
 ### `FitTracker/Views/ConsentView.swift` — P0=0, P1=1
 
@@ -165,12 +162,11 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 |---:|:---:|---|---|
 | 30 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 160, height: 160)` |
 
-### `FitTracker/Views/Onboarding/v2/OnboardingFirstActionView.swift` — P0=1, P1=1
+### `FitTracker/Views/Onboarding/v2/OnboardingFirstActionView.swift` — P0=0, P1=1
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 37 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 80, height: 80)` |
-| 103 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.spring(response: 0.5, dampingFraction: 0.7).delay(0.2)) {` |
 
 ### `FitTracker/Views/Onboarding/v2/OnboardingHealthKitView.swift` — P0=0, P1=1
 
@@ -255,14 +251,13 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 42 | P1 | `DS-MAGIC-FRAME` | `TextField("ms", text: $hrvText).keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)` |
 | 47 | P1 | `DS-MAGIC-FRAME` | `TextField("hrs", text: $sleepText).keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)` |
 
-### `FitTracker/Views/Shared/ReadinessCard.swift` — P0=1, P1=11
+### `FitTracker/Views/Shared/ReadinessCard.swift` — P0=0, P1=11
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 45 | P1 | `DS-MAGIC-FRAME` | `.frame(height: 180)` |
 | 49 | P1 | `DS-MAGIC-PADDING` | `.padding(.bottom, 6)` |
 | 51 | P1 | `DS-MAGIC-FRAME` | `.frame(height: 180)` |
-| 159 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.interpolatingSpring(stiffness: 40, damping: 8)) {` |
 | 192 | P1 | `DS-MAGIC-FRAME` | `.frame(minWidth: 260)` |
 | 211 | P1 | `DS-MAGIC-FRAME` | `.frame(height: 6)` |
 | 217 | P1 | `DS-MAGIC-FRAME` | `.frame(height: 6)` |
@@ -342,12 +337,11 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 201 | P1 | `DS-MAGIC-FRAME` | `.frame(minHeight: 44)` |
 | 217 | P1 | `DS-MAGIC-FRAME` | `.frame(minWidth: 44, minHeight: 44)` |
 
-### `FitTracker/Views/Training/v2/TrainingPlanView.swift` — P0=1, P1=3
+### `FitTracker/Views/Training/v2/TrainingPlanView.swift` — P0=0, P1=3
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 166 | P1 | `DS-MAGIC-FRAME` | `Circle().fill(AppColor.Brand.warmSoft).frame(width: 28, height: 28)` |
 | 168 | P1 | `DS-MAGIC-FRAME` | `Circle().fill(AppColor.Surface.materialStrong).frame(width: 28, height: 28)` |
 | 348 | P1 | `DS-MAGIC-FRAME` | `.frame(height: 72)` |
-| 524 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) { phase = 300 }` |
 

--- a/docs/design-system/ui-audit-baseline.md
+++ b/docs/design-system/ui-audit-baseline.md
@@ -7,9 +7,9 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 
 ## Summary
 
-- **P0 (blocking):** 27
+- **P0 (blocking):** 6
 - **P1 (warning):**  103
-- **Files with findings:** 44
+- **Files with findings:** 42
 - **Files scanned:** 82
 - **Files skipped:** 24 (historical v1 + token-definition files)
 
@@ -18,15 +18,15 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | Area | P0 | P1 | Files |
 |---|---:|---:|---:|
 | `AI` | 0 | 6 | 2 |
-| `Auth` | 9 | 14 | 4 |
-| `ConsentView.swift` | 2 | 1 | 1 |
-| `Main` | 1 | 4 | 3 |
+| `Auth` | 3 | 14 | 4 |
+| `ConsentView.swift` | 0 | 1 | 1 |
+| `Main` | 0 | 4 | 2 |
 | `Nutrition` | 0 | 15 | 6 |
-| `Onboarding` | 9 | 7 | 4 |
-| `Profile` | 2 | 4 | 4 |
+| `Onboarding` | 1 | 7 | 4 |
+| `Profile` | 0 | 4 | 4 |
 | `RootTabView.swift` | 0 | 1 | 1 |
 | `Settings` | 0 | 4 | 3 |
-| `Shared` | 3 | 30 | 9 |
+| `Shared` | 1 | 30 | 8 |
 | `Stats` | 0 | 1 | 1 |
 | `Training` | 1 | 16 | 6 |
 
@@ -48,36 +48,30 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 138 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 60, alignment: .leading)` |
 | 155 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 28, alignment: .trailing)` |
 
-### `FitTracker/Views/Auth/AccountPanelView.swift` — P0=1, P1=2
+### `FitTracker/Views/Auth/AccountPanelView.swift` — P0=0, P1=2
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 146 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.subheadline.weight(.semibold))` |
-| 203 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 | 243 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.subheadline)` |
 
-### `FitTracker/Views/Auth/AuthHubView.swift` — P0=3, P1=6
+### `FitTracker/Views/Auth/AuthHubView.swift` — P0=0, P1=6
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 501 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.caption.weight(.semibold))` |
-| 516 | P0 | `DS-RAW-COLOR-MEMBER` | `.fill(Color.white)` |
 | 534 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.caption.weight(.semibold))` |
 | 548 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 28, height: 28)` |
-| 553 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 | 561 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.caption.weight(.semibold))` |
-| 664 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 | 698 | P1 | `DS-MAGIC-PADDING` | `.padding(.vertical, 13)` |
 | 812 | P1 | `DS-MAGIC-FRAME` | `.frame(height: 58)` |
 
-### `FitTracker/Views/Auth/SignInView.swift` — P0=2, P1=3
+### `FitTracker/Views/Auth/SignInView.swift` — P0=0, P1=3
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
-| 21 | P0 | `DS-RAW-COLOR-UIKIT` | `Color(.systemBackground).ignoresSafeArea()` |
 | 53 | P1 | `DS-A11Y-BUTTON` | `Button { errorBanner = nil } label: {` |
 | 183 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 28)` |
-| 243 | P0 | `DS-RAW-COLOR-UIKIT` | `case .apple:              return Color(.systemBackground)` |
 | 287 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 28)` |
 
 ### `FitTracker/Views/Auth/WelcomeView.swift` — P0=3, P1=3
@@ -91,19 +85,11 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 140 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.easeOut(duration: 0.6).delay(0.4)) {` |
 | 143 | P0 | `DS-RAW-ANIMATION` | `withAnimation(.easeOut(duration: 0.6).delay(0.7)) {` |
 
-### `FitTracker/Views/ConsentView.swift` — P0=2, P1=1
+### `FitTracker/Views/ConsentView.swift` — P0=0, P1=1
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 21 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 160, height: 160)` |
-| 32 | P0 | `DS-RAW-COLOR-MEMBER` | `.background(Circle().fill(Color.white).frame(width: 26, height: 26))` |
-| 95 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
-
-### `FitTracker/Views/Main/BodyCompositionCard.swift` — P0=1, P1=0
-
-| Line | Sev | Rule | Snippet |
-|---:|:---:|---|---|
-| 114 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 
 ### `FitTracker/Views/Main/BodyCompositionDetailView.swift` — P0=0, P1=3
 
@@ -164,22 +150,14 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 776 | P1 | `DS-MAGIC-FRAME` | `.frame(minWidth: 260)` |
 | 939 | P1 | `DS-MAGIC-FRAME` | `.frame(minWidth: 160, idealWidth: 180, maxWidth: 220, alignment: .leading)` |
 
-### `FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift` — P0=8, P1=4
+### `FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift` — P0=0, P1=4
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 31 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 120, height: 120)` |
-| 149 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.blue)` |
 | 161 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.caption.weight(.semibold))` |
-| 179 | P0 | `DS-RAW-COLOR-MEMBER` | `Circle().fill(Color.white).frame(width: 26, height: 26)` |
 | 192 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.caption.weight(.semibold))` |
-| 197 | P0 | `DS-RAW-COLOR-MEMBER` | `.background(Color.white, in: RoundedRectangle(cornerRadius: AppRadius.medium))` |
-| 211 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
-| 216 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 | 223 | P1 | `DS-RAW-FONT-SHORTHAND` | `.font(.caption.weight(.semibold))` |
-| 309 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
-| 350 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
-| 409 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 
 ### `FitTracker/Views/Onboarding/v2/OnboardingConsentView.swift` — P0=0, P1=1
 
@@ -212,13 +190,11 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 |---:|:---:|---|---|
 | 17 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 36, height: 36)` |
 
-### `FitTracker/Views/Profile/ProfileHeroSection.swift` — P0=2, P1=1
+### `FitTracker/Views/Profile/ProfileHeroSection.swift` — P0=0, P1=1
 
 | Line | Sev | Rule | Snippet |
 |---:|:---:|---|---|
 | 30 | P1 | `DS-MAGIC-FRAME` | `.frame(width: 72, height: 72)` |
-| 33 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
-| 54 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 
 ### `FitTracker/Views/Profile/ProfileView.swift` — P0=0, P1=1
 
@@ -278,13 +254,6 @@ every PR that touches a SwiftUI view should keep P0 count at 0.
 | 37 | P1 | `DS-MAGIC-FRAME` | `TextField("bpm", text: $hrText).keyboardType(.numberPad).multilineTextAlignment(.trailing).frame(width: 80)` |
 | 42 | P1 | `DS-MAGIC-FRAME` | `TextField("ms", text: $hrvText).keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)` |
 | 47 | P1 | `DS-MAGIC-FRAME` | `TextField("hrs", text: $sleepText).keyboardType(.decimalPad).multilineTextAlignment(.trailing).frame(width: 80)` |
-
-### `FitTracker/Views/Shared/MilestoneModal.swift` — P0=2, P1=0
-
-| Line | Sev | Rule | Snippet |
-|---:|:---:|---|---|
-| 24 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
-| 41 | P0 | `DS-RAW-COLOR-SHORTHAND` | `.foregroundStyle(.white)` |
 
 ### `FitTracker/Views/Shared/ReadinessCard.swift` — P0=1, P1=11
 

--- a/docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md
+++ b/docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md
@@ -1,0 +1,1099 @@
+# UI-Audit Baseline Burndown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive `make ui-audit` baseline from 27 P0 + 103 P1 → 0 P0 + ≤20 P1, then promote the scanner from advisory to a hard CI gate — without introducing visual regressions.
+
+**Architecture:** Three-layer safety model. (1) **Mirror layer** — before/after simulator screenshots per file, stored in `.build/mirrors/` and diffed before each commit. (2) **Rollback layer** — one file per commit with semantic-tagged baseline, enabling surgical `git revert` or mass revert to `v-ui-audit-baseline-2026-04-20`. (3) **Token layer** — missing AppMotion presets are added BEFORE migration so mappings are 1:1 semantic, not approximation. Burndown proceeds in two clusters (color P0, animation P0) with a hard stop after each phase for review.
+
+**Tech Stack:** SwiftUI, Xcode 16 simulator, Python 3.12 stdlib (scanner), `xcrun simctl io booted screenshot` (mirror tool), `xcodebuild`, `make`.
+
+**PM Workflow framing:** Enhancement to `design-system-v2` feature. Work item type: Enhancement (Tasks → Implement → Test → Merge). Case study tracking: concurrent per the 2026-04-13 rule. Feature state: `.claude/features/ui-audit-baseline-burndown/`.
+
+**Parent branch:** `claude/review-ui-consistency-zSkvJ` (verification layer, 3 commits ahead of main, pushed). This plan extends that branch — verification layer and burndown ship as one logical unit so the gate arrives with P0=0 already satisfied.
+
+**Scope boundary:** This plan covers P0 burndown (27 → 0) + scanner hardening + gate promotion + pbxproj orphan cleanup. **P1 burndown (103 → ≤20) is explicitly deferred to a follow-on plan** — the P1 class (magic padding, missing a11y labels on icon buttons) needs its own token-grid audit and a11y audit that dilute the P0 story. Folding them in triples scope and blurs the rollback story.
+
+---
+
+## Risk mitigation summary
+
+Maps to the 6 risks identified in the prior assessment:
+
+| Risk | Mitigation | Task(s) |
+|---|---|---|
+| **R1. Silent visual regressions from token swaps** | Mirror harness captures before/after screenshots per file; manual diff gate before each commit; dark-mode pass explicitly checked | 0.3, every file task |
+| **R2. Animation token gaps** | Phase 0.1 audits AppMotion coverage against all 6 raw animation call sites; new tokens added to AppMotion.swift BEFORE any file is migrated | 0.1 |
+| **R3. Advisory-only enforcement** | Phase 3.2 promotes `ui-audit` to `verify-local` once baseline P0 = 0, making it a hard gate going forward | 3.2 |
+| **R4. Scanner false negatives** | Phase 4.1 adds regex coverage for computed Color properties, interpolated names, nested modifier chains | 4.1 |
+| **R5. Baseline drift** | Phase 4.2 adds a CI check that re-runs `--baseline --no-fail` on PR and fails if the committed doc differs | 4.2 |
+| **R6. pbxproj orphan cleanup volatility** | Phase 4.3 cleans orphans in a separate PR gated on no-Xcode-UI-opens between diagnosis and merge | 4.3 |
+
+---
+
+## File Structure
+
+### Files created
+- `.claude/features/ui-audit-baseline-burndown/state.json` — PM workflow state
+- `.claude/features/ui-audit-baseline-burndown/case-study.md` — concurrent living case study
+- `scripts/ui-mirror.sh` — wraps `xcrun simctl io booted screenshot` with a named-screen convention
+- `.build/mirrors/` — gitignored directory for before/after PNGs (do NOT commit binaries)
+- `docs/design-system/mirrors/README.md` — documents the mirror workflow and retention policy
+
+### Files modified
+- `scripts/ui-audit.py` — add `--file PATH` flag (Phase 0.2); add new regex rules (Phase 4.1)
+- `FitTracker/DesignSystem/AppMotion.swift` — add new spring/easing/loading tokens identified in Phase 0.1
+- `Makefile` — add `ui-audit` to `verify-local` dependencies (Phase 3.2); add `ui-audit-drift` target (Phase 4.2)
+- `.gitignore` — add `.build/mirrors/` entry
+- `docs/design-system/ui-audit-baseline.md` — regenerated at every P0 fix + final sweep
+- `docs/design-system/feature-memory.md` — one entry per file-task; consolidation entry at end
+- `FitTracker.xcodeproj/project.pbxproj` — Phase 4.3 orphan removal at lines 34 + 40
+- Twelve view files listed in Phase 1 + Phase 2
+
+### Files not modified (guardrails)
+- `CLAUDE.md` — no changes; the Verification Layer section added in commit `573fe8a` already encodes the rules
+- `FitTracker/Services/AppTheme.swift` — token surface is frozen for this plan; new tokens go in `AppMotion.swift` only (color tokens are complete per the chart-color fix in `cf3cf56`)
+- Any v1 `// HISTORICAL` file — read-only; scanner already skips
+
+---
+
+## Burndown procedure (template applied in Phases 1 + 2)
+
+Every file-task in Phase 1 and Phase 2 follows this exact procedure. Defined once here so the per-file tasks stay compact.
+
+- [ ] **P.1 — Capture before-mirror**
+
+Launch Simulator (iPhone 16 Pro, booted). Navigate to the screen this file renders. Run:
+
+```bash
+./scripts/ui-mirror.sh <file-stem>-before-light  # light mode
+# Toggle dark mode in Simulator: Cmd+Shift+A
+./scripts/ui-mirror.sh <file-stem>-before-dark   # dark mode
+```
+
+Expected output: `.build/mirrors/<file-stem>-before-light.png` and `-dark.png` written. If the screen needs preconditions (signed-in state, filled form), use the dev-mode shortcut in `RootTabView` (`AppConfig.devMode`). If a screen cannot be reached from the current simulator state, note the blocker in the task comment and skip mirror — do NOT migrate without a mirror reference.
+
+- [ ] **P.2 — Run scanner on target file, record findings**
+
+```bash
+python3 scripts/ui-audit.py --file FitTracker/Views/<path>/<File>.swift
+```
+
+Expected: N P0 findings matching the Phase table below. If count differs, STOP and surface the discrepancy — the baseline has drifted and the plan needs a re-audit.
+
+- [ ] **P.3 — Apply semantic token migrations**
+
+Read the Mappings subsection for this file. Apply each replacement with the `Edit` tool. Keep edits surgical — no adjacent refactors, no import reorganization, no whitespace churn.
+
+- [ ] **P.4 — Re-run scanner on target file, confirm 0 findings**
+
+```bash
+python3 scripts/ui-audit.py --file FitTracker/Views/<path>/<File>.swift
+```
+
+Expected: `0 P0, 0 P1` for this file (P1 count for this file should also reach 0 as a side-effect; if it doesn't, note remaining P1s — they belong to the deferred P1 plan).
+
+- [ ] **P.5 — Build with `make verify-ios`**
+
+```bash
+make verify-ios 2>&1 | tail -20
+```
+
+Expected: `** BUILD SUCCEEDED **`. If compile fails, the token name is wrong — check against `FitTracker/Services/AppTheme.swift` + `AppMotion.swift`.
+
+- [ ] **P.6 — Capture after-mirror + manual diff**
+
+```bash
+./scripts/ui-mirror.sh <file-stem>-after-light
+# Toggle dark mode
+./scripts/ui-mirror.sh <file-stem>-after-dark
+```
+
+Then manually open before/after pairs side-by-side (Preview.app, Cmd+Option+Return splits the window). Compare:
+- Text contrast on colored backgrounds — inverse tokens should look identical to pure white on brand-orange
+- Dark mode behavior — v2 screens should flip surfaces correctly
+- Animation timing and feel — if migrated an animation, trigger it and watch for perceptible feel change
+
+If any unintended change, STOP, revert the file, re-examine the mapping. Do not commit until diffs are clean.
+
+- [ ] **P.7 — Update feature memory log**
+
+Append one line to `docs/design-system/feature-memory.md`:
+
+```markdown
+### 2026-MM-DD — UI-Audit P0 burndown: <FileName>.swift
+- Replaced N raw literals with semantic tokens (list key ones)
+- Mirror diff: clean (light + dark)
+- Scanner: 0 P0, 0 P1 for file
+```
+
+- [ ] **P.8 — Commit (one file per commit)**
+
+```bash
+git add FitTracker/Views/<path>/<File>.swift docs/design-system/feature-memory.md
+git commit -m "ui-audit: migrate <FileName> raw literals to semantic tokens
+
+N P0 eliminated. Mappings: <summary>.
+Mirror diff verified clean in light + dark.
+Scanner: 0 P0, 0 P1 for file."
+```
+
+- [ ] **P.9 — Regenerate baseline (every 3-4 files or at end of phase)**
+
+Running this per-commit creates excessive churn in `docs/design-system/ui-audit-baseline.md`. Regenerate at natural batch boundaries:
+
+```bash
+python3 scripts/ui-audit.py --baseline --no-fail
+git add docs/design-system/ui-audit-baseline.md
+git commit -m "ui-audit: regenerate baseline after <phase/cluster> completion"
+```
+
+---
+
+## Phase 0: Safety infrastructure
+
+### Task 0.1: Audit AppMotion coverage + add missing tokens
+
+**Goal:** Every raw animation call site in the P0 list has a semantic AppMotion equivalent BEFORE any file is migrated. No approximations.
+
+**Files:**
+- Modify: `FitTracker/DesignSystem/AppMotion.swift`
+
+**Background — raw animation sites in P0 scope:**
+
+| File | Site | Current |
+|---|---|---|
+| `WelcomeView.swift:137` | Hero spring entry | `.spring(response: 0.8, dampingFraction: 0.7).delay(0.1)` |
+| `WelcomeView.swift:140` | Caption fade-in | `.easeOut(duration: 0.6).delay(0.4)` |
+| `WelcomeView.swift:143` | CTA fade-in | `.easeOut(duration: 0.6).delay(0.7)` |
+| `OnboardingFirstActionView.swift:103` | Step advance | `.spring(response: 0.5, dampingFraction: 0.7).delay(0.2)` |
+| `ReadinessCard.swift:22` | Score update | `.easeInOut` (no explicit duration, SwiftUI default ~0.35s) |
+| `ReadinessCard.swift:159` | Dial pulse | `.interpolatingSpring(stiffness: 40, damping: 8)` |
+| `TrainingPlanView.swift:524` | Shimmer loop | `.linear(duration: 1.2).repeatForever(autoreverses: false)` |
+
+**Existing tokens that cover these:**
+- `AppEasing.short` (easeInOut 0.20s) — close to ReadinessCard:22 but slower default may be intentional
+- `AppLoadingAnimation.rotate` (linear 2.0s repeatForever) — close to TrainingPlanView:524 but 1.2s was likely tuned for a specific shimmer
+
+**Tokens to add (proposed):**
+
+```swift
+// MARK: - Duration (extend)
+static let hero: Double = 0.80  // Welcome hero entry
+
+// MARK: - Spring presets (extend)
+/// Hero entry: welcome screen title + brand icon (slow, gentle)
+static let hero       = Animation.spring(response: 0.80, dampingFraction: 0.70)
+/// Step advance: onboarding step transitions
+static let stepAdvance = Animation.spring(response: 0.50, dampingFraction: 0.70)
+/// Dial pulse: readiness dial physics — interpolating spring for continuous physics feel
+static let dialPulse  = Animation.interpolatingSpring(stiffness: 40, damping: 8)
+
+// MARK: - Easing (extend)
+/// Hero caption: slow easeOut for staggered text entry
+static let hero       = Animation.easeOut(duration: AppDuration.hero.map { 0.6 } ?? 0.6)  // actually: .easeOut(0.6)
+static let heroEntry  = Animation.easeOut(duration: 0.60)
+
+// MARK: - Loading animation presets (extend)
+/// Fast shimmer: UI scrolling gradient — linear 1.2s repeatForever.
+/// Use for: progress bar indeterminate states.
+static let fastShimmer = Animation.linear(duration: 1.2).repeatForever(autoreverses: false)
+```
+
+- [ ] **Step 1: Read current AppMotion.swift top-to-bottom**
+
+```bash
+cat FitTracker/DesignSystem/AppMotion.swift
+```
+
+Confirm `AppDuration`, `AppSpring`, `AppEasing`, `AppLoadingAnimation` are the four extension points. Verify nothing I'm about to add already exists under a different name.
+
+- [ ] **Step 2: Add `AppDuration.hero = 0.80`**
+
+Use `Edit` on `FitTracker/DesignSystem/AppMotion.swift`, after the `xLong` line inside `enum AppDuration`:
+
+```swift
+    /// Hero: welcome title entry, celebration lead — 800 ms
+    static let hero: Double = 0.80
+```
+
+- [ ] **Step 3: Add three new springs to `enum AppSpring`**
+
+```swift
+    /// Hero entry: welcome screen title + brand icon (slow, gentle)
+    static let hero        = Animation.spring(response: 0.80, dampingFraction: 0.70)
+    /// Step advance: onboarding step transitions
+    static let stepAdvance = Animation.spring(response: 0.50, dampingFraction: 0.70)
+    /// Dial pulse: readiness physics — interpolating for continuous physics feel
+    static let dialPulse   = Animation.interpolatingSpring(stiffness: 40, damping: 8)
+```
+
+- [ ] **Step 4: Add `AppEasing.heroEntry`**
+
+Inside `enum AppEasing`:
+
+```swift
+    /// Hero caption: slow easeOut for staggered hero text entry
+    static let heroEntry = Animation.easeOut(duration: AppDuration.xLong)  // 0.60
+```
+
+- [ ] **Step 5: Add `AppLoadingAnimation.fastShimmer`**
+
+Inside `enum AppLoadingAnimation`:
+
+```swift
+    /// Fast shimmer: progress bar indeterminate gradient, 1.2s linear loop.
+    /// Use for: progress bar scrolling gradient, skeleton shimmer.
+    static let fastShimmer = Animation.linear(duration: 1.2).repeatForever(autoreverses: false)
+```
+
+- [ ] **Step 6: Build**
+
+```bash
+make verify-ios 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`. If fail, syntax error in new declarations.
+
+- [ ] **Step 7: Sanity check — tokens file references grep clean**
+
+```bash
+grep -c "AppSpring\.\|AppEasing\.\|AppLoadingAnimation\." FitTracker/DesignSystem/AppMotion.swift
+```
+
+Expected: multiple hits (definitions themselves). Just a smoke test — the compile above was the real check.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add FitTracker/DesignSystem/AppMotion.swift
+git commit -m "design-tokens: add AppSpring.hero/stepAdvance/dialPulse, AppEasing.heroEntry, AppLoadingAnimation.fastShimmer
+
+Closes AppMotion coverage gaps for the 7 raw animation call sites
+flagged by ui-audit Phase 1 P0 cluster. No call sites migrated yet —
+tokens land first so Phase 1/2 migrations are 1:1 semantic, not
+approximation."
+```
+
+---
+
+### Task 0.2: Extend scanner with `--file PATH` flag
+
+**Goal:** Enable per-file invocation during burndown so P.2 + P.4 of the procedure run fast and produce per-file reports.
+
+**Files:**
+- Modify: `scripts/ui-audit.py`
+
+- [ ] **Step 1: Read scanner source**
+
+```bash
+wc -l scripts/ui-audit.py
+head -60 scripts/ui-audit.py
+```
+
+Note the argparse setup and the main walk loop.
+
+- [ ] **Step 2: Add `--file PATH` argument**
+
+Locate the argparse block. Add:
+
+```python
+parser.add_argument(
+    "--file",
+    action="append",
+    default=None,
+    help="Scan only specific file(s). Can be repeated. Skips SKIP_FILES check since you opted in.",
+)
+```
+
+- [ ] **Step 3: Branch in main walk**
+
+Locate where the walk starts (likely `for root, _, files in os.walk(...)`). Wrap it:
+
+```python
+if args.file:
+    targets = [Path(p) for p in args.file]
+    violations = []
+    for path in targets:
+        if not path.exists():
+            print(f"ERROR: {path} not found", file=sys.stderr)
+            sys.exit(2)
+        violations.extend(scan_file(path))
+else:
+    # existing walk logic
+```
+
+- [ ] **Step 4: Test on a clean file**
+
+```bash
+python3 scripts/ui-audit.py --file FitTracker/Views/Main/v2/MainScreenView.swift
+```
+
+Expected: low or 0 P0 count (MainScreenView is not in the P0 table). Output format matches the existing report.
+
+- [ ] **Step 5: Test on a dirty file**
+
+```bash
+python3 scripts/ui-audit.py --file FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift
+```
+
+Expected: 8 P0 findings (matches the P0 table in handoff).
+
+- [ ] **Step 6: Test error path**
+
+```bash
+python3 scripts/ui-audit.py --file does/not/exist.swift
+```
+
+Expected: exit code 2, error message on stderr.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/ui-audit.py
+git commit -m "ui-audit: add --file flag for per-file invocation
+
+Enables per-file scanning during burndown procedure (P.2, P.4). Bypasses
+SKIP_FILES for explicit opt-in. Existing full-walk behavior unchanged
+when --file is omitted."
+```
+
+---
+
+### Task 0.3: Mirror harness + feature state scaffolding
+
+**Goal:** Before/after screenshot workflow + PM workflow state + case-study skeleton.
+
+**Files:**
+- Create: `scripts/ui-mirror.sh`
+- Create: `.gitignore` append for `.build/mirrors/`
+- Create: `.claude/features/ui-audit-baseline-burndown/state.json`
+- Create: `.claude/features/ui-audit-baseline-burndown/case-study.md`
+- Create: `docs/design-system/mirrors/README.md`
+
+- [ ] **Step 1: Create `scripts/ui-mirror.sh`**
+
+```bash
+#!/usr/bin/env bash
+# scripts/ui-mirror.sh <label>
+# Captures booted-simulator screenshot to .build/mirrors/<label>.png
+# for before/after visual verification during UI-audit burndown.
+set -euo pipefail
+
+LABEL="${1:-}"
+if [ -z "$LABEL" ]; then
+  echo "Usage: $0 <label>" >&2
+  echo "Example: $0 OnboardingAuthView-before-light" >&2
+  exit 1
+fi
+
+MIRROR_DIR=".build/mirrors"
+mkdir -p "$MIRROR_DIR"
+
+OUT="$MIRROR_DIR/$LABEL.png"
+xcrun simctl io booted screenshot "$OUT"
+echo "Captured: $OUT"
+```
+
+- [ ] **Step 2: chmod +x the script**
+
+```bash
+chmod +x scripts/ui-mirror.sh
+```
+
+- [ ] **Step 3: Smoke-test the harness**
+
+Boot simulator manually (Xcode → Simulator), then:
+
+```bash
+./scripts/ui-mirror.sh smoke-test
+ls -lh .build/mirrors/smoke-test.png
+rm .build/mirrors/smoke-test.png
+```
+
+Expected: a valid PNG file written and removed.
+
+- [ ] **Step 4: Gitignore the mirror directory**
+
+Append to `.gitignore` (confirm `.build/` isn't already covered — if it is, this is a no-op). If `.build/` is already ignored wholesale, skip this step and note in case study.
+
+```
+# UI-audit before/after screenshots — local verification only
+.build/mirrors/
+```
+
+- [ ] **Step 5: Create feature state**
+
+Write `.claude/features/ui-audit-baseline-burndown/state.json`:
+
+```json
+{
+  "feature": "ui-audit-baseline-burndown",
+  "type": "enhancement",
+  "parent_feature": "design-system-v2",
+  "phase": "implement",
+  "phases": {
+    "research": { "skipped": true, "reason": "covered by handoff doc + baseline" },
+    "prd":      { "skipped": true, "reason": "enhancement; parent PRD covers scope" },
+    "tasks":    { "completed": true, "plan": "docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md" },
+    "ux_or_integration": { "skipped": true, "reason": "no new UI; token migration only; v2-refactor checklist N/A" },
+    "implement": { "phase": "in_progress" },
+    "test":      { "phase": "pending" },
+    "review":    { "phase": "pending" },
+    "merge":     { "phase": "pending" },
+    "docs":      { "phase": "pending" }
+  },
+  "metrics": {
+    "primary": "baseline_p0_count",
+    "baseline": 27,
+    "target": 0,
+    "kill_criteria": "visual regressions reported post-merge > 2"
+  },
+  "case_study": ".claude/features/ui-audit-baseline-burndown/case-study.md"
+}
+```
+
+- [ ] **Step 6: Create case-study skeleton**
+
+Write `.claude/features/ui-audit-baseline-burndown/case-study.md` with section headers only (content fills as phases ship):
+
+```markdown
+# UI-Audit Baseline Burndown — Case Study
+
+**Status:** In progress
+**Started:** 2026-04-20
+**Parent feature:** design-system-v2
+**PRs:** TBD
+
+## Context
+[Filled after Phase 0]
+
+## The gap
+[Why verification layer existed but gate couldn't turn on]
+
+## Approach
+[Three-layer safety model: mirror / rollback / motion tokens first]
+
+## Per-file burndown log
+[One entry per commit in Phases 1 + 2]
+
+## Metrics
+- Baseline P0: 27
+- Target P0: 0
+- Visual regressions: 0 (target)
+- Mirror diffs captured: TBD
+- AppMotion tokens added: TBD
+
+## Framework lessons
+[Filled at Phase 5 close-out]
+```
+
+- [ ] **Step 7: Mirror workflow doc**
+
+Write `docs/design-system/mirrors/README.md`:
+
+```markdown
+# UI-Audit Mirror Workflow
+
+Before/after simulator screenshots captured during the UI-audit
+baseline burndown (Phase 1 + 2). Mirrors live at `.build/mirrors/`
+and are gitignored — they are local verification artifacts only.
+
+## Naming
+`<FileStem>-<before|after>-<light|dark>.png`
+
+Example: `OnboardingAuthView-before-light.png`
+
+## Retention
+Mirrors are retained for the duration of the burndown only. Delete
+`.build/mirrors/` after the gate promotes to hard CI (Phase 3.2).
+Long-term visual regression safety is handled by snapshot tests
+(deferred — see `figma-code-sync-status.md` Gap-C).
+
+## Workflow
+See burndown procedure in the implementation plan.
+```
+
+- [ ] **Step 8: Commit infrastructure**
+
+```bash
+git add scripts/ui-mirror.sh .gitignore .claude/features/ui-audit-baseline-burndown/ docs/design-system/mirrors/
+git commit -m "ui-audit: mirror harness + feature state + case-study skeleton
+
+Phase 0 safety infra for the P0 burndown. Mirror harness wraps
+xcrun simctl screenshot with a naming convention; gitignored. Feature
+state scaffolds PM workflow tracking. Case study skeleton ready for
+per-file entries in Phase 1/2."
+```
+
+---
+
+## Phase 1: P0 burndown — color cluster (8 files, 22 P0)
+
+Each file follows the burndown procedure (P.1 → P.9) defined above.
+Tasks are ordered by P0 count descending so the biggest wins land first.
+
+### Task 1.1: OnboardingAuthView.swift — 8 P0
+
+**File:** `FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift`
+
+**Mappings:**
+
+| Line pattern | Before | After |
+|---|---|---|
+| `.foregroundStyle(.white)` × 5 | `.foregroundStyle(.white)` | `.foregroundStyle(AppColor.Text.inversePrimary)` |
+| `Color.white` × 2 | `Color.white` | `AppColor.Text.inversePrimary` |
+| `.foregroundStyle(.blue)` × 1 | `.foregroundStyle(.blue)` | `.foregroundStyle(AppColor.Brand.primary)` |
+
+**Dark-mode check:** The auth screens intentionally use a brand-gradient background in both modes (per memory `feedback_welcome_screen_design.md`). Inverse-primary must remain readable on that gradient in both modes. If the after-dark mirror shows contrast regression, escalate — a new `AppColor.Text.onBrand` token may be needed.
+
+Apply procedure P.1 – P.9. Skip P.9 here (batch at end of cluster).
+
+### Task 1.2: AuthHubView.swift — 3 P0
+
+**File:** `FitTracker/Views/Auth/AuthHubView.swift`
+
+**Mappings:**
+- `.foregroundStyle(.white)` × 2 → `.foregroundStyle(AppColor.Text.inversePrimary)`
+- `Color.white` × 1 → `AppColor.Text.inversePrimary` OR `AppColor.Surface.elevated` — READ CONTEXT: if used as a fill/background it's surface, if text it's inverse. Do not guess.
+
+Apply procedure P.1 – P.8.
+
+### Task 1.3: SignInView.swift — 2 P0
+
+**File:** `FitTracker/Views/Auth/SignInView.swift`
+
+**Mappings:**
+- `Color(.systemBackground)` × 2 → `AppColor.Surface.primary`
+
+**Note:** `.systemBackground` is UIKit bridging. `AppColor.Surface.primary` maps to the colorset that matches system background in light + dark. Verify at P.6.
+
+Apply procedure P.1 – P.8.
+
+### Task 1.4: ConsentView.swift — 2 P0
+
+**File:** `FitTracker/Views/ConsentView.swift`
+
+**Mappings:**
+- `Color.white` × 1 → context-dependent (surface vs inverse text) — read first
+- `.foregroundStyle(.white)` × 1 → `.foregroundStyle(AppColor.Text.inversePrimary)`
+
+Apply procedure P.1 – P.8.
+
+### Task 1.5: ProfileHeroSection.swift — 2 P0
+
+**File:** `FitTracker/Views/Profile/ProfileHeroSection.swift`
+
+**Mappings:**
+- `.foregroundStyle(.white)` × 2 → `.foregroundStyle(AppColor.Text.inversePrimary)`
+
+Apply procedure P.1 – P.8.
+
+### Task 1.6: MilestoneModal.swift — 2 P0
+
+**File:** `FitTracker/Views/Shared/MilestoneModal.swift`
+
+**Mappings:**
+- `.foregroundStyle(.white)` × 2 → `.foregroundStyle(AppColor.Text.inversePrimary)`
+
+**Animation note:** Milestones use `AppSpring.bouncy` historically. If a raw spring is ALSO flagged here (cross-check P.2 output) it's in-cluster and can be fixed at the same time; if it's not flagged, leave animation untouched (out of scope).
+
+Apply procedure P.1 – P.8.
+
+### Task 1.7: AccountPanelView.swift — 1 P0
+
+**File:** `FitTracker/Views/Auth/AccountPanelView.swift`
+
+**Mappings:**
+- `.foregroundStyle(.white)` × 1 → `.foregroundStyle(AppColor.Text.inversePrimary)`
+
+Apply procedure P.1 – P.8.
+
+### Task 1.8: BodyCompositionCard.swift — 1 P0
+
+**File:** `FitTracker/Views/Main/BodyCompositionCard.swift`
+
+**Mappings:**
+- `.foregroundStyle(.white)` × 1 → `.foregroundStyle(AppColor.Text.inversePrimary)`
+
+Apply procedure P.1 – P.8. At P.9, regenerate baseline for Phase 1 cluster.
+
+### Task 1.9: Phase 1 baseline regeneration + review checkpoint
+
+- [ ] **Step 1: Regenerate baseline**
+
+```bash
+python3 scripts/ui-audit.py --baseline --no-fail
+```
+
+- [ ] **Step 2: Verify color-cluster P0 = 0**
+
+```bash
+python3 scripts/ui-audit.py --summary | grep -E "P0|total"
+```
+
+Expected: 8 P0 remaining (all from Phase 2 animation cluster). If higher, the burndown missed a file — diff the fresh baseline against the original.
+
+- [ ] **Step 3: Commit baseline regeneration**
+
+```bash
+git add docs/design-system/ui-audit-baseline.md
+git commit -m "ui-audit: regenerate baseline after Phase 1 color cluster (22 P0 closed)"
+```
+
+- [ ] **Step 4: Append case-study Phase 1 section**
+
+Edit `.claude/features/ui-audit-baseline-burndown/case-study.md` — fill "Per-file burndown log" with 8 entries. Commit.
+
+- [ ] **Step 5: HARD STOP — request review before Phase 2**
+
+Surface to the user: "Phase 1 complete. 22 P0 closed across 8 files. Mirror diffs clean in light + dark. Ready for Phase 2 (animation cluster). Approve?"
+
+---
+
+## Phase 2: P0 burndown — animation cluster (4 files, 6 P0)
+
+### Task 2.1: WelcomeView.swift — 3 P0
+
+**File:** `FitTracker/Views/Auth/WelcomeView.swift`
+
+**Mappings (using tokens added in Task 0.1):**
+
+| Line | Before | After |
+|---|---|---|
+| 137 | `withAnimation(.spring(response: 0.8, dampingFraction: 0.7).delay(0.1))` | `withAnimation(AppSpring.hero.delay(0.1))` |
+| 140 | `withAnimation(.easeOut(duration: 0.6).delay(0.4))` | `withAnimation(AppEasing.heroEntry.delay(0.4))` |
+| 143 | `withAnimation(.easeOut(duration: 0.6).delay(0.7))` | `withAnimation(AppEasing.heroEntry.delay(0.7))` |
+
+Apply procedure P.1 – P.8. Mirror must capture the welcome animation — capture a short video instead of a still if possible (`xcrun simctl io booted recordVideo`); otherwise a still at mid-animation frame is acceptable.
+
+### Task 2.2: OnboardingFirstActionView.swift — 1 P0
+
+**File:** `FitTracker/Views/Onboarding/v2/OnboardingFirstActionView.swift`
+
+**Mappings:**
+- Line 103: `.spring(response: 0.5, dampingFraction: 0.7).delay(0.2)` → `AppSpring.stepAdvance.delay(0.2)`
+
+Apply procedure P.1 – P.8.
+
+### Task 2.3: ReadinessCard.swift — 1 P0 (+ easeInOut is P1, check scope)
+
+**File:** `FitTracker/Views/Shared/ReadinessCard.swift`
+
+**Mappings:**
+- Line 22: `withAnimation(.easeInOut)` — confirm this is flagged as P0 at P.2. If yes: `withAnimation(AppEasing.standard)`.
+- Line 159: `.interpolatingSpring(stiffness: 40, damping: 8)` → `AppSpring.dialPulse`
+
+Apply procedure P.1 – P.8.
+
+### Task 2.4: TrainingPlanView.swift — 1 P0
+
+**File:** `FitTracker/Views/Training/v2/TrainingPlanView.swift`
+
+**Mappings:**
+- Line 524: `.linear(duration: 1.2).repeatForever(autoreverses: false)` → `AppLoadingAnimation.fastShimmer`
+
+Apply procedure P.1 – P.8. At P.9, regenerate baseline for Phase 2 cluster.
+
+### Task 2.5: Phase 2 baseline regeneration + hard stop
+
+- [ ] **Step 1: Regenerate baseline**
+
+```bash
+python3 scripts/ui-audit.py --baseline --no-fail
+```
+
+- [ ] **Step 2: Confirm P0 = 0**
+
+```bash
+python3 scripts/ui-audit.py --summary
+```
+
+Expected: `0 P0, ~103 P1`. P1 is out of scope for this plan — if the count drifted significantly from 103 (e.g., >115 or <85), investigate.
+
+- [ ] **Step 3: Commit + celebrate + HARD STOP**
+
+```bash
+git add docs/design-system/ui-audit-baseline.md
+git commit -m "ui-audit: baseline P0 → 0 after Phase 2 animation cluster closed"
+```
+
+Surface to user: "Baseline P0 = 0. All 27 original findings closed. Ready to promote `ui-audit` to hard gate in `verify-local`. Approve Phase 3?"
+
+---
+
+## Phase 3: Gate the gate
+
+### Task 3.1: Freeze verification — full-tree scan confirms P0 = 0
+
+**Files:** none modified. Verification only.
+
+- [ ] **Step 1: Full scan from clean checkout**
+
+```bash
+git status --short  # should be clean
+python3 scripts/ui-audit.py --summary
+```
+
+Expected: `0 P0, <count> P1`.
+
+- [ ] **Step 2: Run `make tokens-check`**
+
+```bash
+make tokens-check 2>&1 | tail -5
+```
+
+Expected: `tokens check passed`.
+
+- [ ] **Step 3: Run `make verify-ios`**
+
+```bash
+make verify-ios 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+make test 2>&1 | tail -20
+```
+
+Expected: all tests pass. If any regression, investigate immediately — could indicate a token migration broke a snapshot or behavioral test.
+
+No commit — this is a checkpoint.
+
+---
+
+### Task 3.2: Promote `ui-audit` to `verify-local`
+
+**File:** `Makefile`
+
+- [ ] **Step 1: Read the verify-local target**
+
+```bash
+grep -nA 5 "^verify-local:" Makefile
+```
+
+- [ ] **Step 2: Add `ui-audit` as a dependency**
+
+Use `Edit` to change:
+
+```makefile
+verify-local: tokens-check build test
+```
+
+to:
+
+```makefile
+verify-local: tokens-check ui-audit build test
+```
+
+(Position `ui-audit` before `build` so it fails fast on source-level issues before incurring the build cost.)
+
+- [ ] **Step 3: Run verify-local end-to-end**
+
+```bash
+make verify-local 2>&1 | tail -20
+```
+
+Expected: all four stages pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile
+git commit -m "ui-audit: promote to hard gate in verify-local
+
+Baseline P0 reached 0 after Phase 1+2 burndown. ui-audit now runs
+as part of verify-local alongside tokens-check, build, and test.
+Any PR introducing a new P0 (raw Color literal, raw animation, raw
+font, missing colorset) now fails the local gate before CI."
+```
+
+---
+
+## Phase 4: Scanner hardening + orphan cleanup
+
+### Task 4.1: Close known false-negative gaps
+
+**Rationale:** The scanner uses line-level regex. It misses:
+1. Computed color properties: `var tint: Color { .blue }`
+2. String-interpolated asset names: `Color("chart-\(metric)")`
+3. Color inside ternary: `condition ? .white : .black`
+
+**File:** `scripts/ui-audit.py`
+
+- [ ] **Step 1: Add rule for ternary-embedded raw colors**
+
+Add regex under `# Rule matchers`:
+
+```python
+RE_TERNARY_RAW_COLOR = re.compile(r"\?\s*Color\.(white|black|red|blue|green|yellow|orange|purple|pink|gray|clear)\b")
+```
+
+Check in `scan_file()` under the color-literal block. Report as `DS-RAW-COLOR-TERNARY`, severity P0.
+
+- [ ] **Step 2: Add rule for interpolated Color("...") lookups**
+
+```python
+RE_INTERP_ASSET = re.compile(r'Color\(\s*"[^"]*\\\([^)]+\)[^"]*"\s*\)')
+```
+
+Report as `DS-INTERP-ASSET`, severity P1 (warning only — these may be legitimate dynamic lookups but should have a manual comment).
+
+- [ ] **Step 3: Add rule for computed Color properties with raw returns**
+
+Multiline regex:
+
+```python
+RE_COMPUTED_RAW_COLOR = re.compile(
+    r"var\s+\w+:\s*Color\s*\{[^}]*\.(white|black|red|blue|green|yellow|orange|purple|pink|gray|clear)\b[^}]*\}",
+    re.DOTALL,
+)
+```
+
+Report as `DS-COMPUTED-RAW-COLOR`, severity P0.
+
+- [ ] **Step 4: Re-run full scan**
+
+```bash
+python3 scripts/ui-audit.py --summary
+```
+
+Expected: P0 count MAY rise from 0 if these rules surface previously-hidden violations. If so:
+  a) Fix each new finding file-by-file using the procedure in Phase 1/2.
+  b) Regenerate baseline.
+  c) Do NOT re-promote verify-local until P0 is back to 0 — but since the gate is already active, the commit that adds the rules must also fix any new findings OR the commit will fail locally.
+
+- [ ] **Step 5: Commit rule additions + any resulting fixes**
+
+```bash
+git add scripts/ui-audit.py [any view files touched] docs/design-system/ui-audit-baseline.md
+git commit -m "ui-audit: close false-negative gaps (ternary, interpolation, computed properties)"
+```
+
+---
+
+### Task 4.2: Baseline drift CI check
+
+**Goal:** PRs that touch view files must regenerate `ui-audit-baseline.md` — or the baseline becomes misleading.
+
+**File:** `Makefile`
+
+- [ ] **Step 1: Add `ui-audit-drift` target**
+
+Append to Makefile:
+
+```makefile
+.PHONY: ui-audit-drift
+ui-audit-drift:
+	@python3 scripts/ui-audit.py --baseline --no-fail
+	@git diff --quiet docs/design-system/ui-audit-baseline.md || \
+		(echo "ERROR: ui-audit-baseline.md is stale. Run 'make ui-audit-baseline' and commit." && \
+		 git diff docs/design-system/ui-audit-baseline.md && exit 1)
+```
+
+- [ ] **Step 2: Add to verify-local**
+
+```makefile
+verify-local: tokens-check ui-audit ui-audit-drift build test
+```
+
+- [ ] **Step 3: Test — clean state**
+
+```bash
+make ui-audit-drift
+```
+
+Expected: passes silently.
+
+- [ ] **Step 4: Test — dirty state (simulated)**
+
+```bash
+# intentionally modify baseline doc
+echo "drift" >> docs/design-system/ui-audit-baseline.md
+make ui-audit-drift
+# Expected: exit 1 with diff output
+# Reset:
+git checkout -- docs/design-system/ui-audit-baseline.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile
+git commit -m "ui-audit: add ui-audit-drift check to detect stale baseline in PRs"
+```
+
+---
+
+### Task 4.3: pbxproj orphan cleanup (separate PR)
+
+**Goal:** Remove dead PBXBuildFile entries for v1 MainScreenView + v1 TrainingPlanView.
+
+**File:** `FitTracker.xcodeproj/project.pbxproj`
+
+**CRITICAL safety rule:** Xcode must not be open on this project during this task. Xcode regenerates project.pbxproj on save.
+
+- [ ] **Step 1: Confirm Xcode is not running**
+
+```bash
+pgrep -x Xcode || echo "clear"
+```
+
+Expected: `clear`. If pgrep returns a PID, quit Xcode first.
+
+- [ ] **Step 2: Read lines 30-50 of pbxproj**
+
+```bash
+sed -n '30,50p' FitTracker.xcodeproj/project.pbxproj
+```
+
+Confirm lines 34 and 40 are the orphan entries (`A1000001000000000000000B` and `A1000001000000000000000D`).
+
+- [ ] **Step 3: Remove both lines with Edit tool**
+
+Edit once for each line. Grep after to confirm removal:
+
+```bash
+grep -c "A1000001000000000000000B\|A1000001000000000000000D" FitTracker.xcodeproj/project.pbxproj
+```
+
+Expected: 0.
+
+- [ ] **Step 4: Run make verify-ios**
+
+```bash
+make verify-ios 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCEEDED. If fail, restore file from git and escalate — the "orphan" status may have been wrong.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+make test 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit in a separate branch**
+
+This is a separate PR because it touches project.pbxproj, which has higher reviewer scrutiny.
+
+```bash
+git checkout -b chore/pbxproj-orphan-cleanup
+git add FitTracker.xcodeproj/project.pbxproj
+git commit -m "chore: remove two orphan PBXBuildFile entries for historical v1 views
+
+Neither A1000001000000000000000B (v1 MainScreenView) nor
+A1000001000000000000000D (v1 TrainingPlanView) is referenced from
+any Sources phase. Removal is inert — build + tests unchanged.
+
+Verified: Xcode not open during edit; make verify-ios + make test pass."
+git push -u origin chore/pbxproj-orphan-cleanup
+```
+
+Open PR separately. Do NOT merge into the burndown PR — this is a surgical cleanup that deserves its own history entry.
+
+---
+
+## Phase 5: Close out
+
+### Task 5.1: Case study synthesis
+
+**File:** `.claude/features/ui-audit-baseline-burndown/case-study.md`
+
+- [ ] **Step 1: Fill all sections**
+
+Based on PR + commit history, complete:
+- **Context** — what the verification layer was + why the gate couldn't be hard
+- **The gap** — 27 P0 at rest; silent failure mode before DS-MISSING-ASSET rule
+- **Approach** — three-layer safety (mirror / rollback / tokens-first)
+- **Per-file burndown log** — already filled via Phase 1/2 commits
+- **Metrics** — final numbers (baseline P0 27 → 0, mirrors captured count, tokens added count, PRs opened, commits, visual regressions reported)
+- **Framework lessons** — e.g., "mirror-diff-before-commit caught X ambiguities that scanner would have missed"; "tokens-first migration avoided N approximations"; "separate pbxproj PR avoided conflating cleanup with semantic changes"
+
+- [ ] **Step 2: Promote to docs/case-studies/**
+
+```bash
+cp .claude/features/ui-audit-baseline-burndown/case-study.md \
+   docs/case-studies/ui-audit-baseline-burndown.md
+git add docs/case-studies/ui-audit-baseline-burndown.md
+git commit -m "docs: publish UI-audit baseline burndown case study"
+```
+
+- [ ] **Step 3: Update memory index**
+
+Write a new memory file (e.g., `project_ui_audit_burndown.md`) and add one line to `MEMORY.md` under Active.
+
+---
+
+### Task 5.2: PR + post-launch metrics review
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push origin claude/review-ui-consistency-zSkvJ
+```
+
+- [ ] **Step 2: Open PR to main**
+
+Use the existing branch. Title: `ui-audit: baseline P0 27 → 0 + gate activation`.
+
+PR body should include:
+- Commit-by-commit summary
+- Mirror diff attachments (upload 2-3 representative before/after PNG pairs to the PR description)
+- Risk register (this plan's Risk Mitigation table + outcome for each)
+- Metrics snapshot (P0/P1 counts before/after)
+- Case study link
+
+- [ ] **Step 3: Set post-launch metric review**
+
+Schedule: 7 days post-merge. Check:
+- Any P0 regressions introduced via other PRs?
+- Any user-reported visual regressions matching the files touched?
+- `ui-audit-drift` check catch rate in CI (expect: non-zero — means it's working)
+
+Update feature `state.json` phase to `closed` after review.
+
+---
+
+## Self-Review
+
+**1. Spec coverage check:**
+
+The user asked for: ✅ comprehensive plan ✅ case study monitor (Tasks 0.3 + 5.1) ✅ full framework (PM workflow integration, state.json, Enhancement type) ✅ mirror tools (Task 0.3 + procedure P.1/P.6) ✅ rollback safety (one commit per file, semantic tag, separate-PR for pbxproj) ✅ plan for approval (no execution).
+
+**2. Risk coverage check:**
+
+All 6 risks from prior assessment mapped to concrete tasks. R1/R2 have the most elaborate mitigation because they're the most load-bearing — visual regression is the failure mode most likely to reach users undetected.
+
+**3. Placeholder scan:**
+
+No "TBD" beyond the case-study skeleton (intentionally empty, fills during execution). No "implement later" phrases. Every step has exact commands, exact files, exact line numbers where known. Token names verified against existing AppMotion.swift + AppTheme.swift.
+
+**4. Type consistency:**
+
+`AppColor.Text.inversePrimary`, `AppColor.Surface.primary`, `AppColor.Surface.elevated`, `AppColor.Brand.primary` used consistently. New motion tokens (`AppSpring.hero`, `AppSpring.stepAdvance`, `AppSpring.dialPulse`, `AppEasing.heroEntry`, `AppLoadingAnimation.fastShimmer`) declared in Task 0.1 and referenced with the same names in Phase 2 mappings.
+
+**5. Rollback paths:**
+
+Every phase is revertible:
+- Individual file: `git revert <sha>` — each file is one commit
+- Entire phase: revert the phase-boundary baseline-regeneration commit, then the underlying file commits
+- Entire burndown: branch can be reset; verification layer stays intact at `573fe8a`
+- Gate promotion: revert the Makefile commit, scanner continues to run but is advisory again
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md`. Awaiting user approval before starting execution. On approval, two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per file-task, review mirror diffs between tasks, fast iteration
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints at Phase boundaries
+
+Ask on approval which approach to use.

--- a/scripts/ui-audit.py
+++ b/scripts/ui-audit.py
@@ -112,6 +112,12 @@ RE_RAW_ANIMATION = re.compile(
     r"\.(?:easeInOut|easeIn|easeOut|linear|spring|interpolatingSpring|interactiveSpring)"
     r"\(\s*(?:duration|response|dampingFraction|blendDuration|stiffness|damping|initialVelocity)\s*:"
 )
+# Bare animations inside withAnimation(...) or .animation(...) — e.g. .easeInOut
+# with no duration argument. Scoped to these two call sites to avoid false
+# positives on unrelated .easeInOut enum-case uses.
+RE_RAW_ANIMATION_BARE = re.compile(
+    r"(?:\bwithAnimation|\.animation)\s*\(\s*\.(?:easeInOut|easeIn|easeOut|linear|default)(?![\w(])"
+)
 
 # Raw Font.system(...) outside AppTheme — should use AppText.* tokens
 RE_RAW_FONT = re.compile(r"\bFont\.system\(")
@@ -227,8 +233,8 @@ def scan_file(path: Path, bypass_skip: bool = False) -> FileReport:
                     snippet=stripped[:140],
                 ))
 
-        # ── P0: raw animations
-        if RE_RAW_ANIMATION.search(line):
+        # ── P0: raw animations (with or without parenthesized args)
+        if RE_RAW_ANIMATION.search(line) or RE_RAW_ANIMATION_BARE.search(line):
             report.findings.append(Finding(
                 file=rel, line=i, severity="P0", rule="DS-RAW-ANIMATION",
                 message="raw animation literal — use AppMotion.* / AppSpring.* / AppEasing.*",

--- a/scripts/ui-audit.py
+++ b/scripts/ui-audit.py
@@ -179,11 +179,14 @@ def is_historical(path: Path) -> bool:
     return False
 
 
-def scan_file(path: Path) -> FileReport:
-    rel = str(path.relative_to(REPO_ROOT))
+def scan_file(path: Path, bypass_skip: bool = False) -> FileReport:
+    try:
+        rel = str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        rel = str(path)
     report = FileReport(path=path, relative=rel)
 
-    if path.name in SKIP_FILES:
+    if not bypass_skip and path.name in SKIP_FILES:
         report.skipped = "token-definition file"
         return report
     if is_historical(path):
@@ -482,20 +485,36 @@ def main() -> int:
                         help="write docs/design-system/ui-audit-baseline.md")
     parser.add_argument("--no-fail", action="store_true",
                         help="exit 0 even if P0 findings exist (baseline mode)")
+    parser.add_argument("--file", action="append", default=None,
+                        help="scan only these files (repeatable); bypasses SKIP_FILES")
     args = parser.parse_args()
 
-    files = collect_swift_files()
-    reports = [scan_file(f) for f in files]
+    if args.file:
+        if args.baseline:
+            print("ERROR: --baseline and --file are mutually exclusive", file=sys.stderr)
+            return 2
+        reports = []
+        for p in args.file:
+            path = Path(p)
+            if not path.is_absolute():
+                path = (REPO_ROOT / p).resolve()
+            if not path.exists():
+                print(f"ERROR: {p} not found", file=sys.stderr)
+                return 2
+            reports.append(scan_file(path, bypass_skip=True))
+    else:
+        files = collect_swift_files()
+        reports = [scan_file(f) for f in files]
 
-    # Gap A — asset-reference integrity (AppTheme.swift ↔ Assets.xcassets)
-    asset_findings = check_color_assets()
-    if asset_findings:
-        synthetic = FileReport(
-            path=REPO_ROOT / "FitTracker" / "Services" / "AppTheme.swift",
-            relative="FitTracker/Services/AppTheme.swift",
-            findings=asset_findings,
-        )
-        reports.append(synthetic)
+        # Gap A — asset-reference integrity (AppTheme.swift ↔ Assets.xcassets)
+        asset_findings = check_color_assets()
+        if asset_findings:
+            synthetic = FileReport(
+                path=REPO_ROOT / "FitTracker" / "Services" / "AppTheme.swift",
+                relative="FitTracker/Services/AppTheme.swift",
+                findings=asset_findings,
+            )
+            reports.append(synthetic)
 
     if args.baseline:
         out_path = REPO_ROOT / "docs" / "design-system" / "ui-audit-baseline.md"

--- a/scripts/ui-mirror.sh
+++ b/scripts/ui-mirror.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# scripts/ui-mirror.sh <label>
+# Captures booted-simulator screenshot to .build/mirrors/<label>.png
+# for before/after visual verification during UI-audit burndown.
+set -euo pipefail
+
+LABEL="${1:-}"
+if [ -z "$LABEL" ]; then
+  echo "Usage: $0 <label>" >&2
+  echo "Example: $0 OnboardingAuthView-before-light" >&2
+  exit 1
+fi
+
+MIRROR_DIR=".build/mirrors"
+mkdir -p "$MIRROR_DIR"
+
+OUT="$MIRROR_DIR/$LABEL.png"
+xcrun simctl io booted screenshot "$OUT"
+echo "Captured: $OUT"


### PR DESCRIPTION
## Summary

21 commits of UI-audit burndown work that closes the P0 baseline to 0 and promotes `make ui-audit` to a hard gate in `verify-local`. Case study published at `docs/case-studies/ui-audit-baseline-burndown.md` as part of this branch.

## Scope

- **12 view files migrated** — raw color/animation literals → semantic tokens (`AppColor.*`, `AppMotion.*`)
- **5 new AppMotion tokens** — `AppSpring.hero`, `AppSpring.stepAdvance`, `AppSpring.dialPulse`, `AppEasing.heroEntry`, `AppLoadingAnimation.fastShimmer`
- **`scripts/ui-audit.py`** — `--file` flag for per-file invocation; tightened `DS-RAW-ANIMATION` rule to catch bare forms
- **`Makefile`** — `ui-audit` promoted to a hard gate in `verify-local`, new `ui-audit-drift` + `ui-audit-baseline` targets
- **`docs/design-system/ui-audit-baseline.md`** — regenerated baseline (27 P0 → 0 P0)
- **`.claude/features/ui-audit-baseline-burndown/`** — new feature directory with state.json + case study
- **`docs/superpowers/plans/2026-04-20-ui-audit-baseline-burndown.md`** — 1,099-line plan document
- **`scripts/ui-mirror.sh`** — new helper + `docs/design-system/mirrors/README.md`

22 files changed, 1,676 insertions, 108 deletions.

## ⚠️ Known conflicts + regression risk (read before merging)

This branch was authored 2026-04-21 and then sat unmerged while main advanced. A test merge against current main surfaces:

### Makefile conflict

- Main has added: `schema-check`, `install-hooks`, `documentation-debt`, `measurement-adoption`, `runtime-smoke` targets + `.PHONY` entries (Gemini audit Tier 1.3/1.1/3.2/2.1 groundwork)
- This branch has added: `ui-audit-drift`, updated `verify-local` to make `ui-audit` a hard gate
- **Resolution required:** both sets of targets need to land. Expect to manually merge the `.PHONY` line and the body of `verify-local`. No semantic conflict — all targets are additive.

### Swift auto-merge on auth views — manual diff review recommended

The branch migrates color literals in `AuthHubView.swift`, `SignInView.swift`, `OnboardingAuthView.swift`. Main has recently added accessibility identifiers to the SAME views in commit `e74604e` (Tier 2.1 harness closure). Git auto-merge will line up the changes, but the reviewer should verify:

- `auth.hub.passkey.quick`, `auth.hub.{email,google,apple}.{register,login}` identifiers still present
- `auth.signin.*` identifiers on SignInView still present
- `sign_in_surface` staging smoke still passes after merge

The Tier 2.1 harness is what makes `make runtime-smoke PROFILE=sign_in_surface MODE=staging` green. A silent overwrite here would regress the last 72h of audit-remediation work.

## Test plan

- [ ] Resolve Makefile conflict (additive merge of both target sets)
- [ ] `make verify-local` passes — implies `ui-audit` hard gate + `schema-check` + everything else green
- [ ] `make runtime-smoke PROFILE=sign_in_surface MODE=staging DRY_RUN=0` passes (or at least preflight + app_launch still pass; sign_in_surface needs real staging credentials)
- [ ] Grep confirms auth accessibility identifiers survived the merge:
  - `grep -r "auth\.hub\." FitTracker/Views/Auth/` returns ≥ 7 matches
  - `grep -r "auth\.signin\." FitTracker/Views/Auth/SignInView.swift` returns ≥ 1 match
- [ ] `python3 scripts/ui-audit.py` reports 0 P0 findings (reproduces the branch's burndown achievement on top of main's current state)
- [ ] `python3 scripts/check-state-schema.py` passes (new `ui-audit-baseline-burndown` feature state.json uses `current_phase` not `phase`)
- [ ] App builds: `xcodebuild build -project FitTracker.xcodeproj -scheme FitTracker -configuration Debug -destination 'generic/platform=iOS'`
- [ ] `FitTrackerTests` suite stays green

## Background

Per project memory (`project_ui_audit_burndown.md`): the branch was "CODE COMPLETE 2026-04-21" — 21 commits, 12 files migrated, case study published. Phase 5.2 was declared pending as "mirror verification + push + 2 PRs". Push happened during the 2026-04-24 clean-state sync; this PR is the remaining Phase 5.2 step.

The standalone-branch disposition was intentional: the commit message on `fa1aab4` (sibling branch `chore/pbxproj-orphan-cleanup`) records "Deliberately landed on a dedicated branch (off origin/main) so it's independent of the ui-audit baseline burndown and can be reviewed as a standalone cleanup." Same logic applies here — review is what was always planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)