### PR TITLE
feat(hadf): chip-profiles v1.1 schema + Tier-1 expansion (Slices A + B)

### DIFF
--- a/.claude/shared/chip-profiles.json
+++ b/.claude/shared/chip-profiles.json
@@ -1,10 +1,18 @@
 {
-  "version": "1.0",
-  "updated": "2026-04-16",
-  "description": "Static chip capability profiles for HADF Layer 1. Dispatch-oriented — only data that affects routing decisions.",
+  "version": "1.1",
+  "updated": "2026-05-02",
+  "description": "Static chip capability profiles for HADF Layer 1. Dispatch-oriented — only data that affects routing decisions. v1.1 (2026-05-02) replaces preferred_precision (string) with supported_precisions (array) + peak_precision (string), replaces unified_memory (bool) with memory_topology (enum), and adds optional compute_axes (multi-axis SoCs), built_in_networking (datacenter NICs), and vendor_status (independent | acquired_by:<vendor> | defunct | rebranded). See docs/research/2026-04-28-hadf-signature-expansion.md §5 for the gap analysis driving this bump.",
+  "schema_v1_1_notes": {
+    "supported_precisions_enum": ["int2", "int4", "int8", "block_fp16", "float16", "bfloat16", "fp4", "fp6", "fp8", "nvfp4", "mxfp4", "mxfp8", "bitnet_1_58", "none"],
+    "memory_topology_enum": ["discrete", "soc_unified", "in_package_unified", "rack_scale_pooled"],
+    "vendor_status_format": "independent | acquired_by:<vendor> | defunct | rebranded",
+    "compute_axes_optional": "Present only for hybrid/multi-axis SoCs (Intel Lunar/Panther Lake, AMD Strix Halo, Apple M5 family). Single-axis NPU chips omit this field.",
+    "built_in_networking_optional": "Present only for chips with on-package datacenter NICs (Gaudi 3, Jaguar Shores). Schema: {ports, lanes_per_port_gbps, total_gbps}."
+  },
   "profiles": {
     "apple_a18_pro": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "A-series",
       "generation": 18,
       "tier": "flagship",
@@ -13,7 +21,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 38,
         "max_model_size_mb": 4500,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -38,7 +47,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 3500,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -50,6 +59,7 @@
     },
     "apple_a17_pro": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "A-series",
       "generation": 17,
       "tier": "flagship",
@@ -58,7 +68,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 35,
         "max_model_size_mb": 4000,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -83,7 +94,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 3000,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -95,6 +106,7 @@
     },
     "apple_a16": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "A-series",
       "generation": 16,
       "tier": "mid",
@@ -103,7 +115,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 17,
         "max_model_size_mb": 2000,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 1
       },
       "dispatch_hints": {
@@ -128,7 +141,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 2000,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -140,6 +153,7 @@
     },
     "apple_a15": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "A-series",
       "generation": 15,
       "tier": "low",
@@ -148,7 +162,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 15.8,
         "max_model_size_mb": 1500,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 1
       },
       "dispatch_hints": {
@@ -173,7 +188,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 1500,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -185,6 +200,7 @@
     },
     "apple_m4_max": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "M-series",
       "generation": 4,
       "tier": "desktop",
@@ -193,7 +209,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 38,
         "max_model_size_mb": 50000,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 8
       },
       "dispatch_hints": {
@@ -217,7 +234,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 96000,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -229,6 +246,7 @@
     },
     "apple_m3_pro": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "M-series",
       "generation": 3,
       "tier": "desktop",
@@ -237,7 +255,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 18,
         "max_model_size_mb": 20000,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 4
       },
       "dispatch_hints": {
@@ -262,7 +281,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 24000,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -274,6 +293,7 @@
     },
     "apple_m1": {
       "vendor": "Apple",
+      "vendor_status": "independent",
       "family": "M-series",
       "generation": 1,
       "tier": "desktop",
@@ -282,7 +302,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 11,
         "max_model_size_mb": 8000,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -307,7 +328,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 10000,
-        "unified_memory": true,
+        "memory_topology": "soc_unified",
         "swap_penalty": "none"
       },
       "composite_baseline": {
@@ -319,6 +340,7 @@
     },
     "google_tensor_g4": {
       "vendor": "Google",
+      "vendor_status": "independent",
       "family": "Tensor",
       "generation": 4,
       "tier": "flagship",
@@ -327,7 +349,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 30,
         "max_model_size_mb": 3000,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -352,7 +375,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 4000,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "moderate"
       },
       "composite_baseline": {
@@ -364,6 +387,7 @@
     },
     "google_tensor_g3": {
       "vendor": "Google",
+      "vendor_status": "independent",
       "family": "Tensor",
       "generation": 3,
       "tier": "mid",
@@ -372,7 +396,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 22,
         "max_model_size_mb": 2000,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 1
       },
       "dispatch_hints": {
@@ -397,7 +422,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 3000,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "moderate"
       },
       "composite_baseline": {
@@ -409,6 +434,7 @@
     },
     "qualcomm_snapdragon_8_gen3": {
       "vendor": "Qualcomm",
+      "vendor_status": "independent",
       "family": "Snapdragon",
       "generation": 8,
       "tier": "flagship",
@@ -417,7 +443,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 45,
         "max_model_size_mb": 4000,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -442,7 +469,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 4000,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "moderate"
       },
       "composite_baseline": {
@@ -454,6 +481,7 @@
     },
     "qualcomm_snapdragon_7_gen3": {
       "vendor": "Qualcomm",
+      "vendor_status": "independent",
       "family": "Snapdragon",
       "generation": 7,
       "tier": "mid",
@@ -462,7 +490,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 20,
         "max_model_size_mb": 2000,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 1
       },
       "dispatch_hints": {
@@ -487,7 +516,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 2000,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "moderate"
       },
       "composite_baseline": {
@@ -499,6 +528,7 @@
     },
     "qualcomm_snapdragon_x_elite": {
       "vendor": "Qualcomm",
+      "vendor_status": "independent",
       "family": "Snapdragon",
       "generation": 1,
       "tier": "desktop",
@@ -507,7 +537,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 45,
         "max_model_size_mb": 25000,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 4
       },
       "dispatch_hints": {
@@ -532,7 +563,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 20000,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "low"
       },
       "composite_baseline": {
@@ -544,6 +575,7 @@
     },
     "samsung_exynos_2400": {
       "vendor": "Samsung",
+      "vendor_status": "independent",
       "family": "Exynos",
       "generation": 2400,
       "tier": "flagship",
@@ -552,7 +584,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 34,
         "max_model_size_mb": 3500,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -577,7 +610,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 3500,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "moderate"
       },
       "composite_baseline": {
@@ -589,6 +622,7 @@
     },
     "mediatek_dimensity_9300": {
       "vendor": "MediaTek",
+      "vendor_status": "independent",
       "family": "Dimensity",
       "generation": 9300,
       "tier": "flagship",
@@ -597,7 +631,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 40,
         "max_model_size_mb": 3500,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8", "float16"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -622,7 +657,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 3500,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "moderate"
       },
       "composite_baseline": {
@@ -634,6 +669,7 @@
     },
     "arm64_mobile_unknown": {
       "vendor": "Unknown",
+      "vendor_status": "independent",
       "family": "arm64-mobile",
       "generation": 0,
       "tier": "mid",
@@ -642,7 +678,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 15,
         "max_model_size_mb": 1500,
-        "preferred_precision": "int8",
+        "supported_precisions": ["int8"],
+        "peak_precision": "int8",
         "concurrent_ml_tasks": 1
       },
       "dispatch_hints": {
@@ -667,7 +704,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 1500,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "high"
       },
       "composite_baseline": {
@@ -679,6 +716,7 @@
     },
     "arm64_desktop_unknown": {
       "vendor": "Unknown",
+      "vendor_status": "independent",
       "family": "arm64-desktop",
       "generation": 0,
       "tier": "desktop",
@@ -687,7 +725,8 @@
         "on_device_ml_capable": true,
         "npu_tops": 11,
         "max_model_size_mb": 8000,
-        "preferred_precision": "float16",
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
         "concurrent_ml_tasks": 2
       },
       "dispatch_hints": {
@@ -712,7 +751,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 8000,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "low"
       },
       "composite_baseline": {
@@ -724,6 +763,7 @@
     },
     "web_wasm_low": {
       "vendor": "Browser",
+      "vendor_status": "independent",
       "family": "WebAssembly",
       "generation": 0,
       "tier": "low",
@@ -732,7 +772,8 @@
         "on_device_ml_capable": false,
         "npu_tops": 0,
         "max_model_size_mb": 0,
-        "preferred_precision": "none",
+        "supported_precisions": [],
+        "peak_precision": "none",
         "concurrent_ml_tasks": 0
       },
       "dispatch_hints": {
@@ -756,7 +797,7 @@
       },
       "memory_constraints": {
         "available_for_ml_mb": 0,
-        "unified_memory": false,
+        "memory_topology": "discrete",
         "swap_penalty": "none"
       },
       "composite_baseline": {

--- a/.claude/shared/chip-profiles.json
+++ b/.claude/shared/chip-profiles.json
@@ -7,7 +7,8 @@
     "memory_topology_enum": ["discrete", "soc_unified", "in_package_unified", "rack_scale_pooled"],
     "vendor_status_format": "independent | acquired_by:<vendor> | defunct | rebranded",
     "compute_axes_optional": "Present only for hybrid/multi-axis SoCs (Intel Lunar/Panther Lake, AMD Strix Halo, Apple M5 family). Single-axis NPU chips omit this field.",
-    "built_in_networking_optional": "Present only for chips with on-package datacenter NICs (Gaudi 3, Jaguar Shores). Schema: {ports, lanes_per_port_gbps, total_gbps}."
+    "built_in_networking_optional": "Present only for chips with on-package datacenter NICs (Gaudi 3, Jaguar Shores). Schema: {ports, lanes_per_port_gbps, total_gbps}.",
+    "tops_source_optional": "compute_budget.tops_source enum: vendor_published | estimated | secondary. Absent = vendor_published (default). 'estimated' is used when the vendor does not publish an NPU TOPS figure (Apple A19/M5 family, Tensor G5) and the value is the prior-generation floor. 'secondary' is used when only third-party benchmarks (e.g. Geekbench AI) substantiate the number."
   },
   "profiles": {
     "apple_a18_pro": {
@@ -665,6 +666,362 @@
         "cost_score": 0.80,
         "quality_score": 0.70,
         "overall": 0.75
+      }
+    },
+    "apple_a19_pro": {
+      "vendor": "Apple",
+      "vendor_status": "independent",
+      "family": "A-series",
+      "generation": 19,
+      "tier": "flagship",
+      "arch": "arm64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 38,
+        "tops_source": "estimated",
+        "max_model_size_mb": 6000,
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
+        "concurrent_ml_tasks": 2
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning"
+        ],
+        "prefer_cloud": [
+          "long_context",
+          "multi_step_planning",
+          "code_generation"
+        ],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 30,
+        "throttle_risk": "moderate",
+        "battery_sensitivity": "high"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 6000,
+        "memory_topology": "soc_unified",
+        "swap_penalty": "none"
+      },
+      "composite_baseline": {
+        "latency_score": 0.87,
+        "cost_score": 0.91,
+        "quality_score": 0.82,
+        "overall": 0.84
+      }
+    },
+    "apple_m5": {
+      "vendor": "Apple",
+      "vendor_status": "independent",
+      "family": "M-series",
+      "generation": 5,
+      "tier": "desktop",
+      "arch": "arm64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 38,
+        "tops_source": "estimated",
+        "max_model_size_mb": 30000,
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
+        "concurrent_ml_tasks": 6
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning",
+          "long_context",
+          "multi_step_planning"
+        ],
+        "prefer_cloud": [
+          "code_generation"
+        ],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 300,
+        "throttle_risk": "low",
+        "battery_sensitivity": "low"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 28000,
+        "memory_topology": "soc_unified",
+        "swap_penalty": "none"
+      },
+      "composite_baseline": {
+        "latency_score": 0.90,
+        "cost_score": 0.85,
+        "quality_score": 0.88,
+        "overall": 0.88
+      }
+    },
+    "apple_m5_max": {
+      "vendor": "Apple",
+      "vendor_status": "independent",
+      "family": "M-series",
+      "generation": 5,
+      "tier": "desktop",
+      "arch": "arm64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 45,
+        "tops_source": "estimated",
+        "max_model_size_mb": 120000,
+        "supported_precisions": ["float16", "int8"],
+        "peak_precision": "float16",
+        "concurrent_ml_tasks": 12
+      },
+      "compute_axes": {
+        "npu_tops": 45,
+        "gpu_matmul_tops": null,
+        "cpu_matmul_tops": null,
+        "platform_tops": null,
+        "memory_bandwidth_gbps": 614
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning",
+          "long_context",
+          "multi_step_planning",
+          "code_generation"
+        ],
+        "prefer_cloud": [],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 600,
+        "throttle_risk": "low",
+        "battery_sensitivity": "none"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 110000,
+        "memory_topology": "soc_unified",
+        "swap_penalty": "none"
+      },
+      "composite_baseline": {
+        "latency_score": 0.97,
+        "cost_score": 0.86,
+        "quality_score": 0.99,
+        "overall": 0.95
+      }
+    },
+    "qualcomm_snapdragon_8_elite_gen5": {
+      "vendor": "Qualcomm",
+      "vendor_status": "independent",
+      "family": "Snapdragon",
+      "generation": 8,
+      "tier": "flagship",
+      "arch": "arm64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 80,
+        "tops_source": "vendor_published",
+        "max_model_size_mb": 6000,
+        "supported_precisions": ["int2", "int8", "fp8", "float16"],
+        "peak_precision": "int2",
+        "concurrent_ml_tasks": 3
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning",
+          "long_context"
+        ],
+        "prefer_cloud": [
+          "multi_step_planning",
+          "code_generation"
+        ],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 30,
+        "throttle_risk": "moderate",
+        "battery_sensitivity": "high"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 6000,
+        "memory_topology": "discrete",
+        "swap_penalty": "moderate"
+      },
+      "composite_baseline": {
+        "latency_score": 0.88,
+        "cost_score": 0.87,
+        "quality_score": 0.80,
+        "overall": 0.85
+      }
+    },
+    "mediatek_dimensity_9500": {
+      "vendor": "MediaTek",
+      "vendor_status": "independent",
+      "family": "Dimensity",
+      "generation": 9500,
+      "tier": "flagship",
+      "arch": "arm64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 80,
+        "tops_source": "vendor_published",
+        "max_model_size_mb": 6000,
+        "supported_precisions": ["bitnet_1_58", "int8", "float16"],
+        "peak_precision": "bitnet_1_58",
+        "concurrent_ml_tasks": 3
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning",
+          "long_context"
+        ],
+        "prefer_cloud": [
+          "multi_step_planning",
+          "code_generation"
+        ],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 28,
+        "throttle_risk": "moderate",
+        "battery_sensitivity": "high"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 6000,
+        "memory_topology": "discrete",
+        "swap_penalty": "moderate"
+      },
+      "composite_baseline": {
+        "latency_score": 0.85,
+        "cost_score": 0.85,
+        "quality_score": 0.78,
+        "overall": 0.82
+      }
+    },
+    "intel_panther_lake_npu5": {
+      "vendor": "Intel",
+      "vendor_status": "independent",
+      "family": "Core Ultra",
+      "generation": 5,
+      "tier": "flagship",
+      "arch": "x86_64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 50,
+        "tops_source": "vendor_published",
+        "max_model_size_mb": 16000,
+        "supported_precisions": ["int8", "fp8", "float16", "bfloat16"],
+        "peak_precision": "fp8",
+        "concurrent_ml_tasks": 4
+      },
+      "compute_axes": {
+        "npu_tops": 50,
+        "gpu_matmul_tops": 120,
+        "cpu_matmul_tops": 10,
+        "platform_tops": 180,
+        "memory_bandwidth_gbps": 120
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning",
+          "long_context"
+        ],
+        "prefer_cloud": [
+          "multi_step_planning",
+          "code_generation"
+        ],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 60,
+        "throttle_risk": "moderate",
+        "battery_sensitivity": "moderate"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 14000,
+        "memory_topology": "discrete",
+        "swap_penalty": "low"
+      },
+      "composite_baseline": {
+        "latency_score": 0.88,
+        "cost_score": 0.83,
+        "quality_score": 0.82,
+        "overall": 0.85
+      }
+    },
+    "amd_strix_halo_xdna2": {
+      "vendor": "AMD",
+      "vendor_status": "independent",
+      "family": "Ryzen AI",
+      "generation": 2,
+      "tier": "desktop",
+      "arch": "x86_64",
+      "compute_budget": {
+        "on_device_ml_capable": true,
+        "npu_tops": 50,
+        "tops_source": "vendor_published",
+        "max_model_size_mb": 110000,
+        "supported_precisions": ["int8", "block_fp16", "float16", "bfloat16"],
+        "peak_precision": "int8",
+        "concurrent_ml_tasks": 8
+      },
+      "compute_axes": {
+        "npu_tops": 50,
+        "gpu_matmul_tops": null,
+        "cpu_matmul_tops": null,
+        "platform_tops": null,
+        "memory_bandwidth_gbps": 256
+      },
+      "dispatch_hints": {
+        "prefer_on_device": [
+          "text_classification",
+          "embedding",
+          "tokenization",
+          "lightweight_inference",
+          "complex_reasoning",
+          "long_context",
+          "multi_step_planning"
+        ],
+        "prefer_cloud": [
+          "code_generation"
+        ],
+        "hybrid_capable": true
+      },
+      "thermal_profile": {
+        "sustained_workload_seconds": 300,
+        "throttle_risk": "low",
+        "battery_sensitivity": "low"
+      },
+      "memory_constraints": {
+        "available_for_ml_mb": 110000,
+        "memory_topology": "in_package_unified",
+        "swap_penalty": "none"
+      },
+      "composite_baseline": {
+        "latency_score": 0.92,
+        "cost_score": 0.86,
+        "quality_score": 0.94,
+        "overall": 0.91
       }
     },
     "arm64_mobile_unknown": {

--- a/.claude/shared/hadf/hardware-signature-table.json
+++ b/.claude/shared/hadf/hardware-signature-table.json
@@ -1,21 +1,24 @@
 {
-  "version": "1.0",
-  "updated": "2026-04-16",
-  "description": "Cloud inference hardware signatures for HADF Layer 2 classification. Values are illustrative ranges requiring empirical calibration via Phase 2 validation.",
+  "version": "1.1",
+  "updated": "2026-05-02",
+  "description": "Cloud inference hardware signatures for HADF Layer 2 classification. Values are illustrative ranges requiring empirical calibration. v1.1 (2026-05-02) adds 4 Tier-1 datacenter signatures (B300, Trainium3, TPU v7 Ironwood, MI350X) + Groq LPU with vendor_status='acquired_by:nvidia' (Dec 2025 acquisition), and adds a vendor_status field to every existing signature. See docs/research/2026-04-28-hadf-signature-expansion.md §3 for the source landscape and §6 for known classification-schema gaps (precision_class, bandwidth_probe_ratio, container_vs_bare_metal_variance) that remain open.",
   "calibration_status": "uncalibrated",
+  "calibration_notes": "Phase 2 (silhouette 0.5566 at k=5, 700 valid records, 2026-05-01) validated that mechanical clustering on (TTFT, TPS, COV, batch-scaling) discriminates endpoints — but only directly exercised 2 model endpoints (openai gpt-4o-mini, anthropic claude-haiku-4-5), which map to ~2-3 of these signatures. The remaining signatures here are still uncalibrated. Phase 2-bis (Track 5) with a broader endpoint matrix is gated on the architectural fixes in project_post_hadf_phase2_followup_tracks.md.",
   "signatures": {
     "nvidia_h100_class": {
       "vendor": "nvidia",
+      "vendor_status": "independent",
       "chip": "H100 SXM",
       "generation": "hopper",
       "ttft_per_1k_tokens_ms": { "min": 45, "max": 65 },
       "tps_median": { "min": 80, "max": 120 },
       "tps_cov": { "max": 0.08 },
       "batch_scaling_factor": { "min": 0.92, "max": 0.98 },
-      "notes": "Dominant cloud GPU. High throughput, low variance, excellent batch scaling."
+      "notes": "Dominant cloud GPU. High throughput, low variance, excellent batch scaling. FP8 Transformer Engine."
     },
     "nvidia_a100_class": {
       "vendor": "nvidia",
+      "vendor_status": "independent",
       "chip": "A100",
       "generation": "ampere",
       "ttft_per_1k_tokens_ms": { "min": 70, "max": 100 },
@@ -24,8 +27,20 @@
       "batch_scaling_factor": { "min": 0.88, "max": 0.95 },
       "notes": "Previous gen cloud GPU. Still common in cost-optimized deployments."
     },
+    "nvidia_b300_class": {
+      "vendor": "nvidia",
+      "vendor_status": "independent",
+      "chip": "B300",
+      "generation": "blackwell-ultra",
+      "ttft_per_1k_tokens_ms": { "min": 25, "max": 45 },
+      "tps_median": { "min": 150, "max": 250 },
+      "tps_cov": { "max": 0.06 },
+      "batch_scaling_factor": { "min": 0.95, "max": 0.99 },
+      "notes": "Shipping since Jan 2026. 288 GB HBM3e, 15 PFLOPS dense FP4, 1400W. GB300 NVL72 racks. Expected to be ~4x B200 cloud volume by mid-2026."
+    },
     "google_tpu_v5e_class": {
       "vendor": "google",
+      "vendor_status": "independent",
       "chip": "TPU v5e",
       "generation": "v5e",
       "ttft_per_1k_tokens_ms": { "min": 50, "max": 75 },
@@ -36,6 +51,7 @@
     },
     "google_tpu_v4_class": {
       "vendor": "google",
+      "vendor_status": "independent",
       "chip": "TPU v4",
       "generation": "v4",
       "ttft_per_1k_tokens_ms": { "min": 60, "max": 90 },
@@ -44,8 +60,20 @@
       "batch_scaling_factor": { "min": 0.90, "max": 0.96 },
       "notes": "Previous gen TPU. Higher variance than v5e."
     },
+    "google_tpu_v7_ironwood_class": {
+      "vendor": "google",
+      "vendor_status": "independent",
+      "chip": "TPU v7 Ironwood",
+      "generation": "v7",
+      "ttft_per_1k_tokens_ms": { "min": 30, "max": 55 },
+      "tps_median": { "min": 120, "max": 180 },
+      "tps_cov": { "max": 0.08 },
+      "batch_scaling_factor": { "min": 0.96, "max": 0.99 },
+      "notes": "GA Nov 2025. Inference-optimized (distinct from Trillium training role). Anthropic committed >1M units in 2026 — expected to dominate Anthropic cloud inference by H2 2026."
+    },
     "aws_trainium2_class": {
       "vendor": "aws",
+      "vendor_status": "independent",
       "chip": "Trainium 2",
       "generation": "trn2",
       "ttft_per_1k_tokens_ms": { "min": 55, "max": 80 },
@@ -54,25 +82,60 @@
       "batch_scaling_factor": { "min": 0.91, "max": 0.97 },
       "notes": "AWS custom silicon. Used by Anthropic on AWS deployments."
     },
+    "aws_trainium3_class": {
+      "vendor": "aws",
+      "vendor_status": "independent",
+      "chip": "Trainium 3",
+      "generation": "trn3",
+      "ttft_per_1k_tokens_ms": { "min": 35, "max": 60 },
+      "tps_median": { "min": 110, "max": 170 },
+      "tps_cov": { "max": 0.08 },
+      "batch_scaling_factor": { "min": 0.94, "max": 0.99 },
+      "notes": "GA Dec 2025, EC2 Trn3 UltraServers. Native MXFP8 + MXFP4 + structured sparsity. 144 GB HBM3e. First non-Nvidia chip with both microscaled formats."
+    },
     "amd_mi300x_class": {
       "vendor": "amd",
+      "vendor_status": "independent",
       "chip": "MI300X",
       "generation": "cdna3",
       "ttft_per_1k_tokens_ms": { "min": 50, "max": 70 },
       "tps_median": { "min": 75, "max": 105 },
       "tps_cov": { "max": 0.09 },
       "batch_scaling_factor": { "min": 0.93, "max": 0.98 },
-      "notes": "High memory bandwidth. Competitive with H100 on large models."
+      "notes": "High memory bandwidth. Competitive with H100 on large models. 192 GB HBM3."
+    },
+    "amd_mi350x_class": {
+      "vendor": "amd",
+      "vendor_status": "independent",
+      "chip": "MI350X",
+      "generation": "cdna4",
+      "ttft_per_1k_tokens_ms": { "min": 35, "max": 60 },
+      "tps_median": { "min": 110, "max": 170 },
+      "tps_cov": { "max": 0.08 },
+      "batch_scaling_factor": { "min": 0.94, "max": 0.99 },
+      "notes": "H2 2025 GA. First AMD chip with FP4 + FP6 + FP8 (MX) + OCP FP8. 288 GB HBM3E @ 8 TB/s. ROCm 7 unifies datacenter + consumer + Windows stacks."
+    },
+    "groq_lpu_class": {
+      "vendor": "groq",
+      "vendor_status": "acquired_by:nvidia",
+      "chip": "LPU",
+      "generation": "lpu",
+      "ttft_per_1k_tokens_ms": { "min": 15, "max": 35 },
+      "tps_median": { "min": 200, "max": 500 },
+      "tps_cov": { "max": 0.05 },
+      "batch_scaling_factor": { "min": 0.88, "max": 0.95 },
+      "notes": "Deterministic-streaming dataflow architecture; very low TTFT and very high TPS for small/medium models. Nvidia acquired Groq Dec 2025 ($20B). Independent target uncertain going forward — dispatch should treat Groq endpoints as Nvidia-controlled and decay weight on long-term independence assumptions."
     },
     "cpu_fallback_class": {
       "vendor": "generic",
+      "vendor_status": "independent",
       "chip": "CPU",
       "generation": "any",
       "ttft_per_1k_tokens_ms": { "min": 200, "max": 999 },
       "tps_median": { "min": 10, "max": 30 },
       "tps_cov": { "max": 999 },
       "batch_scaling_factor": { "min": 0.60, "max": 0.80 },
-      "notes": "Catch-all for non-accelerated inference. Very slow. Should trigger quality concerns."
+      "notes": "Catch-all for non-accelerated inference. Very slow. Should trigger quality concerns. Distinct from 'CPU with matrix unit' (Granite Rapids AMX, EPYC Turin AVX-512+VNNI) which is faster — see docs/research/2026-04-28-hadf-signature-expansion.md §4 for the proposed server_cpu_profiles bucket (deferred to a future PR)."
     }
   },
   "classification": {


### PR DESCRIPTION
## Summary

Track 2 of the post-HADF-Phase-2 followup. Bumps `.claude/shared/chip-profiles.json` to v1.1 (schema-only, 17 existing profiles migrated) and lands the Tier-1 expansion from [`docs/research/2026-04-28-hadf-signature-expansion.md`](docs/research/2026-04-28-hadf-signature-expansion.md) §8 on top.

Phase 2's verdict (silhouette 0.5566 at k=5, 700 valid records, 2026-05-01 — see [PR #170](https://github.com/Regevba/FitTracker2/pull/170)) cleared the pre-registered "calibrate first, then expand" gate, so the Tier-1 library can land ahead of Phase 2-bis.

Two commits, intentionally split for review clarity:

### Commit 1 — `bea26d1` (Slice A, schema-only)

`chip-profiles.json` v1.0 → v1.1. 17 existing profiles migrated with deterministic mapping. No new profiles in this commit.

| Old field | New field(s) |
|---|---|
| `compute_budget.preferred_precision` (string) | `compute_budget.supported_precisions` (array) + `compute_budget.peak_precision` (string) |
| `memory_constraints.unified_memory` (bool) | `memory_constraints.memory_topology` (enum: `discrete \| soc_unified \| in_package_unified \| rack_scale_pooled`) |
| — (new) | top-level `vendor_status` (enum: `independent \| acquired_by:<vendor> \| defunct \| rebranded`) |
| — (new, optional) | `compute_axes` composite (NPU/GPU/CPU TOPS + memory bandwidth) — for hybrid/multi-axis SoCs |
| — (new, optional) | `built_in_networking` ({ports, lanes_per_port_gbps, total_gbps}) — for chips with on-package datacenter NICs |

Counts after migration: 17 profiles, 17 vendor_status=independent, 10 discrete + 7 soc_unified, 8 peak=float16 + 8 peak=int8 + 1 peak=none.

### Commit 2 — `4784ef2` (Slice B, +7 chip profiles + 4 datacenter signatures + Groq)

`chip-profiles.json`: 17 → 24 profiles. New entries:

- **apple_a19_pro** (Sep 2025, flagship; npu_tops estimated)
- **apple_m5** (Oct 2025, desktop; npu_tops estimated)
- **apple_m5_max** (Mar 2026, desktop; compute_axes populated with 614 GB/s memory bandwidth)
- **qualcomm_snapdragon_8_elite_gen5** (Sep 2025; first chip with `peak_precision=int2`)
- **mediatek_dimensity_9500** (Sep 2025; first chip with `peak_precision=bitnet_1_58`; native compute-in-memory NPU 990)
- **intel_panther_lake_npu5** (Jan 2026; first x86_64 entry; full compute_axes — NPU 50 + GPU XMX 120 + CPU AMX 10 = 180 platform TOPS)
- **amd_strix_halo_xdna2** (Jan 2025; first `memory_topology=in_package_unified` entry; 128 GB unified LPDDR5X-8000 shared CPU+iGPU+NPU)

New optional field added in this commit: `compute_budget.tops_source` ∈ {`vendor_published`, `estimated`, `secondary`}. Absent = `vendor_published`. Used on the 3 Apple chips (Apple does not publish A19/M5 NE TOPS).

`hardware-signature-table.json`: 7 → 12 signatures, all uncalibrated:

- **nvidia_b300_class** (blackwell-ultra, Jan 2026, GB300 NVL72)
- **google_tpu_v7_ironwood_class** (v7, Nov 2025; Anthropic >1M committed for 2026)
- **aws_trainium3_class** (trn3, Dec 2025; native MXFP8/MXFP4)
- **amd_mi350x_class** (cdna4, H2 2025; FP4/FP6/FP8/MX/OCP)
- **groq_lpu_class** with `vendor_status="acquired_by:nvidia"` (Dec 2025 $20B acquisition; dispatch should treat Groq endpoints as Nvidia-controlled)

`vendor_status="independent"` added to all 7 prior HSTable entries.

## Calibration scope

Phase 2 directly exercised **2 model endpoints** (openai gpt-4o-mini, anthropic claude-haiku-4-5) → maps to roughly 2–3 of these 12 signatures. The remaining ~9–10 stay `uncalibrated`. The HSTable's top-level `calibration_status: "uncalibrated"` field is unchanged. Phase 2-bis (Track 5 in [memory: project_post_hadf_phase2_followup_tracks.md](.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_post_hadf_phase2_followup_tracks.md)) with the broader endpoint matrix and the three architectural fixes (worktree-local venv + cp-not-symlink `.env.local` + wrapper self-check) is the right venue for actually filling these numbers.

## Out of scope (deferred to follow-ups)

- **Server CPU bucket** (Granite Rapids AMX, EPYC Turin AVX-512+VNNI) per §4 — schema is materially different (`amx_precisions`, `numa_nodes`); deserves its own block.
- **Tier 2 chip profiles** (Lunar Lake, Arrow Lake, Strix Point, Krackan, Gorgon Point, Tensor G5, Exynos 2500) per §8 — fills mid-tier and "first Intel/AMD client" gaps.
- **Tier 2 datacenter signatures** (B200, TPU v6e Trillium, Gaudi 3, MI300A APU, SambaNova SN40L, Tenstorrent Blackhole, Microsoft Maia 100, Cerebras WSE-3) — deferred to a separate PR.
- **HSTable schema extension** (`precision_class`, `bandwidth_probe_ratio`, `container_vs_bare_metal_variance`) per §6 — needs Phase 2-bis data to validate the new dimensions discriminate.
- **Audit/manifest/state.json text references to "17 profiles"** — left as historical v1.0 audit record. A re-run of the audit will produce a new v1.1 finding rather than retroactively edit the v1.0 finding.

## Live consumer surface

Still none. `.claude/shared/dispatch-intelligence.json::hardware_context.enabled` remains `false`. No Python/Swift/TS/JS code consumes either file (only textual references in `framework-manifest.json`, `audit-findings.json`, and HADF state.json — all unchanged in this PR). Track 6 in the followup memory covers production activation, which is gated on Track 5's positive verdict.

## Test plan

- [x] JSON parse + schema sanity (`python3 -m json.tool`) on both files
- [x] All 24 chip profiles have `vendor_status`, `supported_precisions`, `peak_precision`, `memory_topology`; none have legacy `preferred_precision` or `unified_memory`
- [x] All 12 HSTable signatures have `vendor_status`; Groq has `acquired_by:nvidia`
- [x] Pre-commit gates passed (state-schema + case-study integrity — neither applied to these data files)
- [ ] CI green (pm-framework/pr-integrity + Build-and-Test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)