### PR TITLE
chore(framework): backfill framework_version on 5 post-v6 features + ui-audit dates

### DIFF
--- a/.claude/features/dispatch-intelligence-v5.2/state.json
+++ b/.claude/features/dispatch-intelligence-v5.2/state.json
@@ -7,6 +7,7 @@
   "current_phase": "complete",
   "work_type": "feature",
   "work_subtype": "framework_infrastructure",
+  "framework_version": "v5.2",
   "has_ui": false,
   "requires_analytics": false,
   "parent_feature": null,

--- a/.claude/features/framework-measurement-v6/state.json
+++ b/.claude/features/framework-measurement-v6/state.json
@@ -7,6 +7,7 @@
   "branch": "feature/framework-measurement-v6",
   "current_phase": "complete",
   "work_type": "feature",
+  "framework_version": "v6.0",
   "has_ui": false,
   "requires_analytics": false,
   "github_issue_number": 81,

--- a/.claude/features/framework-story-site/state.json
+++ b/.claude/features/framework-story-site/state.json
@@ -5,6 +5,7 @@
   "branch": "main",
   "current_phase": "closed",
   "work_type": "feature",
+  "framework_version": "v6.0",
   "has_ui": true,
   "requires_analytics": false,
   "repo_scope": "new-external",

--- a/.claude/features/meta-analysis-audit/state.json
+++ b/.claude/features/meta-analysis-audit/state.json
@@ -4,7 +4,7 @@
   "case_study_showcase": "04-case-studies/13-full-system-audit.md",
   "display_name": "Meta-Analysis Full-System Audit",
   "work_type": "chore",
-  "framework_version": "v7.0",
+  "framework_version": "v6.0",
   "current_phase": "complete",
   "status": "complete",
   "created_at": "2026-04-16T00:00:00Z",

--- a/.claude/features/parallel-write-safety-v5.2/state.json
+++ b/.claude/features/parallel-write-safety-v5.2/state.json
@@ -7,6 +7,7 @@
   "current_phase": "complete",
   "work_type": "feature",
   "work_subtype": "framework_infrastructure",
+  "framework_version": "v5.2",
   "has_ui": false,
   "requires_analytics": false,
   "parent_feature": null,

--- a/.claude/features/ui-audit-baseline-burndown/state.json
+++ b/.claude/features/ui-audit-baseline-burndown/state.json
@@ -2,6 +2,8 @@
   "feature": "ui-audit-baseline-burndown",
   "type": "enhancement",
   "parent_feature": "design-system-v2",
+  "created_at": "2026-04-21T07:14:00Z",
+  "framework_version": "v7.1",
   "started": "2026-04-21",
   "current_phase": "complete",
   "status": "complete",


### PR DESCRIPTION
## Summary

Closes the **Tier 1.1 measurement-categorization gap** surfaced in the 2026-04-30 audit (Gap B in `memory: project_framework_gaps_audit_2026_04_30`). Post-v6 features were relying on a `created_at` date heuristic in `scripts/measurement-adoption-report.py` because the canonical `framework_version` field was missing on 4 features. Categorization wasn't auditable.

## Changes (6 files, 7 insertions, 1 modification)

| File | Change |
|---|---|
| `framework-story-site` | + `framework_version: "v6.0"` |
| `framework-measurement-v6` | + `framework_version: "v6.0"` |
| `parallel-write-safety-v5.2` | + `framework_version: "v5.2"` |
| `dispatch-intelligence-v5.2` | + `framework_version: "v5.2"` |
| `meta-analysis-audit` | `framework_version: "v7.0"` → `"v6.0"` (v7.0 isn't a real framework version) |
| `ui-audit-baseline-burndown` | + `created_at` + `framework_version: "v7.1"` (file used legacy `started` key only; the 2026-05-01 honesty-fixes migration missed it) |

## Semantic choices

- `parallel-write-safety` + `dispatch-intelligence` are **v5.2 features in spirit**; their state.json `created_at` is post-v6 only because the state.json itself was retroactively backfilled. `framework_version` reflects the actual framework era, not the file's mtime.
- `meta-analysis-audit` was created 2026-04-16 (v6.0 ship day) and pre-dates v7 entirely.
- `ui-audit-baseline-burndown` started 2026-04-21 (v7.1 ship day); `framework_version` reflects the framework rules in effect at start.

## Verification

- `python3 scripts/check-state-schema.py` → **47/47 pass**
- `make integrity-check` → **0 findings + 2 pre-existing advisories** (TIER_TAG_LIKELY_INCORRECT on the v7.7 case study, unrelated)
- `FRAMEWORK_VERSION_FORMAT` pre-commit gate accepts all new values

## Stops short of

Per the v7.8 anti-pattern #4 ("don't bundle schema migration with new gate in same PR"), this PR explicitly does **not** include:

1. Backfilling 33 pre-v6 features (separate PR — pre-v5.0 vs v5.0 boundary)
2. Promoting `CACHE_HITS_EMPTY_POST_V6` to use `framework_version` instead of `created_at` (separate gate-promotion PR)
3. Adding `framework_version` presence requirement (separate gate PR)

Each lands in its own PR in this 5-PR series.

## Test plan

- [ ] CI `pm-framework/pr-integrity` check stays green
- [ ] `Build and Test` workflow not affected (no Swift code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)