### PR TITLE
feat(framework-v7.8): PR-4 — Mechanism E git merge driver for ledgers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Custom merge drivers (v7.8 Mechanism E — bridge design §4.5)
+#
+# Append-only ledgers use union-dedup-by-key to resolve cross-branch /
+# cross-worktree conflicts automatically. Install the driver in this
+# clone with: make install-hooks (or directly: scripts/install-merge-drivers.sh).
+#
+# Without the driver installed, these files fall back to git's default
+# 3-way merge (which produces conflict markers requiring manual resolution
+# — that's the failure mode HADF Phase 2 surfaced).
+.claude/shared/measurement-adoption-history.json merge=union-dedup-by-key
+.claude/shared/documentation-debt.json merge=union-dedup-by-key

--- a/Makefile
+++ b/Makefile
@@ -145,12 +145,15 @@ runtime-smoke:
 	python3 scripts/runtime-smoke-gate.py --profile "$(PROFILE)" --mode "$(MODE)" $(if $(XCODE_CONFIGURATION),--configuration "$(XCODE_CONFIGURATION)",) $(if $(filter 1,$(DRY_RUN)),--dry-run,)
 
 # Install git hooks into .git/hooks/ by pointing core.hooksPath at .githooks/.
-# Idempotent — run after clone to activate the pre-commit schema check.
+# Also installs custom merge drivers (v7.8 Mechanism E) so append-only
+# ledger conflicts auto-resolve via union-dedup-by-key.
+# Idempotent — run after clone to activate both layers.
 install-hooks:
 	git config core.hooksPath .githooks
 	@echo "Git hooks installed (core.hooksPath = .githooks)."
 	@echo "Pre-commit will reject state.json files with legacy \`phase\` key."
 	@echo "Emergency bypass: git commit --no-verify"
+	@bash scripts/install-merge-drivers.sh
 
 # Install npm dependencies (style-dictionary)
 install:

--- a/scripts/install-merge-drivers.sh
+++ b/scripts/install-merge-drivers.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Install custom git merge drivers for v7.8 Mechanism E.
+#
+# Registers the `union-dedup-by-key` driver in this clone's git config.
+# Files that opt in via .gitattributes (the merge=union-dedup-by-key
+# attribute) will use the driver instead of git's default 3-way merge,
+# resolving append-only ledger conflicts via union-dedup.
+#
+# Per docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md §4.5.
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+driver_script="scripts/merge-driver-dedup.py"
+
+if [[ ! -x "$repo_root/$driver_script" ]]; then
+    echo "Error: $driver_script not found or not executable at $repo_root" >&2
+    exit 1
+fi
+
+git -C "$repo_root" config merge.union-dedup-by-key.name \
+    "Union-dedup ledger merger (v7.8 Mechanism E)"
+git -C "$repo_root" config merge.union-dedup-by-key.driver \
+    "$driver_script %O %A %B %P"
+
+echo "✓ merge-driver-dedup installed in $repo_root/.git/config"
+
+if [[ -f "$repo_root/.gitattributes" ]]; then
+    registered="$(grep -E 'merge=union-dedup-by-key' "$repo_root/.gitattributes" \
+        | awk '{print $1}' | tr '\n' ' ')"
+    if [[ -n "$registered" ]]; then
+        echo "  Registered ledgers: $registered"
+    else
+        echo "  (no .gitattributes entries opt in yet — see bridge design §4.5)"
+    fi
+fi

--- a/scripts/merge-driver-dedup.py
+++ b/scripts/merge-driver-dedup.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Custom git merge driver: union-dedup-by-key for append-only ledgers.
+
+v7.8 Mechanism E (bridge design §4.5). Resolves merge conflicts on
+append-only ledgers like .claude/shared/measurement-adoption-history.json
+and .claude/shared/documentation-debt.json by computing the union of a
+configured array field, deduplicating by a stable key, and sorting.
+
+Why a custom driver:
+  - Both ledgers accumulate dated/ID'd snapshots from concurrent worktrees
+    (HADF Phase 2 demonstrated the failure mode — two unattended jobs
+    appended snapshots on different days, git's default merge produced
+    conflict markers requiring manual resolution).
+  - Union-dedup is the semantically correct merge for these files: every
+    append is an independent observation, never a destructive overwrite.
+  - Custom driver adds zero new dependencies (vs CRDT / Automerge).
+  - Held in reserve for v7.9 promotion to a CRDT layer if observed
+    collisions in v7.8 measurement window justify the upgrade.
+
+Git invocation contract (per git-merge-driver(7)):
+  %O = ancestor's version (we ignore — pure union-dedup is more robust
+       than 3-way for append-only ledgers; ancestor is a subset of both
+       sides by construction).
+  %A = "ours" (current branch's version) — also the OUTPUT path; git
+       expects the merge result written back here.
+  %B = "theirs" (other branch's version).
+  %P = real pathname (used to look up which ledger config applies).
+
+Exit codes:
+  0 = success, %A contains merged result.
+  1 = registered path but parse / structural error → git surfaces a
+      conflict and the user resolves manually. Safer than silently
+      clobbering malformed data.
+  2 = usage error (wrong arg count).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+# Registry: relative-path suffix → merge config.
+# Add new ledgers here as they accumulate with the union-dedup pattern.
+LEDGER_CONFIG = {
+    ".claude/shared/measurement-adoption-history.json": {
+        "array": "snapshots",
+        "key": "date",
+    },
+    ".claude/shared/documentation-debt.json": {
+        "array": "debt_items",
+        "key": "id",
+    },
+}
+
+
+def _config_for(path: str) -> dict | None:
+    """Look up the merge config for `path` by suffix match.
+
+    Git passes %P as a repo-relative path; we accept either form.
+    Returns None (caller bails to git's default conflict markers) if
+    the path isn't registered.
+    """
+    for registered_suffix, cfg in LEDGER_CONFIG.items():
+        if path.endswith(registered_suffix):
+            return cfg
+    return None
+
+
+def merge(
+    path_ancestor: str,
+    path_ours: str,
+    path_theirs: str,
+    path_real: str,
+) -> int:
+    cfg = _config_for(path_real)
+    if cfg is None:
+        print(
+            f"merge-driver-dedup: {path_real} is not registered in "
+            f"LEDGER_CONFIG; falling through to git default conflict resolution",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        ours = json.loads(Path(path_ours).read_text())
+        theirs = json.loads(Path(path_theirs).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(
+            f"merge-driver-dedup: parse error on {path_real}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    array_name = cfg["array"]
+    key_name = cfg["key"]
+
+    ours_arr = ours.get(array_name) or []
+    theirs_arr = theirs.get(array_name) or []
+    if not isinstance(ours_arr, list) or not isinstance(theirs_arr, list):
+        print(
+            f"merge-driver-dedup: {array_name} is not a list in both inputs "
+            f"on {path_real}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Union by key. On collision: theirs wins (last writer wins by branch
+    # ordering convention; in practice the weekly cron is the authoritative
+    # writer and dominates either way). Items missing the dedup key are
+    # silently dropped — they're malformed entries that shouldn't survive
+    # the merge.
+    by_key: dict[str, dict] = {}
+    for item in ours_arr + theirs_arr:
+        if not isinstance(item, dict):
+            continue
+        k = item.get(key_name)
+        if k is None:
+            continue
+        by_key[k] = item
+
+    merged_arr = sorted(
+        by_key.values(),
+        key=lambda x: str(x.get(key_name, "")),
+    )
+
+    # Take ours' structural base (preserves top-level fields like
+    # `version`, `description`, `updated`), replace the array.
+    merged = dict(ours)
+    merged[array_name] = merged_arr
+
+    # Per git contract: write the merged result back to %A (path_ours).
+    # Trailing newline matches the existing files' convention.
+    Path(path_ours).write_text(json.dumps(merged, indent=2) + "\n")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 5:
+        print(f"usage: {sys.argv[0]} %O %A %B %P", file=sys.stderr)
+        return 2
+    return merge(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_merge_driver_dedup.py
+++ b/scripts/tests/test_merge_driver_dedup.py
@@ -1,0 +1,232 @@
+"""Tests for scripts/merge-driver-dedup.py (v7.8 Mechanism E).
+
+Covers union-dedup merge of append-only ledgers:
+  - .claude/shared/measurement-adoption-history.json (snapshots[], dedup by date)
+  - .claude/shared/documentation-debt.json (debt_items[], dedup by id)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "merge_driver_dedup",
+    SCRIPTS_DIR / "merge-driver-dedup.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+merge = _mod.merge
+_config_for = _mod._config_for
+LEDGER_CONFIG = _mod.LEDGER_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# T1 — config lookup by path suffix
+# ---------------------------------------------------------------------------
+
+def test_config_for_adoption_history():
+    cfg = _config_for(".claude/shared/measurement-adoption-history.json")
+    assert cfg == {"array": "snapshots", "key": "date"}
+
+
+def test_config_for_documentation_debt():
+    cfg = _config_for(".claude/shared/documentation-debt.json")
+    assert cfg == {"array": "debt_items", "key": "id"}
+
+
+def test_config_for_absolute_path_works():
+    cfg = _config_for(
+        "/Volumes/DevSSD/FitTracker2/.claude/shared/measurement-adoption-history.json"
+    )
+    assert cfg is not None
+    assert cfg["array"] == "snapshots"
+
+
+def test_config_for_unregistered_returns_none():
+    assert _config_for("docs/something.md") is None
+    assert _config_for(".claude/shared/random.json") is None
+
+
+# ---------------------------------------------------------------------------
+# T2 — union-dedup merge correctness
+# ---------------------------------------------------------------------------
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _make_files(tmp_path: Path, ours: dict, theirs: dict, real_path: str):
+    """Create the four temp files git would pass in. Returns argv tuple."""
+    p_o = tmp_path / "ancestor.json"
+    p_a = tmp_path / "ours.json"  # also the OUTPUT path
+    p_b = tmp_path / "theirs.json"
+    _write(p_o, {})  # ancestor unused — driver ignores %O
+    _write(p_a, ours)
+    _write(p_b, theirs)
+    return str(p_o), str(p_a), str(p_b), real_path
+
+
+def test_disjoint_snapshots_merge_to_union(tmp_path):
+    """No overlapping dates → result is union of both, sorted."""
+    ours = {
+        "version": "1.0",
+        "snapshots": [
+            {"date": "2026-04-25", "summary": {"total": 42}},
+        ],
+    }
+    theirs = {
+        "version": "1.0",
+        "snapshots": [
+            {"date": "2026-04-27", "summary": {"total": 43}},
+        ],
+    }
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/measurement-adoption-history.json",
+    )
+    rc = merge(*args)
+    assert rc == 0
+    result = json.loads(Path(args[1]).read_text())
+    dates = [s["date"] for s in result["snapshots"]]
+    assert dates == ["2026-04-25", "2026-04-27"]
+
+
+def test_overlapping_dates_dedup_theirs_wins(tmp_path):
+    """Same date in both → theirs wins (later writer convention)."""
+    ours = {
+        "snapshots": [
+            {"date": "2026-04-25", "summary": {"source": "ours"}},
+        ],
+    }
+    theirs = {
+        "snapshots": [
+            {"date": "2026-04-25", "summary": {"source": "theirs"}},
+            {"date": "2026-04-27", "summary": {"source": "theirs"}},
+        ],
+    }
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/measurement-adoption-history.json",
+    )
+    assert merge(*args) == 0
+    result = json.loads(Path(args[1]).read_text())
+    by_date = {s["date"]: s for s in result["snapshots"]}
+    assert by_date["2026-04-25"]["summary"]["source"] == "theirs"
+    assert len(result["snapshots"]) == 2
+
+
+def test_top_level_fields_preserved_from_ours(tmp_path):
+    """version / description / updated come from `ours` structurally."""
+    ours = {
+        "version": "1.0",
+        "description": "Append-only daily snapshots",
+        "snapshots": [{"date": "2026-04-25"}],
+    }
+    theirs = {
+        "version": "0.9",  # would be wrong — should NOT win
+        "snapshots": [{"date": "2026-04-27"}],
+    }
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/measurement-adoption-history.json",
+    )
+    assert merge(*args) == 0
+    result = json.loads(Path(args[1]).read_text())
+    assert result["version"] == "1.0"  # ours' top-level wins
+    assert result["description"] == "Append-only daily snapshots"
+    assert len(result["snapshots"]) == 2
+
+
+def test_documentation_debt_dedup_by_id(tmp_path):
+    """debt_items merge by `id`, theirs wins on collision."""
+    ours = {
+        "debt_items": [
+            {"id": "date_written", "count": 6},
+            {"id": "old_only", "count": 1},
+        ],
+    }
+    theirs = {
+        "debt_items": [
+            {"id": "date_written", "count": 5},  # newer count
+            {"id": "new_only", "count": 2},
+        ],
+    }
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/documentation-debt.json",
+    )
+    assert merge(*args) == 0
+    result = json.loads(Path(args[1]).read_text())
+    by_id = {x["id"]: x for x in result["debt_items"]}
+    assert by_id["date_written"]["count"] == 5  # theirs won
+    assert "old_only" in by_id
+    assert "new_only" in by_id
+    assert len(result["debt_items"]) == 3
+
+
+def test_missing_array_treated_as_empty(tmp_path):
+    """One side without the array → other side's entries pass through."""
+    ours = {"version": "1.0"}
+    theirs = {"snapshots": [{"date": "2026-04-25"}]}
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/measurement-adoption-history.json",
+    )
+    assert merge(*args) == 0
+    result = json.loads(Path(args[1]).read_text())
+    assert len(result["snapshots"]) == 1
+
+
+def test_items_missing_dedup_key_dropped(tmp_path):
+    """Malformed item (no `date`) is silently dropped."""
+    ours = {"snapshots": [{"date": "2026-04-25"}, {"summary": "no date"}]}
+    theirs = {"snapshots": []}
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/measurement-adoption-history.json",
+    )
+    assert merge(*args) == 0
+    result = json.loads(Path(args[1]).read_text())
+    assert len(result["snapshots"]) == 1
+    assert result["snapshots"][0]["date"] == "2026-04-25"
+
+
+# ---------------------------------------------------------------------------
+# T3 — error handling
+# ---------------------------------------------------------------------------
+
+def test_unregistered_path_returns_1_for_git_fallback(tmp_path):
+    args = _make_files(tmp_path, {}, {}, "docs/random.json")
+    assert merge(*args) == 1
+
+
+def test_invalid_json_returns_1(tmp_path):
+    p_o = tmp_path / "o.json"
+    p_a = tmp_path / "a.json"
+    p_b = tmp_path / "b.json"
+    p_o.write_text("{}")
+    p_a.write_text("{not valid json")
+    p_b.write_text("{}")
+    rc = merge(
+        str(p_o), str(p_a), str(p_b),
+        ".claude/shared/documentation-debt.json",
+    )
+    assert rc == 1
+
+
+def test_array_not_list_returns_1(tmp_path):
+    ours = {"snapshots": "not-a-list"}
+    theirs = {"snapshots": []}
+    args = _make_files(
+        tmp_path, ours, theirs,
+        ".claude/shared/measurement-adoption-history.json",
+    )
+    assert merge(*args) == 1


### PR DESCRIPTION
## Summary

Custom git merge driver (`union-dedup-by-key`) **auto-resolves merge conflicts on append-only ledgers** via union-dedup. Eliminates the manual-intervention failure mode HADF Phase 2 surfaced — two unattended fingerprint jobs appended snapshots from concurrent worktrees, git's default 3-way merge produced conflict markers.

Per [`docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`](docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md) §4.5 + §7.1 M2 PR-4 (T12 + T13 + T14).

## What's in the PR

### T12 — `scripts/merge-driver-dedup.py` (~140 lines)

- Registry maps path suffixes → `{array, dedup_key}` config:
  - `.claude/shared/measurement-adoption-history.json` → `snapshots[]` by `date`
  - `.claude/shared/documentation-debt.json` → `debt_items[]` by `id`
- Reads `%A` (ours) and `%B` (theirs); **ignores `%O`** — pure union-dedup is more robust than 3-way for append-only files (ancestor is a subset of both sides by construction).
- Computes union, dedups by key, sorts, writes back to `%A`.
- **Collision policy:** theirs wins (last-writer-wins). In practice the weekly cron is the authoritative writer either way.
- Items missing the dedup key are silently dropped (malformed entries shouldn't survive the merge).
- Top-level fields (`version` / `description` / `updated`) preserved from ours' structural base.
- Returns **1 (not 2)** on parse / config errors so git falls back to standard conflict markers — safer than silently clobbering data.

### T13 — `.gitattributes` (NEW)

Registers the driver for the two ledgers:

```
.claude/shared/measurement-adoption-history.json merge=union-dedup-by-key
.claude/shared/documentation-debt.json merge=union-dedup-by-key
```

### T14 — `make install-hooks` extension

- New `scripts/install-merge-drivers.sh`: idempotent registration of `merge.union-dedup-by-key.driver` in this clone's git config.
- `Makefile install-hooks` target invokes it after installing pre-commit hooks. **One command (`make install-hooks`) sets up both layers post-clone.**

### Tests — `scripts/tests/test_merge_driver_dedup.py` (~210 lines, 13 tests)

| # | What |
|---|---|
| T1.1–T1.4 | Config lookup by suffix (relative + absolute paths, unregistered) |
| T2.1 | Disjoint snapshots merge to union |
| T2.2 | Overlapping dates dedup, theirs wins |
| T2.3 | Top-level fields preserved from ours |
| T2.4 | Documentation-debt dedup by `id` |
| T2.5 | Missing array on one side treated as empty |
| T2.6 | Items missing dedup key dropped silently |
| T3.1–T3.3 | Error paths (unregistered, invalid JSON, array not list) |

## Verification

```
$ pytest scripts/tests/test_merge_driver_dedup.py → 13 passed
$ ./scripts/install-merge-drivers.sh
  → ✓ merge-driver-dedup installed in .git/config
  → Registered ledgers: …measurement-adoption-history.json …documentation-debt.json
$ make integrity-check → 0 findings + 2 pre-existing advisories
```

**End-to-end smoke test** (throwaway repo, ledger-aware merge):

```
$ # Two branches each add a unique snapshot date to the ledger.
$ git merge --no-edit branch1
  Merge made by the 'ort' strategy.
$ cat .claude/shared/measurement-adoption-history.json
  {
    "version": "1.0",
    "snapshots": [
      { "date": "2026-04-25", … },  ← from common ancestor
      { "date": "2026-04-26", … },  ← from branch1
      { "date": "2026-04-27", … }   ← from main
    ]
  }
```

No conflict markers. All 3 dates merged automatically, sorted.

## What this is NOT

- **Not Automerge / CRDT.** The bridge design holds those in reserve for v7.9 if a collision is observed in v7.8's measurement window. For files with natural dedup keys, git's 3-way merge with a custom driver is sufficient + zero new dependencies.
- **Not retroactive.** Driver only activates when both branches diverge on a registered ledger AND both clones have run `make install-hooks`. Without the driver installed, git falls back to standard conflict markers (documented).

## How this fits the v7.8 sequence

| Bridge milestone | PR | Status |
|---|---|---|
| M1 PR-1 | #173 | merged (Mechanism C scaffolding + dual-read) |
| M1 PR-1 §8.2 | #185 + #186 | open (framework_version backfill) |
| M1 PR-2 | #187 | open (Mechanism A coverage gates) |
| M2 PR-3 | #188 | open (Mechanism C wiring T9/T10/T11) |
| **M2 PR-4** | **this PR** | **open (Mechanism E merge driver)** |
| M3 PR-5 / PR-6 | _pending_ | _schema bridge fields + Mechanism F membrane status_ |

## Test plan

- [ ] CI `pm-framework/pr-integrity` check stays green
- [ ] `Build and Test` not affected (no Swift changes)
- [ ] After merge: `make install-hooks` activates the driver in each developer's clone
- [ ] Future cron writes to either ledger from concurrent worktrees auto-resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)