### PR TITLE
feat(framework-v7.8): PR-3 — Mechanism C wiring (T9 + T10 + T11 advisory)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -186,7 +186,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '## Active Features' && for f in .claude/features/*/state.json; do [ -f \"$f\" ] && echo \"- $(basename $(dirname $f)): phase=$(python3 -c \"import json,sys; print(json.load(open('$f'))['current_phase'])\" 2>/dev/null || echo 'unknown')\" ; done 2>/dev/null || echo '(none)'"
+            "command": "echo '## Active Features' && for f in .claude/features/*/state.json; do [ -f \"$f\" ] && echo \"- $(basename $(dirname $f)): phase=$(python3 -c \"import json,sys; print(json.load(open('$f'))['current_phase'])\" 2>/dev/null || echo 'unknown')\" ; done 2>/dev/null || echo '(none)'; if [ -f .claude/active-feature ]; then echo ''; echo \"## Active Feature (Mechanism C attribution): $(cat .claude/active-feature)\"; fi"
           }
         ]
       }

--- a/.claude/skills/pm-workflow/SKILL.md
+++ b/.claude/skills/pm-workflow/SKILL.md
@@ -565,14 +565,19 @@ The key invariant: in full isolation, the shared layer is NEVER read between cha
    - If yes: resume from `current_phase`
    - If no: create the directory and initialize state.json from the schema below
 
-2. Read the current state and announce: "Feature **$0** — currently in Phase {N}: {name}. Here's what needs to happen next."
+2. **Write the active-feature lockfile** (v7.8 Mechanism C wiring): write `$0` to `.claude/active-feature`. The PostToolUse:Read hook (`scripts/observe-cache-hit.py`) reads this file to attribute auto-collected cache events to the correct feature in `.claude/logs/_session-<id>.events.jsonl`. Without it, session events accumulate with empty `active_feature` strings and the v7.9 attribution-based gates won't see them.
+   ```bash
+   echo "$0" > .claude/active-feature
+   ```
 
-3. **GitHub Issue sync check:**
+3. Read the current state and announce: "Feature **$0** — currently in Phase {N}: {name}. Here's what needs to happen next."
+
+4. **GitHub Issue sync check:**
    - If `github_issue_number` is set in state.json: verify the issue exists and check its `phase:*` label
    - If no `github_issue_number`: search GitHub Issues for this feature by title. If found, store the number. If not found, offer to create one.
    - If state.json `current_phase` doesn't match the GitHub Issue's `phase:*` label: ask the user which source is correct and reconcile (see Conflict Resolution in Dashboard Sync Automation)
 
-4. If the user says "Move to {phase}" or "Roll back to {phase}": execute the Manual Override procedure (see Dashboard Sync Automation) instead of the normal phase workflow.
+5. If the user says "Move to {phase}" or "Roll back to {phase}": execute the Manual Override procedure (see Dashboard Sync Automation) instead of the normal phase workflow.
 
 ## State Initialization
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Carthage/Build/
 !.claude/logs/
 !.claude/logs/**
 .claude/logs/_session-*.events.jsonl
+.claude/active-feature
 !.claude/entrypoints/
 !.claude/entrypoints/**
 !.claude/settings.json

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -364,6 +364,75 @@ _DATE_WRITTEN_PAT = re.compile(
 _TIER_TAG_PAT = re.compile(r"\bT[123]\b[\s—:.\)\(]")
 
 
+def check_cache_hits_auto_instrumentation_inactive() -> list[dict]:
+    """Advisory: features with attributed Read events but empty cache_hits[].
+
+    v7.8 Mechanism C wiring (T11 — bridge design §4.3, item 6). The
+    PostToolUse:Read hook (`scripts/observe-cache-hit.py`) appends Read
+    events to `.claude/logs/_session-<id>.events.jsonl` tagged with the
+    `.claude/active-feature` lockfile value. This advisory aggregates
+    those attributions and flags features where session events show Reads
+    but `state.json::cache_hits[]` is empty — an early warning that
+    Mechanism C's auto-collection isn't propagating to state.json (which
+    is what v7.9 will promote to enforced via the dual-write contract).
+
+    Severity: ADVISORY only — doesn't affect exit code or finding_count.
+    Silent on a fresh install with no session events yet.
+    """
+    findings: list[dict] = []
+    logs_dir = REPO_ROOT / ".claude" / "logs"
+    features_dir = REPO_ROOT / ".claude" / "features"
+    if not logs_dir.exists() or not features_dir.exists():
+        return findings
+
+    reads_by_feature: dict[str, int] = {}
+    for ledger in logs_dir.glob("_session-*.events.jsonl"):
+        try:
+            text = ledger.read_text()
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("tool_name") != "Read":
+                continue
+            feature = (event.get("active_feature") or "").strip()
+            if not feature:
+                continue
+            reads_by_feature[feature] = reads_by_feature.get(feature, 0) + 1
+
+    for feature, count in sorted(reads_by_feature.items()):
+        state_path = features_dir / feature / "state.json"
+        if not state_path.exists():
+            continue
+        try:
+            state = json.loads(state_path.read_text())
+        except json.JSONDecodeError:
+            continue
+        cache_hits = state.get("cache_hits")
+        if isinstance(cache_hits, list) and len(cache_hits) > 0:
+            continue
+        findings.append({
+            "feature": feature,
+            "severity": "ADVISORY",
+            "code": "CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE",
+            "message": (
+                f"{feature}: session ledgers attribute {count} Read "
+                f"event(s) to this feature, but state.json::cache_hits[] "
+                f"is empty/absent. v7.8 Mechanism C captures session "
+                f"events; state.json::cache_hits requires manual "
+                f"scripts/log-cache-hit.py until v7.9 promotes "
+                f"observe-cache-hit.py to dual-write. See bridge design "
+                f"§4.3 + .claude/active-feature lockfile."
+            ),
+        })
+    return findings
+
+
 def check_tier_tags_advisory() -> list[dict]:
     """Run validate-tier-tags.py; emit findings as ADVISORY (not failure).
 
@@ -481,10 +550,14 @@ def build_snapshot(snapshot_trigger: str) -> dict:
     findings.extend(audit_case_study_tier_tags())
 
     # v7.7 M3 T18: advisory tier-tag correctness heuristic (14th check code).
-    # Advisory findings are included in findings[] for observability, but are
-    # NOT counted in finding_count so they don't trigger regression detection
-    # or non-zero exit. Promotion to gating at +7d T20 review.
-    advisory_findings = check_tier_tags_advisory()
+    # v7.8 M2 PR-3 T11: advisory cache_hits auto-instrumentation early-warning
+    # (15th check code). Both are ADVISORY severity — included in findings[]
+    # for observability but NOT counted in finding_count (preserves regression
+    # detection / exit code).
+    advisory_findings = (
+        check_tier_tags_advisory()
+        + check_cache_hits_auto_instrumentation_inactive()
+    )
     all_findings = findings + advisory_findings
 
     non_advisory_count = len(findings)

--- a/scripts/set-active-feature.sh
+++ b/scripts/set-active-feature.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Set the active feature for Mechanism C cache-event attribution.
+#
+# Writes <feature-name> to .claude/active-feature so observe-cache-hit.py
+# (the PostToolUse:Read hook) tags subsequent Read events with the right
+# feature in .claude/logs/_session-<id>.events.jsonl.
+#
+# /pm-workflow writes this lockfile automatically on entry. Use this
+# script when working outside /pm-workflow (ad-hoc edits, debugging,
+# investigating a non-feature task that should still attribute its
+# Reads to a particular feature for the v7.9 measurement window).
+#
+# The lockfile is gitignored (per-clone, per-developer). To clear:
+#   ./scripts/set-active-feature.sh --clear
+#
+# Per docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md §4.3.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+lockfile="$repo_root/.claude/active-feature"
+
+if [[ "${1:-}" == "--clear" ]]; then
+    rm -f "$lockfile"
+    echo "Cleared active feature."
+    exit 0
+fi
+
+if [[ $# -lt 1 ]]; then
+    if [[ -f "$lockfile" ]]; then
+        echo "Active feature: $(cat "$lockfile")"
+    else
+        echo "No active feature set."
+    fi
+    echo ""
+    echo "Usage: $0 <feature-name>"
+    echo "       $0 --clear"
+    exit 0
+fi
+
+feature="$1"
+feature_dir="$repo_root/.claude/features/$feature"
+
+if [[ ! -d "$feature_dir" ]]; then
+    echo "Warning: .claude/features/$feature/ does not exist." >&2
+    echo "Setting anyway — the lockfile is just a string; cache events will" >&2
+    echo "attribute to '$feature' regardless." >&2
+fi
+
+mkdir -p "$repo_root/.claude"
+echo "$feature" > "$lockfile"
+echo "Active feature set: $feature"
+echo "(.claude/active-feature lockfile written)"


### PR DESCRIPTION
## Summary

Closes the **active-feature attribution gap** left by v7.8 PR-1 (#173). #173 shipped the `PostToolUse:Read` hook + `scripts/observe-cache-hit.py`, but nothing was writing the `.claude/active-feature` lockfile that the script reads for attribution. Result: every observed Read landed in the session ledger with `active_feature=""` — auto-collection captured tool calls, but feature attribution was 0%.

Per [`docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`](docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md) §4.3 + §7.1 M2 PR-3 — **T7 + T8 done in #173, T9 + T10 + T11 done here.**

## What's in the PR

### T10 — `/pm-workflow` writes `.claude/active-feature` on entry

`.claude/skills/pm-workflow/SKILL.md` adds Step 2 to the Setup section:

```bash
echo "$0" > .claude/active-feature
```

Subsequent PostToolUse:Read hooks now attribute to the right feature automatically while a /pm-workflow session is active.

### T9 — SessionStart hook surfaces the active feature

`.claude/settings.json`: SessionStart hook command extended with a conditional that reads `.claude/active-feature` (if present) and prints:

> ## Active Feature (Mechanism C attribution): `<name>`

So a fresh agent session knows which feature its Reads will attribute to. No-op when the lockfile is absent.

### T11 — `CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE` advisory

New `check_cache_hits_auto_instrumentation_inactive()` in `scripts/integrity-check.py` aggregates Read events from `.claude/logs/_session-*.events.jsonl` by `active_feature`, then emits an ADVISORY finding for any feature where the session ledger shows ≥1 attributed Read but `state.json::cache_hits[]` is empty/absent.

- **15th cycle-time check code** (advisory, mirrors v7.7's TIER_TAG_LIKELY_INCORRECT pattern)
- Does not affect exit code or `finding_count`
- Silent on a fresh install with no session events

### Plus

- **`scripts/set-active-feature.sh`** — small CLI helper for setting the lockfile manually (useful outside the /pm-workflow flow). Validates feature dir exists; supports `--clear`.
- **`.gitignore`** — adds `.claude/active-feature` (per-developer state, not committed evidence; same pattern as `.claude/logs/_session-*.events.jsonl`).

## Verification

```
$ make integrity-check  → 0 findings + 2 pre-existing advisories
$ # synthetic ledger entry for `settings` (no cache_hits[]):
$ #   → Found new ADVISORY: CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE
$ ./scripts/set-active-feature.sh smart-reminders → lockfile written
$ ./scripts/set-active-feature.sh --clear → lockfile removed
$ # SessionStart hook smoke test → "Active Feature ..." line
$ # surfaces only when lockfile present
```

## What this is NOT

- **Not v7.9's dual-write contract.** `observe-cache-hit.py` still only writes the session ledger. Promotion to also call `scripts/log-cache-hit.py` lands in v7.9.
- **Not enforced.** T11 is ADVISORY only. The early-warning fires when the hook captures Reads but state.json drifts.

## How this fits the v7.8 sequence

| Bridge milestone | PR | Status |
|---|---|---|
| M1 PR-1 | #173 | merged (Mechanism C scaffolding + dual-read fix) |
| M1 PR-1 §8.2 | #185 + #186 | open (framework_version backfill) |
| M1 PR-2 | #187 | open (Mechanism A coverage gates) |
| **M2 PR-3** | **this PR** | **open (Mechanism C T9/T10/T11)** |
| M2 PR-4 | _next_ | _Mechanism E merge driver_ |

## Test plan

- [ ] CI `pm-framework/pr-integrity` check stays green
- [ ] `Build and Test` not affected (no Swift changes)
- [ ] Synthetic session-event smoke test fires the new advisory

🤖 Generated with [Claude Code](https://claude.com/claude-code)