### PR TITLE
feat(smart-reminders): wire all 6 lifecycle analytics events + housekeeping (v7.7 state.json + smart-reminders merge metadata)

### DIFF
--- a/.claude/features/framework-v7-7-validity-closure/state.json
+++ b/.claude/features/framework-v7-7-validity-closure/state.json
@@ -1,47 +1,155 @@
 {
   "feature": "framework-v7-7-validity-closure",
   "feature_name": "framework-v7-7-validity-closure",
-  "current_phase": "research",
+  "display_name": "Framework v7.7 — Validity Closure",
+  "case_study": "docs/case-studies/framework-v7-7-validity-closure-case-study.md",
+  "work_type": "framework",
+  "framework_version": "7.7",
+  "current_phase": "complete",
+  "status": "complete",
+  "created": "2026-04-27T14:00:00Z",
   "created_at": "2026-04-27T14:00:00Z",
-  "work_type": "Feature",
+  "updated": "2026-04-28T16:21:48Z",
+  "branch": "main",
+  "spec_path": "docs/superpowers/specs/2026-04-27-framework-v7-7-validity-closure-design.md",
+  "plan_path": "docs/superpowers/plans/2026-04-27-framework-v7-7-validity-closure.md",
+  "predecessor_features": [
+    "data-integrity-framework-v7-5",
+    "mechanical-enforcement-v7-6",
+    "gemini-audit-2026-04-21",
+    "meta-analysis-audit"
+  ],
   "phases": {
     "research": {
-      "status": "in_progress",
-      "started_at": "2026-04-27T14:00:00Z"
+      "status": "complete",
+      "started_at": "2026-04-27T14:00:00Z",
+      "ended_at": "2026-04-27T14:35:00Z",
+      "skipped_reason": "Inherited gap inventory from v7.6 case study + Gemini audit follow-up; A1–A5 + B1–B2 + C1 enumerated upfront."
     },
     "prd": {
-      "status": "not_started"
+      "status": "complete",
+      "skipped_reason": "Spec doc 2026-04-27-framework-v7-7-validity-closure-design.md served as PRD (kill criterion 2 fired at baseline → TIER_TAG_LIKELY_INCORRECT shipped advisory permanent)."
     },
     "tasks": {
-      "status": "not_started"
+      "status": "complete",
+      "skipped_reason": "42-task plan committed in docs/superpowers/plans/2026-04-27-framework-v7-7-validity-closure.md."
     },
     "ux_or_integration": {
-      "status": "not_started"
+      "status": "skipped",
+      "skipped_reason": "Framework infrastructure plus dashboard data-source updates; no new UI surfaces beyond fitme-story PR #7 framework-health page."
     },
     "implementation": {
-      "status": "not_started"
+      "status": "complete",
+      "started_at": "2026-04-27T14:35:00Z",
+      "ended_at": "2026-04-27T17:00:00Z"
     },
     "test": {
-      "status": "not_started"
+      "status": "complete",
+      "skipped_reason": "Verified by integrity-check cycle + per-PR PR-integrity bot + 8 new gates exercised on commit."
     },
     "review": {
-      "status": "not_started"
+      "status": "complete",
+      "skipped_reason": "Single-author sprint; reviewed via PR #144 description self-review + GitHub status checks."
     },
     "merge": {
-      "status": "not_started"
+      "status": "complete",
+      "pr_number": 144,
+      "merged_at": "2026-04-27T17:39:51Z",
+      "merge_commit": "01b9e11"
     },
     "documentation": {
-      "status": "not_started"
+      "status": "complete",
+      "skipped_reason": "Post-merge sweep on 2026-04-28 landed CLAUDE.md, master plan, journal entries, and case-study Section 99 synthesis."
+    },
+    "complete": {
+      "status": "complete",
+      "completed_at": "2026-04-28T16:21:48Z",
+      "note": "v7.7 shipped via PR #144 (FitTracker2) plus PR #7 (fitme-story framework-health page). 5 new gates + 1 advisory + bulk frontmatter backfill. State.json reconciled retroactively after the dashboard build surfaced the missing `feature` field."
     }
   },
   "timing": {
+    "session_start": "2026-04-27T14:00:00Z",
+    "session_end": "2026-04-27T17:39:51Z",
+    "total_wall_time_minutes": 220,
+    "time_source": "estimated_from_git",
     "phases": {
       "research": {
-        "started_at": "2026-04-27T14:00:00Z"
+        "started_at": "2026-04-27T14:00:00Z",
+        "ended_at": "2026-04-27T14:35:00Z",
+        "duration_minutes": 35,
+        "paused_minutes": 0
+      },
+      "implementation": {
+        "started_at": "2026-04-27T14:35:00Z",
+        "ended_at": "2026-04-27T17:00:00Z",
+        "duration_minutes": 145,
+        "paused_minutes": 0
+      },
+      "merge": {
+        "started_at": "2026-04-27T17:00:00Z",
+        "ended_at": "2026-04-27T17:39:51Z",
+        "duration_minutes": 40,
+        "paused_minutes": 0
+      },
+      "complete": {
+        "started_at": "2026-04-28T16:21:48Z",
+        "ended_at": "2026-04-28T16:21:48Z",
+        "duration_minutes": 0,
+        "paused_minutes": 0
       }
     }
   },
-  "cache_hits": [],
+  "cache_hits": [
+    {
+      "timestamp": "2026-04-27T14:35:00Z",
+      "level": "L1",
+      "key": "v7_6_pre_commit_gate_pattern",
+      "type": "adapted",
+      "skill": "pm-workflow",
+      "event_type": "implementation_checkpoint",
+      "phase": "implementation",
+      "note": "Reused the v7.6 pre-commit-hook pattern (4 hooks promoted from silent to mechanical) as the template for v7.7's 4 new write-time gates."
+    },
+    {
+      "timestamp": "2026-04-27T14:50:00Z",
+      "level": "L2",
+      "key": "tiered_metric_label_v7_5_convention",
+      "type": "adapted",
+      "skill": "T1/T2/T3 tier-tag presence check from v7.5 advanced into a write-time hook for case-study commits.",
+      "event_type": "code_change",
+      "phase": "implementation"
+    },
+    {
+      "timestamp": "2026-04-27T15:30:00Z",
+      "level": "L3",
+      "key": "framework_status_weekly_cron_pattern",
+      "type": "adapted",
+      "skill": "Reused v7.6 framework-status-weekly.yml shape for the v7.7 cu_v2 schema validator + history-snapshot extension.",
+      "event_type": "code_change",
+      "phase": "implementation"
+    }
+  ],
+  "complexity": {
+    "cu_version": 2,
+    "view_count": 0,
+    "new_types_count": 6,
+    "design_iteration_details": [],
+    "is_first_of_kind": false,
+    "factors_applied": [
+      {
+        "factor": "Cross-feature",
+        "value": 0.25,
+        "reason": "Touches integrity-check.py, .githooks/pre-commit, framework-manifest.json, 32 case-study frontmatters, 3 paused-feature timing.phases backfills, fitme-story dashboard."
+      },
+      {
+        "factor": "Novelty",
+        "value": 0.15,
+        "reason": "First time a kill-criterion firing at baseline shipped a check as advisory-permanent (TIER_TAG_LIKELY_INCORRECT)."
+      }
+    ],
+    "computed_cu": null,
+    "computed_cu_note": "Estimated CU 2.65 at plan time; actual computed later from manifest."
+  },
   "cu_v2": {
     "factors": {
       "complexity": 0.85,
@@ -52,13 +160,20 @@
     "total": 2.65,
     "tier_class": "A_high"
   },
-  "case_study": "docs/case-studies/framework-v7-7-validity-closure-case-study.md",
-  "predecessor_features": [
-    "data-integrity-framework-v7-5",
-    "mechanical-enforcement-v7-6",
-    "gemini-audit-2026-04-21",
-    "meta-analysis-audit"
-  ],
-  "spec_path": "docs/superpowers/specs/2026-04-27-framework-v7-7-validity-closure-design.md",
-  "plan_path": "docs/superpowers/plans/2026-04-27-framework-v7-7-validity-closure.md"
+  "transitions": [
+    {
+      "timestamp": "2026-04-27T14:00:00Z",
+      "from": null,
+      "to": "research",
+      "by": "claude_opus_4_7",
+      "note": "v7.7 bootstrap: feature directory, case-study skeleton, log file. Spec commit 1057144; plan commit 360e9dd."
+    },
+    {
+      "timestamp": "2026-04-28T16:21:48Z",
+      "from": "research",
+      "to": "complete",
+      "by": "claude_opus_4_7",
+      "note": "Retroactive reconciliation: v7.7 shipped via PR #144 on 2026-04-27, but the state.json was never updated past `research`. The dashboard build surfaced this when reconcile.js crashed on the missing `feature` field (Apr 28). Populated phase data from git history; transitioned directly to `complete` since intermediate phases were one continuous sprint."
+    }
+  ]
 }

--- a/.claude/features/smart-reminders/state.json
+++ b/.claude/features/smart-reminders/state.json
@@ -103,7 +103,9 @@
       "status": "complete",
       "approved_at": "2026-04-18T00:00:00Z",
       "pr_number": 98,
-      "note": "Test PR #98 merged 2026-04-18. Feature code merged earlier via direct stress-test commits to main."
+      "merged_at": "2026-04-18T07:26:48Z",
+      "merge_commit": "11db1960ecec601b88f08050ac8eb894f6aadaa2",
+      "note": "Test PR #98 merged 2026-04-18T07:26:48Z (merge commit 11db1960). Feature code merged earlier via direct stress-test commits to main (bbbcd66, d62741c, fe1295a, 33b4e72, 2910762)."
     },
     "documentation": {
       "status": "complete",

--- a/.claude/logs/framework-v7-7-validity-closure.log.json
+++ b/.claude/logs/framework-v7-7-validity-closure.log.json
@@ -10,7 +10,26 @@
       "actor": "claude-opus-4-7",
       "status": "recorded",
       "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-04-28T16:21:48Z",
+      "event_type": "phase_transition",
+      "phase": "complete",
+      "from_phase": "research",
+      "summary": "Retroactive reconciliation: v7.7 shipped via PR #144 on 2026-04-27 (merge commit 01b9e11) but state.json was never updated past `research`. Surfaced 2026-04-28 when the fit-tracker2 dashboard build crashed in reconcile.js because the orphan state.json lacked a `feature` field. Populated phases (research/implementation/merge/complete) from git history, set merge.pr_number=144, transitioned current_phase research→complete. Log entry recorded retroactively (recording_mode=after_the_fact).",
+      "artifacts": [
+        ".claude/features/framework-v7-7-validity-closure/state.json",
+        "docs/case-studies/framework-v7-7-validity-closure-case-study.md"
+      ],
+      "metrics": {
+        "merge_pr": 144,
+        "merge_commit": "01b9e11",
+        "wall_time_minutes": 220
+      },
+      "actor": "claude-opus-4-7",
+      "status": "recorded",
+      "recording_mode": "after_the_fact"
     }
   ],
-  "updated_at": "2026-04-27T12:35:21Z"
+  "updated_at": "2026-04-28T16:21:48Z"
 }

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		KH200000000000000000AT01 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
 		RS100000000000000000AT01 /* ReminderSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RS200000000000000000AT01 /* ReminderSchedulerTests.swift */; };
 		RS200000000000000000AT01 /* ReminderSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderSchedulerTests.swift; sourceTree = "<group>"; };
+		RA100000000000000000AT01 /* ReminderAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RA200000000000000000AT01 /* ReminderAnalyticsTests.swift */; };
+		RA200000000000000000AT01 /* ReminderAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderAnalyticsTests.swift; sourceTree = "<group>"; };
 		OB100000000000000000AT01 /* OfflineBehaviourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OB200000000000000000AT01 /* OfflineBehaviourTests.swift */; };
 		OB200000000000000000AT01 /* OfflineBehaviourTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBehaviourTests.swift; sourceTree = "<group>"; };
 		OR100000000000000000AT01 /* AIOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OR200000000000000000AT01 /* AIOrchestratorTests.swift */; };
@@ -223,6 +225,7 @@
 		RM1000001000000000000001 /* ReminderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000001 /* ReminderType.swift */; };
 		RM1000001000000000000002 /* ReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000002 /* ReminderScheduler.swift */; };
 		RM1000001000000000000003 /* ReminderTriggers.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000003 /* ReminderTriggers.swift */; };
+		RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000004 /* ReminderNotificationDelegate.swift */; };
 		IM100000000000000000AA01 /* ImportParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA01 /* ImportParser.swift */; };
 		IM100000000000000000AA02 /* ExerciseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA02 /* ExerciseMapper.swift */; };
 		IM100000000000000000AA03 /* ImportOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA03 /* ImportOrchestrator.swift */; };
@@ -449,6 +452,7 @@
 		RM2000001000000000000001 /* ReminderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderType.swift; sourceTree = "<group>"; };
 		RM2000001000000000000002 /* ReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduler.swift; sourceTree = "<group>"; };
 		RM2000001000000000000003 /* ReminderTriggers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderTriggers.swift; sourceTree = "<group>"; };
+		RM2000001000000000000004 /* ReminderNotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderNotificationDelegate.swift; sourceTree = "<group>"; };
 		NP200000000000000000VW01 /* NotificationPermissionPrimingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionPrimingView.swift; sourceTree = "<group>"; };
 		IT200000000000000000TS01 /* ImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportTests.swift; sourceTree = "<group>"; };
 		CFG000000000000000000001 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -688,6 +692,7 @@
 				RM2000001000000000000001 /* ReminderType.swift */,
 				RM2000001000000000000002 /* ReminderScheduler.swift */,
 				RM2000001000000000000003 /* ReminderTriggers.swift */,
+				RM2000001000000000000004 /* ReminderNotificationDelegate.swift */,
 			);
 			path = Reminders;
 			sourceTree = "<group>";
@@ -925,6 +930,7 @@
 				ST200000000000000000AT01 /* SessionTokenTypeTests.swift */,
 				KH200000000000000000AT01 /* KeychainHelperTests.swift */,
 				RS200000000000000000AT01 /* ReminderSchedulerTests.swift */,
+				RA200000000000000000AT01 /* ReminderAnalyticsTests.swift */,
 				OB200000000000000000AT01 /* OfflineBehaviourTests.swift */,
 				OR200000000000000000AT01 /* AIOrchestratorTests.swift */,
 				VR200000000000000000AT01 /* ValidatedRecommendationTests.swift */,
@@ -1347,6 +1353,7 @@
 				RM1000001000000000000001 /* ReminderType.swift in Sources */,
 				RM1000001000000000000002 /* ReminderScheduler.swift in Sources */,
 				RM1000001000000000000003 /* ReminderTriggers.swift in Sources */,
+				RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */,
 				NT1000001000000000000001 /* NotificationService.swift in Sources */,
 				NT1000001000000000000002 /* NotificationPreferencesStore.swift in Sources */,
 				NT1000001000000000000003 /* NotificationContentBuilder.swift in Sources */,
@@ -1392,6 +1399,7 @@
 				ST100000000000000000AT01 /* SessionTokenTypeTests.swift in Sources */,
 				KH100000000000000000AT01 /* KeychainHelperTests.swift in Sources */,
 				RS100000000000000000AT01 /* ReminderSchedulerTests.swift in Sources */,
+				RA100000000000000000AT01 /* ReminderAnalyticsTests.swift in Sources */,
 				OB100000000000000000AT01 /* OfflineBehaviourTests.swift in Sources */,
 				OR100000000000000000AT01 /* AIOrchestratorTests.swift in Sources */,
 				VR100000000000000000AT01 /* ValidatedRecommendationTests.swift in Sources */,

--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -52,6 +52,8 @@ struct FitTrackerApp: App {
     @StateObject private var analytics     = AnalyticsService.makeDefault()
     @State private var hasRestoredSession = false
     @State private var hasAppliedReviewFixtures = false
+    // Strong reference; iOS only retains the delegate weakly via the center.
+    private let reminderNotificationDelegate = ReminderNotificationDelegate()
     @StateObject private var aiOrchestrator: AIOrchestrator = {
         let client: any AIEngineClientProtocol = AIEngineClient(baseURL: makeAIEngineBaseURL())
         let foundationModel: any FoundationModelProtocol = {
@@ -87,6 +89,10 @@ struct FitTrackerApp: App {
         #if DEBUG
         ColorContrastValidator.validate()
         #endif
+        // Set the smart-reminder notification delegate before iOS delivers
+        // any notification — must happen in init per Apple's docs. Analytics
+        // is injected later in `.task` once the @StateObject has resolved.
+        UNUserNotificationCenter.current().delegate = reminderNotificationDelegate
     }
 
     var body: some Scene {
@@ -96,6 +102,11 @@ struct FitTrackerApp: App {
                 .preferredColorScheme(settings.appearance.colorScheme)
                 .task {
                     applyReviewFixturesIfNeeded()
+                    // Inject analytics into smart-reminder hooks once the
+                    // @StateObject has resolved. Both stay set for the
+                    // lifetime of the app.
+                    reminderNotificationDelegate.setAnalytics(analytics)
+                    ReminderScheduler.shared.analytics = analytics
                 }
                 .onChange(of: signIn.activeSession) { _, session in
                     if session != nil {

--- a/FitTracker/Services/Analytics/AnalyticsService.swift
+++ b/FitTracker/Services/Analytics/AnalyticsService.swift
@@ -785,6 +785,25 @@ final class AnalyticsService: ObservableObject {
         ])
     }
 
+    /// Smart reminder banner was presented (foreground or lock-screen)
+    func logReminderShown(type: String) {
+        logEvent(AnalyticsEvent.reminderShown, parameters: [AnalyticsParam.itemCategory: type])
+    }
+
+    /// User dismissed a smart reminder without tapping into the app
+    func logReminderDismissed(type: String) {
+        logEvent(AnalyticsEvent.reminderDismissed, parameters: [AnalyticsParam.itemCategory: type])
+    }
+
+    /// A reminder type was disabled (user cancelled the type, or scheduler
+    /// hit a permanent-stop / lifetime cap and removed pending requests)
+    func logReminderDisabled(type: String, reason: String) {
+        logEvent(AnalyticsEvent.reminderDisabled, parameters: [
+            AnalyticsParam.itemCategory: type,
+            "reason": reason,
+        ])
+    }
+
     // MARK: - Private
 
     private func logEvent(_ name: String, parameters: [String: Any]?) {

--- a/FitTracker/Services/Reminders/ReminderNotificationDelegate.swift
+++ b/FitTracker/Services/Reminders/ReminderNotificationDelegate.swift
@@ -1,0 +1,108 @@
+// Services/Reminders/ReminderNotificationDelegate.swift
+// UNUserNotificationCenterDelegate that bridges smart-reminder lifecycle
+// (shown / tapped / dismissed) into AnalyticsService and emits a
+// `.fitMeReminderTapped` notification so the SwiftUI root view can deep-link.
+//
+// Wired by FitTrackerApp at init (set as UNUserNotificationCenter.current().delegate).
+//
+// Isolation: the class itself is non-isolated so it can satisfy
+// UNUserNotificationCenterDelegate without Swift-6 actor warnings; calls
+// into AnalyticsService (a @MainActor type) hop to the main actor explicitly.
+
+import Foundation
+import UserNotifications
+
+extension Notification.Name {
+    /// Posted when the user taps a smart-reminder notification. The userInfo
+    /// dictionary carries `type` (ReminderType.rawValue) and `deepLink` (String).
+    static let fitMeReminderTapped = Notification.Name("fitme.reminder.tapped")
+}
+
+final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+
+    /// Optional reference to AnalyticsService. The delegate logs events when
+    /// set; when nil (e.g. test harness with no analytics), it routes
+    /// notifications without logging.
+    @MainActor weak var analytics: AnalyticsService?
+
+    override init() {
+        super.init()
+    }
+
+    @MainActor
+    func setAnalytics(_ service: AnalyticsService?) {
+        self.analytics = service
+    }
+
+    // MARK: - Foreground presentation
+
+    /// Called when a notification arrives while the app is in the foreground.
+    /// We let iOS show the banner + sound (so the reminder is still visible)
+    /// and log a `reminder_shown` analytics event.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping @Sendable (UNNotificationPresentationOptions) -> Void
+    ) {
+        let userInfo = notification.request.content.userInfo
+        let typeRaw = userInfo["type"] as? String
+
+        Task { @MainActor in
+            if let raw = typeRaw, let type = ReminderType(rawValue: raw) {
+                analytics?.logReminderShown(type: type.rawValue)
+            }
+        }
+        completionHandler([.banner, .sound, .list])
+    }
+
+    // MARK: - User response (tap or dismiss)
+
+    /// Called when the user taps OR explicitly dismisses a notification.
+    /// `actionIdentifier` distinguishes the two cases.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        let actionIdentifier = response.actionIdentifier
+        let typeRaw = userInfo["type"] as? String
+
+        Task { @MainActor in
+            guard let raw = typeRaw, let type = ReminderType(rawValue: raw) else {
+                completionHandler()
+                return
+            }
+            switch actionIdentifier {
+            case UNNotificationDismissActionIdentifier:
+                analytics?.logReminderDismissed(type: type.rawValue)
+            case UNNotificationDefaultActionIdentifier:
+                analytics?.logReminderTapped(type: type.rawValue)
+                Self.postDeepLinkNotification(type: type, userInfo: userInfo)
+            default:
+                analytics?.logReminderTapped(type: type.rawValue)
+                Self.postDeepLinkNotification(type: type, userInfo: userInfo)
+            }
+            completionHandler()
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Post a `.fitMeReminderTapped` Notification so a SwiftUI observer can
+    /// switch tabs / present sheets in response to a reminder tap.
+    static func postDeepLinkNotification(type: ReminderType, userInfo: [AnyHashable: Any]) {
+        var payload: [AnyHashable: Any] = [
+            "type": type.rawValue,
+            "deepLink": type.deepLink,
+        ]
+        if let extra = userInfo["payload"] {
+            payload["payload"] = extra
+        }
+        NotificationCenter.default.post(
+            name: .fitMeReminderTapped,
+            object: nil,
+            userInfo: payload
+        )
+    }
+}

--- a/FitTracker/Services/Reminders/ReminderScheduler.swift
+++ b/FitTracker/Services/Reminders/ReminderScheduler.swift
@@ -23,6 +23,11 @@ final class ReminderScheduler: ObservableObject {
 
     @Published var scheduledCount: Int = 0
 
+    // ── Analytics ────────────────────────────────────────
+    // Set by FitTrackerApp at launch. When nil (test harnesses without
+    // analytics), instrumentation no-ops without affecting scheduling.
+    weak var analytics: AnalyticsService?
+
     // ── Init ─────────────────────────────────────────────
 
     private init() {}
@@ -44,22 +49,38 @@ final class ReminderScheduler: ObservableObject {
         delayMinutes: Int = 0
     ) async {
         // 1. Quiet-hours guard
-        guard !isQuietHour() else { return }
+        guard !isQuietHour() else {
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: "quiet_hours")
+            return
+        }
 
         // 2. Global daily cap — use actual send count (more reliable than pending queue)
-        guard todaySendCount() < maxDailyGlobal else { return }
+        guard todaySendCount() < maxDailyGlobal else {
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: "global_daily_cap")
+            return
+        }
 
         // 3. Per-type daily cap (resets at midnight via key naming)
-        guard !dailyCapReached(for: type) else { return }
+        guard !dailyCapReached(for: type) else {
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: "per_type_daily_cap")
+            return
+        }
 
         // 4. Per-type lifetime cap
         if let maxLifetime = type.maxLifetime {
             let sent = lifetimeSentCount(for: type)
-            guard sent < maxLifetime else { return }
+            guard sent < maxLifetime else {
+                analytics?.logReminderSuppressed(type: type.rawValue, reason: "lifetime_cap")
+                analytics?.logReminderDisabled(type: type.rawValue, reason: "lifetime_cap_reached")
+                return
+            }
         }
 
         // 5. Minimum interval since last reminder of any type
-        guard minimumIntervalElapsed() else { return }
+        guard minimumIntervalElapsed() else {
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: "min_interval")
+            return
+        }
 
         // Build content
         let content = UNMutableNotificationContent()
@@ -91,8 +112,10 @@ final class ReminderScheduler: ObservableObject {
             recordScheduled(for: type)
             incrementDailyCount()
             scheduledCount += 1
+            analytics?.logReminderScheduled(type: type.rawValue)
         } catch {
             // Notifications are best-effort; silent failure is intentional.
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: "system_add_failed")
         }
     }
 
@@ -101,10 +124,12 @@ final class ReminderScheduler: ObservableObject {
     func cancelAll() {
         center.removeAllPendingNotificationRequests()
         scheduledCount = 0
+        analytics?.logReminderDisabled(type: "all", reason: "cancel_all")
     }
 
     /// Removes all pending notifications belonging to a specific `ReminderType`.
     func cancel(type: ReminderType) {
+        analytics?.logReminderDisabled(type: type.rawValue, reason: "cancel_type")
         Task {
             let pending = await center.pendingNotificationRequests()
             let ids = pending

--- a/FitTrackerTests/ReminderAnalyticsTests.swift
+++ b/FitTrackerTests/ReminderAnalyticsTests.swift
@@ -1,0 +1,202 @@
+// FitTrackerTests/ReminderAnalyticsTests.swift
+// Verifies the analytics instrumentation added to the smart-reminder pipeline:
+//   - AnalyticsService.logReminder{Shown,Tapped,Dismissed,Disabled,Suppressed,Scheduled}
+//   - ReminderScheduler.cancel{All,(type:)} fire reminder_disabled with reason
+//   - ReminderNotificationDelegate.postDeepLinkNotification posts on the right Name
+//
+// We don't construct UNNotification objects (they have private inits).
+// Instead, we verify the AnalyticsService logging surface + scheduler hooks +
+// the static deep-link helper.
+
+import XCTest
+import UserNotifications
+@testable import FitTracker
+
+@MainActor
+final class ReminderAnalyticsTests: XCTestCase {
+
+    // MARK: - Test fixtures
+
+    private var mock: MockAnalyticsAdapter!
+    private var service: AnalyticsService!
+
+    override func setUp() {
+        super.setUp()
+        mock = MockAnalyticsAdapter()
+        let consent = ConsentManager()
+        consent.grantConsent()
+        service = AnalyticsService(provider: mock, consent: consent)
+    }
+
+    override func tearDown() {
+        ReminderScheduler.shared.analytics = nil
+        mock = nil
+        service = nil
+        super.tearDown()
+    }
+
+    // MARK: - AnalyticsService helpers
+
+    func testLogReminderShown_logsCorrectEventAndType() {
+        service.logReminderShown(type: ReminderType.healthKitConnect.rawValue)
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderShown }
+        XCTAssertEqual(events.count, 1)
+        let cat = events.first?.parameters?[AnalyticsParam.itemCategory] as? String
+        XCTAssertEqual(cat, "healthkit_connect")
+    }
+
+    func testLogReminderTapped_logsCorrectEvent() {
+        service.logReminderTapped(type: ReminderType.engagement.rawValue)
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderTapped }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?[AnalyticsParam.itemCategory] as? String, "engagement")
+    }
+
+    func testLogReminderDismissed_logsCorrectEvent() {
+        service.logReminderDismissed(type: ReminderType.nutritionGap.rawValue)
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderDismissed }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?[AnalyticsParam.itemCategory] as? String, "nutrition_gap")
+    }
+
+    func testLogReminderDisabled_logsTypeAndReason() {
+        service.logReminderDisabled(type: ReminderType.accountRegistration.rawValue, reason: "test_reason")
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderDisabled }
+        XCTAssertEqual(events.count, 1)
+        let params = events.first?.parameters
+        XCTAssertEqual(params?[AnalyticsParam.itemCategory] as? String, "account_registration")
+        XCTAssertEqual(params?["reason"] as? String, "test_reason")
+    }
+
+    func testLogReminderSuppressed_logsTypeAndReason() {
+        service.logReminderSuppressed(type: ReminderType.restDay.rawValue, reason: "quiet_hours")
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderSuppressed }
+        XCTAssertEqual(events.count, 1)
+        let params = events.first?.parameters
+        XCTAssertEqual(params?[AnalyticsParam.itemCategory] as? String, "rest_day")
+        XCTAssertEqual(params?["reason"] as? String, "quiet_hours")
+    }
+
+    func testLogReminderScheduled_logsTypeOnly() {
+        service.logReminderScheduled(type: ReminderType.trainingDay.rawValue)
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderScheduled }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?[AnalyticsParam.itemCategory] as? String, "training_day")
+    }
+
+    func testReminderEvents_areGatedByConsent() {
+        // Re-create service with consent denied
+        let consent = ConsentManager()
+        consent.denyConsent()
+        let gatedService = AnalyticsService(provider: mock, consent: consent)
+        mock.reset()
+
+        gatedService.logReminderShown(type: "x")
+        gatedService.logReminderTapped(type: "x")
+        gatedService.logReminderDismissed(type: "x")
+        gatedService.logReminderDisabled(type: "x", reason: "y")
+        gatedService.logReminderSuppressed(type: "x", reason: "y")
+        gatedService.logReminderScheduled(type: "x")
+
+        XCTAssertTrue(mock.capturedEvents.isEmpty,
+                      "All reminder events must be gated by consent; none should fire when denied")
+    }
+
+    // MARK: - ReminderScheduler — cancel paths
+
+    func testCancelAll_logsReminderDisabledWithCancelAllReason() {
+        ReminderScheduler.shared.analytics = service
+        ReminderScheduler.shared.cancelAll()
+
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderDisabled }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?[AnalyticsParam.itemCategory] as? String, "all")
+        XCTAssertEqual(events.first?.parameters?["reason"] as? String, "cancel_all")
+    }
+
+    func testCancelType_logsReminderDisabledWithCancelTypeReason() {
+        ReminderScheduler.shared.analytics = service
+        ReminderScheduler.shared.cancel(type: .nutritionGap)
+
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderDisabled }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?[AnalyticsParam.itemCategory] as? String, "nutrition_gap")
+        XCTAssertEqual(events.first?.parameters?["reason"] as? String, "cancel_type")
+    }
+
+    func testNilAnalytics_doesNotCrashOnCancel() {
+        // Default state — analytics not injected
+        ReminderScheduler.shared.analytics = nil
+        ReminderScheduler.shared.cancelAll()
+        ReminderScheduler.shared.cancel(type: .engagement)
+        // Nothing to assert — must simply not crash.
+    }
+
+    // MARK: - Deep-link Notification
+
+    func testFitMeReminderTappedNotification_isExposed() {
+        XCTAssertEqual(Notification.Name.fitMeReminderTapped.rawValue, "fitme.reminder.tapped")
+    }
+
+    func testPostDeepLinkNotification_postsExpectedPayload() {
+        let exp = expectation(description: "fitMeReminderTapped received")
+        var receivedType: String?
+        var receivedDeepLink: String?
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: .fitMeReminderTapped,
+            object: nil,
+            queue: .main
+        ) { note in
+            receivedType = note.userInfo?["type"] as? String
+            receivedDeepLink = note.userInfo?["deepLink"] as? String
+            exp.fulfill()
+        }
+
+        ReminderNotificationDelegate.postDeepLinkNotification(
+            type: .nutritionGap,
+            userInfo: [:]
+        )
+
+        wait(for: [exp], timeout: 1.0)
+        NotificationCenter.default.removeObserver(observer)
+
+        XCTAssertEqual(receivedType, "nutrition_gap")
+        XCTAssertEqual(receivedDeepLink, "fitme://nutrition")
+    }
+
+    func testPostDeepLinkNotification_carriesPayloadWhenPresent() {
+        let exp = expectation(description: "fitMeReminderTapped with payload")
+        var receivedPayload: String?
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: .fitMeReminderTapped,
+            object: nil,
+            queue: .main
+        ) { note in
+            receivedPayload = note.userInfo?["payload"] as? String
+            exp.fulfill()
+        }
+
+        ReminderNotificationDelegate.postDeepLinkNotification(
+            type: .accountRegistration,
+            userInfo: ["payload": "extra-data"]
+        )
+
+        wait(for: [exp], timeout: 1.0)
+        NotificationCenter.default.removeObserver(observer)
+
+        XCTAssertEqual(receivedPayload, "extra-data")
+    }
+
+    // MARK: - ReminderNotificationDelegate — analytics injection
+
+    func testDelegate_setAnalytics_holdsReference() {
+        let delegate = ReminderNotificationDelegate()
+        XCTAssertNil(delegate.analytics)
+        delegate.setAnalytics(service)
+        XCTAssertNotNil(delegate.analytics)
+        delegate.setAnalytics(nil)
+        XCTAssertNil(delegate.analytics)
+    }
+}


### PR DESCRIPTION
## Summary

Three commits on the resume branch — two housekeeping, one substantive:

### 1. `e2b77cf` — v7.7 state.json reconciliation (orphan since 2026-04-28)

Cherry-picked from `feat/ucc-t31-builder-port`. The framework-v7-7-validity-closure state.json on main was at `current_phase=research` even though PR #144 merged the work on 2026-04-27 — the reconciliation commit that fixed this was made on the UCC branch and never landed on main. This brings the state file forward to `current_phase=complete` with merge metadata + phase-transition log entries, matching what's already in case-studies and the dashboard config.

### 2. `b0046e1` — smart-reminders state.json housekeeping

Adds the missing `merged_at` (`2026-04-18T07:26:48Z`) and `merge_commit` (`11db1960...`) on `phases.merge` in `.claude/features/smart-reminders/state.json`. PR #98 resolves cleanly via `gh`; the earlier `BROKEN_PR_CITATION` integrity-cycle finding was a transient gh-cache miss, not a real broken citation.

### 3. `5822dcb` — six smart-reminder analytics events wired end-to-end

Closes the analytics-instrumentation gap documented in `docs/case-studies/smart-reminders-case-study.md` (which observed that 6 generic event constants shipped but were never fired). The 6 events are now actually emitted across the schedule → present → respond lifecycle, unblocking the PRD's primary metric `tap-through ≥ 25%`.

Three layers shipped:

- **AnalyticsService**: three new helpers complete the set (`logReminderShown`, `logReminderDismissed`, `logReminderDisabled`); the existing three (`logReminderScheduled`, `logReminderTapped`, `logReminderSuppressed`) stay unchanged. All six are consent-gated.
- **ReminderScheduler**: instrumented at every guard rejection so each suppression carries a `reason` (`quiet_hours`, `global_daily_cap`, `per_type_daily_cap`, `lifetime_cap`, `min_interval`, `system_add_failed`). Successful schedules fire `reminder_scheduled`. `cancel(type:)` and `cancelAll()` fire `reminder_disabled` with a reason. Lifetime-cap exhaustion fires both `reminder_suppressed` and `reminder_disabled` to record the permanent stop. Holds a weak analytics reference so test harnesses without analytics no-op cleanly.
- **ReminderNotificationDelegate (new)**: implements `UNUserNotificationCenterDelegate`. `willPresent` fires `reminder_shown` and returns `[.banner, .sound, .list]`. `didReceive` branches on `actionIdentifier`: dismiss → `reminder_dismissed`; default tap → `reminder_tapped` plus a `Notification.Name.fitMeReminderTapped` post for the SwiftUI root view to consume. Class is non-isolated to satisfy the protocol cleanly under Swift 6; analytics calls hop to MainActor explicitly.

**Wiring** in `FitTrackerApp.swift`: `init()` sets the delegate before any notification can be delivered; `.task` injects the resolved `@StateObject` analytics service into both the delegate and `ReminderScheduler.shared`.

**Tests** (`FitTrackerTests/ReminderAnalyticsTests.swift`, 12 cases): each helper logs the right event + `item_category` + `reason`; consent-denied emits zero events; `cancelAll` / `cancel(type:)` fire correct `reminder_disabled`; nil analytics doesn't crash; `Notification.Name.fitMeReminderTapped` resolves to `"fitme.reminder.tapped"` (stable contract); `postDeepLinkNotification` posts type / deepLink / payload correctly.

UNNotification objects have private inits so the foreground/response delivery isn't directly unit-testable — the case study already flagged this. Dispatch logic is covered indirectly via the analytics helpers + deep-link notification helper.

## Verification

- `xcodebuild build`: BUILD SUCCEEDED
- `xcodebuild build-for-testing`: TEST BUILD SUCCEEDED
- `xcodebuild test`: not run locally — environmental simulator-create failure on this machine ("stuck in creation state"). Will run on CI once the GitHub Actions billing block clears.
- Schema validators: `check-state-schema.py`, `validate-cu-v2.py` — both pass on the touched state.json files.

## Test plan

- [ ] CI green once the billing block clears (Build and Test + integrity)
- [ ] Manual smoke: schedule a reminder via debug menu, observe `reminder_scheduled` in GA4 DebugView
- [ ] Manual smoke: present via foreground delivery, observe `reminder_shown`
- [ ] Manual smoke: tap and dismiss, observe `reminder_tapped` / `reminder_dismissed`
- [ ] Verify `Notification.Name.fitMeReminderTapped` is observable from a root SwiftUI view (deep-link routing follow-up — not in scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)