### PR TITLE
docs(manifest): add 7 capability flags for v7.7 + v7.8 PR-1

### DIFF
--- a/.claude/shared/framework-manifest.json
+++ b/.claude/shared/framework-manifest.json
@@ -79,7 +79,14 @@
     "weekly_status_cron": true,
     "unclosable_gaps_documented": true,
     "mechanical_phase_transition_enforcement": true,
-    "mechanical_case_study_preflight": true
+    "mechanical_case_study_preflight": true,
+    "mechanical_cache_hits_post_v6_gate": true,
+    "mechanical_cu_v2_validation": true,
+    "mechanical_state_case_study_linkage": true,
+    "mechanical_case_study_field_validation": true,
+    "advisory_tier_tag_correctness": true,
+    "post_tool_use_observation_hooks": true,
+    "auto_cache_hit_instrumentation_advisory": true
   },
   "v7_1_integrity_cycle": {
     "description": "72-hour recurring audit of .claude/features/*/state.json. Catches 'shipped but unreconciled' drift within 72h of occurrence instead of weeks later.",


### PR DESCRIPTION
## Summary

Backfill 7 capability flags into \`framework-manifest.json:capabilities\` that were missed when v7.7 (validity-closure) and v7.8 PR-1 (Mechanism C) shipped:

| Flag | Version | Mode |
|---|---|---|
| \`mechanical_cache_hits_post_v6_gate\` | v7.7 | enforced (effective post-2026-05-02) |
| \`mechanical_cu_v2_validation\` | v7.7 | enforced |
| \`mechanical_state_case_study_linkage\` | v7.7 | enforced |
| \`mechanical_case_study_field_validation\` | v7.7 | enforced |
| \`advisory_tier_tag_correctness\` | v7.7 | permanent advisory |
| \`post_tool_use_observation_hooks\` | v7.8 PR-1 | enforced (hook fires) |
| \`auto_cache_hit_instrumentation_advisory\` | v7.8 PR-1 | advisory (until v7.9 flip 2026-05-09) |

The \`v7_7_validity_closure\` and \`v7_8_pr1_advisory\` sections were added in PR #177; this PR makes the corresponding capability flags discoverable in the same map consumers already read.

## Verification

\`python3 -c 'import json; json.load(open(".claude/shared/framework-manifest.json"))'\` → valid ✓

## Test plan

- [ ] CI \`pm-framework/pr-integrity\` green
- [ ] Manifest still parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)