### PR TITLE
chore(repo): hygiene — .gitignore + research notes (audit cleanup)

### DIFF
--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -83,7 +83,48 @@
           "post_v6_percent": 62.5
         }
       }
+    },
+    {
+      "date": "2026-04-30",
+      "generated_at": "2026-04-30T19:23:02Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 46,
+        "features_post_v6": 11,
+        "features_pre_v6": 35,
+        "fully_adopted": 3,
+        "partial_adopted": 9,
+        "zero_adopted": 34,
+        "fully_adopted_post_v6": 3,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 7,
+          "overall_percent": 15.2,
+          "post_v6_present": 7,
+          "post_v6_percent": 63.6
+        },
+        "per_phase_timing": {
+          "overall_present": 12,
+          "overall_percent": 26.1,
+          "post_v6_present": 8,
+          "post_v6_percent": 72.7
+        },
+        "cache_hits": {
+          "overall_present": 5,
+          "overall_percent": 10.9,
+          "post_v6_present": 5,
+          "post_v6_percent": 45.5
+        },
+        "cu_v2": {
+          "overall_present": 7,
+          "overall_percent": 15.2,
+          "post_v6_present": 7,
+          "post_v6_percent": 63.6
+        }
+      }
     }
   ],
-  "updated": "2026-04-27T07:37:37Z"
+  "updated": "2026-04-30T19:23:02Z"
 }

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,46 +1,47 @@
 {
   "version": "1.0",
-  "updated": "2026-04-27T17:15:47Z",
+  "updated": "2026-04-30T19:23:02Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {
-    "features_total": 45,
-    "features_post_v6": 9,
-    "features_pre_v6": 36,
-    "fully_adopted": 2,
-    "partial_adopted": 8,
-    "zero_adopted": 35,
-    "fully_adopted_post_v6": 2,
+    "features_total": 46,
+    "features_post_v6": 11,
+    "features_pre_v6": 35,
+    "fully_adopted": 3,
+    "partial_adopted": 9,
+    "zero_adopted": 34,
+    "fully_adopted_post_v6": 3,
     "tier_1_1_status": "partial"
   },
   "dimension_coverage": {
     "timing_wall_time": {
-      "overall_present": 5,
-      "overall_percent": 11.1,
-      "post_v6_present": 5,
-      "post_v6_percent": 55.6
+      "overall_present": 7,
+      "overall_percent": 15.2,
+      "post_v6_present": 7,
+      "post_v6_percent": 63.6
     },
     "per_phase_timing": {
-      "overall_present": 10,
-      "overall_percent": 22.2,
-      "post_v6_present": 6,
-      "post_v6_percent": 66.7
+      "overall_present": 12,
+      "overall_percent": 26.1,
+      "post_v6_present": 8,
+      "post_v6_percent": 72.7
     },
     "cache_hits": {
-      "overall_present": 3,
-      "overall_percent": 6.7,
-      "post_v6_present": 3,
-      "post_v6_percent": 33.3
+      "overall_present": 5,
+      "overall_percent": 10.9,
+      "post_v6_present": 5,
+      "post_v6_percent": 45.5
     },
     "cu_v2": {
-      "overall_present": 6,
-      "overall_percent": 13.3,
-      "post_v6_present": 6,
-      "post_v6_percent": 66.7
+      "overall_present": 7,
+      "overall_percent": 15.2,
+      "post_v6_present": 7,
+      "post_v6_percent": 63.6
     }
   },
   "fully_adopted_features": [
     "data-integrity-framework-v7-6",
+    "framework-v7-7-validity-closure",
     "meta-analysis-audit"
   ],
   "partial_adopted_features": [
@@ -51,6 +52,15 @@
         "per_phase_timing": true,
         "cache_hits": false,
         "cu_v2": true
+      }
+    },
+    {
+      "feature": "case-study-presentation",
+      "adoption": {
+        "timing_wall_time": true,
+        "per_phase_timing": true,
+        "cache_hits": true,
+        "cu_v2": false
       }
     },
     {
@@ -182,11 +192,6 @@
       "feature": "framework-story-site",
       "created": "2026-04-19",
       "post_v6": true
-    },
-    {
-      "feature": "framework-v7-7-validity-closure",
-      "created": null,
-      "post_v6": false
     },
     {
       "feature": "gdpr-compliance",
@@ -397,7 +402,7 @@
       "feature": "auth-polish-v2",
       "created": "2026-04-27",
       "post_v6": true,
-      "current_phase": "prd",
+      "current_phase": "implementation",
       "adoption": {
         "timing_wall_time": true,
         "per_phase_timing": true,
@@ -420,6 +425,20 @@
       },
       "fully_adopted": false,
       "any_adopted": false
+    },
+    {
+      "feature": "case-study-presentation",
+      "created": "2026-04-28",
+      "post_v6": true,
+      "current_phase": "complete",
+      "adoption": {
+        "timing_wall_time": true,
+        "per_phase_timing": true,
+        "cache_hits": true,
+        "cu_v2": false
+      },
+      "fully_adopted": false,
+      "any_adopted": true
     },
     {
       "feature": "data-integrity-framework-v7-6",
@@ -521,17 +540,17 @@
     },
     {
       "feature": "framework-v7-7-validity-closure",
-      "created": null,
-      "post_v6": false,
-      "current_phase": "research",
+      "created": "2026-04-27",
+      "post_v6": true,
+      "current_phase": "complete",
       "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
+        "timing_wall_time": true,
+        "per_phase_timing": true,
+        "cache_hits": true,
+        "cu_v2": true
       },
-      "fully_adopted": false,
-      "any_adopted": false
+      "fully_adopted": true,
+      "any_adopted": true
     },
     {
       "feature": "gdpr-compliance",
@@ -635,7 +654,7 @@
       "feature": "meta-analysis-audit",
       "created": "2026-04-16",
       "post_v6": true,
-      "current_phase": "documentation",
+      "current_phase": "complete",
       "adoption": {
         "timing_wall_time": true,
         "per_phase_timing": true,
@@ -845,7 +864,7 @@
       "feature": "stats-v2",
       "created": "2026-04-10",
       "post_v6": false,
-      "current_phase": "tasks",
+      "current_phase": "implementation",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Git pre-commit hook — gates the v7.5/v7.6 Data Integrity Framework's
+# Git pre-commit hook — gates the v7.5/v7.6/v7.7 Data Integrity Framework's
 # write-time defenses. Blocks commits that would introduce:
 #
 #   v7.5 (shipped 2026-04-21):
@@ -14,6 +14,19 @@
 #     - BROKEN_PR_CITATION (case study cites a PR that doesn't resolve)
 #     - CASE_STUDY_MISSING_TIER_TAGS (post-2026-04-21 case study without
 #       T1/T2/T3 tier tags)
+#
+#   v7.7 (shipped 2026-04-27 via PR #144 [merge `01b9e11`]):
+#     - CACHE_HITS_EMPTY_POST_V6 (post-v6 feature reaches current_phase=complete
+#       with empty cache_hits[]). KNOWN GAP per 2026-04-30 audit: the gate
+#       reads state.get("created_at", "") and 43 of 46 features use the
+#       legacy "created" field, so effective coverage is currently 0%.
+#       Closure tracked in v7.8 plan.
+#     - CU_V2_INVALID (state.json.cu_v2 schema malformed or missing required
+#       factor keys: complexity / blast_radius / novelty / verification_difficulty)
+#     - STATE_NO_CASE_STUDY_LINK (terminal state.json missing case_study link
+#       AND not tagged with EXEMPT_CASE_STUDY_TYPES)
+#     - CASE_STUDY_MISSING_FIELDS (case-study frontmatter missing required
+#       fields per v7.7 schema validator)
 #
 # Enable with: make install-hooks
 # Bypass (emergency only): git commit --no-verify

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,14 @@ GoogleService-Info.plist
 Config/Local/*.xcconfig
 !Config/Local/*.example.xcconfig
 !Config/Local/README.md
+
+# Auth-polish-v2 / Sentry / HADF / Vercel local artifacts (never commit)
+.env.local
+.sentryclirc
+.venv-hadf-phase2/
+.vercel/
+.claude/shared/hadf/logs/
+.claude/shared/hadf/pre-merge-backup-*/
+.claude/shared/hadf/*.pre-isolation-archive
+.claude/shared/hadf/phase2-fingerprint-*.json
+.claude/shared/sentry-recovery/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Use `/pm-workflow {name}` and select the work type. Skipped phases are recorded 
 - **CI requirement:** both branches must pass before merge is approved
 - **High-risk areas** that require extra review: DomainModels.swift, EncryptionService.swift, SupabaseSyncService.swift, CloudKitSyncService.swift, SignInService.swift, AuthManager.swift, AIOrchestrator.swift
 
-## Data Integrity Framework (v7.5 → v7.6 → v7.7-IN-PROGRESS, shipped 2026-04-24 → 2026-04-25 → ___)
+## Data Integrity Framework (v7.5 → v7.6 → v7.7, shipped 2026-04-24 → 2026-04-25 → 2026-04-27)
 
 The 72h Integrity Cycle shipped at v7.1 is now one of **eight cooperating defenses** in the v7.5 Data Integrity Framework — triggered by the 2026-04-21 Google Gemini 2.5 Pro independent audit. v7.6 (Mechanical Enforcement, shipped 2026-04-25) closes the remaining Class B → Class A gap by promoting four silent agent-attention checks into pre-commit failures and adding two recurring CI defenses (per-PR review bot, weekly framework-status cron).
 
@@ -87,7 +87,7 @@ This framework exists because we empirically observed 7+ features sit in "shippe
 - **Weekly framework-status cron** — [`.github/workflows/framework-status-weekly.yml`](.github/workflows/framework-status-weekly.yml) fires Mondays 05:00 UTC. Appends a snapshot to [`.claude/shared/measurement-adoption-history.json`](.claude/shared/measurement-adoption-history.json) (dedup by date). Opens `framework-status` issue on regression (decrease in `fully_adopted` or `any_adopted`).
 - **Append-only adoption history** — `make measurement-adoption` now writes a dated snapshot to the history ledger; trend mode unlocks after 3 snapshots accumulate.
 
-**v7.7 Validity Closure (ready for merge as of 2026-04-27):**
+**v7.7 Validity Closure (shipped 2026-04-27 via PR #144 [merge `01b9e11`]; state.json reconciled in PR #158):**
 Closes A1–A5 + B1–B2 + C1 from the post-v7.6 gap inventory across two PRs:
 
 - **FitTracker2 PR #144** — 5 new gates: 4 write-time pre-commit hooks (`CACHE_HITS_EMPTY_POST_V6`, `CU_V2_INVALID`, `STATE_NO_CASE_STUDY_LINK`, `CASE_STUDY_MISSING_FIELDS`) + 1 cycle-time check code (`CU_V2_INVALID`) + 1 cycle-time advisory (`TIER_TAG_LIKELY_INCORRECT`, kill criterion 2 fired at baseline so it ships **advisory permanent**). Plus bulk-backfill of 32 case-study frontmatters and timing.phases backfill on 3 paused features.
@@ -108,7 +108,9 @@ Closes A1–A5 + B1–B2 + C1 from the post-v7.6 gap inventory across two PRs:
 - Tier 1.1 trend mode unlocks at 3 history snapshots — earliest **2026-05-04** (Monday cron appends snapshot #3).
 - Tier 3.2 trend mode unlocks at 3 cycle snapshots — earliest **~2026-05-03 to -06** (72h cycle accumulates 3rd snapshot).
 
-A scheduled +7d agent will append the verification + journal entry once both fire, and flip this section's banner from "ready for merge" to "shipped 2026-05-XX".
+A scheduled +7d agent will append the verification + journal entry once both fire.
+
+**Known gap (2026-04-30 audit, inputs to v7.8):** the `CACHE_HITS_EMPTY_POST_V6` write-time gate is implemented in `scripts/check-state-schema.py:225-266` but cannot fire on 0 of 46 features in the repo because (a) the gate reads `state.get("created_at", "")` and 43 of 46 state.json files use the legacy `created` field instead, and (b) of the 2 files that use `created_at`, neither has `current_phase: complete`. Effective gate coverage = **0%**. Issue #140 is closed in spec but open in practice. Full audit + closure plan in agent memory at `project_framework_gaps_audit_2026_04_30.md` and `project_framework_v7_8_research_plan.md`.
 
 Spec: [`docs/superpowers/specs/2026-04-27-framework-v7-7-validity-closure-design.md`](docs/superpowers/specs/2026-04-27-framework-v7-7-validity-closure-design.md).
 Plan: [`docs/superpowers/plans/2026-04-27-framework-v7-7-validity-closure.md`](docs/superpowers/plans/2026-04-27-framework-v7-7-validity-closure.md).

--- a/docs/research/2026-04-28-hadf-signature-expansion.md
+++ b/docs/research/2026-04-28-hadf-signature-expansion.md
@@ -1,0 +1,326 @@
+# HADF Signature Library Expansion — April 2026 Research Note
+
+> **Status:** RESEARCH (2026-04-28). Baseline: 17 mobile/desktop profiles + 7 cloud signatures shipped in PR #82 (2026-04-16). This note proposes a delta against that baseline based on three research passes covering Apple/Android/Datacenter/RISC-V, Intel, and AMD.
+>
+> **Out of scope:** spec writing, schema changes, RTL changes. This note collects the candidate profiles, flags architectural primitives that don't fit the current schema, and proposes a prioritization. Implementation lands as a follow-up PR against `.claude/shared/chip-profiles.json` and `.claude/shared/hadf/hardware-signature-table.json`.
+>
+> **Companion note:** [ORCHID + framework v7.x mapping](2026-04-28-orchid-framework-v7-mapping.md).
+
+---
+
+## 1. What the current baseline covers
+
+`chip-profiles.json` v1.0 (17 entries, Apr 16 2026):
+
+- Apple A-series: A18 Pro, A17 Pro, A16, A15
+- Apple M-series: M4 Max, M3 Pro, M1
+- Google Tensor: G4, G3
+- Qualcomm Snapdragon: 8 Gen 3, 7 Gen 3, X Elite
+- Samsung Exynos: 2400
+- MediaTek Dimensity: 9300
+- Fallbacks: arm64-mobile-unknown, arm64-desktop-unknown, web-wasm-low
+
+`hardware-signature-table.json` v1.0 (7 entries):
+
+- Nvidia: H100-class, A100-class
+- Google TPU: v5e-class, v4-class
+- AWS Trainium2-class
+- AMD MI300X-class
+- CPU fallback
+
+**Notable gaps even before this expansion:**
+- No Intel mobile/desktop chip at all (Core Ultra Series 1/2/3 missing).
+- No AMD client chip at all (Ryzen AI Strix Point/Halo/Krackan missing).
+- No EPYC / Xeon CPU profile despite CPU-only inference being a real fallback path.
+- No FP4 / FP6 / FP8 / MXFP encoding in the precision field — it's `int8` / `float16` only.
+- No "platform TOPS" composite — peak NPU TOPS is the only compute axis.
+- Cloud signature table has 7 entries with `calibration_status: "uncalibrated"` and a comment saying values "require empirical calibration via Phase 2 validation" — Phase 2 has not yet been run (per [project_hadf_research.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_hadf_research.md)).
+
+---
+
+## 2. Mobile / desktop chips to add
+
+Each entry below is a **candidate** for `chip-profiles.json`. Specs sourced from the three research passes; numbers without a vendor-published TOPS figure are tagged `tops_source: "secondary"` so HADF can downweight them in dispatch.
+
+### Apple
+
+| Profile id | Tier | Released | Key delta vs baseline |
+|---|---|---|---|
+| `apple_a19` | flagship | Sep 2025 | Adds GPU-integrated Neural Accelerators per GPU core. **No Apple-published TOPS.** |
+| `apple_a19_pro` | flagship | Sep 2025 | 12 GB LPDDR5X-9600, 76.8 GB/s. NPU and GPU AI both relevant. |
+| `apple_m5` | desktop | Oct 2025 | 153.6 GB/s memory; Apple claims 4× peak GPU AI compute vs M4. |
+| `apple_m5_pro` | desktop | Mar 2026 | Up to 64 GB / 307 GB/s. |
+| `apple_m5_max` | desktop | Mar 2026 | Up to 128 GB / 460 GB/s (32-CU) or 614 GB/s (40-CU). 4× faster LLM prompt processing vs M4 Max. |
+
+**Schema implication:** Apple's A19/M5 family is the first to put XMX-style matmul in the GPU rather than only the NPU. The current `npu_tops` single-axis model under-represents these chips. See §5 for the proposed `compute_axes` extension.
+
+### Qualcomm
+
+| Profile id | Tier | Released | Key delta |
+|---|---|---|---|
+| `qualcomm_snapdragon_8_elite` | flagship | Q4 2024 | Replaces "8 Gen 4" — Qualcomm renamed the generation. |
+| `qualcomm_snapdragon_8_elite_gen5` | flagship | Sep 2025 | Hexagon supports **INT2** and **FP8** natively. Up to 220 tok/s on-device LLM. Galaxy S26 (Mar 2026). |
+
+**Schema implication:** INT2 and FP8 are not in the current `preferred_precision` enum.
+
+### MediaTek / Samsung / Google
+
+| Profile id | Tier | Released | Key delta |
+|---|---|---|---|
+| `mediatek_dimensity_9500` | flagship | Sep 2025 | **NPU 990 — first mobile NPU with integrated compute-in-memory.** Native BitNet 1.58-bit. 2× compute vs 9400. |
+| `samsung_exynos_2500` | flagship | Jun 2025 | **59 TOPS** (Samsung-published). 2× 12K MAC clusters. RDNA 3-derived Xclipse 950 GPU. |
+| `google_tensor_g5` | flagship | Aug 2025 | TSMC 3nm (first time off Samsung Foundry). 4th-gen TPU. 2.6× Gemini Nano perf vs G4. No published TOPS. |
+
+**Schema implication:** Compute-in-memory (Dimensity 9500) and BitNet 1.58-bit are dispatch-relevant but not in the current `preferred_precision` enum.
+
+### Intel client (entirely new vendor in HADF)
+
+| Profile id | Tier | Released | NPU TOPS | Key delta |
+|---|---|---|---|---|
+| `intel_meteor_lake_npu3` | mid | Dec 2023 | 10–11 INT8 | NPU 3, sub-Copilot+ baseline |
+| `intel_arrow_lake_s_npu3` | desktop | Oct 2024 | 13 INT8 | First desktop with integrated NPU |
+| `intel_arrow_lake_h_hx` | flagship | Jan 2025 | 13 INT8 | Gaming-laptop tier |
+| `intel_lunar_lake_npu4` | flagship | Sep 2024 | 48 INT8 + FP16 | Copilot+ thin-and-light. Platform total ~115 TOPS (NPU 48 + GPU XMX 67). |
+| `intel_panther_lake_npu5` | flagship | Jan 2026 | 50 INT8 + native FP8 | **First 18A client product.** Platform total ~180 TOPS (NPU 50 + Xe3 XMX 120 + CPU). |
+
+**Schema implication:** Intel's **platform-TOPS-split** model (NPU + GPU XMX + CPU AMX) is materially different from Apple/Qualcomm's NPU-dominant model. A 50-TOPS Panther Lake NPU is not a "mid-tier" chip if dispatch can use Xe3 XMX + AMX simultaneously.
+
+### AMD client (entirely new vendor in HADF)
+
+| Profile id | Tier | Released | NPU TOPS | Key delta |
+|---|---|---|---|---|
+| `amd_strix_point_xdna2` | flagship | Jul 2024 | 50 (HX 370) / 55 (HX 375) | XDNA 2 NPU. Block FP16 (FP16 accuracy at INT8 cost). RDNA 3.5 iGPU. |
+| `amd_krackan_point_xdna2` | mid | Jan 2025 | 50 INT8 | Same NPU at lower CPU/iGPU tier. |
+| `amd_strix_halo_xdna2` | desktop | Jan 2025 | 50+ | **Workstation-class unified-memory client.** Up to 128 GB LPDDR5X-8000 shared CPU+iGPU+NPU. 40-CU RDNA 3.5 iGPU. Client-tier analogue of MI300A. |
+| `amd_gorgon_point_xdna2` | flagship | 2026 | 55+ | XDNA 2 refresh. CES 2026. |
+
+**Schema implication:** Strix Halo's **128 GB unified memory across CPU+iGPU+NPU** is a tier the baseline doesn't represent. `available_for_ml_mb` of "1500–4000" doesn't fit a 128 GB unified-memory client. Block FP16 also doesn't fit the precision enum.
+
+### Fallback updates
+
+Current `arm64_mobile_unknown` (15 TOPS NPU) is now below the median 2026 flagship. Recommend:
+- Add `arm64_mobile_2026_unknown` at 30 TOPS, FP16 + INT8.
+- Add `x86_64_npu_2026_unknown` (Intel-style or AMD-style client with dedicated NPU) at 40 TOPS.
+- Keep the existing 15-TOPS entry as `arm64_mobile_legacy_unknown` for older devices.
+
+---
+
+## 3. Cloud / datacenter signatures to add
+
+Current `hardware-signature-table.json` has 7 entries. Below adds 11 distinct generations / vendors that have shipped or moved into broad GA since April 2026.
+
+| Signature id | Vendor | Generation | Status April 2026 | Distinct primitive |
+|---|---|---|---|---|
+| `nvidia_b200_class` | nvidia | blackwell | Production at scale, sold out through mid-2026 | NVFP4 native, 192 GB HBM3e, 8 TB/s, FP4 dense 10 PFLOPS |
+| `nvidia_b300_class` | nvidia | blackwell-ultra | Shipping since Jan 2026 | 288 GB HBM3e, **15 PFLOPS dense FP4**, 1400W, GB300 NVL72 |
+| `google_tpu_v6e_trillium_class` | google | v6e | GA late 2024, used for Gemini 2.0 training | First post-v5e TPU, training/inference |
+| `google_tpu_v7_ironwood_class` | google | v7 | GA Nov 2025; Anthropic committed >1M units in 2026 | **Inference-optimized** (distinct from Trillium) |
+| `aws_trainium3_class` | aws | trn3 | GA Dec 2025, EC2 Trn3 UltraServers | **Native MXFP8 + MXFP4** + structured sparsity. 144 GB HBM3e. First non-Nvidia chip with both microscaled formats. |
+| `amd_mi325x_class` | amd | cdna3-refresh | Q4 2024 / Q1 2025 GA | 256 GB HBM3E @ 6 TB/s |
+| `amd_mi350x_class` | amd | cdna4 | H2 2025 GA | **FP4 + FP6 + FP8 (MX) + OCP FP8.** 288 GB HBM3E @ 8 TB/s |
+| `amd_mi300a_apu_class` | amd | cdna3-apu | Volume since 2023 | **Unified CPU+GPU+HBM3 memory** (128 GB). No PCIe copy. Distinct dispatch primitive. |
+| `intel_gaudi3_class` | intel | gaudi3 | GA Q3 2024; IBM Cloud GA | 1.8 PFLOPS FP8 / 1.8 PFLOPS BF16. **24× 200 GbE on-package** (distinct scale-out primitive). 128 GB HBM2e. |
+| `sambanova_sn40l_class` | sambanova | rdu | Production via SambaNova Cloud | **Pure dataflow / RDU** (not GPU/TPU). 520 MiB SRAM + 64 GiB HBM + up to 1.5 TiB DDR. |
+| `tenstorrent_blackhole_class` | tenstorrent | blackhole | **Galaxy GA today (Apr 28 2026)** | 774 TFLOPS FP8/chip, 16 RISC-V CPU cores per chip, 12× 400 GbE per chip. RISC-V + Tensix++ dataflow. |
+| `microsoft_maia100_class` | microsoft | maia1 | Production in Azure since 2024 | First-party Azure inference silicon. (Maia 200 / Braga delayed to 2026.) |
+| `cerebras_wse3_class` | cerebras | wse3 | Production; Meta + OpenAI named customers | Wafer-scale; >1000 tok/s on Llama 3.1-405B. |
+| `groq_lpu_class` | groq | lpu (now nvidia) | Production; **Nvidia acquired Groq Dec 2025 for $20B** | Tag with vendor-status change; future independent target uncertain. |
+
+### Vendor / market events that should be encoded in dispatch heuristics
+
+- **Nvidia ↔ Groq merger (Dec 2025, $20B).** HADF dispatch should treat Groq endpoints as Nvidia-controlled going forward.
+- **Esperanto Technologies folded mid-2025.** Drop ET-SoC-1 from any tracking — it never shipped at scale and the company is gone.
+- **Falcon Shores cancelled (2025).** Don't add a Falcon Shores profile; Intel's discrete-card AI roadmap moved to Jaguar Shores (H2 2026).
+- **Intel Diamond Rapids slipped to mid-2027.** AMX-FP8 is at least 14 months away on Intel CPU.
+- **AMD ROCm 7 (Sept 2025) unified datacenter + consumer + Windows.** Treat MI350 and RX 9070 XT as dispatch siblings now, not separate stacks.
+
+---
+
+## 4. Server CPU (entirely new bucket — not in baseline)
+
+The current baseline has **no server-CPU profile at all**. CPU inference is real (Xeon Max, EPYC + AVX-512 VNNI, AMX on Granite Rapids) and a non-zero share of cloud-inference traffic still routes there for cost or sovereignty reasons. Proposed new bucket `server_cpu_profiles`:
+
+| Profile id | Vendor | Cores | AI primitive | Memory |
+|---|---|---|---|---|
+| `intel_xeon_6900p_granite_rapids` | intel | up to 128 P | AMX (INT8/BF16/**FP16**), AVX10.1, AVX-512 | 12-ch DDR5-6400, MRDIMM-8800, 6 TB |
+| `intel_xeon_6900e_sierra_forest` | intel | up to 288 E | AVX2 only (**no AMX, no AVX-512**) | 12-ch DDR5 |
+| `intel_xeon_6_clearwater_forest` | intel | 288 Darkmont E | First 18A server (H1 2026) | 12-ch DDR5-8000 |
+| `amd_epyc_turin_9005` | amd | up to 128 c (Zen 5) | Full 512-bit AVX-512 + VNNI + BF16 | 12-ch DDR5-6400, CXL 2.0 |
+| `amd_epyc_turin_dense_9005` | amd | up to 192 c (Zen 5c) | Same ISA as Zen 5 (scale-out) | 12-ch DDR5 |
+| `amd_epyc_4005_grado` | amd | up to 16 c | AVX-512 + VNNI + BF16, AM5 socket | DDR5-5600 ECC |
+
+**Why this bucket matters for dispatch:** AMX-FP16 on a 128-core Granite Rapids node is a legitimate small-LLM inference target without a GPU. AVX-512 VNNI on EPYC Turin is too. Treating them as `cpu_fallback_class` (the current 200–999 ms TTFT entry) under-fits real cost-optimized inference paths — a "CPU with matrix unit" tier is genuinely faster than a CPU without.
+
+---
+
+## 5. Schema gaps the current `chip-profiles.json` doesn't cover
+
+Five primitives surfaced across the three research passes that don't fit the current v1.0 schema:
+
+### 5.1 Precision enum is too narrow
+**Current:** `"int8" | "float16" | "none"`.
+**Needed (April 2026 reality):**
+
+| Format | First seen in production | Where |
+|---|---|---|
+| `fp8` | Late 2023 / Hopper | H100 Transformer Engine |
+| `nvfp4` | 2025 | Blackwell B200/B300 |
+| `mxfp8` | Dec 2025 | AWS Trainium3 |
+| `mxfp4` | Dec 2025 / 2025 | Trainium3, AMD MI350 |
+| `fp6` | 2025 | AMD MI350 |
+| `int2` | 2025 | Snapdragon 8 Elite Gen 5 |
+| `bitnet_1_58` | 2025 | MediaTek Dimensity 9500 NPU 990 |
+| `block_fp16` | 2024 | AMD XDNA 2 (Strix Point family) |
+
+Recommendation: replace `preferred_precision` (string) with `supported_precisions` (array) and add `peak_precision` separately.
+
+### 5.2 No "platform TOPS split" for hybrid SoCs
+Current schema has one `npu_tops` field. This under-fits:
+- Intel Lunar Lake (NPU 48 + GPU XMX 67 = ~115 platform)
+- Intel Panther Lake (NPU 50 + Xe3 XMX 120 + CPU AMX = ~180 platform)
+- AMD Strix Halo (NPU 50 + 40-CU RDNA 3.5 iGPU)
+- Apple M5 family (NE + per-GPU-core Neural Accelerators)
+
+Recommendation: composite `compute_axes`:
+```json
+{
+  "npu_tops": 50,
+  "gpu_matmul_tops": 120,
+  "cpu_matmul_tops": 10,
+  "platform_tops": 180,
+  "memory_bandwidth_gbps": 76.8
+}
+```
+
+### 5.3 No unified-memory tier
+MI300A (128 GB HBM3 unified CPU+GPU) and Strix Halo (128 GB LPDDR5X unified CPU+iGPU+NPU) eliminate the host↔device copy step. The current `unified_memory: bool` field doesn't distinguish "Apple-style on-die unified" from "MI300A in-package unified" from "no unified."
+
+Recommendation: `memory_topology` enum: `"discrete" | "soc_unified" | "in_package_unified" | "rack_scale_pooled"` (last entry for Helios + Vulcano + future CXL pools).
+
+### 5.4 No on-package networking primitive
+Gaudi 3's 24×200 GbE on-package and Jaguar Shores' silicon-photonics interconnect are dispatch-relevant for scale-out workloads. Current schema has no networking field.
+
+Recommendation: optional `built_in_networking` field with `{ports, lanes_per_port_gbps, total_gbps}`.
+
+### 5.5 Vendor / market-event tagging
+HADF currently treats vendor as a fixed string. Three 2025–2026 events broke that:
+- Nvidia acquired Groq.
+- Esperanto folded.
+- Microsoft Maia 200 / Intel Falcon Shores both delayed/cancelled.
+
+Recommendation: `vendor_status` field: `"independent" | "acquired_by:<vendor>" | "defunct" | "rebranded"`. Lets dispatch decay weight on at-risk vendors without removing the profile.
+
+---
+
+## 6. Cloud-fingerprinting heuristic gaps
+
+The current `signatures` table (7 entries) classifies by `(ttft_per_1k_tokens_ms, tps_median, tps_cov, batch_scaling_factor)`. Phase 2 (50×5×3 = 750 data points) was never run per [project_hadf_research.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_hadf_research.md), and this baseline has known weaknesses:
+
+1. **No precision-class signal.** Trainium3 (MXFP4) and B300 (NVFP4) produce different per-token latencies than B200 (FP8), but the 4-tuple above doesn't capture that.
+2. **No NUMA / topology probe.** A B200 in a single-node deployment vs an NVL72 GB200 cluster has different batch_scaling_factor — it's already in the schema, but Phase 2 hasn't tuned it.
+3. **No instruction-mix benchmark.** A Mahalanobis distance on (TTFT, TPS) confuses an under-utilized H100 with an A100. Adding an embedding-throughput probe (small batch + large batch deltas) could disambiguate.
+4. **Container vs bare-metal detection.** A B200 in a serverless inference endpoint runs at lower percentile-99 than a dedicated B200 node. Variance signal helps but doesn't disambiguate the cause.
+5. **No memory-bandwidth probe.** For long-context workloads, HBM bandwidth dominates; for short-context, compute does. A two-workload probe (small-context vs long-context same prompt) would discriminate.
+
+Recommendation: Phase 2 calibration should add at least `(precision_class, bandwidth_probe_ratio, container_vs_bare_metal_variance)` to the signature schema before any new generation is added.
+
+---
+
+## 7. Architectural primitives that warrant new dispatch categories
+
+These are primitives genuinely new since the April 2026 baseline that don't have a clean dispatch hint today:
+
+| Primitive | Vendor / first chip | Why dispatch cares |
+|---|---|---|
+| **Compute-in-memory NPU** | MediaTek Dimensity 9500 NPU 990 | Bandwidth wall doesn't apply; very-low-bit (BitNet 1.58) inference becomes attractive. |
+| **GPU-integrated Neural Accelerators per core** | Apple A19 / M5 family | NPU vs GPU dispatch is no longer cleanly separable on Apple. |
+| **Block FP16** | AMD XDNA 2 (Strix Point/Halo/Krackan) | Lets the dispatcher treat the NPU as INT8-cost / FP16-accuracy — distinct from generic FP16. |
+| **Microscaled FP (MXFP4/MXFP8)** | AWS Trainium3 | Distinct from generic FP4/FP8; routing decisions for low-precision inference should prefer it where available. |
+| **In-package CPU+GPU unified memory** | AMD MI300A | Eliminates host↔device copy; latency profile of large-model dispatch changes. |
+| **On-package datacenter networking** | Intel Gaudi 3 (24×200GbE), Jaguar Shores (silicon photonics) | Scale-out dispatch decisions weight idle-time differently. |
+| **Dataflow / RDU architecture** | SambaNova SN40L/SN50, Tenstorrent Blackhole | Different cost curve than GPU/TPU; some agentic workloads (long-context, sparse) favor dataflow. |
+| **Wafer-scale** | Cerebras WSE-3 | All-in-SRAM, very low TPS variance; dispatch should weight cost-per-token over latency at scale. |
+| **Native FP4 / FP6 on consumer GPU** | AMD RX 9070 XT | First time a consumer GPU is a legitimate FP8 inference target — opens at-edge cloud workloads. |
+| **No-AMX-on-EPYC negative primitive** | AMD EPYC Turin | Important to encode: a 128-core Turin without AMX is not interchangeable with a 128-core Granite Rapids with AMX. |
+| **ROCm 7 unified stack** | AMD MI350 + RX 9070 XT + Strix Halo | Consumer + datacenter dispatch can share kernels; closes the long-standing CUDA-fragmentation gap on AMD. |
+
+---
+
+## 8. Recommended prioritization
+
+Three tiers based on dispatch impact × evidence strength:
+
+### Tier 1 — Add now (high impact, ships in production today)
+1. `nvidia_b300_class` — Blackwell Ultra, 4× the dispatch volume of B200 by mid-2026.
+2. `aws_trainium3_class` — first non-Nvidia chip with MXFP8/MXFP4; Anthropic on AWS uses it.
+3. `google_tpu_v7_ironwood_class` — Anthropic committed >1M chips; will dominate cloud inference.
+4. `amd_mi350x_class` — first AMD chip with FP4/FP6.
+5. `intel_panther_lake_npu5` — first Intel client chip with native FP8 NPU.
+6. `amd_strix_halo_xdna2` — establishes the unified-memory-client tier.
+7. `qualcomm_snapdragon_8_elite_gen5` — INT2 + FP8 on mobile.
+8. `mediatek_dimensity_9500` — compute-in-memory primitive.
+9. `apple_a19_pro` + `apple_m5` + `apple_m5_max` — current Apple flagship reality.
+10. **Schema additions:** precision enum expansion, `compute_axes` composite, `memory_topology` enum.
+
+### Tier 2 — Add next quarter (moderate impact or mid-tier)
+11. `intel_lunar_lake_npu4` + `intel_arrow_lake_*` — fills the entirely-missing Intel client bucket.
+12. `amd_strix_point_xdna2` + `amd_krackan_point_xdna2` + `amd_gorgon_point_xdna2` — fills Ryzen client bucket.
+13. `samsung_exynos_2500` + `google_tensor_g5` — fills mobile flagship gaps.
+14. Server-CPU bucket: `intel_xeon_6900p_granite_rapids` + `amd_epyc_turin_9005` + `amd_epyc_turin_dense_9005` — opens CPU-only inference dispatch.
+15. `amd_mi300a_apu_class` — codifies unified-memory datacenter tier.
+16. `intel_gaudi3_class` — codifies on-package networking primitive.
+17. `sambanova_sn40l_class` + `tenstorrent_blackhole_class` — codifies dataflow / RDU class.
+
+### Tier 3 — Track but don't add yet (announced, not shipping at scale)
+- `nvidia_rubin_r100_class` (sampling Q4 2026)
+- `amd_mi400_class` (mid-2026 production target)
+- `aws_trainium4_class` (in development)
+- `microsoft_maia200_class` (delayed to 2026)
+- `intel_jaguar_shores_class` (H2 2026 target)
+- `intel_diamond_rapids_class` (slipped to mid-2027)
+- `amd_zen6_medusa_xdna3` (2027)
+- `apple_a20` / `apple_m6` family (unannounced)
+
+### Tier 4 — Drop or rebrand
+- `qualcomm_snapdragon_8_gen3` → keep but mark as non-current.
+- ET-SoC-1 / Esperanto — never had a profile; do not add.
+- `groq_lpu_class` — add with `vendor_status: "acquired_by:nvidia"`.
+
+---
+
+## 9. Open questions
+
+1. **Phase 2 cloud-fingerprinting validation has not run.** All 7 cloud signatures are currently `calibration_status: "uncalibrated"`. Adding 11 more uncalibrated signatures may worsen classification accuracy if Phase 2 isn't run first. Two options:
+   - **Option A:** Run Phase 2 with the existing 7 first (per the original plan), then add the new 11 calibrated.
+   - **Option B:** Add all 18 uncalibrated, run Phase 2 once across the full set.
+   Option B saves an iteration but trades classification accuracy for breadth. Recommendation: A.
+2. **Should HADF carry "announced but not shipping" profiles?** Adding Tier-3 chips lets HADF prepare without code changes when they ship, but creates the risk of stale entries (Falcon Shores cancellation pattern). Recommendation: do not add Tier 3 to the active table; keep them in this research note as a watchlist.
+3. **Server-CPU profiles — same table or separate?** Schema today is mobile/desktop only. Two options:
+   - Add a new `server_cpu_profiles` block.
+   - Extend `chip-profiles.json` with a `tier: "server_cpu"` value.
+   Recommendation: separate block, because the field set is materially different (`amx_precisions`, `avx10_level`, `numa_nodes` don't apply to mobile).
+
+---
+
+## 10. Next steps
+
+1. **Decide on schema changes** (§5) — these need to land before Tier-1 profiles can be encoded faithfully. ~1 PR, schema-only.
+2. **Run Phase 2 cloud fingerprinting** with the existing 7 signatures (50×5×3 = 750 calls, ~$5).
+3. **Land Tier 1 profiles** (10 entries + schema updates) in a single PR. Includes vendor_status tagging for Groq.
+4. **Land Tier 2 profiles** (~9 entries + server-CPU bucket) in a second PR.
+5. **Update the dispatch confidence-gate rollout plan** in [`dispatch-intelligence.json`](../../.claude/shared/dispatch-intelligence.json) to account for the larger profile library — current 0.4/0.7 gates were calibrated against 17 entries.
+6. **Cross-link** this note from [project_hadf_research.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_hadf_research.md) and the backlog item under "High Priority (Architecture & Framework)" in [`docs/product/backlog.md`](../product/backlog.md).
+
+---
+
+## Appendix A — Source material
+
+Primary research passes captured in this note:
+1. **General chip landscape (Apple/Android/Datacenter/RISC-V):** Apple A19 family (Wikipedia, Tom's Hardware), Apple M5 family (Apple newsroom, MacRumors), Snapdragon 8 Elite Gen 5 (Qualcomm press release), Dimensity 9500 (MediaTek product page), Exynos 2500 (SamMobile, Samsung), Tensor G5 (Google blog, Android Authority), Blackwell B200/B300 (NVIDIA newsroom, Spheron), Trainium3 (HPCwire, AWS), TPU v7 Ironwood (SemiAnalysis, GCP docs), Cerebras WSE-3 (IntuitionLabs), Tenstorrent Blackhole (The Register Apr 28 2026, Tenstorrent docs), SambaNova SN40L/SN50 (SambaNova product pages), Lightmatter Passage (Lightmatter press), Mythic memBrain (Globe Newswire).
+2. **Intel:** Panther Lake / Arrow Lake / Lunar Lake / Meteor Lake (Wikipedia, AnandTech, Intel EDC, Intel Newsroom CES 2026, PBXScience), Granite Rapids / Sierra Forest / Clearwater Forest / Diamond Rapids (Phoronix, Tom's Hardware, Wikipedia, VideoCardz, WCCFTech), Gaudi 3 (Intel white paper, IBM Newsroom), Falcon Shores cancellation + Jaguar Shores (Tom's Hardware, TrendForce), Arc Battlemage / Pro B60 (Intel Newsroom, TechPowerUp, StorageReview).
+3. **AMD:** Ryzen AI 300 series + Strix Halo + Krackan + Gorgon Point (AMD product pages, Tom's Hardware, Notebookcheck, ServeTheHome), EPYC Turin 9005 + EPYC 4005 (AMD datasheets, Phoronix), Instinct MI300A/MI300X/MI325X/MI350X/MI400 (AMD blogs, Tweaktown, Tom's Hardware, AMD IR), RX 9070 XT (AMD product page, Oreate AI), Versal AI Edge Gen 2 + Alveo V80/V70 (AMD blog), ROCm 7 (AMD blog, AMD docs, Tom's Hardware).
+
+Caveats:
+- Apple does not publish TOPS for A19/M5 family. All TOPS figures for those chips are secondary-source.
+- "Snapdragon 8 Elite Gen 5 = ~100 TOPS" is secondary; Qualcomm's press release says "37% faster NPU" without a number.
+- Cloud-signature Phase 2 calibration has not been run; all signatures (existing 7 + proposed 11) are inference-grade until that completes.

--- a/docs/research/2026-04-28-orchid-framework-v7-mapping.md
+++ b/docs/research/2026-04-28-orchid-framework-v7-mapping.md
@@ -1,0 +1,317 @@
+# ORCHID v2 — Mapping Framework v6.0 → v7.7 Capabilities Back to Hardware
+
+> **Status:** RESEARCH (2026-04-28). Companion note to [HADF signature expansion](2026-04-28-hadf-signature-expansion.md).
+>
+> **Premise:** ORCHID's initial design (Phase 1 Layer A complete, 26K+ runs, 7 functional units U1–U7, case study published in `github.com/Regevba/orchid` and PR #83) was anchored to framework v5.0–v5.2 and v6.0. Since then the framework advanced through v7.1 (integrity cycle), v7.5 (cooperating defenses), v7.6 (mechanical enforcement), and v7.7 (validity closure + advisory gates). Each of those releases shipped software primitives that did not exist when ORCHID's spec was written.
+>
+> **Question this note answers:** for each new v7.x capability, is there a silicon-layer analogue that should land in an ORCHID v2 spec? If yes, what unit hosts it, and what does it cost in area / cycles?
+>
+> **Out of scope:** RTL changes, Chisel code, Layer B/C plan rewrites. This note proposes the v2 mapping; spec writing is downstream.
+
+---
+
+## 1. ORCHID v1 baseline (recap)
+
+7 functional units, mapped from v5.0–v5.2 + v6.0:
+
+| Unit | Name | Framework origin | Silicon analogue |
+|---|---|---|---|
+| U1 | Dispatch Scorer | v5.2 dispatch-intelligence.json | Combinational, stateless |
+| U2 | Skill Router | skill-routing.json phase_skills | ROM LUT + decoder |
+| U3 | Cache Controller | v5.0 cache compression | Scratchpad SRAM + compression |
+| U4 | Batch Scheduler | v5.1 batch dispatch | FIFO + round-robin arbiter |
+| U5 | Speculative Prefetcher | v5.1 speculative preload | Prediction table (BTB-style) |
+| U6 | Coherence Unit | v5.2 parallel write safety | MESI-like FSM |
+| U7 | Systolic Array | v5.1 systolic chains | Gemmini |
+
+Interconnect: TileLink. Host: Rocket (RISC-V) + RoCC.
+
+OrchidConfig key knobs (post-v6.0 calibration): `scoreBits=7`, `inputBusWidth=13` (CU v2), `maxSkills=16`, `cacheEntries=15`, `scratchpadKB=48`, `prefetchStagingKB=16`, `contextBitsPerEntry=4`, `maxConcurrentTasks=8`, `predictionTableEntries=64` (recommended drop to 16 per design space exploration), `maxWriters=8`, `meshRows/Cols=8`, `dataWidth=16`.
+
+Design space exploration findings (26K runs, [research_orchid_design_space_findings.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/research_orchid_design_space_findings.md)):
+- `prefetch_ahead=0` often wins on diverse workloads.
+- `cache_entries < 10` thrashes catastrophically; 10–15 is the safe band.
+- `max_concurrent`, `prediction_table_size`, `mesh_rows/cols` showed zero impact on synthetic traces — design space was under-stressed.
+
+---
+
+## 2. What landed between v6.0 and v7.7 (software side)
+
+This is the universe of new framework primitives ORCHID v2 must consider:
+
+### v7.1 — 72h Integrity Cycle (shipped 2026-04-21)
+First framework capability triggered by **wall-clock elapsed time**, not by user/agent action. Runs `scripts/integrity-check.py` against all `state.json` and case studies every 72h via GitHub Actions. 13 cycle-time check codes.
+
+### v7.5 — Data Integrity Framework / cooperating defenses (shipped 2026-04-24)
+Eight cooperating defenses across three timing classes:
+- **Write-time gates** (fire on `git commit`): `SCHEMA_DRIFT`, `PR_NUMBER_UNRESOLVED`, etc.
+- **Cycle-time gates** (every 72h): the v7.1 integrity-check codes.
+- **Readout-time dashboards** (any time): `make documentation-debt`, `make measurement-adoption`, `make runtime-smoke`.
+
+Plus the **T1/T2/T3 data quality tier** convention — every quantitative metric must carry a tag indicating whether it is Instrumented (T1), Declared (T2), or Narrative (T3).
+
+### v7.6 — Mechanical Enforcement (shipped 2026-04-25)
+Promoted four silent agent-attention checks to pre-commit failures:
+- `PHASE_TRANSITION_NO_LOG` — phase change without a feature log entry within 15 min
+- `PHASE_TRANSITION_NO_TIMING` — phase change without timing.phases entries
+- `BROKEN_PR_CITATION` — case-study PR# that doesn't resolve in cached `gh pr list`
+- `CASE_STUDY_MISSING_TIER_TAGS` — scoped case-study commits without T1/T2/T3 tags
+
+Plus two recurring CI defenses:
+- Per-PR review bot ([`.github/workflows/pr-integrity-check.yml`](../../.github/workflows/pr-integrity-check.yml))
+- Weekly framework-status cron ([`.github/workflows/framework-status-weekly.yml`](../../.github/workflows/framework-status-weekly.yml))
+
+### v7.7 — Validity Closure (in progress, 2026-04-27 freeze)
+Closes A1–A5 + B1–B2 + C1 from the post-v7.6 gap inventory:
+- 4 new write-time pre-commit hooks (`CACHE_HITS_EMPTY_POST_V6`, `CU_V2_INVALID`, `STATE_NO_CASE_STUDY_LINK`, `CASE_STUDY_MISSING_FIELDS`)
+- 1 new cycle-time check code (`CU_V2_INVALID`)
+- 1 cycle-time **advisory** (`TIER_TAG_LIKELY_INCORRECT`) — ships permanent advisory because kill criterion 2 fired at baseline
+- Bulk backfill of 32 case-study frontmatters
+- Framework-health dashboard (`/control-room/framework`) surfacing 19 mechanical gates + 1 advisory
+
+**Total framework gates:** 18 (12 cycle + 6 write-time) → **25 gates + 1 advisory**.
+
+### Plus: known mechanical limits
+Five gaps remain mechanically unclosable per [`docs/case-studies/meta-analysis/unclosable-gaps.md`](../case-studies/meta-analysis/unclosable-gaps.md):
+1. `cache_hits[]` writer-path adoption
+2. `cu_v2` factor *correctness* (judgment-based)
+3. T1/T2/T3 tag *correctness*
+4. Tier 2.1 real-provider auth checklist (human required)
+5. Tier 3.3 external replication (external operator required)
+
+---
+
+## 3. Per-capability mapping audit
+
+For each v7.x capability, three questions:
+1. **Does it have a silicon-layer analogue?**
+2. **If yes, which ORCHID unit hosts it?**
+3. **What's the rough cost (area, cycles, new unit)?**
+
+### 3.1 v7.1 — 72h Integrity Cycle
+**Silicon analogue:** YES — **periodic hardware self-audit / built-in self-test (BIST) primitive.**
+Real chips do this: ECC scrubbers walk DRAM looking for bit flips on a cadence; CPU LBIST runs at boot and during low-utilization windows; storage controllers run periodic patrol reads. The v7.1 trigger model (wall-clock elapsed → walk all state) maps exactly to a hardware patrol scrubber.
+
+**ORCHID host:** New unit **U8 — Patrol Scrubber.**
+- Walks U3's scratchpad and U6's coherence directory on a programmable cadence.
+- Detects stale entries (timestamp > threshold), corrupt CRCs, orphaned cache lines.
+- Raises an interrupt to the Rocket host on detection (the silicon analogue of opening a `framework-status` GitHub issue).
+
+**Cost:** ~0.5% area overhead (a small FSM + counter + cadence register). One new RoCC instruction `orchid.scrub.start`. Estimated 1 cycle to start, runs in background.
+
+**Why this matters:** ORCHID v1 has no notion of *time-elapsed* as a trigger — it only acts on dispatch. A Patrol Scrubber gives the chip the same self-audit posture the framework has on the software side.
+
+### 3.2 v7.5 — Cooperating defenses (write-time / cycle-time / readout-time)
+**Silicon analogue:** YES — **multi-stage validation pipeline.**
+This is exactly how silicon validates itself today. Hardware bugs are caught at three stages: (a) at design write time (lint, formal verification), (b) periodically post-tapeout (BIST, in-field telemetry), (c) on demand (debug interface, scan chains).
+
+**ORCHID host:** Distributed across units, plus one new unit **U9 — Validation Bus.**
+- Write-time check → U1 Dispatch Scorer rejects ill-formed dispatch packets at the input stage (1-cycle FSM in input pipeline).
+- Cycle-time check → U8 Patrol Scrubber (above).
+- Readout-time → U9 Validation Bus exposes a memory-mapped register file (status, counters, last-error) accessible from Rocket.
+
+**Cost:** U9 is small (a register file + arbiter), maybe 0.2% area. The big cost is wiring — every functional unit needs a `valid` and `error_code` output line into U9. Estimated +5% wire density. No cycle penalty on the dispatch fast path.
+
+**Why this matters:** v7.5's three-tier defense model is essentially a hardware design pattern that hasn't been explicitly named in ORCHID v1. Adding U9 makes the chip's validation surface as queryable as the framework's.
+
+### 3.3 v7.5 — T1/T2/T3 data quality tier convention
+**Silicon analogue:** YES — **confidence/provenance bits on data flowing through the pipeline.**
+Hardware floating-point already has this primitive (signaling NaN, denormal flags, IEEE-754 status bits). The conceptual move is: every value carries a tier tag, propagated through computation, raising an interrupt or routing differently when a low-tier value enters a high-trust path.
+
+**ORCHID host:** **OrchidConfig schema change** — add `tierBits=2` per data entry across U3 (cache), U4 (scheduler), U7 (systolic array result tags). Plus a new dispatch_hint in U1: `min_tier_required` per workload class.
+
+**Cost:** 2 bits per cache entry × 15 entries = 30 bits. 2 bits per scheduler slot × 8 slots = 16 bits. Trivial area. The cost is in the wires: every dataflow path in the chip widens by 2 bits. Estimated +2% wire density. No cycle penalty.
+
+**Why this matters:** ORCHID's composite score (latency × throughput × energy) currently treats every data point as equal. Adding tier propagation lets the dispatcher de-rate paths that operate on T3 (narrative) data — analogous to how the framework refuses to declare "kill criterion fired" on a T3 metric.
+
+### 3.4 v7.6 — Mechanical enforcement (Class B → Class A promotion)
+**Silicon analogue:** YES — **soft-assertion → hard-assertion promotion in synthesizable RTL.**
+Verilog has both `assert` (compile-time) and `assume` (runtime) plus `expect`/`cover` for verification — and the equivalent of v7.6 promotion is moving an assertion from `simulation_only` to `synthesizable_with_trap`. Real chips do this: AArch64 has watchpoint registers that escalate from log-only → trap-on-write based on a config bit.
+
+**ORCHID host:** **U1 Dispatch Scorer** + new `assertion_mode` register per unit.
+- Each unit gets an `assert_mode` field: `OFF | LOG | TRAP`.
+- LOG mode = current ORCHID v1 behavior (counter increments on violation, dispatch continues).
+- TRAP mode = new behavior — violation raises an interrupt to Rocket and stalls the offending unit.
+
+**Cost:** 2-bit register per unit × 7 units = 14 bits. The trap path needs a wire to Rocket's interrupt controller. Maybe 0.1% area. The harder cost is the *verification effort* to certify each assertion is truly trap-safe (the silicon analogue of writing pre-commit hooks).
+
+**Why this matters:** v7.6's Class B → Class A promotion is the canonical example of "moving from advisory to mandatory." ORCHID v1 has no notion of advisory vs mandatory for any unit. v2 should bake it in from day one.
+
+### 3.5 v7.6 — Per-PR review bot + weekly cron
+**Silicon analogue:** PARTIAL — **per-transaction validation (per-PR analogue) + periodic full-system check (cron analogue).**
+The PR bot equivalent is a "per-dispatch validation" that runs *before* the result commits; the cron equivalent is the U8 Patrol Scrubber from §3.1. So PR-bot is a new pattern.
+
+**ORCHID host:** U1 Dispatch Scorer gets a **pre-commit phase** — score is computed, but the result is held in a staging register until U9 Validation Bus signals OK.
+
+**Cost:** One staging register per dispatch slot. +1 cycle pipeline depth on dispatch (was combinational, now has a pre-commit phase). This is a real cycle-time hit. Needs evaluation.
+
+**Why this matters:** It's the difference between catching a bad dispatch *before it routes* vs *after it executes*. The framework moved this needle in v7.6. ORCHID's v1 dispatch was purely speculative (combinational, single-cycle); v2 should consider a 2-cycle dispatch with a validation gate.
+
+### 3.6 v7.7 — Validity closure (5 new gates + 1 advisory)
+**Silicon analogue:** YES — **soft-fail vs hard-fail assertion modes with one always-soft channel.**
+The advisory gate (`TIER_TAG_LIKELY_INCORRECT`, ships permanent advisory because kill criterion 2 fired at baseline) is genuinely interesting from a hardware perspective: it's an assertion that *cannot* be promoted to hard-fail because the underlying signal is judgment-based. Hardware analogue: thermal sensors and aging counters — they always log, never trap, because false-positive rates are too high.
+
+**ORCHID host:** **U9 Validation Bus** gets two channels:
+- `mandatory_channel` — feeds the trap path to Rocket.
+- `advisory_channel` — feeds a separate counter file, never traps.
+
+**Cost:** Doubles the wire count out of each unit but at very narrow widths (4-bit error codes). Still small.
+
+**Why this matters:** Hardware design has long suffered from "every error is fatal" or "every error is silent." The v7.7 advisory model is a third way: log-with-priority. Worth encoding in the chip from the start.
+
+### 3.7 v7.7 — `cache_hits[]` mechanical limit
+**Silicon analogue:** YES — **observability primitive (performance counters).**
+The framework's struggle to make `cache_hits[]` write-path-mandatory mirrors the chip-level struggle to make every event counter-tracked. Modern chips solve this with PMU (Performance Monitoring Unit) registers — every cache miss / branch mispredict / TLB walk is counted automatically by hardware.
+
+**ORCHID host:** **U3 Cache Controller** already has a hit/miss counter (per [research_orchid_design_space_findings.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/research_orchid_design_space_findings.md)). v2 should expose it as a memory-mapped PMU register accessible from Rocket — the silicon equivalent of write-time-mandatory `cache_hits[]`.
+
+**Cost:** Already implemented. Just needs to be wired to U9 Validation Bus and exposed via memory map. Trivial.
+
+**Why this matters:** It closes the only Class B mechanical gap that v7.7 couldn't promote (per the framework's own mechanical-limits doc). Hardware can do this trivially because it has dedicated counter silicon. The framework cannot because the writer-path is human/agent.
+
+### 3.8 v7.x — `cu_v2` continuous factors
+**Silicon analogue:** YES — **dynamic dispatch input vector.**
+ORCHID v1 already encodes CU v2 as `inputBusWidth=13` per the post-v6.0 calibration. So this is already in the spec. The v7.x novelty is `CU_V2_INVALID` as a write-time gate — schema validation. The silicon analogue is **input-bus protocol checking**: every dispatch packet entering U1 Dispatch Scorer is validated against the protocol before scoring begins.
+
+**ORCHID host:** **U1 Dispatch Scorer** input pipeline gets a 1-cycle protocol-check FSM. If the input vector is malformed (wrong bit count, out-of-range factor), the scorer rejects the packet and signals U9.
+
+**Cost:** 1 cycle on the dispatch fast path (2 cycles total: protocol-check → score). Same cost as §3.5 above; can share the staging register.
+
+**Why this matters:** The whole point of `inputBusWidth=13` is to encode v6.0 CU v2 factors faithfully. Adding protocol-check makes the encoding *enforced*, not just *documented*.
+
+---
+
+## 4. Summary mapping table
+
+| Framework capability | New ORCHID unit / change | Cost | Priority |
+|---|---|---|---|
+| v7.1 — 72h integrity cycle | **U8 — Patrol Scrubber** | ~0.5% area, +1 RoCC instr | **P0** |
+| v7.5 — three-tier defenses | **U9 — Validation Bus** + per-unit error wires | ~0.2% area + 5% wire density | **P0** |
+| v7.5 — T1/T2/T3 data tiers | **OrchidConfig: tierBits=2** + U1 min_tier_required hint | ~2% wire density | **P0** |
+| v7.6 — Class B → Class A | **assertion_mode** register per unit | ~0.1% area, verification cost is real | **P1** |
+| v7.6 — per-PR pre-commit gate | **U1 staging register + pre-commit phase** | +1 cycle dispatch pipeline depth | **P1** (eval first) |
+| v7.7 — advisory vs mandatory channels | **U9: mandatory + advisory channels** | minor wire count | **P1** |
+| v7.7 — `cache_hits[]` PMU | **U3 PMU register exposure** to U9 + memmap | trivial | **P0** (cheap) |
+| v7.x — `cu_v2` protocol check | **U1 input pipeline FSM** | shares staging with v7.6 | **P1** (folds into v7.6 work) |
+
+---
+
+## 5. Proposed ORCHID v2 architecture sketch
+
+```
+ORCHID v2 SoC
+├── RISC-V Core (Rocket) ──RoCC──► Orchestration Accelerator Complex
+│                                   ├── U1: Dispatch Scorer (combinational + pre-commit phase)
+│                                   │       └── input pipeline FSM (cu_v2 protocol check)
+│                                   ├── U2: Skill Router (LUT + decoder)
+│                                   ├── U3: Cache Controller (scratchpad + PMU registers)
+│                                   ├── U4: Batch Scheduler (FIFO+arbiter, tier-aware)
+│                                   ├── U5: Speculative Prefetcher (BTB-style)
+│                                   ├── U6: Coherence Unit (MESI-like)
+│                                   ├── U7: Systolic Array (Gemmini)
+│                                   ├── U8: Patrol Scrubber (NEW — periodic self-audit)  ← v7.1
+│                                   └── U9: Validation Bus (NEW — mandatory + advisory)  ← v7.5/v7.7
+├── TileLink Interconnect (result forwarding bus)
+│       └── 2-bit tier propagation widening                                              ← v7.5
+└── Memory Subsystem (L1 scratchpad with tier tags, L2 compressed, DRAM)
+```
+
+Key v2 deltas vs v1:
+- Two new functional units (U8, U9) — one for periodic self-audit, one for validation surface.
+- Per-unit `assertion_mode` register lets ops promote silent counters to traps without RTL change.
+- 2-bit data tier propagation across the interconnect.
+- 1-cycle pre-commit phase on U1 dispatch fast path (configurable; can be disabled for raw throughput).
+
+---
+
+## 6. What v7.x does NOT translate to silicon
+
+Three v7.x capabilities have no clean silicon analogue and should stay framework-only:
+
+1. **Bulk backfill of 32 case-study frontmatters (v7.7)** — this is a one-time data migration, not a recurring primitive. Silicon equivalent would be a one-time microcode patch, which is not worth designing for.
+2. **Per-PR review bot fetching `origin/main` baseline via git worktree** — git is irrelevant to silicon. The conceptual analogue (compare-against-baseline) is already covered by U8 Patrol Scrubber.
+3. **Pre-PRD `success_metrics` / `kill_criteria` / `dispatch_pattern` markers** — these are PRD-stage artifacts. The hardware analogue would be design intent / requirements traceability, which is a different layer (probably a verification IP layer, not a silicon unit).
+
+---
+
+## 7. Cross-coordination with HADF expansion
+
+Three of the proposed v2 changes interact with the HADF signature library expansion ([2026-04-28-hadf-signature-expansion.md](2026-04-28-hadf-signature-expansion.md)):
+
+1. **Tier propagation (§3.3)** — if HADF adds T1/T2/T3 to its dispatch hints, ORCHID's `tierBits` can be the silicon-side enforcement.
+2. **PMU exposure (§3.7)** — once HADF adds new chip profiles whose dispatch-hint tables include `cache_hits` as a measured input, ORCHID's U3 PMU is the place those metrics land.
+3. **Networking primitive on real chips** — Gaudi 3's 24×200 GbE on-package and Jaguar Shores' silicon photonics (per the HADF note) are the upstream hardware analogue of ORCHID's TileLink bus. v2 should consider whether the result-forwarding interconnect should support multi-chip scale-out or stay single-die.
+
+---
+
+## 8. Recommendation: ORCHID v2 vs ORCHID v1.5
+
+Two options for landing this:
+
+### Option A — ORCHID v2 (full spec rev)
+Add U8 + U9, change OrchidConfig schema, document advisory/mandatory channels, write a new spec. Net cost: 1 new spec doc + 4 new plans (Phase 6: U8, Phase 7: U9, Phase 8: tier propagation, Phase 9: assertion_mode). Estimated 3–4 weeks of plan-writing before any RTL.
+
+### Option B — ORCHID v1.5 (incremental)
+Keep the v1 7-unit architecture, but extend OrchidConfig with `tierBits` and `assertionModes` per unit. Add a single `Patrol Scrubber` unit (P0 only). Defer U9 Validation Bus and pre-commit-gate work to v2. Net cost: 1 spec addendum + 1 plan. ~1 week.
+
+**Recommendation: Option B (v1.5).** Three reasons:
+1. Phases 2–5 of the original ORCHID plan are still ready-to-execute (Layer B + Layer C). Forking to v2 risks abandoning that progress.
+2. The P0 changes (U8 Patrol Scrubber, tier propagation, U3 PMU exposure) are additive and don't break Phase 2–5 RTL.
+3. The P1 changes (U9, pre-commit gate, assertion_mode) genuinely benefit from running ORCHID Layer B/C first to gather real cycle-time data — guessing the cost of "+1 cycle on dispatch fast path" without measurement is exactly the kind of thing v6.0 measurement infrastructure exists to prevent.
+
+---
+
+## 9. Open questions
+
+1. **Should U8 Patrol Scrubber walk DRAM, or only on-chip state?** Walking DRAM at the cadence the framework uses (every 72h equivalent) would be a real bandwidth tax. Recommend: on-chip only for v1.5; revisit DRAM scrubbing in v2.
+2. **Does tier propagation belong on TileLink, or as side-band metadata?** Widening TileLink by 2 bits affects every IP block on the bus; side-band keeps the bus stable but adds wiring complexity. Open question for the Layer B Chisel work.
+3. **Is the advisory channel worth its own physical wires, or can it share the mandatory channel with a 1-bit "is_advisory" tag?** Tag is cheaper but increases parsing complexity at U9. Recommend: tag in v1.5, separate wires only if profiling shows contention.
+4. **Should the 26K-run design space exploration be re-run with new tier-aware traces?** Original DSE used synthetic traces with no tier dimension. Adding T1/T2/T3 to the trace generator would let DSE confirm the dispatcher actually de-rates T3 paths. Estimated cost: 1 day to extend the trace generator + ~2 days of DSE wall-clock.
+5. **How does this affect HADF integration?** Currently HADF Layer 4 (evolutionary learning) writes to `chip-affinity-map.json`. If ORCHID v1.5 PMU exposure becomes the canonical source of dispatch-affinity data on Orchid-equipped systems, the affinity map writer needs a hardware-source mode. Open for a follow-up.
+
+---
+
+## 10. Next steps
+
+1. **Decide Option A vs Option B** (§8) — one approval needed before any spec/plan work begins.
+2. **If Option B chosen:**
+   - Write a 1-page ORCHID v1.5 spec addendum covering U8 + tier propagation + U3 PMU exposure.
+   - Add 1 plan: `2026-04-28-orchid-v1-5-patrol-scrubber.md` (~3 tasks: behavioral model in Layer A, Chisel RTL in Layer B, integration with U3).
+   - Re-run the DSE with tier-aware traces (per §9, item 4) to validate that the dispatcher uses the new bits.
+3. **If Option A chosen:** the spec rewrite is a real 3–4-week job. Recommend deferring until ORCHID Layer B Phase 2 (U1+U2 Chisel) is complete — that gives real cycle-time data to ground the P1 cost estimates.
+4. **Cross-link** this note from [research_cloud_emulated_chip_design.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/research_cloud_emulated_chip_design.md), [research_framework_to_hardware_mapping.md](../../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/research_framework_to_hardware_mapping.md), and the backlog item under "High Priority (Architecture & Framework)" in [`docs/product/backlog.md`](../product/backlog.md).
+5. **Coordinate with HADF expansion** ([2026-04-28-hadf-signature-expansion.md](2026-04-28-hadf-signature-expansion.md)) — three changes interact (§7).
+
+---
+
+## Appendix A — Framework version → ORCHID unit cross-reference (full table)
+
+| Framework version | Capability | ORCHID v1 home | ORCHID v2 change |
+|---|---|---|---|
+| v5.0 | Skill-on-demand loading | U2 Skill Router | unchanged |
+| v5.0 | Cache compression | U3 Cache Controller | unchanged |
+| v5.1 | Batch dispatch | U4 Batch Scheduler | tier-aware (v7.5) |
+| v5.1 | Result forwarding | TileLink interconnect | +2-bit tier widening (v7.5) |
+| v5.1 | Model tiering | U1 Dispatch Scorer | min_tier_required hint (v7.5) |
+| v5.1 | Speculative preload | U5 Speculative Prefetcher | unchanged |
+| v5.1 | Systolic chains | U7 Systolic Array | unchanged |
+| v5.1 | Task complexity gate | U1 + U4 dispatch logic | unchanged |
+| v5.2 | Dispatch intelligence | U1 Dispatch Scorer | + protocol-check FSM (v7.x cu_v2) |
+| v5.2 | Parallel write safety | U6 Coherence Unit | unchanged |
+| v6.0 | Deterministic measurement | OrchidConfig (cu_v2 input bus) | already encoded |
+| v7.1 | 72h integrity cycle | **none** | **NEW: U8 Patrol Scrubber** |
+| v7.5 | Cooperating defenses | **none** | **NEW: U9 Validation Bus** |
+| v7.5 | T1/T2/T3 data tiers | **none** | **NEW: tierBits propagation** |
+| v7.6 | Class B → A mechanical | **none** | **NEW: assertion_mode register per unit** |
+| v7.6 | Per-PR pre-commit gate | **none** | **NEW: U1 staging register + pre-commit phase** |
+| v7.7 | Advisory vs mandatory | **none** | **NEW: U9 dual-channel** |
+| v7.7 | `cache_hits[]` PMU | U3 has counters | **NEW: PMU register exposure to U9** |
+
+---
+
+## Appendix B — What this note does NOT claim
+
+- It does **not** claim ORCHID v2 will be faster than v1. The new units (U8, U9) are validation/observability, not compute. Composite score may not improve.
+- It does **not** claim every v7.x capability is silicon-relevant. Three explicitly are not (§6).
+- It does **not** claim hardware costs given here are accurate to within 10%. They are sketches; real numbers come from Layer B Chisel + Verilator runs.
+- It does **not** claim Option B (v1.5) is the right call universally. It is the right call **given** the existing Phase 2–5 plans are ready to execute and there is no business reason to fork. If the business reason changes, Option A becomes attractive.

--- a/docs/research/2026-05-01-framework-v7-8-branch-isolation-survey.md
+++ b/docs/research/2026-05-01-framework-v7-8-branch-isolation-survey.md
@@ -1,0 +1,368 @@
+# v7.8 Branch-Isolation Membrane — Research Note + Design Analysis
+
+**Status:** Research-only. The user's instruction (2026-05-01) was to document this idea and the analysis regardless of whether we move forward. This note is the input to the eventual v7.8 design doc, not the design doc itself.
+
+**Trigger:** HADF Phase 2 experiment + the 2026-05-01 PR #169 fallout both surfaced that parallel agents working on separate branches in this repo are NOT actually isolated from each other in practice. The user's framing (verbatim, 2026-05-01):
+
+> can we create or mimic an agent or branch dedicated partial sandbox membrane, that agents are aware to the work of other agents and any feature work that is being done doesn't interfere with the work of other agents
+
+**Source memos:**
+- `memory: project_framework_gaps_audit_2026_04_30.md`
+- `memory: project_bug_retrospective_2026_05_01.md`
+- `memory: project_framework_v7_8_research_plan.md` (Topic 7)
+- `memory: project_framework_honesty_fixes_shipped_2026_05_01.md` (the empirical case)
+- `memory: project_unified_control_center.md` (architectural neighbor)
+
+---
+
+## 1. The problem (specific to this codebase)
+
+Two recent incidents are the empirical input. They reveal that "isolation" is failing in two distinct ways.
+
+### 1.1 HADF Phase 2 — concurrent shared-state writes
+
+The HADF campaign runs an unattended fingerprint-collection job in a worktree at `/Volumes/DevSSD/FitTracker2-hadf-campaign/`, while parallel feature work continues on `main` and on feature branches in the primary worktree. Observed collisions:
+
+- `.claude/settings.local.json` drifts on every commit; both worktrees' working copies disagree
+- `.claude/shared/hadf/*` lives on disk and gets clobbered by whichever worktree commits last
+- The launchd plist for the HADF wrapper writes to a relative path that resolves to whichever `WorkingDirectory` is current — required pinning to a specific worktree path to avoid orphaning data
+
+### 1.2 PR #169 — schema migration breaks downstream consumer silently
+
+Today's `created` → `created_at` rename across 43 state.json files broke `scripts/measurement-adoption-report.py` because the consumer read the legacy field name. The break was silent: report ran without errors but returned `post-v6: 0` instead of `post-v6: 11`. Caught by the user's mid-session instruction to "run against the entire gating system" — would have shipped to main otherwise.
+
+The deeper pattern: a schema change on a path many consumers read crossed agent-task boundaries that nothing in our framework currently models. Agent A (the migration agent) had no way to discover Agent B (the report-builder agent) and vice versa.
+
+### 1.3 What "isolation" should mean
+
+The user's framing decomposes into four properties:
+
+| Property | What it gives | What today's setup does |
+|---|---|---|
+| **Read-shared, write-isolated** | Agents see each other's work; writes are scoped to declared paths | Worktrees give file-tree isolation but shared dirs (`.claude/shared/*`, `.claude/settings.local.json`) are race-able |
+| **Awareness without blocking** | Agent B can see "Agent A is mid-flight on path X" without locking X | No mechanism. Discovery is at PR-merge time, after-the-fact |
+| **Conflict detection at write-time** | First overlapping write triggers a coordination event, not a merge conflict | Merge-conflict detection is the current mechanism; runs at PR-rebase or PR-merge — too late |
+| **Recoverable state** | Abandoned/rolled-back agent work cleans up automatically | Stashes pile up; orphan worktrees survive; settings.local.json drifts persist |
+
+---
+
+## 2. Prior art surveyed
+
+(Compressed from the research agent's full survey — see memory `project_framework_v7_8_research_plan.md` Topic 7 for the working list. The agent's report is reproduced verbatim in §99 below for the next-session design doc to cite.)
+
+### 2.1 Five clusters of prior art
+
+**A. Version-control isolation:** Git worktrees + sparse-checkout (current de-facto, leaky on shared dirs); Pijul (patch-based, explicit deps between changes); Sapling smartlog (Meta's stacked-diff awareness UX); Jujutsu (op-log per workspace, replayable rollback).
+
+**B. Concurrent-edit / merge models:** CRDTs — Yjs/Automerge (commutative ops, deterministic merge); MRDTs — invariant-preserving CRDTs (Microsoft Research India); append-only logs — Hypercore/multifeed (per-author log, merged-on-read view); OT (centralized, dominated by CRDTs for offline-first cases).
+
+**C. Hermetic build / action models:** Bazel remote execution (declared inputs/outputs, content-addressed); Nix profiles + overlays (declarative path isolation); Vercel Sandbox / Firecracker microVMs (process-level isolation — overkill for cooperative agents).
+
+**D. Filesystem-level sandboxing:** Linux Landlock / macOS App Sandbox (kernel-enforced declarative scopes); inotify/fsevents mediator (detect-and-broadcast pattern, lightweight, OS-portable).
+
+**E. Multi-agent coordination:** LangGraph reducers (per-key merge-semantics declared at graph-build time); AutoGen GroupChat (serialized turn-taking — coordinator pattern, not isolation); AI agent tool-call sandboxing (host-mediated tool layer is the natural enforcement point).
+
+### 2.2 Top-3 primitives ranked for our problem
+
+1. **LangGraph-style per-key reducers + Bazel-style action manifests.** Each shared path declares its merge semantics (append, replace, max, exclusive-write, …). Each agent task declares `reads:[paths]` and `writes:[paths]`. A pre-dispatch coordinator detects overlapping writes and either schedules them serially or rejects the second writer with a clear "Agent X holds path Y" message. Highest leverage, lightest infrastructure.
+
+2. **MRDTs for shared append-mostly ledgers.** `measurement-adoption-history.json`, `documentation-debt.json`, per-feature logs. Every entry carries causal metadata; merges become deterministic and concurrent appends never conflict. State.json itself stays a normal file because its invariants (current_phase ∈ enum, timing.phases monotonic) are too sharp for a generic CRDT — they need invariant-preserving merge functions.
+
+3. **Sapling-smartlog awareness view + jj op-log recovery.** A live, non-blocking view of every active agent's branch + which paths it has declared as in-flight + how many minutes since its last write. Agents query this view before deciding to proceed. Op-log gives cheap, replayable rollback when an agent abandons work.
+
+### 2.3 The pivotal open question
+
+Before any v7.8 design can be drafted, one classification question needs an answer:
+
+> Are shared-path conflicts in this project predominantly on **append-mostly ledgers** (which CRDTs solve cleanly) or on **invariant-bearing documents** (which require either a coordinator or invariant-preserving merges)?
+
+Inputs to classify:
+- The HADF Phase 2 incident (which class of file collided?)
+- The PR #169 fallout (which class of file caused the silent break?)
+- The 2026-04-30 merge-marathon stashes (9 stashes still around — what paths do they touch?)
+
+Until that classification is in, choosing between Primitive 1 (action manifests) and Primitive 2 (CRDTs) is premature.
+
+---
+
+## 3. What would change in the framework
+
+This section assumes — for the sake of analysis — that we adopt a hybrid of Primitives 1 + 2 + 3 (action manifests + CRDTs for ledgers + smartlog view). Section 4 then asks whether we *should*. Section 6 gives the honest call.
+
+### 3.1 Schema additions
+
+**Per-feature `state.json`:**
+
+```json
+{
+  "feature_name": "...",
+  "current_phase": "implementation",
+  "agent_manifest": {
+    "reads": [
+      ".claude/shared/skill-routing.json",
+      ".claude/shared/measurement-adoption.json"
+    ],
+    "writes": [
+      ".claude/features/auth-polish-v2/state.json",
+      ".claude/logs/auth-polish-v2.log.json"
+    ],
+    "shared_writes": [
+      {
+        "path": ".claude/shared/measurement-adoption-history.json",
+        "merge_strategy": "append",
+        "reducer": "snapshot_dedup_by_date"
+      }
+    ]
+  }
+}
+```
+
+**New `.claude/shared/agent-leases.json`** — the live coordinator state:
+
+```json
+{
+  "version": "1.0",
+  "leases": [
+    {
+      "agent": "auth-polish-v2",
+      "branch": "feature/auth-polish-v2",
+      "worktree": "/Volumes/DevSSD/FitTracker2",
+      "started_at": "2026-05-01T04:00:00Z",
+      "last_heartbeat": "2026-05-01T04:42:00Z",
+      "writes": ["..."]
+    }
+  ]
+}
+```
+
+**New `.claude/shared/path-reducers.json`** — the merge-semantics registry:
+
+```json
+{
+  "version": "1.0",
+  "paths": {
+    ".claude/shared/measurement-adoption-history.json": {
+      "merge_strategy": "append_dedup",
+      "dedup_key": "date"
+    },
+    ".claude/shared/skill-routing.json": {
+      "merge_strategy": "exclusive_write",
+      "owner_features": ["framework-v*"]
+    },
+    ".claude/features/*/state.json": {
+      "merge_strategy": "exclusive_write_per_path",
+      "owner": "the feature directory's name"
+    }
+  }
+}
+```
+
+### 3.2 Tooling additions
+
+**1. `scripts/membrane-acquire.py <feature> --writes <paths> --reads <paths>`** — registers a lease in `agent-leases.json`. Refuses if any declared write conflicts with a live lease whose path-reducer is `exclusive_write`. Emits a "see also: agent X mid-flight on Y" message when conflicts are detected so agents have awareness before action.
+
+**2. Pre-commit hook extension** — already-staged files must match the lease's declared writes. A commit that touches `.claude/shared/measurement-adoption-history.json` without that path being in the lease is rejected. Closes the case where Agent A "just edits the shared file because it's there."
+
+**3. CRDT layer for ledgers.** `scripts/append-cache-hit.py`, `scripts/append-feature-log.py`, and the measurement-adoption history writer rewrite their underlying file via a CRDT-aware library (e.g., Automerge bindings) instead of `json.load → mutate → json.dump`. Concurrent appends stop racing.
+
+**4. `scripts/membrane-status.py`** — text-mode smartlog. Lists all live leases, their declared write sets, last heartbeat, and any overlapping in-flight changes on PRs not yet merged. Surfaces the "Agent B knows Agent A is mid-flight" property.
+
+**5. Heartbeat / cleanup daemon (optional, OS-portable).** A `launchd` (macOS) / `systemd-user` (Linux) job that prunes stale leases (no heartbeat for >2h) and removes orphan worktrees. Without this, leases accumulate.
+
+### 3.3 Workflow additions
+
+**Per agent session start** (`/pm-workflow {feature}`):
+1. Lease acquisition — `membrane-acquire` is called automatically
+2. Schema check verifies the manifest declares paths the work will actually touch
+3. Lease emits a notification (today: stdout; tomorrow: control-room dashboard event)
+
+**Per commit** (pre-commit hook):
+1. Verify all staged paths are in the lease's `writes`
+2. Verify no path's reducer is violated (e.g., not appending to an `append_dedup` ledger via `>` overwrite)
+3. Refresh lease heartbeat
+
+**Per PR open** (PR-integrity bot):
+1. Render the `membrane-status` of the PR's feature branch + 5 most-recently-active others into the PR description
+2. Flag any "PR's writes overlap with live leases on other branches" with the specific paths
+
+**Per session end:**
+1. Lease release — explicit `membrane-release` OR auto-cleanup on no-heartbeat-for-2h
+
+### 3.4 Integration with the existing v7.7 mechanical gates
+
+| Existing gate | How v7.8 membrane augments it |
+|---|---|
+| `SCHEMA_DRIFT` (legacy `phase` / `created`) | Unchanged. Membrane is orthogonal — schema gates check intra-file invariants, membrane checks inter-agent conflicts. |
+| `PHASE_TRANSITION_NO_LOG` | The lease acquisition records a `phase_started` log event automatically — closes the same gap from a different angle. |
+| `PHASE_TRANSITION_NO_TIMING` | Lease records `started_at`; release records `ended_at`. Reduces agent-attention burden. |
+| `CACHE_HITS_EMPTY_POST_V6` | Membrane writer-path manifests are the *prerequisite* for the unclosable Class B gap (issue #140). When a manifest declares "I read `.claude/shared/skill-routing.json`," wrapping that read with `log-cache-hit.py` becomes mechanical, not agent-attention-dependent. |
+| `CU_V2_INVALID` | Unchanged. |
+| `STATE_NO_CASE_STUDY_LINK` | Unchanged. |
+| `BROKEN_PR_CITATION` | Unchanged. |
+| `CASE_STUDY_MISSING_TIER_TAGS` | Unchanged. |
+| `CASE_STUDY_MISSING_FIELDS` | Unchanged. |
+| `FRAMEWORK_VERSION_FORMAT` (today's PR) | Unchanged. |
+| `BROKEN_PR_CITATION` (write-time) | Unchanged. |
+| 13 cycle-time codes | A 14th could be added: `ORPHAN_LEASE` — a lease whose feature has no `current_phase` change in 7 days. |
+
+The membrane sits *above* the existing gates conceptually: "before you commit, your write set must be a subset of your declared lease," and the existing gates fire on whatever does pass that subset check.
+
+### 3.5 Integration with the UCC + control-room dashboard
+
+`/control-room/framework` is the natural surface for the lease/smartlog view. New section: **§7 Active leases** — live table of every agent's branch, declared writes, last heartbeat, conflict count. Updates via the same sync pipeline that already feeds the framework-health page.
+
+This means the membrane is *visible to the operator at a glance*. The user can see, in admin-only mode at the control-room URL, "Agent A is on PR #169 with writes {schema, 45 state.json}; Agent B is on `feat/ucc-t31-builder-port` with writes {dashboard sync}; no conflicts" — a property that doesn't exist in any other multi-agent framework I know of, because they don't have a published-status-page model.
+
+---
+
+## 4. Tradeoffs
+
+### 4.1 What it costs
+
+**Engineering cost (one-time):**
+- Schema migration to add `agent_manifest` + `shared_writes` to all 46 state.json files
+- 5 new scripts (acquire/release/status + heartbeat daemon + CRDT writer wrappers)
+- Pre-commit hook extension + 1 new cycle-time check code
+- CRDT library (Automerge) added as project dependency
+- Documentation: agent-onboarding guide, reducer authoring guide
+- PR-integrity bot rendering changes
+- Control-room dashboard §7 view
+
+Estimated: **5-8 dev days for the minimum viable version, 12-15 for the full hybrid.**
+
+**Engineering cost (recurring):**
+- Every new feature needs its manifest authored (similar weight to authoring `success_metrics`)
+- Every new shared path needs a reducer registered
+- The path-reducer registry needs a review process so reducer-authoring doesn't drift
+
+**Runtime cost:**
+- ~50ms per pre-commit (lease check + reducer validation against staged files)
+- ~100KB-1MB on-disk for the leases + history files
+- Heartbeat daemon: negligible (one wakeup per 5 min)
+
+**Cognitive cost:**
+- Authors must learn what reducers are, which one applies to their writes
+- Mental model shift: "I'm not just writing files, I'm operating under a lease"
+- Failure mode: agents routed around the lease via `--no-verify` and the membrane silently degrades to current state
+
+### 4.2 What it prevents
+
+| Failure mode caught today only at merge | Caught by membrane at write-time |
+|---|---|
+| HADF-style worktree shared-path collision | Yes — second worktree's `.claude/shared/hadf/*` write rejected |
+| PR #169-style downstream consumer silent break | Partially — the consumer's `reads` declaration would have flagged that the schema change touched a path the consumer reads. Not a perfect check (read-set declarations are coarse) but creates a discovery surface. |
+| Stale settings.local.json drift | Partially — if `.claude/settings.local.json` reducer is `local_only_no_commit`, commits touching it are rejected. Doesn't prevent disk drift, only commit drift. |
+| Two agents both editing the same state.json | Yes — exclusive_write reducer per-path means second agent's lease acquisition fails. |
+| Append-only ledger race (measurement-adoption history) | Yes — CRDT writer makes concurrent appends commutative; no overwrites. |
+| Orphan worktrees from abandoned agent runs | Yes — heartbeat cleanup. |
+
+### 4.3 Where it would be overkill
+
+If the project's parallel-agent volume stayed at the current level (1-3 active branches at any time, mostly serial dispatch because F6-F9 framework bugs block parallel), the membrane is overkill. The existing process — careful merging, occasional manual janitorial work — is cheaper per-incident than 5-8 dev-days upfront + per-feature manifest authoring.
+
+If the project's shared paths stayed at the current count (~5 ledger files, ~46 state.json files, all owned by a clear feature directory), reducer registration is mostly mechanical and the registry stays small.
+
+But if either of those scales — say, 5+ concurrent agents with overlapping write sets, or 20+ shared mutable paths — the merge-time conflict resolution cost grows super-linearly while the membrane's cost grows linearly.
+
+### 4.4 Where it would create system overload
+
+**Risk: bureaucracy without value.** A lease per agent task means every `/pm-workflow` invocation grows ~10 seconds of acquire/check overhead. If most tasks don't actually conflict with anything, the overhead is dead weight. Mitigation: skip lease acquisition for chore work-type tasks (smaller blast radius, fewer shared writes).
+
+**Risk: reducer-registry rot.** New shared paths get added without reducer registration. The registry becomes incomplete; agents work around the gap with `--no-verify`. Mitigation: the registry itself is a state.json-style auditable file; missing entries become a cycle-time finding.
+
+**Risk: false positives.** Two agents legitimately need to append to the same history file. If the reducer is wrong (`exclusive_write` instead of `append_dedup`), legit work is blocked. Mitigation: reducer authoring needs a 1-2 person review like a schema migration.
+
+**Risk: opacity.** Agents fail with "lease conflict on path X" without enough context to resolve. Mitigation: every lease conflict message must include "see PR #N for the in-flight work" + "to take over, contact Agent A" + "to coordinate, see /control-room/framework §7."
+
+---
+
+## 5. Recommendation
+
+**Honest read:** the membrane is a real solution to a real problem we genuinely have, but the problem is currently 5-10x smaller than the membrane's full scope. A phased thin-slice approach — primitive 2 first, then primitive 1 if usage stays high — is what I'd recommend.
+
+### 5.1 Conditions under which I'd recommend implementing now (vs. deferring)
+
+- The classification question in §2.3 resolves toward append-mostly ledgers (Primitive 2 is cheap; ship the CRDT layer for `measurement-adoption-history.json` first)
+- F6-F9 (parallel-dispatch framework bugs) get fixed AND parallel agent dispatch becomes routine — at which point Primitive 1 (action manifests) earns its keep within weeks
+- A second HADF-style incident lands (worktree collision pattern recurs), proving the failure mode is not a one-off
+
+### 5.2 Conditions under which I'd recommend NOT implementing
+
+- Parallel dispatch stays blocked indefinitely → the current serial pattern means the lease layer adds cost without preventing failures we have
+- The shared-path inventory stays at ~5 ledgers + state.jsons → reducer registry is overhead
+- The team's tolerance for one merge-time conflict per month is high → the membrane's per-task overhead exceeds the per-incident cost
+
+### 5.3 Open questions still
+
+| Q# | Question | Why it matters |
+|---|---|---|
+| Q1 | Are conflicts dominantly on append-mostly ledgers or invariant-bearing docs? | Determines whether to ship Primitive 2 (CRDT) or Primitive 1 (action manifests) first |
+| Q2 | What's the actual rate of HADF-style collisions across the past 6 months? | If it's ≤2 incidents, the membrane is over-engineering. If it's ≥6, it's underdue. |
+| Q3 | Does the user want enforcement (reject commits violating leases) or advisory (annotate but allow)? | Strict enforcement is the v7.5 pattern; advisory is the F1-F9 lesson (don't bite hand that feeds you in early bug-shake-out) |
+| Q4 | Where does the membrane's authority live — in the same pre-commit hook, or in a separate orchestrator? | Pre-commit hook = simple but agent-local; orchestrator = systemic but a single point of failure |
+| Q5 | What's the recovery path when the lease registry itself gets corrupted? | Membrane that protects everything except itself = bootstrap problem |
+
+---
+
+## 6. If we choose to implement: phased thin-slice path
+
+**Phase 1 (1-2 days, advisory only):**
+- Ship `scripts/membrane-status.py` as a read-only smartlog over current state — no enforcement, no schema changes. Just a view.
+- Surface in `/control-room/framework` §7 as a static summary.
+- Run for 2 weeks. Count how many times "Agent A would have hit B" actually happens.
+
+**Phase 2 (2-3 days, append-only ledger CRDT):**
+- Convert `measurement-adoption-history.json`, `documentation-debt.json` to Automerge-backed reads (file-on-disk stays JSON for human inspection; the writer wraps an Automerge document).
+- Test: can two simulated agents append concurrently without overwriting each other?
+- This is the single highest-value primitive because it directly fixes the Hobby-tier auto-deploy committer race + the HADF write collisions.
+
+**Phase 3 (3-5 days, action manifests + lease enforcement):**
+- Add `agent_manifest` to state.json schema.
+- Pre-commit hook extension: staged files must be subset of `manifest.writes`.
+- Lease acquisition at `/pm-workflow` start.
+- Heartbeat daemon.
+
+**Phase 4 (1-2 days, polish):**
+- PR-integrity bot renders membrane status into PR descriptions.
+- New cycle-time code `ORPHAN_LEASE`.
+- Documentation: agent-onboarding guide, reducer authoring guide.
+
+**Total:** 7-12 dev days for the full membrane, fronted by the lowest-risk highest-value piece (Phase 2).
+
+**Off-ramp signal:** if Phase 1's 2-week observation finds ≤1 conflict, halt. Membrane is over-engineering.
+
+---
+
+## 7. Closing observation
+
+The strongest evidence for the membrane is not the HADF incident or the PR #169 fallout — those are recoverable. The strongest evidence is what *almost happened today*: my v1 migration script silently corrupted Unicode em-dashes across 45 files, and the only thing that caught it was the user's mid-session instruction. A membrane with a manifest declaring "this agent writes 45 state.json files" + a per-file diff-size sanity-check (Bazel-style action contract: "expected diff is ≤2 lines per file; 96 lines is a contract violation") would have caught that *mechanically* before the diff ever staged.
+
+So the question is whether the framework wants to extend its v7.5/v7.6/v7.7 trajectory ("write-time gates over post-hoc audit") into the inter-agent coordination layer. The pattern is the same; the surface area is wider. The cost is real but bounded; the failure mode it prevents is precisely the class that has eluded every gate we've shipped so far.
+
+My honest one-line: **build Phase 2 (CRDT for ledgers) when issue #140 closure becomes necessary; build Phase 3 (action manifests) only after F6-F9 unblock parallel dispatch and the empirical conflict rate justifies it.**
+
+---
+
+## §99 — Appendix: research-agent verbatim survey
+
+(Inlined for the v7.8 design-doc to cite without re-running the survey.)
+
+> # Branch-Isolation Membrane for Parallel Agents — Prior Art Survey
+>
+> **Version Control / Branch Isolation:** Git worktrees + sparse-checkout (already in use; sparse-checkout is a *visibility* filter, not a *write* gate; HADF Phase 2 hit untracked-and-shared-path collisions); Pijul (patches with explicit deps; conflicts as set-union); Sapling smartlog (live tree of in-flight stacks — UX for "who's touching this file"); Jujutsu (op-log per workspace, replayable rollback).
+>
+> **Concurrent-Edit / Merge Models:** CRDTs Yjs/Automerge (commutative ops with vector clocks; cleanly fits append-mostly ledgers); MRDTs (invariant-preserving CRDTs from MSR India — relevant to state.json invariants); Hypercore/multifeed (per-author log + cross-feed indexer); Operational Transform (server-mediated; dominated by CRDTs for offline-first cases — skip).
+>
+> **Build/Execution Isolation:** Bazel remote execution (declared inputs/outputs + content-addressed); Nix profiles + overlays (declarative path isolation; macOS overlay-FS support is weaker); Vercel Sandbox / Firecracker (process-level — overkill for cooperative agents — skip).
+>
+> **Filesystem Sandboxing:** macOS App Sandbox / Linux Landlock (kernel-enforced declarative scopes; declarative-scope-schema is the right contract shape even if cooperative-only enforcement); fsevents/inotify mediator (detect-and-broadcast; OS-portable).
+>
+> **Multi-Agent Coordination:** LangGraph reducers (`Annotated[list, add]` declares merge semantics — closest direct analog); AutoGen GroupChat (serialization, not parallelism); CrewAI (sequential — skip); Anthropic Agent SDK / OpenAI Assistants (host-mediated tool layer is the natural enforcement point); MRDT literature (invariant-preserving CRDTs — directly addresses the state.json gap).
+>
+> **Top-3 ranked:** (1) LangGraph-style reducers + Bazel-style action manifests; (2) MRDTs for shared ledgers; (3) Sapling-smartlog awareness + jj op-log recovery.
+>
+> **Pivotal open question:** Are conflicts dominantly on append-mostly ledgers (CRDT-solvable) or on invariant-bearing documents (need coordinator or invariant-preserving merges)?
+
+---
+
+**Tier tags:** §1 (problem statement) is T1 for the empirical incidents (PR #169 today's session diff stats; HADF Phase 2 docs in memory); T2 for the inferred patterns. §2 (prior art) is T2 — research agent's review, not first-hand verification. §3-§5 (design + tradeoffs + recommendation) is T3 (analysis + judgment), with quantitative claims (5-8 dev-days, ~50ms overhead, etc.) marked T3 as estimates rather than measurements.


### PR DESCRIPTION
## Summary

Two related housekeeping items surfaced by the post-Phase-1 merge audit (2026-04-30 21:55Z):

1. **\`.gitignore\` gains 9 entries** for local-only artifacts that should never land in the repo (\`.env.local\`, \`.sentryclirc\`, \`.venv-hadf-phase2/\`, \`.vercel/\`, HADF campaign byproducts, sentry-recovery notes).
2. **\`docs/research/\`** — 2 substantive research notes from 2026-04-28 that have been sitting untracked. Both referenced by the existing memory entry; should be on main.

## Test plan

- [ ] CI green (taxonomy / integrity / pr-integrity bot)
- [ ] Verify \`.gitignore\` lines correctly filter the local artifacts (manual: \`git status\` should not list them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)