### PR TITLE
fix(dashboard): unbreak after v7.7 — state.json feature_name vs feature schema drift

### DIFF
--- a/.claude/features/framework-v7-7-validity-closure/state.json
+++ b/.claude/features/framework-v7-7-validity-closure/state.json
@@ -1,4 +1,5 @@
 {
+  "feature": "framework-v7-7-validity-closure",
   "feature_name": "framework-v7-7-validity-closure",
   "current_phase": "research",
   "created_at": "2026-04-27T14:00:00Z",
@@ -8,18 +9,36 @@
       "status": "in_progress",
       "started_at": "2026-04-27T14:00:00Z"
     },
-    "prd": {"status": "not_started"},
-    "tasks": {"status": "not_started"},
-    "ux_or_integration": {"status": "not_started"},
-    "implementation": {"status": "not_started"},
-    "test": {"status": "not_started"},
-    "review": {"status": "not_started"},
-    "merge": {"status": "not_started"},
-    "documentation": {"status": "not_started"}
+    "prd": {
+      "status": "not_started"
+    },
+    "tasks": {
+      "status": "not_started"
+    },
+    "ux_or_integration": {
+      "status": "not_started"
+    },
+    "implementation": {
+      "status": "not_started"
+    },
+    "test": {
+      "status": "not_started"
+    },
+    "review": {
+      "status": "not_started"
+    },
+    "merge": {
+      "status": "not_started"
+    },
+    "documentation": {
+      "status": "not_started"
+    }
   },
   "timing": {
     "phases": {
-      "research": {"started_at": "2026-04-27T14:00:00Z"}
+      "research": {
+        "started_at": "2026-04-27T14:00:00Z"
+      }
     }
   },
   "cache_hits": [],

--- a/dashboard/src/scripts/parsers/state.js
+++ b/dashboard/src/scripts/parsers/state.js
@@ -16,6 +16,15 @@ export function parseStateFiles() {
 
     try {
       const data = JSON.parse(readFileSync(statePath, 'utf-8'));
+      // Backstop: ensure `feature` is always populated. v7.7+ state.json
+      // schema introduced `feature_name` as the primary key; older state
+      // files use `feature`. Reconcile.js + downstream consumers all read
+      // `feature`, so fall back through feature_name → directory name to
+      // prevent normalize(undefined).toLowerCase() crashes (the dashboard
+      // 500 we hit on 2026-04-28 after v7.7 shipped).
+      if (!data.feature) {
+        data.feature = data.feature_name || dir.name;
+      }
       features.push(data);
     } catch {
       // Skip malformed state files


### PR DESCRIPTION
## What was broken

Reported as "Knowledge ↔ Home navigation broken in the control center."
Actual cause: dashboard was returning **HTTP 500** with a 75-byte
TypeError page on every request. No nav → user perceived broken nav.

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at normalize (dashboard/src/scripts/reconcile.js:9:15)
    at Array.map (<anonymous>)
    at buildDashboardData (controlCenter.js:797:36)
    at $$result (index.astro:6:29)
```

## Root cause

When v7.7 shipped 2026-04-27, the new feature directory used **`feature_name`** as its primary key in state.json (the convention v7.7 introduced to align with Python tooling like `check-state-schema.py` which reads `state.get('feature_name', 'unknown')`).

The legacy Astro dashboard's `reconcile.js:32` reads `s.feature` directly with **no fallback**:

```js
const stateNames = new Set(stateFiles.map(s => normalize(s.feature)));
```

All 44 pre-v7.7 state.json files use `feature` (top-level). The 45th — v7.7 — used `feature_name`. `normalize(undefined).toLowerCase()` → 💥.

## Fix (two parts)

### 1. Restore data parity in v7.7's state.json
Added `feature` field alongside the existing `feature_name`. Same value. Both keys present. Python scripts continue reading `feature_name`; JS dashboard now reads `feature` cleanly.

### 2. Make the parser tolerant
`dashboard/src/scripts/parsers/state.js` `parseStateFiles` now backstops `data.feature` with `feature_name → directory name`. Future state.json files with either schema (or both, or neither) won't crash the dashboard.

## Verification

```
$ cd dashboard && npm run dev
$ curl -s -o /tmp/page.html -w "HTTP %{http_code} | size %{size_download}b\n" http://localhost:4321/
HTTP 200 | size 526776b   ← was 500 / 75b
$ grep -c "Control Room\|Knowledge" /tmp/page.html
2                          ← nav rendered
$ grep -i "error" server.log
(empty)
```

## Test plan

- [x] `npm run dev` returns HTTP 200 (was 500)
- [x] Page renders with nav buttons (Control Room, Knowledge, Board, Tasks, Table)
- [x] No TypeError in server log
- [x] All 25 v7.5/v7.6/v7.7 hooks pass on commit
- [x] Python check-state-schema.py still passes (reads `feature_name`)

## Note on temporary nature

This is a tactical patch. The proper fix is the in-progress UCC migration (T18-T42 in `unified-control-center` state.json) which ports the Astro dashboard to fitme-story Next.js with a unified state.json reader. After that ships, both legacy + new will read the same source consistently and this kind of schema drift won't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)