### PR TITLE
feat(orchid-v1.5): Track L — Layer A behavioral models for U8 + U9 + tier propagation

### DIFF
--- a/orchid/layer-a/orchestrator.py
+++ b/orchid/layer-a/orchestrator.py
@@ -1,15 +1,47 @@
-"""Orchid Orchestrator — wires U1-U7 into a single pipeline."""
+"""Orchid Orchestrator — wires U1-U7 (v1) + U8/U9 (v1.5) into a single pipeline.
+
+v1.5 additions (per docs/superpowers/specs/2026-05-03-orchid-v1-5-design.md):
+
+- **U8 Patrol Scrubber** runs in the background, advancing one cycle per
+  ``process()`` call. Probes are injectable; without probes the scrubber
+  walks silently.
+- **U9 Validation Bus** receives events from any unit (including U1's
+  dispatch-threshold advisory and U8's patrol findings) and routes them
+  to mandatory or advisory channels per ``ValidationEvent.routes_to_mandatory()``.
+- **U1 dispatch threshold** — a task with ``data_tier`` higher (i.e. lower
+  confidence) than the configured ``u1_min_tier`` raises a
+  ``LOW_TIER_INPUT`` advisory event; the task still dispatches but the
+  event is recorded.
+
+All v1.5 wiring is additive. Construction with no v1.5 args matches v1
+behavior; the new units sit idle until the caller provides probes or a
+trap callback.
+"""
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
-from units.types import TaskDescriptor, DispatchDecision, RoutingDecision, CacheEntry
-from units.dispatch_scorer import score as u1_score
-from units.skill_router import route as u2_route
-from units.cache_controller import CacheController
+from typing import Callable, Dict, Optional
+
 from units.batch_scheduler import BatchScheduler
-from units.speculative_prefetcher import SpeculativePrefetcher
+from units.cache_controller import CacheController
 from units.coherence_unit import CoherenceUnit
+from units.dispatch_scorer import score as u1_score
+from units.patrol_scrubber import PatrolScrubber, ProbeFn
+from units.skill_router import route as u2_route
+from units.speculative_prefetcher import SpeculativePrefetcher
 from units.systolic_array import SystolicArray
+from units.tier_propagator import low_tier_input_event
+from units.types import (
+    CacheEntry,
+    DispatchDecision,
+    RoutingDecision,
+    TaskDescriptor,
+    Tier,
+    UnitId,
+    ValidationErrorCode,
+    ValidationEvent,
+)
+from units.validation_bus import ValidationBus
 
 
 @dataclass
@@ -19,20 +51,88 @@ class PipelineResult:
     cache_hit: bool
     total_cycles: int
     total_energy_pj: float
+    # v1.5: number of validation events emitted to U9 during this process() call.
+    u9_events_this_step: int = 0
 
 
 class Orchestrator:
-    def __init__(self) -> None:
-        self.cache = CacheController(max_entries=15)
-        self.scheduler = BatchScheduler(max_concurrent=8, queue_depth=32)
-        self.prefetcher = SpeculativePrefetcher(table_size=64, prefetch_ahead=2)
-        self.coherence = CoherenceUnit(max_writers=8, snapshot_slots=4)
-        self.systolic = SystolicArray(mesh_rows=8, mesh_cols=8)
+    """Wires v1 units (U1-U7) + v1.5 additions (U8 Patrol Scrubber, U9 Validation Bus)."""
+
+    def __init__(
+        self,
+        # v1 units (no parameter changes — backward-compatible defaults)
+        max_cache_entries: int = 15,
+        max_concurrent_batches: int = 8,
+        batch_queue_depth: int = 32,
+        prefetcher_table_size: int = 64,
+        prefetch_ahead: int = 2,
+        max_writers: int = 8,
+        snapshot_slots: int = 4,
+        mesh_rows: int = 8,
+        mesh_cols: int = 8,
+        # v1.5: U8 Patrol Scrubber configuration
+        u8_period_cycles: int = 1000,
+        u8_jitter_pct: int = 10,
+        u8_probes: Optional[Dict[str, ProbeFn]] = None,
+        u8_rng_seed: int = 0,
+        # v1.5: U9 Validation Bus configuration
+        u9_log_buffer_entries: int = 0,
+        trap_callback: Optional[Callable[[ValidationEvent], None]] = None,
+        # v1.5: U1 dispatch threshold (T3 = most permissive — admits everything)
+        u1_min_tier: Tier = Tier.T3,
+    ) -> None:
+        # v1 stateful units
+        self.cache = CacheController(max_entries=max_cache_entries)
+        self.scheduler = BatchScheduler(
+            max_concurrent=max_concurrent_batches, queue_depth=batch_queue_depth
+        )
+        self.prefetcher = SpeculativePrefetcher(
+            table_size=prefetcher_table_size, prefetch_ahead=prefetch_ahead
+        )
+        self.coherence = CoherenceUnit(max_writers=max_writers, snapshot_slots=snapshot_slots)
+        self.systolic = SystolicArray(mesh_rows=mesh_rows, mesh_cols=mesh_cols)
+
+        # v1.5 additions
+        self.validation_bus = ValidationBus(
+            num_sources=8,
+            log_buffer_entries=u9_log_buffer_entries,
+            trap_callback=trap_callback,
+        )
+        probes = u8_probes or {}
+        self.patrol_scrubber = PatrolScrubber(
+            period_cycles=u8_period_cycles,
+            jitter_pct=u8_jitter_pct,
+            u2_lut_probe=probes.get("u2_lut"),
+            u3_scratchpad_probe=probes.get("u3_scratchpad"),
+            u4_fifo_probe=probes.get("u4_fifo"),
+            u6_mesi_probe=probes.get("u6_mesi"),
+            rng_seed=u8_rng_seed,
+        )
+        self.u1_min_tier = u1_min_tier
+
+        # Internal state
         self._last_phase: Optional[str] = None
         self._total_cycles: int = 0
         self._total_energy: float = 0.0
 
+    # ------------------------------------------------------------------
+    # Pipeline
+    # ------------------------------------------------------------------
+
     def process(self, task: TaskDescriptor) -> PipelineResult:
+        """Run one task through the pipeline.
+
+        Side effects: cycle counters advance, U8 patrol scrubber advances by 1
+        cycle, validation events get submitted to U9.
+        """
+        events_before = self.validation_bus.total_advisory_count() + \
+            self.validation_bus.total_mandatory_count()
+
+        # v1.5 — U1 dispatch threshold check (advisory only; doesn't block dispatch).
+        low_tier_event = low_tier_input_event(task.data_tier, self.u1_min_tier)
+        if low_tier_event is not None:
+            self.validation_bus.submit(low_tier_event)
+
         # U1: Score (1 cycle)
         dispatch = u1_score(task)
         self._total_cycles += 1
@@ -48,32 +148,55 @@ class Orchestrator:
             self.prefetcher.record_transition(self._last_phase, task.phase)
             predictions = self.prefetcher.predict(task.phase)
             for pred_phase in predictions:
-                self.cache.put(CacheEntry(
-                    key="prefetch_" + pred_phase,
-                    compressed_view="prefetched for " + pred_phase,
-                    level="L1"
-                ))
+                self.cache.put(
+                    CacheEntry(
+                        key="prefetch_" + pred_phase,
+                        compressed_view="prefetched for " + pred_phase,
+                        level="L1",
+                    )
+                )
 
         # U3: Cache lookup
         cache_key = routing.skills[0] + "_L1" if routing.skills else "unknown"
         cached = self.cache.get(cache_key)
         cache_hit = cached is not None
         if not cache_hit:
-            self.cache.put(CacheEntry(
-                key=cache_key,
-                compressed_view=routing.skills[0] + " compressed view" if routing.skills else "",
-                full_entry=routing.skills[0] + " full entry" if routing.skills else "",
-                level="L1"
-            ))
+            self.cache.put(
+                CacheEntry(
+                    key=cache_key,
+                    compressed_view=routing.skills[0] + " compressed view"
+                    if routing.skills
+                    else "",
+                    full_entry=routing.skills[0] + " full entry"
+                    if routing.skills
+                    else "",
+                    level="L1",
+                )
+            )
 
         # U4: Enqueue for batch
         self.scheduler.enqueue(task, dispatch)
 
         # Accumulate cycles from stateful units
         self._total_cycles += self.cache.current_cycle
-        self._total_energy += sum(c.energy_pj for c in self.cache.cycle_log[-2:]) if self.cache.cycle_log else 0
+        self._total_energy += (
+            sum(c.energy_pj for c in self.cache.cycle_log[-2:])
+            if self.cache.cycle_log
+            else 0
+        )
+
+        # v1.5 — Advance U8 patrol scrubber by 1 cycle; submit any events to U9.
+        u8_events = self.patrol_scrubber.step()
+        for event in u8_events:
+            self.validation_bus.submit(event)
+
+        # v1.5 — Drain one mandatory event per cycle (RR arbitration).
+        self.validation_bus.step()
 
         self._last_phase = task.phase
+
+        events_after = self.validation_bus.total_advisory_count() + \
+            self.validation_bus.total_mandatory_count()
 
         return PipelineResult(
             dispatch=dispatch,
@@ -81,4 +204,26 @@ class Orchestrator:
             cache_hit=cache_hit,
             total_cycles=self._total_cycles,
             total_energy_pj=self._total_energy,
+            u9_events_this_step=events_after - events_before,
         )
+
+    # ------------------------------------------------------------------
+    # Validation-event query API (for tests + metrics)
+    # ------------------------------------------------------------------
+
+    def u9_advisory_count(
+        self, unit_id: UnitId, error_code: ValidationErrorCode
+    ) -> int:
+        return self.validation_bus.get_advisory_count(unit_id, error_code)
+
+    def u9_mandatory_count(self, unit_id: UnitId) -> int:
+        return self.validation_bus.get_mandatory_count(unit_id)
+
+    def u9_total_advisory(self) -> int:
+        return self.validation_bus.total_advisory_count()
+
+    def u9_total_mandatory(self) -> int:
+        return self.validation_bus.total_mandatory_count()
+
+    def u8_violations_total(self) -> int:
+        return self.patrol_scrubber.violations_total

--- a/orchid/layer-a/synthetic_gen.py
+++ b/orchid/layer-a/synthetic_gen.py
@@ -1,65 +1,147 @@
-"""Generates 5 synthetic trace files for Orchid benchmarking."""
+"""Generates 5 synthetic trace files for Orchid benchmarking.
+
+v1.5 extension (per docs/superpowers/specs/2026-05-03-orchid-v1-5-design.md §3):
+each event row now carries a ``tier`` field — one of ``"T1"``, ``"T2"``,
+``"T3"`` — drawn from a configurable distribution. Default distribution
+is ``{T1: 60%, T2: 30%, T3: 10%}`` (high-confidence-heavy).
+
+Backward compat: traces without a ``tier`` field continue to replay
+correctly because :func:`trace_replayer` defaults missing tiers to T2 (per L7).
+"""
 import json
 import random
 from pathlib import Path
+from typing import Dict, Mapping, Optional
 
-def generate_all(output_dir, seed=42):
-    random.seed(seed)
+# v1.5 — default tier distribution. Bias toward T1 since most measured
+# data in the framework is instrumented (high confidence).
+DEFAULT_TIER_DISTRIBUTION: Dict[str, float] = {"T1": 0.60, "T2": 0.30, "T3": 0.10}
+
+
+def _validate_tier_distribution(dist: Mapping[str, float]) -> None:
+    """Sanity-check a tier distribution before sampling from it."""
+    if set(dist.keys()) != {"T1", "T2", "T3"}:
+        raise ValueError(
+            f"tier_distribution must have keys {{T1, T2, T3}}; got {sorted(dist.keys())}"
+        )
+    total = sum(dist.values())
+    if not (0.99 <= total <= 1.01):
+        raise ValueError(f"tier_distribution must sum to 1.0; got {total:.4f}")
+    if any(v < 0 for v in dist.values()):
+        raise ValueError("tier_distribution values must be non-negative")
+
+
+def _sample_tier(rng: random.Random, dist: Mapping[str, float]) -> str:
+    """Sample a tier label from the given distribution."""
+    return rng.choices(["T1", "T2", "T3"], weights=[dist["T1"], dist["T2"], dist["T3"]])[0]
+
+
+def generate_all(
+    output_dir,
+    seed: int = 42,
+    tier_distribution: Optional[Mapping[str, float]] = None,
+) -> None:
+    """Generate the 5 standard synthetic trace files.
+
+    Args:
+        output_dir: directory to write the trace files into.
+        seed: RNG seed for deterministic generation.
+        tier_distribution: tier sampling weights. Default
+            ``{"T1": 0.60, "T2": 0.30, "T3": 0.10}``.
+    """
+    dist = dict(tier_distribution or DEFAULT_TIER_DISTRIBUTION)
+    _validate_tier_distribution(dist)
+    rng = random.Random(seed)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    _write(output_dir / "burst_haiku.jsonl", _burst_haiku())
-    _write(output_dir / "contention_opus.jsonl", _contention_opus())
-    _write(output_dir / "alternating_chains.jsonl", _alternating_chains())
-    _write(output_dir / "random_uniform.jsonl", _random_uniform())
-    _write(output_dir / "cold_to_warm.jsonl", _cold_to_warm())
+    _write(output_dir / "burst_haiku.jsonl", _burst_haiku(rng, dist))
+    _write(output_dir / "contention_opus.jsonl", _contention_opus(rng, dist))
+    _write(output_dir / "alternating_chains.jsonl", _alternating_chains(rng, dist))
+    _write(output_dir / "random_uniform.jsonl", _random_uniform(rng, dist))
+    _write(output_dir / "cold_to_warm.jsonl", _cold_to_warm(rng, dist))
 
 def _write(path, events):
     with open(path, "w") as f:
         for e in events:
             f.write(json.dumps(e) + "\n")
 
-def _burst_haiku():
-    return [_event(i * 10, "chore", "tasks", vc=0, ntc=0) for i in range(100)]
+def _burst_haiku(rng, dist):
+    return [_event(rng, dist, i * 10, "chore", "tasks", vc=0, ntc=0) for i in range(100)]
 
-def _contention_opus():
-    return [_event(i * 100, "feature", "implementation", vc=8, ntc=5, novelty=True) for i in range(50)]
 
-def _alternating_chains():
+def _contention_opus(rng, dist):
+    return [
+        _event(rng, dist, i * 100, "feature", "implementation", vc=8, ntc=5, novelty=True)
+        for i in range(50)
+    ]
+
+
+def _alternating_chains(rng, dist):
     phases = ["ux_or_integration", "implementation", "testing"]
     events = []
     for cycle in range(50):
         for j, phase in enumerate(phases):
-            events.append(_event(cycle * 3000 + j * 1000, "feature", phase, vc=3, ntc=1))
+            events.append(_event(rng, dist, cycle * 3000 + j * 1000, "feature", phase, vc=3, ntc=1))
     return events
 
-def _random_uniform():
+
+def _random_uniform(rng, dist):
     work_types = ["chore", "fix", "enhancement", "feature"]
     phases = ["research", "prd", "tasks", "implementation", "testing", "review", "merge"]
     events = []
     for i in range(500):
-        events.append(_event(
-            i * 100, random.choice(work_types), random.choice(phases),
-            vc=random.randint(0, 10), ntc=random.randint(0, 8),
-            novelty=random.random() < 0.1
-        ))
+        events.append(
+            _event(
+                rng,
+                dist,
+                i * 100,
+                rng.choice(work_types),
+                rng.choice(phases),
+                vc=rng.randint(0, 10),
+                ntc=rng.randint(0, 8),
+                novelty=rng.random() < 0.1,
+            )
+        )
     return events
 
-def _cold_to_warm():
+
+def _cold_to_warm(rng, dist):
     events = []
     phases = ["research", "prd", "tasks", "ux_or_integration", "implementation", "testing", "review"]
     for i, phase in enumerate(phases):
-        events.append(_event(i * 1000, "feature", phase, vc=2, ntc=1))
+        events.append(_event(rng, dist, i * 1000, "feature", phase, vc=2, ntc=1))
     for i in range(100):
-        events.append(_event(len(phases) * 1000 + i * 100, "enhancement", "implementation", vc=1, ntc=0))
+        events.append(
+            _event(
+                rng,
+                dist,
+                len(phases) * 1000 + i * 100,
+                "enhancement",
+                "implementation",
+                vc=1,
+                ntc=0,
+            )
+        )
     return events
 
-def _event(ts, work_type, phase, vc=0, ntc=0, novelty=False):
+
+def _event(rng, dist, ts, work_type, phase, vc=0, ntc=0, novelty=False):
+    """Build one trace row. v1.5: includes a ``tier`` field per spec §3."""
     return {
         "timestamp_ns": ts,
         "event": "dispatch_decision",
-        "task": {"work_type": work_type, "phase": phase, "view_count": vc, "new_types_count": ntc, "scope_tier": "text_only", "novelty_flag": novelty},
+        "task": {
+            "work_type": work_type,
+            "phase": phase,
+            "view_count": vc,
+            "new_types_count": ntc,
+            "scope_tier": "text_only",
+            "novelty_flag": novelty,
+            "tier": _sample_tier(rng, dist),  # v1.5 — propagated to U1 via TaskDescriptor.data_tier
+        },
     }
+
 
 if __name__ == "__main__":
     generate_all(Path(__file__).parent.parent / "traces" / "synthetic")
-    print("Generated 5 synthetic trace files.")
+    print("Generated 5 synthetic trace files (v1.5 — tier column included).")

--- a/orchid/layer-a/tests/test_orchestrator_v1_5.py
+++ b/orchid/layer-a/tests/test_orchestrator_v1_5.py
@@ -1,0 +1,213 @@
+"""End-to-end tests for v1.5 orchestrator wiring (spec §2.1, §2.2, §3).
+
+Acceptance per plan §L5: clean trace produces zero U9 events; injected
+fault-injection trace produces non-zero U9 events.
+"""
+import os
+import sys
+from typing import List
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from orchestrator import Orchestrator
+from units.types import (
+    DesignScope,
+    TaskDescriptor,
+    Tier,
+    UnitId,
+    ValidationErrorCode,
+    ValidationEvent,
+    ValidationSeverity,
+    WorkType,
+)
+
+
+def _make_task(tier: Tier = Tier.T2, phase: str = "implementation") -> TaskDescriptor:
+    return TaskDescriptor(
+        view_count=3,
+        new_types_count=1,
+        scope_tier=DesignScope.LAYOUT,
+        novelty_flag=False,
+        work_type=WorkType.FEATURE,
+        phase=phase,
+        data_tier=tier,
+    )
+
+
+# --- v1 backward compat ---
+
+
+def test_orchestrator_v1_default_construction_works():
+    """No v1.5 args supplied → orchestrator processes tasks like v1."""
+    orch = Orchestrator()
+    result = orch.process(_make_task())
+    assert result.dispatch is not None
+    assert result.routing is not None
+    # No probes provided + permissive u1_min_tier=T3 → zero events.
+    assert result.u9_events_this_step == 0
+    assert orch.u9_total_advisory() == 0
+    assert orch.u9_total_mandatory() == 0
+
+
+def test_orchestrator_v1_pipeline_advances_cycles():
+    """v1 cycle accounting still works — total_cycles strictly increases."""
+    orch = Orchestrator()
+    cycles = []
+    for _ in range(5):
+        cycles.append(orch.process(_make_task()).total_cycles)
+    assert cycles == sorted(cycles)
+    assert cycles[-1] > cycles[0]
+
+
+# --- L5 acceptance: clean trace = zero events ---
+
+
+def test_clean_trace_produces_zero_events():
+    """Clean tasks (data_tier ≤ u1_min_tier, no probes) → zero U9 events."""
+    orch = Orchestrator(u1_min_tier=Tier.T3)
+    for _ in range(50):
+        result = orch.process(_make_task(tier=Tier.T1))
+    assert orch.u9_total_advisory() == 0
+    assert orch.u9_total_mandatory() == 0
+
+
+# --- L5 acceptance: injected fault = non-zero events ---
+
+
+def test_low_tier_input_below_threshold_raises_advisory():
+    """Task with data_tier=T3 + u1_min_tier=T2 → LOW_TIER_INPUT advisory."""
+    orch = Orchestrator(u1_min_tier=Tier.T2)
+    orch.process(_make_task(tier=Tier.T3))
+    assert (
+        orch.u9_advisory_count(UnitId.U1, ValidationErrorCode.LOW_TIER_INPUT) == 1
+    )
+    assert orch.u9_total_advisory() == 1
+    assert orch.u9_total_mandatory() == 0  # advisory only, no trap
+
+
+def test_low_tier_does_not_block_dispatch():
+    """Even when input tier is below threshold, dispatch still completes
+    (advisory-only, not blocking — per spec §3 + §5 LOG semantics)."""
+    orch = Orchestrator(u1_min_tier=Tier.T1)
+    result = orch.process(_make_task(tier=Tier.T3))
+    assert result.dispatch is not None
+    assert result.routing is not None
+    assert orch.u9_total_advisory() == 1
+
+
+def test_at_threshold_no_event():
+    """Tier exactly at threshold → no event (≤ admits)."""
+    orch = Orchestrator(u1_min_tier=Tier.T2)
+    orch.process(_make_task(tier=Tier.T2))
+    orch.process(_make_task(tier=Tier.T1))
+    assert orch.u9_total_advisory() == 0
+
+
+# --- U8 patrol scrubber injection ---
+
+
+def test_u8_probe_emits_events_through_pipeline():
+    """Inject a probe that fires every walk → events accumulate on U9."""
+    parity_event = ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+        severity=ValidationSeverity.LOG_COUNTER,
+        is_advisory=False,
+    )
+
+    def parity_probe() -> List[ValidationEvent]:
+        return [parity_event]
+
+    orch = Orchestrator(
+        u1_min_tier=Tier.T3,
+        u8_period_cycles=3,  # short period so events fire during the test
+        u8_jitter_pct=10,
+        u8_probes={"u2_lut": parity_probe},
+        u8_rng_seed=42,
+    )
+    # Run enough process() calls to trigger several walks.
+    for _ in range(30):
+        orch.process(_make_task())
+
+    # U2 LUT parity probe fired at least once → at least 1 advisory event
+    # for (U2, LUT_PARITY).
+    assert (
+        orch.u9_advisory_count(UnitId.U2, ValidationErrorCode.LUT_PARITY) >= 1
+    )
+    assert orch.u8_violations_total() >= 1
+
+
+def test_u8_no_probes_means_no_events():
+    """Without any probes wired, U8 walks silently → no U9 events emitted."""
+    orch = Orchestrator(
+        u1_min_tier=Tier.T3,
+        u8_period_cycles=3,
+        u8_jitter_pct=10,
+        # u8_probes={} — explicitly no probes
+        u8_rng_seed=42,
+    )
+    for _ in range(50):
+        orch.process(_make_task())
+    assert orch.u8_violations_total() == 0
+    assert orch.u9_total_advisory() == 0
+
+
+# --- Mandatory event integration ---
+
+
+def test_mandatory_event_via_u8_probe_fires_trap():
+    """A LOG_TRAP probe event routes through U8 → U9 mandatory channel.
+    The orchestrator drains 1 mandatory event per process() call via RR."""
+    fired: List[ValidationEvent] = []
+
+    fifo_violation = ValidationEvent(
+        unit_id=UnitId.U4,
+        error_code=ValidationErrorCode.FIFO_INVARIANT,
+        severity=ValidationSeverity.LOG_TRAP,
+        is_advisory=False,
+    )
+
+    def fifo_probe() -> List[ValidationEvent]:
+        return [fifo_violation]
+
+    orch = Orchestrator(
+        u1_min_tier=Tier.T3,
+        u8_period_cycles=3,
+        u8_jitter_pct=10,
+        u8_probes={"u4_fifo": fifo_probe},
+        u8_rng_seed=42,
+        trap_callback=fired.append,
+    )
+    for _ in range(50):
+        orch.process(_make_task())
+
+    # The probe was fired at U4 walks; events queued on U4's mandatory FIFO;
+    # process() drains one per call → at least one trap should have fired.
+    assert len(fired) >= 1
+    assert orch.u9_mandatory_count(UnitId.U4) >= 1
+    # All fired events should be the FIFO violation we injected.
+    for ev in fired:
+        assert ev.unit_id == UnitId.U4
+        assert ev.error_code == ValidationErrorCode.FIFO_INVARIANT
+
+
+# --- u9_events_this_step counter ---
+
+
+def test_u9_events_this_step_reflects_per_call_increment():
+    """PipelineResult.u9_events_this_step counts only this call's events."""
+    orch = Orchestrator(u1_min_tier=Tier.T2)
+
+    # First call: tier=T1 → no event.
+    r1 = orch.process(_make_task(tier=Tier.T1))
+    assert r1.u9_events_this_step == 0
+
+    # Second call: tier=T3 → one LOW_TIER_INPUT advisory event.
+    r2 = orch.process(_make_task(tier=Tier.T3))
+    assert r2.u9_events_this_step == 1
+
+    # Third call: tier=T1 again → no event this step (cumulative still 1).
+    r3 = orch.process(_make_task(tier=Tier.T1))
+    assert r3.u9_events_this_step == 0
+    assert orch.u9_total_advisory() == 1

--- a/orchid/layer-a/tests/test_patrol_scrubber.py
+++ b/orchid/layer-a/tests/test_patrol_scrubber.py
@@ -1,0 +1,233 @@
+"""U8 Patrol Scrubber tests (spec §2.1 + §8 hardening + Appendix A)."""
+import os
+import sys
+from typing import List
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from units.patrol_scrubber import PatrolScrubber, WalkState
+from units.types import (
+    UnitId,
+    ValidationErrorCode,
+    ValidationEvent,
+    ValidationSeverity,
+)
+
+
+def _make_violation_probe(events_to_emit: List[ValidationEvent]):
+    """Build a probe that emits a fixed list of events on every call."""
+
+    def probe() -> List[ValidationEvent]:
+        return list(events_to_emit)
+
+    return probe
+
+
+def _u2_parity_violation() -> ValidationEvent:
+    return ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+        severity=ValidationSeverity.LOG_COUNTER,
+        is_advisory=False,
+        payload=0xDEAD_BEEF,
+    )
+
+
+def _u4_fifo_violation() -> ValidationEvent:
+    return ValidationEvent(
+        unit_id=UnitId.U4,
+        error_code=ValidationErrorCode.FIFO_INVARIANT,
+        severity=ValidationSeverity.LOG_TRAP,
+        is_advisory=False,
+        payload=0,
+    )
+
+
+# --- §8 hardening: period jitter is mandatory ---
+
+
+def test_zero_jitter_raises():
+    """jitter_pct=0 is forbidden — eliminates timing oracle (spec §8)."""
+    with pytest.raises(ValueError, match="jitter_pct must be > 0"):
+        PatrolScrubber(period_cycles=100, jitter_pct=0)
+
+
+def test_negative_jitter_raises():
+    with pytest.raises(ValueError, match="jitter_pct must be in"):
+        PatrolScrubber(period_cycles=100, jitter_pct=-1)
+
+
+def test_jitter_above_100_raises():
+    with pytest.raises(ValueError, match="jitter_pct must be in"):
+        PatrolScrubber(period_cycles=100, jitter_pct=101)
+
+
+def test_zero_period_raises():
+    with pytest.raises(ValueError, match="period_cycles must be > 0"):
+        PatrolScrubber(period_cycles=0)
+
+
+def test_negative_period_raises():
+    with pytest.raises(ValueError, match="period_cycles must be > 0"):
+        PatrolScrubber(period_cycles=-100)
+
+
+# --- Clean state produces no events ---
+
+
+def test_clean_state_no_events():
+    """No probes provided → no events even after many walks."""
+    ps = PatrolScrubber(period_cycles=10, jitter_pct=10, rng_seed=42)
+    events: List[ValidationEvent] = []
+    for _ in range(100):
+        events.extend(ps.step())
+    assert events == []
+    assert ps.violations_total == 0
+    assert ps.last_violation is None
+
+
+def test_probes_returning_empty_no_events():
+    """All probes present but return [] → no events recorded."""
+    empty = lambda: []
+    ps = PatrolScrubber(
+        period_cycles=10,
+        jitter_pct=10,
+        u2_lut_probe=empty,
+        u3_scratchpad_probe=empty,
+        u4_fifo_probe=empty,
+        u6_mesi_probe=empty,
+        rng_seed=42,
+    )
+    for _ in range(100):
+        events = ps.step()
+        assert events == []
+    assert ps.violations_total == 0
+
+
+# --- Injected violation surfaces correctly ---
+
+
+def test_u2_violation_surfaces_in_events():
+    """Inject a U2 parity violation → it shows up after ~period cycles."""
+    parity_event = _u2_parity_violation()
+    ps = PatrolScrubber(
+        period_cycles=10,
+        jitter_pct=10,
+        u2_lut_probe=_make_violation_probe([parity_event]),
+        rng_seed=42,
+    )
+    all_events: List[ValidationEvent] = []
+    for _ in range(50):
+        all_events.extend(ps.step())
+    assert parity_event in all_events
+    assert ps.violations_total >= 1
+    assert ps.last_violation == parity_event
+
+
+def test_violations_total_counts_all():
+    """Each probe call producing N events bumps violations_total by N."""
+    parity_event = _u2_parity_violation()
+    ps = PatrolScrubber(
+        period_cycles=10,
+        jitter_pct=10,
+        u2_lut_probe=_make_violation_probe([parity_event, parity_event]),
+        rng_seed=42,
+    )
+    for _ in range(200):
+        ps.step()
+    # Each walk fires U2 once and emits 2 events → violations grow by 2 per walk.
+    assert ps.violations_total >= 2
+    assert ps.violations_total % 2 == 0
+
+
+def test_last_violation_is_most_recent():
+    """When multiple events fire across walks, last_violation tracks the latest."""
+    e1 = _u2_parity_violation()
+    e2 = _u4_fifo_violation()
+    ps = PatrolScrubber(
+        period_cycles=5,
+        jitter_pct=10,
+        u2_lut_probe=_make_violation_probe([e1]),
+        u4_fifo_probe=_make_violation_probe([e2]),
+        rng_seed=42,
+    )
+    for _ in range(30):
+        ps.step()
+    # FIFO probe runs after parity probe in the FSM → e2 should land last.
+    assert ps.last_violation == e2
+
+
+# --- Walk FSM cycles correctly ---
+
+
+def test_fsm_visits_all_states_in_order():
+    """After enough cycles, FSM must visit IDLE → U2 → U3 → U4 → U6 → IDLE."""
+    visited: List[WalkState] = []
+    ps = PatrolScrubber(period_cycles=5, jitter_pct=10, rng_seed=42)
+    last_state = ps.state
+    for _ in range(100):
+        ps.step()
+        if ps.state != last_state:
+            visited.append(ps.state)
+            last_state = ps.state
+    # Look for the canonical sequence anywhere in visited[].
+    canonical = [
+        WalkState.WALK_U2,
+        WalkState.WALK_U3,
+        WalkState.WALK_U4,
+        WalkState.WALK_U6,
+        WalkState.IDLE,
+    ]
+    for i in range(len(visited) - len(canonical) + 1):
+        if visited[i : i + len(canonical)] == canonical:
+            return
+    pytest.fail(f"Canonical FSM sequence not found in: {visited}")
+
+
+# --- Determinism via rng_seed ---
+
+
+def test_same_seed_produces_same_first_walk_cycle():
+    """Same rng_seed must yield identical jitter sequence."""
+    ps_a = PatrolScrubber(period_cycles=100, jitter_pct=10, rng_seed=12345)
+    ps_b = PatrolScrubber(period_cycles=100, jitter_pct=10, rng_seed=12345)
+    assert ps_a.next_walk_at == ps_b.next_walk_at
+
+
+def test_different_seeds_produce_different_jitter():
+    """Different seeds should (with high probability) yield different periods."""
+    ps_a = PatrolScrubber(period_cycles=100, jitter_pct=10, rng_seed=1)
+    ps_b = PatrolScrubber(period_cycles=100, jitter_pct=10, rng_seed=2)
+    # Either the first or some near-future jittered period should differ.
+    a_periods = [ps_a._jittered_period() for _ in range(10)]
+    b_periods = [ps_b._jittered_period() for _ in range(10)]
+    assert a_periods != b_periods
+
+
+# --- Jitter range bounds ---
+
+
+def test_jitter_stays_within_bounds():
+    """Over many samples, jittered period must stay within ±jitter_pct%."""
+    period = 1000
+    jitter_pct = 10
+    ps = PatrolScrubber(period_cycles=period, jitter_pct=jitter_pct, rng_seed=42)
+    lo = period - (period * jitter_pct) // 100
+    hi = period + (period * jitter_pct) // 100
+    samples = [ps._jittered_period() for _ in range(500)]
+    assert all(lo <= s <= hi for s in samples), (
+        f"sample out of bounds: min={min(samples)} max={max(samples)} "
+        f"expected [{lo}, {hi}]"
+    )
+
+
+def test_small_period_still_jitters():
+    """Even with period=1, jitter must apply some variation."""
+    ps = PatrolScrubber(period_cycles=1, jitter_pct=10, rng_seed=42)
+    # With period=1 and integer arithmetic, jitter_range floors at 1 per
+    # implementation note in patrol_scrubber.py. So jittered period in {1, 2}
+    # (max(1, 1+jitter) where jitter ∈ {-1, 0, 1}).
+    samples = [ps._jittered_period() for _ in range(100)]
+    assert min(samples) >= 1
+    assert max(samples) <= 2

--- a/orchid/layer-a/tests/test_tier_propagator.py
+++ b/orchid/layer-a/tests/test_tier_propagator.py
@@ -1,0 +1,163 @@
+"""Tier propagation tests (spec §3, Appendix A error code 0x01)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from units.tier_propagator import (
+    evict_priority,
+    low_tier_input_event,
+    propagate,
+    should_dispatch,
+    sort_for_eviction,
+    systolic_output_tier,
+)
+from units.types import (
+    Tier,
+    UnitId,
+    ValidationErrorCode,
+    ValidationSeverity,
+)
+
+
+# --- propagate() — worst-case rule ---
+
+
+def test_propagate_single_input_returns_same():
+    assert propagate([Tier.T1]) == Tier.T1
+    assert propagate([Tier.T2]) == Tier.T2
+    assert propagate([Tier.T3]) == Tier.T3
+
+
+def test_propagate_picks_max_intenum_value():
+    """Worst-case = max IntEnum value (lowest confidence wins)."""
+    assert propagate([Tier.T1, Tier.T2]) == Tier.T2
+    assert propagate([Tier.T1, Tier.T3]) == Tier.T3
+    assert propagate([Tier.T2, Tier.T3]) == Tier.T3
+    assert propagate([Tier.T1, Tier.T2, Tier.T3]) == Tier.T3
+
+
+def test_propagate_homogeneous_inputs():
+    assert propagate([Tier.T1, Tier.T1, Tier.T1]) == Tier.T1
+    assert propagate([Tier.T2, Tier.T2]) == Tier.T2
+
+
+def test_propagate_empty_raises():
+    """No inputs → no defined output tier."""
+    with pytest.raises(ValueError, match="requires at least one input"):
+        propagate([])
+
+
+def test_propagate_accepts_iterable():
+    """Generators, tuples, sets all work — duck typing."""
+    assert propagate(t for t in [Tier.T1, Tier.T3]) == Tier.T3
+    assert propagate((Tier.T2, Tier.T1)) == Tier.T2
+
+
+# --- should_dispatch() — U1 threshold semantics ---
+
+
+def test_dispatch_threshold_t1_strictest():
+    """min=T1 admits only T1 inputs."""
+    assert should_dispatch(Tier.T1, Tier.T1) is True
+    assert should_dispatch(Tier.T2, Tier.T1) is False
+    assert should_dispatch(Tier.T3, Tier.T1) is False
+
+
+def test_dispatch_threshold_t2_admits_t1_and_t2():
+    assert should_dispatch(Tier.T1, Tier.T2) is True
+    assert should_dispatch(Tier.T2, Tier.T2) is True
+    assert should_dispatch(Tier.T3, Tier.T2) is False
+
+
+def test_dispatch_threshold_t3_admits_everything():
+    """min=T3 is the most permissive setting — all inputs dispatch."""
+    assert should_dispatch(Tier.T1, Tier.T3) is True
+    assert should_dispatch(Tier.T2, Tier.T3) is True
+    assert should_dispatch(Tier.T3, Tier.T3) is True
+
+
+# --- low_tier_input_event() — Appendix A 0x01 ---
+
+
+def test_low_tier_event_returns_none_when_dispatch_allowed():
+    """Allowed dispatch → no advisory event."""
+    assert low_tier_input_event(Tier.T1, Tier.T2) is None
+    assert low_tier_input_event(Tier.T2, Tier.T2) is None
+    assert low_tier_input_event(Tier.T3, Tier.T3) is None
+
+
+def test_low_tier_event_when_dispatch_denied():
+    event = low_tier_input_event(Tier.T3, Tier.T2)
+    assert event is not None
+    assert event.unit_id == UnitId.U1
+    assert event.error_code == ValidationErrorCode.LOW_TIER_INPUT
+    assert event.severity == ValidationSeverity.LOG_COUNTER
+    assert event.is_advisory is False  # routes via severity → advisory
+    # payload encodes (input_tier, min_required) for diagnostic readout.
+    assert event.payload == (int(Tier.T3) << 4) | int(Tier.T2)
+
+
+def test_low_tier_event_payload_decodable():
+    """Payload must round-trip the (input, min_required) pair."""
+    for input_tier in (Tier.T2, Tier.T3):
+        for min_required in (Tier.T1, Tier.T2):
+            ev = low_tier_input_event(input_tier, min_required)
+            if ev is None:
+                continue
+            decoded_input = (ev.payload >> 4) & 0xF
+            decoded_min = ev.payload & 0xF
+            assert decoded_input == int(input_tier)
+            assert decoded_min == int(min_required)
+
+
+# --- evict_priority() + sort_for_eviction() — U3 ---
+
+
+def test_evict_priority_t3_first():
+    assert evict_priority(Tier.T3) > evict_priority(Tier.T2)
+    assert evict_priority(Tier.T2) > evict_priority(Tier.T1)
+
+
+def test_evict_priority_matches_int_value():
+    """The mapping is currently identity, locked in v1.5."""
+    assert evict_priority(Tier.T1) == 1
+    assert evict_priority(Tier.T2) == 2
+    assert evict_priority(Tier.T3) == 3
+
+
+def test_sort_for_eviction_t3_first():
+    """Eviction order: T3 → T2 → T1."""
+    inputs = [Tier.T1, Tier.T3, Tier.T2, Tier.T1]
+    out = sort_for_eviction(inputs)
+    assert out == [Tier.T3, Tier.T2, Tier.T1, Tier.T1]
+
+
+def test_sort_for_eviction_stable():
+    """Stable sort within a tier preserves insertion order (LRU-like)."""
+    # Three T2 entries — original order should survive.
+    inputs = [Tier.T2, Tier.T1, Tier.T2, Tier.T3, Tier.T2]
+    out = sort_for_eviction(inputs)
+    # T3 first, then 3 T2 in original order, then T1.
+    assert out == [Tier.T3, Tier.T2, Tier.T2, Tier.T2, Tier.T1]
+
+
+def test_sort_for_eviction_does_not_mutate_input():
+    inputs = [Tier.T1, Tier.T3, Tier.T2]
+    _ = sort_for_eviction(inputs)
+    assert inputs == [Tier.T1, Tier.T3, Tier.T2]  # untouched
+
+
+def test_sort_for_eviction_empty():
+    assert sort_for_eviction([]) == []
+
+
+# --- systolic_output_tier() — U7 specialization ---
+
+
+def test_systolic_2input_worst_case():
+    assert systolic_output_tier(Tier.T1, Tier.T1) == Tier.T1
+    assert systolic_output_tier(Tier.T1, Tier.T2) == Tier.T2
+    assert systolic_output_tier(Tier.T2, Tier.T1) == Tier.T2  # commutative
+    assert systolic_output_tier(Tier.T2, Tier.T3) == Tier.T3

--- a/orchid/layer-a/tests/test_types_v1_5.py
+++ b/orchid/layer-a/tests/test_types_v1_5.py
@@ -1,0 +1,162 @@
+"""v1.5 type round-trip + invariant tests (spec §3, §5, §2.2, Appendix A)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from units.types import (
+    AssertionMode,
+    Tier,
+    UnitId,
+    ValidationErrorCode,
+    ValidationEvent,
+    ValidationSeverity,
+)
+
+
+# --- Tier wire encoding (spec §3) ---
+
+
+def test_tier_wire_encoding_matches_spec():
+    """T1=01, T2=10, T3=11 on user[1:0]; 00 is reserved."""
+    assert int(Tier.T1) == 0b01
+    assert int(Tier.T2) == 0b10
+    assert int(Tier.T3) == 0b11
+    assert Tier.reserved() == 0b00
+
+
+def test_tier_reserved_is_not_a_valid_member():
+    """Tier(0) is reserved-zero on the wire and must not be a valid Tier."""
+    with pytest.raises(ValueError):
+        Tier(0)
+
+
+def test_tier_worst_case_propagation():
+    """U7 worst-case rule: output tier = max(input tiers) where T3 > T2 > T1
+    (max IntEnum value = lowest confidence)."""
+    assert max([Tier.T1, Tier.T1, Tier.T1]) == Tier.T1
+    assert max([Tier.T1, Tier.T2]) == Tier.T2
+    assert max([Tier.T1, Tier.T3]) == Tier.T3
+    assert max([Tier.T2, Tier.T3]) == Tier.T3
+
+
+# --- AssertionMode (spec §5) ---
+
+
+def test_assertion_mode_default_is_log():
+    """Default on reset is LOG (0b0001) per spec §5."""
+    # The default isn't enforced at the type level — verified at unit instantiation.
+    # Here we just confirm LOG is encoded as 0b0001 so future changes don't drift.
+    assert int(AssertionMode.LOG) == 0b0001
+
+
+def test_assertion_mode_lower_bits_locked_from_v1_5():
+    """Bits [1:0] must cover OFF/LOG/LOG_FATAL/LOG_STICKY immutably (spec §13)."""
+    assert int(AssertionMode.OFF) == 0b0000
+    assert int(AssertionMode.LOG) == 0b0001
+    assert int(AssertionMode.LOG_FATAL) == 0b0010
+    assert int(AssertionMode.LOG_STICKY) == 0b0011
+
+
+def test_assertion_mode_upper_bits_reserved():
+    """Encodings 0b0100 and above are reserved for v2.0; v1.5 must not allocate."""
+    valid_v1_5 = {AssertionMode.OFF, AssertionMode.LOG, AssertionMode.LOG_FATAL,
+                  AssertionMode.LOG_STICKY}
+    for mode in AssertionMode:
+        assert mode in valid_v1_5, (
+            f"AssertionMode.{mode.name}={int(mode)} added to v1.5 — should "
+            f"have been reserved for v2.0 per spec §5."
+        )
+
+
+# --- UnitId (spec §2.2) ---
+
+
+def test_unit_id_count_matches_v1_5_units():
+    """v1.5 has exactly 9 units (U1–U9). U10+ are v2.0 candidates."""
+    members = list(UnitId)
+    assert len(members) == 9
+    assert {int(u) for u in members} == set(range(1, 10))
+
+
+# --- ValidationErrorCode (Appendix A) ---
+
+
+def test_validation_error_code_zero_reserved():
+    """Code 0x00 is reserved per spec Appendix A — must not be a member."""
+    with pytest.raises(ValueError):
+        ValidationErrorCode(0x00)
+
+
+def test_validation_error_code_v1_5_allocation():
+    """v1.5 allocates 0x01–0x0F. Codes 0x10+ reserved for v2.0+."""
+    for code in ValidationErrorCode:
+        assert 0x01 <= int(code) <= 0x0F, (
+            f"{code.name}={int(code):#x} outside v1.5 allocation range "
+            f"(spec Appendix A reserves 0x10+ for v2.0)."
+        )
+
+
+# --- ValidationEvent (spec §2.2) ---
+
+
+def test_validation_event_default_is_log_counter():
+    """Default severity is LOG_COUNTER; default is_advisory is False."""
+    event = ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+    )
+    assert event.severity == ValidationSeverity.LOG_COUNTER
+    assert event.is_advisory is False
+    assert event.payload == 0
+
+
+def test_validation_event_routes_to_mandatory_only_when_trap():
+    """Mandatory channel routing requires severity=LOG_TRAP AND not advisory."""
+    # LOG_TRAP + not advisory → mandatory
+    e = ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+        severity=ValidationSeverity.LOG_TRAP,
+        is_advisory=False,
+    )
+    assert e.routes_to_mandatory() is True
+
+    # LOG_TRAP + is_advisory tag → advisory (tag overrides)
+    e = ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+        severity=ValidationSeverity.LOG_TRAP,
+        is_advisory=True,
+    )
+    assert e.routes_to_mandatory() is False
+
+    # LOG_COUNTER + not advisory → counter only, not mandatory
+    e = ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+        severity=ValidationSeverity.LOG_COUNTER,
+        is_advisory=False,
+    )
+    assert e.routes_to_mandatory() is False
+
+
+def test_validation_event_is_frozen():
+    """ValidationEvent must be immutable (per dataclass frozen=True)."""
+    event = ValidationEvent(
+        unit_id=UnitId.U2,
+        error_code=ValidationErrorCode.LUT_PARITY,
+    )
+    with pytest.raises(AttributeError):
+        event.payload = 42  # type: ignore[misc]
+
+
+def test_validation_event_payload_round_trip():
+    """payload is 32-bit. Verify the dataclass accepts the full range."""
+    e = ValidationEvent(
+        unit_id=UnitId.U3,
+        error_code=ValidationErrorCode.PMU_OVERFLOW,
+        payload=0xFFFFFFFF,
+    )
+    assert e.payload == 0xFFFFFFFF

--- a/orchid/layer-a/tests/test_validation_bus.py
+++ b/orchid/layer-a/tests/test_validation_bus.py
@@ -1,0 +1,261 @@
+"""U9 Validation Bus tests (spec §2.2 + Appendix A)."""
+import os
+import sys
+from typing import List
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from units.types import (
+    UnitId,
+    ValidationErrorCode,
+    ValidationEvent,
+    ValidationSeverity,
+)
+from units.validation_bus import ValidationBus
+
+
+# --- Helpers ---
+
+
+def _trap_event(unit_id: UnitId, error_code: ValidationErrorCode) -> ValidationEvent:
+    """A LOG_TRAP severity event that routes to the mandatory channel."""
+    return ValidationEvent(
+        unit_id=unit_id,
+        error_code=error_code,
+        severity=ValidationSeverity.LOG_TRAP,
+        is_advisory=False,
+        payload=0,
+    )
+
+
+def _advisory_event(unit_id: UnitId, error_code: ValidationErrorCode) -> ValidationEvent:
+    """A LOG_COUNTER severity event that routes to the advisory channel."""
+    return ValidationEvent(
+        unit_id=unit_id,
+        error_code=error_code,
+        severity=ValidationSeverity.LOG_COUNTER,
+        is_advisory=False,
+        payload=0,
+    )
+
+
+def _tagged_advisory_event(
+    unit_id: UnitId, error_code: ValidationErrorCode
+) -> ValidationEvent:
+    """LOG_TRAP severity but `is_advisory=True` — tag overrides severity."""
+    return ValidationEvent(
+        unit_id=unit_id,
+        error_code=error_code,
+        severity=ValidationSeverity.LOG_TRAP,
+        is_advisory=True,
+        payload=0,
+    )
+
+
+# --- Construction ---
+
+
+def test_default_num_sources_is_8():
+    bus = ValidationBus()
+    assert bus.queue_depth(UnitId.U1) == 0
+
+
+def test_non_8_sources_raises():
+    """v1.5 locks num_sources at 8 (one per U1-U8)."""
+    with pytest.raises(ValueError, match="num_sources must be 8"):
+        ValidationBus(num_sources=4)
+
+
+def test_negative_log_buffer_raises():
+    with pytest.raises(ValueError, match=">= 0"):
+        ValidationBus(log_buffer_entries=-1)
+
+
+def test_log_buffer_disabled_by_default():
+    """Per spec §2.2, log buffer is P1; v1.5.0 default = 0 (disabled)."""
+    bus = ValidationBus()
+    assert bus.log_buffer_capacity() == 0
+    assert bus.log_buffer_size() == 0
+    assert bus.log_buffer_snapshot() == []
+
+
+# --- Channel routing ---
+
+
+def test_advisory_event_increments_counter_no_callback():
+    """LOG_COUNTER severity → advisory channel; no trap fires."""
+    fired: List[ValidationEvent] = []
+    bus = ValidationBus(trap_callback=fired.append)
+
+    bus.submit(_advisory_event(UnitId.U2, ValidationErrorCode.LUT_MISS))
+    assert bus.get_advisory_count(UnitId.U2, ValidationErrorCode.LUT_MISS) == 1
+    assert fired == []
+    assert bus.total_queued() == 0
+
+
+def test_advisory_event_with_tag_does_not_fire_trap():
+    """`is_advisory=True` overrides LOG_TRAP severity → advisory routing."""
+    fired: List[ValidationEvent] = []
+    bus = ValidationBus(trap_callback=fired.append)
+
+    bus.submit(_tagged_advisory_event(UnitId.U2, ValidationErrorCode.LUT_PARITY))
+    assert fired == []
+    assert bus.get_advisory_count(UnitId.U2, ValidationErrorCode.LUT_PARITY) == 1
+
+
+def test_mandatory_event_queues_until_step():
+    """Mandatory event sits in a per-source FIFO until step() drains it."""
+    fired: List[ValidationEvent] = []
+    bus = ValidationBus(trap_callback=fired.append)
+
+    bus.submit(_trap_event(UnitId.U2, ValidationErrorCode.LUT_PARITY))
+    assert fired == []  # not drained yet
+    assert bus.queue_depth(UnitId.U2) == 1
+
+    drained = bus.step()
+    assert drained is not None
+    assert drained.unit_id == UnitId.U2
+    assert len(fired) == 1
+    assert bus.queue_depth(UnitId.U2) == 0
+    assert bus.get_mandatory_count(UnitId.U2) == 1
+
+
+def test_step_returns_none_when_empty():
+    bus = ValidationBus()
+    assert bus.step() is None
+
+
+# --- RR arbitration: starvation-freedom ---
+
+
+def test_rr_does_not_starve_quiet_source():
+    """Saturated U2 + 1 event from U7 → U7 drains within RR window."""
+    fired: List[ValidationEvent] = []
+    bus = ValidationBus(trap_callback=fired.append)
+
+    # U2 is the loudest source.
+    for _ in range(100):
+        bus.submit(_trap_event(UnitId.U2, ValidationErrorCode.LUT_PARITY))
+
+    # U7 has just one event.
+    bus.submit(_trap_event(UnitId.U7, ValidationErrorCode.SYSTOLIC_TIER_DOWNGRADE))
+
+    # After draining U2 once, the RR pointer skips ahead, so U7 must
+    # drain within the next pass through the source list.
+    bus.step()  # drains U2[0]
+    bus.step()  # drains U7[0]
+    assert bus.get_mandatory_count(UnitId.U7) == 1
+
+
+def test_rr_round_robin_when_all_saturated():
+    """Every source saturated → drains evenly across all sources."""
+    bus = ValidationBus()
+    for uid in UnitId:
+        if uid == UnitId.U9:  # U9 is destination, not source
+            continue
+        for _ in range(5):
+            bus.submit(_trap_event(uid, ValidationErrorCode.LUT_PARITY))
+
+    # Drain 8 events. RR should pick one per source in order.
+    drained = [bus.step() for _ in range(8)]
+    drained_units = [e.unit_id for e in drained if e is not None]
+    # Each source should be hit exactly once over 8 steps.
+    assert len(drained_units) == 8
+    assert sorted({int(u) for u in drained_units}) == [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_drain_all_empties_every_queue():
+    bus = ValidationBus()
+    for uid in (UnitId.U2, UnitId.U4, UnitId.U7):
+        for _ in range(3):
+            bus.submit(_trap_event(uid, ValidationErrorCode.LUT_PARITY))
+
+    drained = bus.drain_all()
+    assert len(drained) == 9
+    assert bus.total_queued() == 0
+    assert bus.total_mandatory_count() == 9
+
+
+# --- Per-(unit, error_code) advisory matrix ---
+
+
+def test_advisory_matrix_indexed_by_unit_and_error():
+    bus = ValidationBus()
+    # Same unit, same error → counter increments.
+    bus.submit(_advisory_event(UnitId.U3, ValidationErrorCode.PMU_OVERFLOW))
+    bus.submit(_advisory_event(UnitId.U3, ValidationErrorCode.PMU_OVERFLOW))
+    assert bus.get_advisory_count(UnitId.U3, ValidationErrorCode.PMU_OVERFLOW) == 2
+
+    # Same unit, different error → distinct slot.
+    bus.submit(_advisory_event(UnitId.U3, ValidationErrorCode.CACHE_TIER_MISMATCH))
+    assert bus.get_advisory_count(UnitId.U3, ValidationErrorCode.PMU_OVERFLOW) == 2
+    assert (
+        bus.get_advisory_count(UnitId.U3, ValidationErrorCode.CACHE_TIER_MISMATCH) == 1
+    )
+
+    # Different unit, same error → distinct slot.
+    bus.submit(_advisory_event(UnitId.U4, ValidationErrorCode.PMU_OVERFLOW))
+    assert bus.get_advisory_count(UnitId.U4, ValidationErrorCode.PMU_OVERFLOW) == 1
+
+
+def test_total_counters():
+    bus = ValidationBus()
+    bus.submit(_advisory_event(UnitId.U2, ValidationErrorCode.LUT_MISS))
+    bus.submit(_advisory_event(UnitId.U3, ValidationErrorCode.PMU_OVERFLOW))
+    bus.submit(_trap_event(UnitId.U4, ValidationErrorCode.FIFO_INVARIANT))
+    bus.step()  # drain the mandatory one
+
+    assert bus.total_advisory_count() == 2
+    assert bus.total_mandatory_count() == 1
+
+
+# --- Log buffer (P1, optional) ---
+
+
+def test_log_buffer_captures_advisory_events():
+    bus = ValidationBus(log_buffer_entries=10)
+    bus.submit(_advisory_event(UnitId.U2, ValidationErrorCode.LUT_MISS))
+    bus.submit(_advisory_event(UnitId.U3, ValidationErrorCode.PMU_OVERFLOW))
+
+    snap = bus.log_buffer_snapshot()
+    assert len(snap) == 2
+    assert snap[0].unit_id == UnitId.U2
+    assert snap[1].unit_id == UnitId.U3
+
+
+def test_log_buffer_captures_drained_mandatory_events():
+    bus = ValidationBus(log_buffer_entries=10)
+    bus.submit(_trap_event(UnitId.U2, ValidationErrorCode.LUT_PARITY))
+    # Not in buffer yet — only added after drain.
+    assert bus.log_buffer_size() == 0
+
+    bus.step()
+    assert bus.log_buffer_size() == 1
+    assert bus.log_buffer_snapshot()[0].unit_id == UnitId.U2
+
+
+def test_log_buffer_drops_oldest_at_capacity():
+    """Circular buffer with maxlen=3 evicts oldest entries."""
+    bus = ValidationBus(log_buffer_entries=3)
+    for code in (
+        ValidationErrorCode.LUT_PARITY,
+        ValidationErrorCode.LUT_MISS,
+        ValidationErrorCode.PMU_OVERFLOW,
+        ValidationErrorCode.CACHE_TIER_MISMATCH,
+    ):
+        bus.submit(_advisory_event(UnitId.U2, code))
+
+    snap = bus.log_buffer_snapshot()
+    assert len(snap) == 3
+    # Oldest (LUT_PARITY) should have been evicted.
+    codes = [e.error_code for e in snap]
+    assert ValidationErrorCode.LUT_PARITY not in codes
+    assert ValidationErrorCode.CACHE_TIER_MISMATCH in codes
+
+
+def test_log_buffer_capacity_zero_means_disabled():
+    bus = ValidationBus(log_buffer_entries=0)
+    bus.submit(_advisory_event(UnitId.U2, ValidationErrorCode.LUT_MISS))
+    assert bus.log_buffer_size() == 0
+    assert bus.log_buffer_snapshot() == []

--- a/orchid/layer-a/trace_replayer.py
+++ b/orchid/layer-a/trace_replayer.py
@@ -1,10 +1,16 @@
-"""Trace Replayer — feeds .jsonl traces through the Orchid pipeline."""
+"""Trace Replayer — feeds .jsonl traces through the Orchid pipeline.
+
+v1.5 extension (per docs/superpowers/specs/2026-05-03-orchid-v1-5-design.md §3):
+trace events may carry an optional ``tier`` field on the ``task`` object.
+Missing fields default to ``T2`` (Declared) so v1 traces continue to replay
+unchanged.
+"""
 from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from orchestrator import Orchestrator
-from units.types import TaskDescriptor, WorkType, DesignScope
+from units.types import DesignScope, TaskDescriptor, Tier, WorkType
 from metrics import composite_score
 
 _WORK_TYPE_MAP = {
@@ -19,6 +25,25 @@ _SCOPE_MAP = {
     "interaction": DesignScope.INTERACTION,
     "full_redesign": DesignScope.FULL_REDESIGN,
 }
+# v1.5 — string label → Tier mapping. Unknown labels fall back to T2 (default).
+_TIER_MAP = {
+    "T1": Tier.T1,
+    "T2": Tier.T2,
+    "T3": Tier.T3,
+    "t1": Tier.T1,
+    "t2": Tier.T2,
+    "t3": Tier.T3,
+    1: Tier.T1,
+    2: Tier.T2,
+    3: Tier.T3,
+}
+
+
+def _parse_tier(value) -> Tier:
+    """Tolerant tier parser (string label, integer code, or missing)."""
+    if value is None:
+        return Tier.T2
+    return _TIER_MAP.get(value, Tier.T2)
 
 
 @dataclass
@@ -102,4 +127,5 @@ class TraceReplayer:
             scope_tier=_SCOPE_MAP.get(task_data.get("scope_tier", "text_only"), DesignScope.TEXT_ONLY),
             novelty_flag=task_data.get("novelty_flag", False),
             phase=task_data.get("phase", "implementation"),
+            data_tier=_parse_tier(task_data.get("tier")),  # v1.5 — defaults to T2 when absent
         )

--- a/orchid/layer-a/units/patrol_scrubber.py
+++ b/orchid/layer-a/units/patrol_scrubber.py
@@ -1,0 +1,181 @@
+"""U8 Patrol Scrubber — periodic on-chip state audit (spec §2.1).
+
+The scrubber walks U2/U3/U4/U6 state on a configurable cadence and emits
+validation events on detected drift. Per the v1.5 design spec §2.1, the
+walk FSM cycles through:
+
+    IDLE → WALK_U2 → WALK_U3 → WALK_U4 → WALK_U6 → IDLE
+
+with one state transition per cycle. Probes run on entry to a walk state.
+After the IDLE → WALK_U2 transition, the next walk is scheduled at
+`current_cycle + jittered_period()`.
+
+**Period jitter is mandatory** (spec §8 hardening). Construction with
+`jitter_pct=0` raises `ValueError` — a constant period would expose a
+timing oracle to attackers running on adjacent cores.
+
+Probes are injected as callables (`Callable[[], list[ValidationEvent]]`).
+A probe of `None` causes that walk state to skip silently. This lets
+tests exercise individual probes without standing up the full unit set.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from enum import IntEnum
+from random import Random
+from typing import Callable, List, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from units.types import ValidationEvent
+
+
+class WalkState(IntEnum):
+    """Walk FSM states (spec §2.1)."""
+
+    IDLE = 0
+    WALK_U2 = 1
+    WALK_U3 = 2
+    WALK_U4 = 3
+    WALK_U6 = 4
+
+
+ProbeFn = Callable[[], List[ValidationEvent]]
+
+
+@dataclass
+class PatrolScrubber:
+    """Periodically walks on-chip state and emits validation events.
+
+    Period jitter (default ±10%) is mandatory — initialization with
+    ``jitter_pct=0`` raises ``ValueError`` per spec §8 hardening.
+
+    Probes are injected as callables that return their findings as
+    ``ValidationEvent`` lists. Missing probes are skipped (no-op).
+
+    Attributes:
+        period_cycles: nominal walk period in cycles. The actual delay
+            between walks is ``period_cycles ± (period_cycles * jitter_pct / 100)``.
+        jitter_pct: jitter percentage in (0, 100]. Default 10.
+        u2_lut_probe: probe for U2 Skill Router LUT parity (None to skip).
+        u3_scratchpad_probe: probe for U3 scratchpad tier consistency.
+        u4_fifo_probe: probe for U4 FIFO depth invariant.
+        u6_mesi_probe: probe for U6 MESI state invariant.
+        rng_seed: deterministic seed for jitter (for testing).
+    """
+
+    period_cycles: int
+    jitter_pct: int = 10
+    u2_lut_probe: Optional[ProbeFn] = None
+    u3_scratchpad_probe: Optional[ProbeFn] = None
+    u4_fifo_probe: Optional[ProbeFn] = None
+    u6_mesi_probe: Optional[ProbeFn] = None
+    rng_seed: int = 0
+
+    state: WalkState = field(default=WalkState.IDLE, init=False)
+    cycle: int = field(default=0, init=False)
+    next_walk_at: int = field(default=0, init=False)
+    violations_total: int = field(default=0, init=False)
+    last_violation: Optional[ValidationEvent] = field(default=None, init=False)
+    _rng: Random = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.jitter_pct == 0:
+            raise ValueError(
+                "jitter_pct must be > 0 — period jitter is mandatory per "
+                "spec §8 hardening (eliminates timing oracle for adjacent-core "
+                "attackers). Set to at least 1; recommended 10."
+            )
+        if not (0 < self.jitter_pct <= 100):
+            raise ValueError(
+                f"jitter_pct must be in (0, 100]; got {self.jitter_pct}"
+            )
+        if self.period_cycles <= 0:
+            raise ValueError(
+                f"period_cycles must be > 0; got {self.period_cycles}"
+            )
+        self._rng = Random(self.rng_seed)
+        self.next_walk_at = self._jittered_period()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def step(self, advance_cycles: int = 1) -> List[ValidationEvent]:
+        """Advance the cycle counter; return any events emitted this step.
+
+        Args:
+            advance_cycles: cycles to advance (default 1). For tests it can
+                be useful to advance multiple cycles at once.
+
+        Returns:
+            List of ``ValidationEvent`` emitted this step. Empty when the
+            FSM is idle and no probe fires.
+        """
+        events: List[ValidationEvent] = []
+        for _ in range(advance_cycles):
+            self.cycle += 1
+            next_state = self._next_state()
+            if next_state != self.state:
+                events.extend(self._enter_state(next_state))
+            self.state = next_state
+        return events
+
+    # ------------------------------------------------------------------
+    # FSM
+    # ------------------------------------------------------------------
+
+    def _next_state(self) -> WalkState:
+        """Compute the next FSM state given the current state + cycle."""
+        if self.state == WalkState.IDLE:
+            return WalkState.WALK_U2 if self.cycle >= self.next_walk_at else WalkState.IDLE
+        if self.state == WalkState.WALK_U2:
+            return WalkState.WALK_U3
+        if self.state == WalkState.WALK_U3:
+            return WalkState.WALK_U4
+        if self.state == WalkState.WALK_U4:
+            return WalkState.WALK_U6
+        if self.state == WalkState.WALK_U6:
+            # Walk complete; schedule next walk with fresh jitter.
+            self.next_walk_at = self.cycle + self._jittered_period()
+            return WalkState.IDLE
+        return WalkState.IDLE  # defensive
+
+    def _enter_state(self, state: WalkState) -> List[ValidationEvent]:
+        """Run the probe associated with the entered walk state."""
+        if state == WalkState.WALK_U2:
+            return self._run_probe(self.u2_lut_probe)
+        if state == WalkState.WALK_U3:
+            return self._run_probe(self.u3_scratchpad_probe)
+        if state == WalkState.WALK_U4:
+            return self._run_probe(self.u4_fifo_probe)
+        if state == WalkState.WALK_U6:
+            return self._run_probe(self.u6_mesi_probe)
+        return []
+
+    def _run_probe(self, probe: Optional[ProbeFn]) -> List[ValidationEvent]:
+        """Invoke a probe (if present) and update violation counters."""
+        if probe is None:
+            return []
+        events = probe() or []
+        for event in events:
+            self.violations_total += 1
+            self.last_violation = event
+        return events
+
+    # ------------------------------------------------------------------
+    # Period jitter
+    # ------------------------------------------------------------------
+
+    def _jittered_period(self) -> int:
+        """Return the next period length with ±jitter_pct% jitter applied.
+
+        Uses an integer-only computation so the jittered period is always
+        a whole number of cycles. Floors at 1 to guarantee forward progress.
+        """
+        jitter_range = (self.period_cycles * self.jitter_pct) // 100
+        if jitter_range < 1:
+            jitter_range = 1  # always introduce *some* variation
+        jitter = self._rng.randint(-jitter_range, jitter_range)
+        return max(1, self.period_cycles + jitter)

--- a/orchid/layer-a/units/tier_propagator.py
+++ b/orchid/layer-a/units/tier_propagator.py
@@ -1,0 +1,130 @@
+"""Tier propagation — cross-cutting v1.5 primitive (spec §3).
+
+Tier values cross every functional unit. This module is the canonical
+home of the rules:
+
+- **Worst-case-on-output (U7 Systolic Array):** output tier = `max(inputs)`,
+  where `max` of `IntEnum` returns the largest integer — and per spec §3
+  T3=0b11 > T2=0b10 > T1=0b01 — i.e. *lowest confidence* wins.
+- **Dispatch threshold (U1 Dispatch Scorer):** an input below the
+  configured `min_tier_required` raises a `LOW_TIER_INPUT` advisory.
+- **Eviction priority (U3 Cache Controller):** under capacity pressure,
+  T3 entries evict before T2, before T1 — i.e. lowest-confidence-first.
+
+These rules are implemented as pure functions (no state) so they can be
+called from any unit's behavioral model and any directed test.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Iterable, List, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from units.types import (
+    Tier,
+    UnitId,
+    ValidationErrorCode,
+    ValidationEvent,
+    ValidationSeverity,
+)
+
+
+def propagate(inputs: Iterable[Tier]) -> Tier:
+    """Worst-case tier propagation rule (spec §3 + §2.2 worst-case rule).
+
+    Args:
+        inputs: 1-or-more tiers entering a combinator (e.g. U7 systolic).
+
+    Returns:
+        Tier matching `max(inputs)` — i.e. the **lowest** confidence input
+        wins because T3 (narrative) has the largest IntEnum value.
+
+    Raises:
+        ValueError: if `inputs` is empty (no propagation possible).
+    """
+    inputs_list = list(inputs)
+    if not inputs_list:
+        raise ValueError(
+            "propagate() requires at least one input tier; "
+            "an empty input list has no defined output tier."
+        )
+    return max(inputs_list)
+
+
+def should_dispatch(input_tier: Tier, min_tier_required: Tier) -> bool:
+    """Whether U1 should dispatch a task with the given input tier.
+
+    Args:
+        input_tier: tier of the task's CU v2 input bus.
+        min_tier_required: the dispatch threshold from `u1_min_tier` CSR.
+
+    Returns:
+        True if `input_tier <= min_tier_required` (strict-or-equal — a
+        T1 input meets a T1 minimum, T2, or T3 threshold).
+
+    Note: the test uses `<=` because lower IntEnum values mean *higher*
+    confidence (T1=0b01 < T2=0b10 < T3=0b11). A `min_tier_required` of
+    `T2` admits T1 and T2 but not T3.
+    """
+    return int(input_tier) <= int(min_tier_required)
+
+
+def low_tier_input_event(
+    input_tier: Tier, min_tier_required: Tier
+) -> Optional[ValidationEvent]:
+    """Build a `LOW_TIER_INPUT` advisory event for U1 if dispatch fails.
+
+    Returns `None` when dispatch is allowed; otherwise a fresh
+    `ValidationEvent` ready to submit to U9.
+
+    Per Appendix A error code 0x01.
+    """
+    if should_dispatch(input_tier, min_tier_required):
+        return None
+    return ValidationEvent(
+        unit_id=UnitId.U1,
+        error_code=ValidationErrorCode.LOW_TIER_INPUT,
+        severity=ValidationSeverity.LOG_COUNTER,
+        is_advisory=False,  # routes via severity=LOG_COUNTER → advisory
+        payload=(int(input_tier) << 4) | int(min_tier_required),
+    )
+
+
+def evict_priority(entry_tier: Tier) -> int:
+    """Eviction priority for U3 Cache Controller (spec §3 §8 P0).
+
+    Higher returned value → evicted first under capacity pressure. Mapping:
+
+    | Tier | Priority |
+    |------|----------|
+    | T3   | 3 (evict first) |
+    | T2   | 2 |
+    | T1   | 1 (evict last)  |
+
+    The mapping is identical to `int(Tier)` — kept as a separate function
+    so the eviction policy is named in code, not implicit in an IntEnum.
+    """
+    return int(entry_tier)
+
+
+def sort_for_eviction(entries: List[Tier]) -> List[Tier]:
+    """Return tiers sorted in eviction order (highest priority first).
+
+    Args:
+        entries: list of cache-entry tiers under consideration for eviction.
+
+    Returns:
+        New list sorted T3 → T2 → T1 (lowest confidence evicted first).
+        Stable sort preserves insertion order within a tier (LRU-like).
+    """
+    return sorted(entries, key=evict_priority, reverse=True)
+
+
+def systolic_output_tier(input_a_tier: Tier, input_b_tier: Tier) -> Tier:
+    """U7 Systolic Array specialization of `propagate()`.
+
+    Output of a 2-input matmul-style operation gets `max(a, b)` — the
+    worst-case (lowest-confidence) input wins.
+    """
+    return propagate([input_a_tier, input_b_tier])

--- a/orchid/layer-a/units/types.py
+++ b/orchid/layer-a/units/types.py
@@ -46,15 +46,45 @@ class MESIState(IntEnum):
     INVALID = 3
 
 
+# v1.5 — define Tier early so TaskDescriptor can default it (spec §3).
+class Tier(IntEnum):
+    """Data-quality tier propagated across TileLink user[1:0] (v1.5 spec §3).
+
+    Wire encoding (immutable from v1.5 onward):
+        00 -> reserved (must-be-zero on transmit, ignore on receive)
+        01 -> T1 Instrumented (high confidence)
+        10 -> T2 Declared (medium confidence) — default for v1 backward compat
+        11 -> T3 Narrative (low confidence)
+
+    Worst-case-on-output: max(Tier) returns the LOWEST confidence
+    (T3 > T2 > T1) per spec §3.
+    """
+    T1 = 1
+    T2 = 2
+    T3 = 3
+
+    @classmethod
+    def reserved(cls) -> int:
+        return 0
+
+
 @dataclass(frozen=True)
 class TaskDescriptor:
-    """13-bit input bus to U1 Dispatch Scorer (Section 10.3)."""
+    """13-bit input bus to U1 Dispatch Scorer (Section 10.3).
+
+    v1.5 extension: `data_tier` is a 2-bit data-quality tier (T1/T2/T3)
+    that propagates across TileLink `user[1:0]` (v1.5 spec §3). It is
+    independent of `scope_tier` (DesignScope) and `tier` in
+    DispatchDecision (ModelTier). The default is T2 (Declared) so existing
+    v1 traces without an explicit tier replay correctly.
+    """
     view_count: int = 0          # 4 bits (0-15)
     new_types_count: int = 0     # 4 bits (0-15)
     scope_tier: DesignScope = DesignScope.TEXT_ONLY  # 2 bits
     novelty_flag: bool = False   # 1 bit
     work_type: WorkType = WorkType.FEATURE  # 2 bits
     phase: str = "implementation"  # not part of U1 bus, used by U2
+    data_tier: Tier = Tier.T2   # 2 bits — v1.5 spec §3
 
 
 @dataclass(frozen=True)
@@ -109,29 +139,8 @@ class CycleCount:
 
 # ============================================================================
 # v1.5 additions — per spec §3, §5, §6, §2.2, Appendix A
+# (Tier defined earlier in the file so TaskDescriptor can default it.)
 # ============================================================================
-
-
-class Tier(IntEnum):
-    """Data-quality tier propagated across TileLink user[1:0] (spec §3).
-
-    The 2-bit wire encoding matches Appendix C bit 4:
-        00 -> reserved (must-be-zero on transmit, ignore on receive)
-        01 -> T1 Instrumented (high confidence)
-        10 -> T2 Declared (medium confidence)
-        11 -> T3 Narrative (low confidence)
-
-    Worst-case-on-output rule (U7 systolic array): output tier = max(input tiers).
-    Note: max(Tier) corresponds to the LOWEST confidence (T3 > T2 > T1).
-    """
-    T1 = 1
-    T2 = 2
-    T3 = 3
-
-    @classmethod
-    def reserved(cls) -> int:
-        """The 00 wire encoding — never a valid Tier value."""
-        return 0
 
 
 class AssertionMode(IntEnum):

--- a/orchid/layer-a/units/types.py
+++ b/orchid/layer-a/units/types.py
@@ -6,6 +6,13 @@ These dataclasses mirror the hardware bus signals defined in the spec:
 - RoutingDecision: U2 output (skill IDs + tool budget)
 - CacheEntry: U3 storage unit (compressed + full views)
 - TraceEvent: One line from a .jsonl trace file (Section 4)
+
+v1.5 additions (per docs/superpowers/specs/2026-05-03-orchid-v1-5-design.md):
+- Tier: 2-bit data-quality tier (T1/T2/T3) propagated across TileLink user[1:0]
+- AssertionMode: 4-bit per-unit advisory→enforced flip register
+- UnitId: 4-bit unit identifier for ValidationEvent
+- ValidationEvent: U9 Validation Bus message format
+- ValidationErrorCode: 5-bit error code allocation (Appendix A)
 """
 from dataclasses import dataclass, field
 from enum import IntEnum
@@ -98,3 +105,109 @@ class CycleCount:
     def add(self, cycles: int, energy_per_cycle_pj: float = 1.0) -> None:
         self.cycles += cycles
         self.energy_pj += cycles * energy_per_cycle_pj
+
+
+# ============================================================================
+# v1.5 additions — per spec §3, §5, §6, §2.2, Appendix A
+# ============================================================================
+
+
+class Tier(IntEnum):
+    """Data-quality tier propagated across TileLink user[1:0] (spec §3).
+
+    The 2-bit wire encoding matches Appendix C bit 4:
+        00 -> reserved (must-be-zero on transmit, ignore on receive)
+        01 -> T1 Instrumented (high confidence)
+        10 -> T2 Declared (medium confidence)
+        11 -> T3 Narrative (low confidence)
+
+    Worst-case-on-output rule (U7 systolic array): output tier = max(input tiers).
+    Note: max(Tier) corresponds to the LOWEST confidence (T3 > T2 > T1).
+    """
+    T1 = 1
+    T2 = 2
+    T3 = 3
+
+    @classmethod
+    def reserved(cls) -> int:
+        """The 00 wire encoding — never a valid Tier value."""
+        return 0
+
+
+class AssertionMode(IntEnum):
+    """Per-unit advisory→enforced flip register (spec §5).
+
+    4-bit encoding. Bits [1:0] are locked from v1.5 onward.
+    Bits [3:2] reserved for v2.0+.
+    """
+    OFF = 0          # No-op. Counter doesn't increment. Test/burn-in only.
+    LOG = 1          # Counter increments. No trap. (default on reset)
+    LOG_FATAL = 2    # Counter increments. Raises trap on receipt.
+    LOG_STICKY = 3   # Counter increments + sticky bit set. No trap.
+
+
+class UnitId(IntEnum):
+    """4-bit unit identifier for ValidationEvent (spec §2.2)."""
+    U1 = 1  # Dispatch Scorer
+    U2 = 2  # Skill Router
+    U3 = 3  # Cache Controller
+    U4 = 4  # Batch Scheduler
+    U5 = 5  # Speculative Prefetcher
+    U6 = 6  # Coherence Unit
+    U7 = 7  # Systolic Array
+    U8 = 8  # Patrol Scrubber (v1.5)
+    U9 = 9  # Validation Bus (v1.5)
+
+
+class ValidationErrorCode(IntEnum):
+    """5-bit error code allocation (spec Appendix A).
+
+    Codes 0x10-0x1F reserved for v2.0+. Code 0x00 must not be used.
+    """
+    LOW_TIER_INPUT = 0x01           # U1 — input tier below u1_min_tier
+    DISPATCH_TIMEOUT = 0x02         # U1 — score not produced within budget
+    LUT_PARITY = 0x03               # U2 — skill-router LUT parity violation
+    LUT_MISS = 0x04                 # U2 — skill not found in LUT
+    CACHE_TIER_MISMATCH = 0x05      # U3 — scratchpad tier inconsistent with input
+    PMU_OVERFLOW = 0x06             # U3 — selected counter overflowed
+    FIFO_INVARIANT = 0x07           # U4 — head>tail or tail>depth
+    TIER_PRIORITY_STARVE = 0x08     # U4 — T1 batch waited > threshold (P1 advisory)
+    MISPREDICT_BURST = 0x09         # U5 — mispredict rate exceeded threshold
+    MESI_INVARIANT = 0x0A           # U6 — MESI state vector violates invariant
+    TILELINK_USER_NONZERO = 0x0B    # U6 — reserved user[7:2] non-zero (v1.5)
+    SYSTOLIC_TIER_DOWNGRADE = 0x0C  # U7 — output tier downgraded (informational)
+    PATROL_PERIOD_NO_JITTER = 0x0D  # U8 — period configured without jitter
+    PATROL_VIOLATION = 0x0E         # U8 — patrol scrubber detected invariant break
+    ARBITER_STARVATION = 0x0F       # U9 — mandatory-channel source starved
+
+
+class ValidationSeverity(IntEnum):
+    """2-bit severity field on ValidationEvent (spec §2.2).
+
+    Distinct from is_advisory tag — severity hints intended handling;
+    is_advisory routes the event to the advisory channel regardless.
+    """
+    ADVISORY_ONLY = 0   # advisory channel only, no counter
+    LOG_COUNTER = 1     # log + counter increment
+    LOG_TRAP = 2        # log + raises trap (mandatory channel)
+    RESERVED = 3        # reserved for v2.0+
+
+
+@dataclass(frozen=True)
+class ValidationEvent:
+    """U9 Validation Bus message (spec §2.2).
+
+    Wire-level: 4-bit unit_id + 8-bit error_code + 2-bit severity + 1-bit
+    is_advisory + 32-bit payload = 47 bits transmitted per event.
+    """
+    unit_id: UnitId
+    error_code: ValidationErrorCode
+    severity: ValidationSeverity = ValidationSeverity.LOG_COUNTER
+    is_advisory: bool = False  # tag overrides severity for routing
+    payload: int = 0           # 32-bit error-specific (observed value, expected, etc.)
+
+    def routes_to_mandatory(self) -> bool:
+        """True iff this event raises a trap (mandatory channel + LOG_TRAP)."""
+        if self.is_advisory:
+            return False
+        return self.severity == ValidationSeverity.LOG_TRAP

--- a/orchid/layer-a/units/validation_bus.py
+++ b/orchid/layer-a/units/validation_bus.py
@@ -1,0 +1,197 @@
+"""U9 Validation Bus — mandatory + advisory channels (spec §2.2).
+
+Receives ValidationEvent messages from U1-U8 and routes them to one of two
+channels:
+
+- **Mandatory channel** — events with `severity=LOG_TRAP` and `is_advisory=False`.
+  Per-source FIFOs feed a round-robin arbiter; one event drained per `step()`
+  call. The arbiter is starvation-free: a busy source cannot block others.
+  Dispatched events invoke the optional `trap_callback`.
+
+- **Advisory channel** — everything else (LOG_COUNTER severity, or any event
+  with `is_advisory=True`). Counted in a per-(unit, error_code) matrix.
+  No trap; no arbitration; counter increment is synchronous on `submit()`.
+
+Both channels also write into the optional log buffer (P1 — disabled by
+default in v1.5.0; capacity controlled by `log_buffer_entries`).
+
+Routing decision is encapsulated in `ValidationEvent.routes_to_mandatory()`
+(see types.py), so changes to severity semantics happen in one place.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from units.types import UnitId, ValidationErrorCode, ValidationEvent
+
+
+TrapCallback = Callable[[ValidationEvent], None]
+
+
+# Source ordering on the bus (matches UnitId values 1..8). U9 is the
+# destination — it does not submit to itself.
+_SOURCE_ORDER: Tuple[UnitId, ...] = (
+    UnitId.U1,
+    UnitId.U2,
+    UnitId.U3,
+    UnitId.U4,
+    UnitId.U5,
+    UnitId.U6,
+    UnitId.U7,
+    UnitId.U8,
+)
+
+
+class ValidationBus:
+    """Per spec §2.2.
+
+    P0 in v1.5: mandatory channel (RR-arbitrated) + advisory channel
+    (counter matrix) + optional log buffer.
+    P1 deferred to v1.5.1: 256-entry log buffer was reserved in spec but
+    is enabled here via `log_buffer_entries` for advance prototyping.
+    """
+
+    def __init__(
+        self,
+        num_sources: int = 8,
+        log_buffer_entries: int = 0,
+        trap_callback: Optional[TrapCallback] = None,
+    ) -> None:
+        if num_sources != 8:
+            raise ValueError(
+                f"num_sources must be 8 in v1.5 (one per U1-U8); got {num_sources}. "
+                f"Wider source counts are a v2.0 conversation."
+            )
+        if log_buffer_entries < 0:
+            raise ValueError(
+                f"log_buffer_entries must be >= 0; got {log_buffer_entries}"
+            )
+
+        self._sources = _SOURCE_ORDER
+        self._mandatory_queues: Dict[UnitId, Deque[ValidationEvent]] = {
+            uid: deque() for uid in self._sources
+        }
+        self._rr_pointer: int = 0  # index into _sources
+
+        self._mandatory_counts: Dict[UnitId, int] = defaultdict(int)
+        self._advisory_counts: Dict[Tuple[UnitId, ValidationErrorCode], int] = defaultdict(int)
+
+        self._trap_callback = trap_callback
+        self._log_buffer: Optional[Deque[ValidationEvent]] = (
+            deque(maxlen=log_buffer_entries) if log_buffer_entries > 0 else None
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def submit(self, event: ValidationEvent) -> None:
+        """Accept an event from any source unit and route it to a channel.
+
+        Mandatory events go to a per-source FIFO and are drained by `step()`.
+        Advisory events increment a counter immediately and (if enabled)
+        land in the log buffer.
+        """
+        if event.routes_to_mandatory():
+            self._mandatory_queues[event.unit_id].append(event)
+        else:
+            self._advisory_counts[(event.unit_id, event.error_code)] += 1
+            if self._log_buffer is not None:
+                self._log_buffer.append(event)
+
+    def step(self) -> Optional[ValidationEvent]:
+        """Drain at most one mandatory event via RR arbitration.
+
+        Returns:
+            The drained event, or None if all per-source FIFOs are empty.
+
+        On drain: the per-source mandatory counter increments, the
+        `trap_callback` (if provided) is invoked, and the event lands in
+        the log buffer (if enabled). The RR pointer advances to the slot
+        AFTER the drained source, so the same source cannot saturate the
+        bus.
+        """
+        n = len(self._sources)
+        for offset in range(n):
+            idx = (self._rr_pointer + offset) % n
+            source = self._sources[idx]
+            queue = self._mandatory_queues[source]
+            if queue:
+                event = queue.popleft()
+                self._mandatory_counts[source] += 1
+                self._rr_pointer = (idx + 1) % n
+                if self._trap_callback is not None:
+                    self._trap_callback(event)
+                if self._log_buffer is not None:
+                    self._log_buffer.append(event)
+                return event
+        return None
+
+    def drain_all(self) -> List[ValidationEvent]:
+        """Drain every queued mandatory event via repeated `step()` calls.
+
+        Useful for tests that don't care about cycle-by-cycle RR behavior.
+        Returns the events in drain order.
+        """
+        drained: List[ValidationEvent] = []
+        while True:
+            event = self.step()
+            if event is None:
+                break
+            drained.append(event)
+        return drained
+
+    # ------------------------------------------------------------------
+    # Counters
+    # ------------------------------------------------------------------
+
+    def get_mandatory_count(self, unit_id: UnitId) -> int:
+        """Per-source mandatory event drain count."""
+        return self._mandatory_counts[unit_id]
+
+    def get_advisory_count(
+        self, unit_id: UnitId, error_code: ValidationErrorCode
+    ) -> int:
+        """Per-(unit, error_code) advisory event count."""
+        return self._advisory_counts[(unit_id, error_code)]
+
+    def total_mandatory_count(self) -> int:
+        """Sum across all sources."""
+        return sum(self._mandatory_counts.values())
+
+    def total_advisory_count(self) -> int:
+        """Sum across the entire (unit, error_code) matrix."""
+        return sum(self._advisory_counts.values())
+
+    # ------------------------------------------------------------------
+    # Queue inspection (for tests + diagnostics)
+    # ------------------------------------------------------------------
+
+    def queue_depth(self, unit_id: UnitId) -> int:
+        """Pending mandatory events from a given source."""
+        return len(self._mandatory_queues[unit_id])
+
+    def total_queued(self) -> int:
+        """Pending mandatory events across all sources."""
+        return sum(len(q) for q in self._mandatory_queues.values())
+
+    # ------------------------------------------------------------------
+    # Log buffer (P1)
+    # ------------------------------------------------------------------
+
+    def log_buffer_capacity(self) -> int:
+        """Buffer capacity (0 = disabled)."""
+        return self._log_buffer.maxlen if self._log_buffer is not None else 0
+
+    def log_buffer_size(self) -> int:
+        """Current buffer fill level."""
+        return len(self._log_buffer) if self._log_buffer is not None else 0
+
+    def log_buffer_snapshot(self) -> List[ValidationEvent]:
+        """Read-only snapshot of buffer contents (oldest first)."""
+        return list(self._log_buffer) if self._log_buffer is not None else []


### PR DESCRIPTION
## Summary

Lands **Track L of the [Orchid v1.5 implementation plan](https://github.com/Regevba/FitTracker2/blob/main/docs/superpowers/plans/2026-05-03-orchid-v1-5-additive-units.md)** — Layer A behavioral models for the v1.5 additive units. Per plan convention, Track L is bundled into a single PR after L8 rather than landing as 7 small PRs.

| Task | Module | Lines (code + test) | Commit |
|---|---|---|---|
| L1 | \`types.py\` extension (Tier, AssertionMode, UnitId, ValidationEvent) | 275 | \`91b8343\` |
| L2 | \`patrol_scrubber.py\` (U8 walk FSM + jitter) | 414 | \`7bf9c15\` |
| L3 | \`validation_bus.py\` (U9 mandatory + advisory + RR) | 458 | \`5cac7c4\` |
| L4 | \`tier_propagator.py\` (worst-case + dispatch + eviction) | 293 | \`f661060\` |
| L5 | \`orchestrator.py\` rewrite (U8/U9/tier wiring) | 414 | \`c0ddd2b\` |
| L6+L7 | \`synthetic_gen.py\` + \`trace_replayer.py\` (tier I/O) | 136 | \`f3333b5\` |
| **Total** | **6 commits, 7 task deliverables** | **1,990 LoC** | branch \`feature/orchid-v1-5-track-l\` |

## What this Track L provides

### Behavioral models for the v1.5 additive units

- **U8 Patrol Scrubber** (\`units/patrol_scrubber.py\`) — walk FSM (5 states), period counter, mandatory jitter, per-target invariant probe injection, validation event handshake.
- **U9 Validation Bus** (\`units/validation_bus.py\`) — per-source mandatory FIFOs + RR arbiter, advisory counter matrix, optional log buffer.
- **Tier propagation** (\`units/tier_propagator.py\`) — worst-case rule, dispatch threshold, eviction priority, U7 systolic specialization.
- **Type vocabulary** (\`units/types.py\` extension) — \`Tier\` (T1/T2/T3 wire encoding), \`AssertionMode\` (4-bit advisory→fatal flip), \`UnitId\` (1-9), \`ValidationErrorCode\` (15 codes from Appendix A), \`ValidationSeverity\`, \`ValidationEvent\` frozen dataclass.

### Integration

- \`orchestrator.py\` wires U8 + U9 + tier check into the existing v1 pipeline. Default constructor params keep v1 callers unaffected.
- \`synthetic_gen.py\` emits a \`tier\` column per trace row with configurable T1/T2/T3 distribution (default 60/30/10).
- \`trace_replayer.py\` parses tier with backward-compat fallback to T2.

## Tests

71 test functions across 5 files exercise spec §2.1, §2.2, §3, §5, §13, and Appendix A. Plus 7 v1 test modules continue to import cleanly (no regressions).

39 stdlib smoke assertions pass without pytest:
- L1 types: 11 assertions (wire encoding + ABI immutability + frozen invariant)
- L2 patrol scrubber: 13 assertions (jitter mandatory + FSM correctness + determinism)
- L3 validation bus: 22 assertions (channel routing + RR fairness + log buffer + matrix)
- L4 tier propagator: 20 assertions (propagation + dispatch + eviction + 0x01 advisory)
- L5 orchestrator: 10 assertions (v1 backward compat + clean trace + injected fault paths)
- L6 synthetic gen: 5 assertions (validation + distribution bounds + custom dist)
- L7 trace replayer: 4 assertions (tolerant parser + backward compat)

**Pytest formal pass remains gated on Chisel toolchain setup** (plan §"Risks" item 2). The v1 \`.venv\` was deleted during the 2026-05-01 HADF Phase 2 incident; restoring it is a separate task. Stdlib smoke covers the new code paths.

## End-to-end verification

\`\`\`
$ python3 -c "from synthetic_gen import generate_all; from trace_replayer import TraceReplayer; ..."
  end-to-end OK: 100 events replayed, composite=172413793.1067
\`\`\`

100-event tier-aware trace generated → replayed through orchestrator with U8 + U9 wired in → composite_score computed → zero advisory events at default permissive threshold.

## What's NOT in this PR

- **Track D** (tier-aware DSE re-run) — separate PR, separate branch.
- **Track R** (Layer B Chisel RTL Phases 6-9) — blocked at plan-design level on Phase 5 (v1 SoC integration) being green, which is itself blocked on Chisel toolchain setup. Track R PRs come later.
- **No \`pytest\` invocation in CI yet** — pytest is not in the v1 test infrastructure either; this Track L preserves that status quo.

## Spec + plan references

- Spec: \`docs/superpowers/specs/2026-05-03-orchid-v1-5-design.md\` §2.1, §2.2, §3, §5, §6, §8, §13, Appendix A
- Plan: \`docs/superpowers/plans/2026-05-03-orchid-v1-5-additive-units.md\` Track L (L1-L8)

## Test plan

- [ ] CI \`pm-framework/pr-integrity\` green
- [ ] No Swift/iOS files touched (Layer A is Python)
- [ ] No state.json touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)