### PR TITLE
feat(smart-reminders): behavioral learning PR 1 — iOS data layer + toggle-off (backend deferred)

### DIFF
--- a/.claude/features/smart-reminders-behavioral-learning/research/open-questions.md
+++ b/.claude/features/smart-reminders-behavioral-learning/research/open-questions.md
@@ -80,3 +80,123 @@ Until these are filled in, the feature stays in `current_phase: research`.
 ## Recommended next step
 
 Bring OQ-1 through OQ-5 to the user via brainstorming (`/superpowers:brainstorming` or equivalent) and lock decisions before any code lands.
+
+---
+
+## Decisions locked 2026-04-30 (brainstorm session — paused mid-flow)
+
+> Session paused after OQ-5 lock; sequencing approach (A/B/C), design sections, spec doc, and writing-plans
+> all still pending. Resume by re-loading the brainstorming skill and picking up at "Approach A / B / C".
+
+### OQ-1 → β (SR-17 + SR-18)
+
+V1 scope: data-collection layer (SR-17, already in parent PRD P2) **plus** timing-automation layer
+(SR-18, also in parent PRD P2). Matches parent PRD's Phase 3 rollout sequence: ship data collection,
+then automation. Picked over α (SR-17 alone) and γ (SR-17 + non-PRD automation) because β ships visible
+behaviour change and can be A/B-measured immediately, while α requires a follow-up release for the
+visible win.
+
+**Constraint surfaced during brainstorm:** Of the six ReminderTypes, only **three are realistic
+personalisation targets**:
+
+| Type | Lifetime cap | Verdict |
+|---|---|---|
+| HealthKit Connect | 3 lifetime | ❌ never enough data |
+| Account Registration | 3 lifetime | ❌ never enough data |
+| Engagement | 3 per lapse, sparse | ❌ bursty + thin |
+| **Nutrition Gap** | 5/week | ✅ ~20+ obs in 30 days |
+| **Training Day** | 1/day | ✅ ~12 obs in 30 days |
+| **Rest Day** | 1/day | ✅ ~10 obs in 30 days |
+
+The other three keep their static defaults. SR-18 in v1 = adaptive timing for {Nutrition Gap,
+Training Day, Rest Day} only.
+
+### OQ-2 → (b) Bayesian update with static-default prior
+
+Always personalise; no count-threshold cliff. The per-user posterior is weighted by observation count
+vs the population prior. The "prior" is the existing static fire time per type (4 PM nutrition,
+10 AM training, etc.) — already in code, no bootstrap needed. Below ~5 observations, posterior is
+indistinguishable from the static default; behaviour drifts smoothly toward personal as observations
+accumulate. Picked over (a) hard count threshold (cliff effect) and (c) time + count hybrid (defeats
+the purpose for users with fast data accumulation).
+
+### OQ-3 → (3) Hybrid (cohort prior server-side + posterior on-device) + backend implementation task
+
+Server-side prior comes from existing Supabase `cohort_stats` table + `increment_cohort_frequency` RPC
+(migrations 000001-000003), which AI engine already writes to via service-key. On-device posterior
+update lives in a new Swift store (likely `BehavioralLearningStore` next to `ReminderScheduler`).
+**No new Supabase table needed** — the existing schema (`segment` / `field_name` / `field_value` /
+`frequency`) is generic enough to fit the new reminder cohort signal. Backend scope:
+
+- Reuse existing `cohort_stats` table with new segment values like `reminders.tap_through.<type>`,
+  field_name = hour-of-day bucket (00–23).
+- Add a **read RPC** (read path doesn't exist today; existing infrastructure is write-only on the
+  client side via service-key).
+- Add an **AI-engine writer hook** so each `reminder_shown` / `reminder_tapped` event also emits an
+  anonymised cohort write (via the existing `increment_cohort_frequency` path).
+- Extend the existing pg_cron retention job (migration 000004) to cover the new segment values.
+
+Picked over (1) pure on-device (slower learning, no cross-user signal benefit) and (2) pure server-side
+(violates parent PRD's existing GDPR commitment "all trigger evaluation and scheduling is fully
+local"). Hybrid splits the responsibilities cleanly: prior is shared, posterior + decision-making
+stays local.
+
+### OQ-4 → (d) Global toggle + per-type "Why?" affordance
+
+In Settings → Notifications, one global "Smart timing" toggle alongside the existing per-type
+enable/disable toggles. **On by default.** Off = revert to static fire times for all three
+personalisable types. **Plus** a per-type "Why this time?" affordance (per-type row shows the
+current send time; tap opens an `AIIntelligenceSheet`-style explanation panel: "Currently sending
+around 17:30. Shifted from 16:00 because you tap more often after 17:00."). Reuses the existing
+AI-Coaching `AIIntelligenceSheet` pattern. Picked over (a) no UI (fails GDPR Article 22 on automated
+decision-making), (b) no transparency (toggle without explanation), and (c) per-type toggles
+(over-promises since 3 of 6 types don't personalise).
+
+### OQ-5 → (c) Aggregate-primary + per-type kill, with flexible readout window
+
+| Metric | Target | Kill threshold |
+|---|---|---|
+| Aggregate tap-through lift (treatment − control) | **≥ +5 pp** at p < 0.05 | < +0 pp at end of window |
+| Per-type regression (treatment − control, per personalised type) | (n/a — composite kill) | **< −3 pp** on any single personalised type → per-type rollback to static |
+| Dismiss-rate change | flat or down | > +5 pp from baseline (advisory) |
+| Disable-rate change | flat or down | > +3 pp (advisory; parent PRD already kills at +25 pp/month) |
+
+**Readout window: 14 ± 4 days** (10–18 day floor / ceiling) per user, flexible to absorb non-uniform
+sample accumulation rates. Earliest readout: day 10 (when per-user observation count crosses Bayesian
+saturation point). Latest readout: day 18 (cap to prevent indefinite waiting). **Plus a post-population
+aggregation later** — once corpus volume supports stable per-segment baselines, run a meta-analysis
+across users to produce robust per-cohort priors. Picked over (a) aggregate-only (per-type regressions
+hidden by average), (b) per-type lift (slower readout, higher sample-size requirement per type), and
+(d) full composite (rigorous but likely under-calls wins).
+
+### OQ-6 → resolved by PR #158 merge
+
+PR #158 (the six lifecycle analytics events) merged 2026-04-30. The signal feeding this feature is
+live on main. No remaining dependency.
+
+---
+
+## Still open at session pause
+
+1. **Sequencing approach (A / B / C)** — proposed in last brainstorm message:
+   - **A: Big-bang** — single PR ships everything (SR-17 + SR-18 + Settings UI + "Why?" sheet +
+     Supabase migration + AI-engine writer hook + retention extension), ~15-20 files / ~1,500 LOC.
+   - **B: Staged (recommended)** — three PRs:
+     - PR 1: SR-17 data layer + Settings toggle (defaults off) + Supabase + AI-engine hook (zero
+       user impact, validates write path).
+     - PR 2: SR-18 timing automation (toggle defaults on, A/B begins).
+     - PR 3: "Why?" sheet + per-type transparency UI.
+   - **C: Vertical slice** — full stack but Nutrition Gap only in v1; expand in follow-up PR.
+2. **Design sections** — architecture / components / data flow / error handling / testing — to be
+   presented and approved one section at a time.
+3. **Spec doc** at `docs/superpowers/specs/2026-04-30-smart-reminders-behavioral-learning-design.md`
+   — not yet drafted.
+4. **Spec self-review** + user review.
+5. **Writing-plans skill invocation** — terminal step of brainstorming, produces the implementation
+   plan.
+
+## How to resume
+
+Re-load the brainstorming skill (`/superpowers:brainstorming` or `Skill superpowers:brainstorming`),
+re-read this section, and pick a sequencing approach (A / B / C). After that, the design sections,
+spec doc, and plan can proceed without re-asking the locked questions.

--- a/.claude/features/smart-reminders-behavioral-learning/research/open-questions.md
+++ b/.claude/features/smart-reminders-behavioral-learning/research/open-questions.md
@@ -1,0 +1,82 @@
+# Smart Reminders — Behavioral Learning Layer (research / open questions)
+
+> **Status:** Research phase started 2026-04-29. No design decisions locked.
+> Brainstorming with user required before PRD.
+
+## Context
+
+The parent feature `smart-reminders` (shipped 2026-04-16, PR #98) ships six reminder types with hardcoded frequency caps, fixed quiet hours (22:00–07:00), and a fixed minimum interval (4h). The case study explicitly defers a behavioral-learning sub-feature: *"Future sub-task: behavioral learning layer"*. PR #158 (currently in flight) adds the six lifecycle events that are the input signal this feature would consume.
+
+This file captures the scope decisions that must be made before a PRD can be written. Each section is an open question — no decisions are pre-baked here.
+
+## OQ-1 — What does "behavioral learning" actually adapt?
+
+Three candidates, ordered by ambition:
+
+1. **Per-user quiet hours.** Today the window is 22:00–07:00 for everyone. A user who logs meals at 23:30 every night is treated as if they're asleep. The feature could shift the window per-user based on observed app-open / log-event distribution.
+2. **Per-type frequency caps.** Today the per-type daily cap is 1 across all types. A user who taps every nutrition reminder but never taps engagement reminders would benefit from more nutrition pings and fewer (or zero) engagement pings.
+3. **Per-type send time.** Today nutrition gap fires at 4 PM and training reminder at 10 AM. A user whose lunch tap-through rate is 80% at 12:30 and 5% at 14:00 would benefit from a per-user send time, not a global one.
+
+Lock at least one. Ambition can stack but each adds verification difficulty.
+
+## OQ-2 — What's the minimum signal volume before adapting?
+
+The per-type tap-through events from PR #158 land in GA4. The behavioral layer needs a copy on-device (no network round-trip per send decision). Question: how many shown/tapped/dismissed events per type before we trust the per-user signal?
+
+- Industry baseline: most adaptive notification systems wait for 7–14 days of observations before personalizing.
+- FitMe-specific: nutrition gap fires at most 5/week per the cap, so 14 days = at most 10 observations. That's very thin.
+- Decision: stick with the population default until the per-user posterior has N observations? Or weight a Bayesian update that always has the population as the prior?
+
+Lock the threshold (or the model), and lock how it's stored (UserDefaults? On-device CoreData? Encrypted blob?).
+
+## OQ-3 — Is this on-device, server-side, or hybrid?
+
+Three architectural shapes:
+
+1. **Pure on-device.** Everything runs in `ReminderTriggers.swift` extensions; observations stay on the device. No network. Privacy-clean. Slower learning (single user signal).
+2. **Server-side cohort intelligence.** Aggregate observations across users via `AIOrchestrator` cohort intelligence. Per-user pulls a "people like you tap nutrition gap at 12:00" suggestion. Faster learning. Requires backend work + privacy review.
+3. **Hybrid.** Population prior comes from server, posterior updates happen on-device. Best of both. More complex.
+
+Lock the shape before any code lands.
+
+## OQ-4 — What's the disable / opt-out path?
+
+Today the user can disable a reminder type entirely from Settings (writes to `NotificationPreferencesStore`). The behavioral layer adds a new dimension: the timing / frequency. Should the user see "Smart timing on/off" in Settings? Or is it always-on with the population default + per-user adjustment, no UI surface?
+
+Lock UI footprint (if any) before design.
+
+## OQ-5 — How do we measure success?
+
+The parent feature's PRD primary metric is `tap-through ≥ 25% across all types`. The behavioral layer's hypothesis is *adaptive timing lifts the rate further*. Success means an A/B test where:
+
+- Control group keeps the static timing.
+- Treatment group gets adaptive timing.
+- After 30 days, treatment's tap-through rate is X% higher than control's at p < 0.05.
+
+Lock the X (5%? 10%? 20%?) and the kill criterion (e.g. *treatment tap-through is statistically lower or equal at 30 days* → kill).
+
+## OQ-6 — What's the dependency on PR #158?
+
+PR #158 adds the six lifecycle events. The behavioral layer needs:
+
+- `reminder_shown` per type (denominator)
+- `reminder_tapped` per type (numerator → tap-through rate)
+- `reminder_dismissed` per type (signal of annoyance)
+- Optional: `reminder_suppressed` reasons (signal that the user "would have wanted" but the cap/quiet-hour blocked)
+
+These have to land first. Mark this feature as blocked-on-PR-#158 in state.json.
+
+## Research deliverables (to produce after brainstorming)
+
+1. **PRD** at `docs/product/prd/smart-reminders-behavioral-learning.md` with the OQ-1..5 decisions locked.
+2. **Tasks list** at `.claude/features/smart-reminders-behavioral-learning/tasks.md`.
+3. **UX spec** if OQ-4 lands a Settings surface.
+4. **Success metrics** populated in `state.json` per the v7.7 forward-only doc-debt rule.
+5. **Kill criteria** populated in `state.json`.
+6. **Dispatch pattern** chosen (likely `serial` for a single-author sub-feature).
+
+Until these are filled in, the feature stays in `current_phase: research`.
+
+## Recommended next step
+
+Bring OQ-1 through OQ-5 to the user via brainstorming (`/superpowers:brainstorming` or equivalent) and lock decisions before any code lands.

--- a/.claude/features/smart-reminders-behavioral-learning/state.json
+++ b/.claude/features/smart-reminders-behavioral-learning/state.json
@@ -5,11 +5,11 @@
   "case_study": "docs/case-studies/smart-reminders-behavioral-learning-case-study.md",
   "work_type": "feature",
   "framework_version": "v7.7",
-  "current_phase": "tasks",
+  "current_phase": "implementation",
   "status": "in_progress",
   "created": "2026-04-29T18:55:00Z",
   "created_at": "2026-04-29T18:55:00Z",
-  "updated": "2026-05-03T06:08:40Z",
+  "updated": "2026-05-03T12:55:34Z",
   "branch": "feature/smart-reminders-behavioral-learning",
   "parent_feature": "smart-reminders",
   "predecessor_features": [
@@ -42,14 +42,17 @@
       "status": "not_started"
     },
     "tasks": {
-      "status": "in_progress",
-      "started_at": "2026-05-03T06:08:40Z"
+      "status": "complete",
+      "started_at": "2026-05-03T06:08:40Z",
+      "ended_at": "2026-05-03T12:55:34Z"
     },
     "ux_or_integration": {
       "status": "not_started"
     },
     "implementation": {
-      "status": "not_started"
+      "status": "in_progress",
+      "started_at": "2026-05-03T12:55:34Z",
+      "note": "PR-1 iOS data layer complete: T1-T5 + T9-T13 shipped (10 commits, 23 tests pass, BUILD SUCCEEDED, UI audit P0=0). Backend Tasks 6/7/8 (AI-engine endpoints + Supabase migration) deferred \u2014 blocked on ai-engine venv setup + supabase MCP/CLI auth. Tracked as known_followups for the next session."
     },
     "test": {
       "status": "not_started"
@@ -79,6 +82,12 @@
       },
       "tasks": {
         "started_at": "2026-05-03T06:08:40Z",
+        "ended_at": "2026-05-03T12:55:34Z",
+        "duration_minutes": null,
+        "paused_minutes": 0
+      },
+      "implementation": {
+        "started_at": "2026-05-03T12:55:34Z",
         "ended_at": null,
         "duration_minutes": null,
         "paused_minutes": 0
@@ -117,5 +126,25 @@
       "note": "Discovered existing Supabase cohort_stats table + increment_cohort_frequency RPC (migrations 000001-000003) used by AI engine for cohort intelligence. OQ-3 'hybrid backend' shrinks from 'new schema + new endpoint' to 'reuse table with new segment values + +1 read RPC + AI-engine writer hook'."
     }
   ],
-  "notes": "Brainstorm session 2026-04-30 locked OQ-1..OQ-5: (1) v1 scope = SR-17 data layer + SR-18 timing automation; (2) Bayesian update with static-default fire-time prior, no count-threshold cliff; (3) hybrid architecture - server cohort prior via existing Supabase cohort_stats + on-device per-user posterior + new backend writer hook + retention extension; (4) single global 'Smart timing' toggle in Settings -> Notifications (on by default) PLUS per-type 'Why this time?' affordance reusing AIIntelligenceSheet pattern; (5) success metric = aggregate tap-through lift >= +5 pp at p < 0.05 with per-type kill at -3 pp; readout window 14 +/- 4 days flexible per-user, plus post-population aggregation later for stable per-segment baselines. Constraint surfaced during brainstorm: only 3 of 6 ReminderTypes are personalisable (Nutrition Gap, Training Day, Rest Day); HealthKit/Account/Engagement keep static defaults due to lifetime caps. Approach A/B/C sequencing pick still open at session pause; design sections + spec doc + writing-plans not yet done. Resume by reading research/open-questions.md 'Decisions locked 2026-04-30' section."
+  "notes": "Brainstorm session 2026-04-30 locked OQ-1..OQ-5: (1) v1 scope = SR-17 data layer + SR-18 timing automation; (2) Bayesian update with static-default fire-time prior, no count-threshold cliff; (3) hybrid architecture - server cohort prior via existing Supabase cohort_stats + on-device per-user posterior + new backend writer hook + retention extension; (4) single global 'Smart timing' toggle in Settings -> Notifications (on by default) PLUS per-type 'Why this time?' affordance reusing AIIntelligenceSheet pattern; (5) success metric = aggregate tap-through lift >= +5 pp at p < 0.05 with per-type kill at -3 pp; readout window 14 +/- 4 days flexible per-user, plus post-population aggregation later for stable per-segment baselines. Constraint surfaced during brainstorm: only 3 of 6 ReminderTypes are personalisable (Nutrition Gap, Training Day, Rest Day); HealthKit/Account/Engagement keep static defaults due to lifetime caps. Approach A/B/C sequencing pick still open at session pause; design sections + spec doc + writing-plans not yet done. Resume by reading research/open-questions.md 'Decisions locked 2026-04-30' section.",
+  "known_followups": [
+    {
+      "id": "pr1-T6",
+      "title": "AI engine POST /reminder-cohort-event endpoint + pytest",
+      "status": "deferred",
+      "reason": "ai-engine .venv not set up on this machine; pip install pytest required"
+    },
+    {
+      "id": "pr1-T7",
+      "title": "AI engine GET /reminder-cohort-priors endpoint + pytest",
+      "status": "deferred",
+      "reason": "same as T6"
+    },
+    {
+      "id": "pr1-T8",
+      "title": "Supabase migration 000009 \u2014 extend pg_cron retention to reminders.* segments",
+      "status": "deferred",
+      "reason": "supabase MCP server disconnected this session; needs reauth or local supabase CLI"
+    }
+  ]
 }

--- a/.claude/features/smart-reminders-behavioral-learning/state.json
+++ b/.claude/features/smart-reminders-behavioral-learning/state.json
@@ -9,24 +9,33 @@
   "status": "in_progress",
   "created": "2026-04-29T18:55:00Z",
   "created_at": "2026-04-29T18:55:00Z",
-  "updated": "2026-04-29T18:55:00Z",
+  "updated": "2026-04-30T00:00:00Z",
   "branch": "feature/smart-reminders-behavioral-learning",
   "parent_feature": "smart-reminders",
   "predecessor_features": [
     "smart-reminders"
   ],
   "depends_on": [
-    "PR #158 — six lifecycle analytics events shipped (must merge first; behavioral learning consumes the per-type tap-through signal)"
+    "PR #158 — six lifecycle analytics events (MERGED 2026-04-30; ready)",
+    "Existing Supabase cohort_stats table + increment_cohort_frequency RPC (migrations 000001-000003); new read RPC + segment values to be added by this feature"
   ],
-  "success_metrics": null,
-  "kill_criteria": null,
-  "dispatch_pattern": null,
+  "success_metrics": [
+    "Aggregate tap-through (treatment vs control) lifts by >= +5 pp at p < 0.05 over the per-user readout window (14 days +/- 4)",
+    "Post-population aggregation (later, once corpus volume supports stable per-segment baselines) confirms the per-user signal at the cohort level",
+    "Of the three personalisable types (Nutrition Gap, Training Day, Rest Day) none regresses below its static-baseline tap-through by >= -3 pp"
+  ],
+  "kill_criteria": [
+    "Aggregate tap-through lift < +0 pp at end of per-user readout window AND post-population aggregate also fails",
+    "Any single personalised type regresses by >= -3 pp vs its static baseline -> per-type rollback to static fire time",
+    "Disable rate increases >= +3 pp from baseline OR dismiss rate increases >= +5 pp from baseline (advisory composite, parent PRD already gates disable rate at +25 pp/month)"
+  ],
+  "dispatch_pattern": "serial",
   "phases": {
     "research": {
       "status": "in_progress",
       "started_at": "2026-04-29T18:55:00Z",
       "skipped_reason": null,
-      "note": "Open questions documented in research/open-questions.md. Awaiting user brainstorming to lock scope before PRD."
+      "note": "Brainstorm session 2026-04-30 locked OQ-1 through OQ-5; sequencing approach (A/B/C) + design sections still open. See research/open-questions.md 'Decisions locked 2026-04-30' section for the full lock record."
     },
     "prd": {
       "status": "not_started"
@@ -78,6 +87,27 @@
     "total": 2.15,
     "tier_class": "B_medium"
   },
-  "cache_hits": [],
-  "notes": "Scaffolded 2026-04-29 to track the deferred behavioral-learning sub-feature flagged by the smart-reminders parent feature ('Future sub-task: behavioral learning layer'). Research phase explicitly captures open questions rather than pre-baked decisions; brainstorming with user required before PRD. CU v2 estimate is provisional — will be revisited at PRD lock."
+  "cache_hits": [
+    {
+      "timestamp": "2026-04-30T00:00:00Z",
+      "level": "L1",
+      "key": "smart_reminders_prd_phase_3_sequencing",
+      "type": "applied",
+      "skill": "brainstorming",
+      "event_type": "research_checkpoint",
+      "phase": "research",
+      "note": "Reused the parent PRD's existing Phase 3 wording ('SR-17 data collection only, no UI; begin collecting data for SR-18') as the OQ-1 frame, narrowing the brainstorm from generic 'what does it adapt' to a concrete pick between SR-17 alone, SR-17+SR-18, or SR-17 + non-PRD automation."
+    },
+    {
+      "timestamp": "2026-04-30T00:05:00Z",
+      "level": "L2",
+      "key": "supabase_cohort_stats_existing_table",
+      "type": "adapted",
+      "skill": "brainstorming",
+      "event_type": "research_checkpoint",
+      "phase": "research",
+      "note": "Discovered existing Supabase cohort_stats table + increment_cohort_frequency RPC (migrations 000001-000003) used by AI engine for cohort intelligence. OQ-3 'hybrid backend' shrinks from 'new schema + new endpoint' to 'reuse table with new segment values + +1 read RPC + AI-engine writer hook'."
+    }
+  ],
+  "notes": "Brainstorm session 2026-04-30 locked OQ-1..OQ-5: (1) v1 scope = SR-17 data layer + SR-18 timing automation; (2) Bayesian update with static-default fire-time prior, no count-threshold cliff; (3) hybrid architecture - server cohort prior via existing Supabase cohort_stats + on-device per-user posterior + new backend writer hook + retention extension; (4) single global 'Smart timing' toggle in Settings -> Notifications (on by default) PLUS per-type 'Why this time?' affordance reusing AIIntelligenceSheet pattern; (5) success metric = aggregate tap-through lift >= +5 pp at p < 0.05 with per-type kill at -3 pp; readout window 14 +/- 4 days flexible per-user, plus post-population aggregation later for stable per-segment baselines. Constraint surfaced during brainstorm: only 3 of 6 ReminderTypes are personalisable (Nutrition Gap, Training Day, Rest Day); HealthKit/Account/Engagement keep static defaults due to lifetime caps. Approach A/B/C sequencing pick still open at session pause; design sections + spec doc + writing-plans not yet done. Resume by reading research/open-questions.md 'Decisions locked 2026-04-30' section."
 }

--- a/.claude/features/smart-reminders-behavioral-learning/state.json
+++ b/.claude/features/smart-reminders-behavioral-learning/state.json
@@ -1,0 +1,83 @@
+{
+  "feature": "smart-reminders-behavioral-learning",
+  "feature_name": "smart-reminders-behavioral-learning",
+  "display_name": "Smart Reminders — Behavioral Learning Layer",
+  "case_study": "docs/case-studies/smart-reminders-behavioral-learning-case-study.md",
+  "work_type": "feature",
+  "framework_version": "7.7",
+  "current_phase": "research",
+  "status": "in_progress",
+  "created": "2026-04-29T18:55:00Z",
+  "created_at": "2026-04-29T18:55:00Z",
+  "updated": "2026-04-29T18:55:00Z",
+  "branch": "feature/smart-reminders-behavioral-learning",
+  "parent_feature": "smart-reminders",
+  "predecessor_features": [
+    "smart-reminders"
+  ],
+  "depends_on": [
+    "PR #158 — six lifecycle analytics events shipped (must merge first; behavioral learning consumes the per-type tap-through signal)"
+  ],
+  "success_metrics": null,
+  "kill_criteria": null,
+  "dispatch_pattern": null,
+  "phases": {
+    "research": {
+      "status": "in_progress",
+      "started_at": "2026-04-29T18:55:00Z",
+      "skipped_reason": null,
+      "note": "Open questions documented in research/open-questions.md. Awaiting user brainstorming to lock scope before PRD."
+    },
+    "prd": {
+      "status": "not_started"
+    },
+    "tasks": {
+      "status": "not_started"
+    },
+    "ux_or_integration": {
+      "status": "not_started"
+    },
+    "implementation": {
+      "status": "not_started"
+    },
+    "test": {
+      "status": "not_started"
+    },
+    "review": {
+      "status": "not_started"
+    },
+    "merge": {
+      "status": "not_started",
+      "pr_number": null
+    },
+    "documentation": {
+      "status": "not_started"
+    },
+    "complete": {
+      "status": "not_started"
+    }
+  },
+  "timing": {
+    "session_start": "2026-04-29T18:55:00Z",
+    "phases": {
+      "research": {
+        "started_at": "2026-04-29T18:55:00Z",
+        "ended_at": null,
+        "duration_minutes": null,
+        "paused_minutes": 0
+      }
+    }
+  },
+  "cu_v2": {
+    "factors": {
+      "complexity": 0.65,
+      "blast_radius": 0.4,
+      "novelty": 0.55,
+      "verification_difficulty": 0.55
+    },
+    "total": 2.15,
+    "tier_class": "B_medium"
+  },
+  "cache_hits": [],
+  "notes": "Scaffolded 2026-04-29 to track the deferred behavioral-learning sub-feature flagged by the smart-reminders parent feature ('Future sub-task: behavioral learning layer'). Research phase explicitly captures open questions rather than pre-baked decisions; brainstorming with user required before PRD. CU v2 estimate is provisional — will be revisited at PRD lock."
+}

--- a/.claude/features/smart-reminders-behavioral-learning/state.json
+++ b/.claude/features/smart-reminders-behavioral-learning/state.json
@@ -1,22 +1,22 @@
 {
   "feature": "smart-reminders-behavioral-learning",
   "feature_name": "smart-reminders-behavioral-learning",
-  "display_name": "Smart Reminders — Behavioral Learning Layer",
+  "display_name": "Smart Reminders \u2014 Behavioral Learning Layer",
   "case_study": "docs/case-studies/smart-reminders-behavioral-learning-case-study.md",
   "work_type": "feature",
-  "framework_version": "7.7",
-  "current_phase": "research",
+  "framework_version": "v7.7",
+  "current_phase": "tasks",
   "status": "in_progress",
   "created": "2026-04-29T18:55:00Z",
   "created_at": "2026-04-29T18:55:00Z",
-  "updated": "2026-04-30T00:00:00Z",
+  "updated": "2026-05-03T06:08:40Z",
   "branch": "feature/smart-reminders-behavioral-learning",
   "parent_feature": "smart-reminders",
   "predecessor_features": [
     "smart-reminders"
   ],
   "depends_on": [
-    "PR #158 — six lifecycle analytics events (MERGED 2026-04-30; ready)",
+    "PR #158 \u2014 six lifecycle analytics events (MERGED 2026-04-30; ready)",
     "Existing Supabase cohort_stats table + increment_cohort_frequency RPC (migrations 000001-000003); new read RPC + segment values to be added by this feature"
   ],
   "success_metrics": [
@@ -32,16 +32,18 @@
   "dispatch_pattern": "serial",
   "phases": {
     "research": {
-      "status": "in_progress",
+      "status": "complete",
       "started_at": "2026-04-29T18:55:00Z",
       "skipped_reason": null,
-      "note": "Brainstorm session 2026-04-30 locked OQ-1 through OQ-5; sequencing approach (A/B/C) + design sections still open. See research/open-questions.md 'Decisions locked 2026-04-30' section for the full lock record."
+      "note": "Brainstorm session 2026-04-30 locked OQ-1 through OQ-5; sequencing approach (A/B/C) + design sections still open. See research/open-questions.md 'Decisions locked 2026-04-30' section for the full lock record.",
+      "ended_at": "2026-05-03T06:08:40Z"
     },
     "prd": {
       "status": "not_started"
     },
     "tasks": {
-      "status": "not_started"
+      "status": "in_progress",
+      "started_at": "2026-05-03T06:08:40Z"
     },
     "ux_or_integration": {
       "status": "not_started"
@@ -71,6 +73,12 @@
     "phases": {
       "research": {
         "started_at": "2026-04-29T18:55:00Z",
+        "ended_at": "2026-05-03T06:08:40Z",
+        "duration_minutes": null,
+        "paused_minutes": 0
+      },
+      "tasks": {
+        "started_at": "2026-05-03T06:08:40Z",
         "ended_at": null,
         "duration_minutes": null,
         "paused_minutes": 0

--- a/.claude/logs/smart-reminders-behavioral-learning.log.json
+++ b/.claude/logs/smart-reminders-behavioral-learning.log.json
@@ -6,13 +6,24 @@
   "current_phase": "research",
   "framework_version": "7.7",
   "started_at": "2026-04-29T15:52:34Z",
-  "updated_at": "2026-04-29T15:52:34Z",
+  "updated_at": "2026-04-30T13:20:14Z",
   "events": [
     {
       "timestamp": "2026-04-29T15:52:34Z",
       "event_type": "phase_started",
       "phase": "research",
       "summary": "Behavioral learning sub-feature scaffolded 2026-04-29: state.json + research/open-questions.md document 6 open questions (OQ-1 OQ-6). Brainstorming with user required before PRD.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-04-30T13:20:14Z",
+      "event_type": "research_checkpoint",
+      "phase": "research",
+      "summary": "Brainstorm session 2026-04-30 paused after locking OQ-1 through OQ-5. State.json populated with success_metrics + kill_criteria + dispatch_pattern. Sequencing approach (A/B/C), design sections, spec doc, and writing-plans still pending. See research/open-questions.md 'Decisions locked 2026-04-30' section for the full lock record.",
       "artifacts": [],
       "metrics": {},
       "actor": "human_or_agent",

--- a/.claude/logs/smart-reminders-behavioral-learning.log.json
+++ b/.claude/logs/smart-reminders-behavioral-learning.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "smart-reminders-behavioral-learning",
+  "title": "smart reminders behavioral learning",
+  "work_type": "feature",
+  "current_phase": "research",
+  "framework_version": "7.7",
+  "started_at": "2026-04-29T15:52:34Z",
+  "updated_at": "2026-04-29T15:52:34Z",
+  "events": [
+    {
+      "timestamp": "2026-04-29T15:52:34Z",
+      "event_type": "phase_started",
+      "phase": "research",
+      "summary": "Behavioral learning sub-feature scaffolded 2026-04-29: state.json + research/open-questions.md document 6 open questions (OQ-1 OQ-6). Brainstorming with user required before PRD.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/.claude/logs/smart-reminders-behavioral-learning.log.json
+++ b/.claude/logs/smart-reminders-behavioral-learning.log.json
@@ -6,7 +6,7 @@
   "current_phase": "research",
   "framework_version": "7.7",
   "started_at": "2026-04-29T15:52:34Z",
-  "updated_at": "2026-05-03T06:08:40Z",
+  "updated_at": "2026-05-03T12:55:34Z",
   "events": [
     {
       "timestamp": "2026-04-29T15:52:34Z",
@@ -35,6 +35,17 @@
       "event_type": "phase_started",
       "phase": "tasks",
       "summary": "Tasks phase started 2026-05-03. Spec at docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md. Plan at docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md (15 tasks).",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-03T12:55:34Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "iOS PR-1 data layer complete: T1-T5 (state.json + ReminderType + 3 new services) + T9-T12 (delegate wiring + app bootstrap + GDPR extension + Settings toggle) + T13 (full test pass: 23/23 + UI audit P0=0). Backend T6/T7/T8 deferred \u2014 tracked in known_followups.",
       "artifacts": [],
       "metrics": {},
       "actor": "human_or_agent",

--- a/.claude/logs/smart-reminders-behavioral-learning.log.json
+++ b/.claude/logs/smart-reminders-behavioral-learning.log.json
@@ -6,7 +6,7 @@
   "current_phase": "research",
   "framework_version": "7.7",
   "started_at": "2026-04-29T15:52:34Z",
-  "updated_at": "2026-04-30T13:20:14Z",
+  "updated_at": "2026-05-03T06:08:40Z",
   "events": [
     {
       "timestamp": "2026-04-29T15:52:34Z",
@@ -24,6 +24,17 @@
       "event_type": "research_checkpoint",
       "phase": "research",
       "summary": "Brainstorm session 2026-04-30 paused after locking OQ-1 through OQ-5. State.json populated with success_metrics + kill_criteria + dispatch_pattern. Sequencing approach (A/B/C), design sections, spec doc, and writing-plans still pending. See research/open-questions.md 'Decisions locked 2026-04-30' section for the full lock record.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-03T06:08:40Z",
+      "event_type": "phase_started",
+      "phase": "tasks",
+      "summary": "Tasks phase started 2026-05-03. Spec at docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md. Plan at docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md (15 tasks).",
       "artifacts": [],
       "metrics": {},
       "actor": "human_or_agent",

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -244,6 +244,8 @@
 		BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */; };
 		CC1000001000000000000001 /* CohortPriorClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000001000000000000001 /* CohortPriorClient.swift */; };
 		CC100000000000000000AT01 /* CohortPriorClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200000000000000000AT01 /* CohortPriorClientTests.swift */; };
+		CP1000001000000000000001 /* CohortPriorCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = CP2000001000000000000001 /* CohortPriorCache.swift */; };
+		CP100000000000000000AT01 /* CohortPriorCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CP200000000000000000AT01 /* CohortPriorCacheTests.swift */; };
 		IM100000000000000000AA01 /* ImportParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA01 /* ImportParser.swift */; };
 		IM100000000000000000AA02 /* ExerciseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA02 /* ExerciseMapper.swift */; };
 		IM100000000000000000AA03 /* ImportOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA03 /* ImportOrchestrator.swift */; };
@@ -485,6 +487,8 @@
 		BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStoreTests.swift; sourceTree = "<group>"; };
 		CC2000001000000000000001 /* CohortPriorClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohortPriorClient.swift; sourceTree = "<group>"; };
 		CC200000000000000000AT01 /* CohortPriorClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohortPriorClientTests.swift; sourceTree = "<group>"; };
+		CP2000001000000000000001 /* CohortPriorCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohortPriorCache.swift; sourceTree = "<group>"; };
+		CP200000000000000000AT01 /* CohortPriorCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohortPriorCacheTests.swift; sourceTree = "<group>"; };
 		NP200000000000000000VW01 /* NotificationPermissionPrimingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionPrimingView.swift; sourceTree = "<group>"; };
 		IT200000000000000000TS01 /* ImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportTests.swift; sourceTree = "<group>"; };
 		CFG000000000000000000001 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -738,6 +742,7 @@
 				RM2000001000000000000004 /* ReminderNotificationDelegate.swift */,
 				BL2000001000000000000001 /* BehavioralLearningStore.swift */,
 				CC2000001000000000000001 /* CohortPriorClient.swift */,
+				CP2000001000000000000001 /* CohortPriorCache.swift */,
 			);
 			path = Reminders;
 			sourceTree = "<group>";
@@ -985,6 +990,7 @@
 				RA200000000000000000AT01 /* ReminderAnalyticsTests.swift */,
 				BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */,
 				CC200000000000000000AT01 /* CohortPriorClientTests.swift */,
+				CP200000000000000000AT01 /* CohortPriorCacheTests.swift */,
 				OB200000000000000000AT01 /* OfflineBehaviourTests.swift */,
 				OR200000000000000000AT01 /* AIOrchestratorTests.swift */,
 				VR200000000000000000AT01 /* ValidatedRecommendationTests.swift */,
@@ -1421,6 +1427,7 @@
 				RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */,
 				BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */,
 				CC1000001000000000000001 /* CohortPriorClient.swift in Sources */,
+				CP1000001000000000000001 /* CohortPriorCache.swift in Sources */,
 				NT1000001000000000000001 /* NotificationService.swift in Sources */,
 				NT1000001000000000000002 /* NotificationPreferencesStore.swift in Sources */,
 				NT1000001000000000000003 /* NotificationContentBuilder.swift in Sources */,
@@ -1471,6 +1478,7 @@
 				RA100000000000000000AT01 /* ReminderAnalyticsTests.swift in Sources */,
 				BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */,
 				CC100000000000000000AT01 /* CohortPriorClientTests.swift in Sources */,
+				CP100000000000000000AT01 /* CohortPriorCacheTests.swift in Sources */,
 				OB100000000000000000AT01 /* OfflineBehaviourTests.swift in Sources */,
 				OR100000000000000000AT01 /* AIOrchestratorTests.swift in Sources */,
 				VR100000000000000000AT01 /* ValidatedRecommendationTests.swift in Sources */,

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -242,6 +242,8 @@
 		RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000004 /* ReminderNotificationDelegate.swift */; };
 		BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL2000001000000000000001 /* BehavioralLearningStore.swift */; };
 		BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */; };
+		CC1000001000000000000001 /* CohortPriorClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000001000000000000001 /* CohortPriorClient.swift */; };
+		CC100000000000000000AT01 /* CohortPriorClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC200000000000000000AT01 /* CohortPriorClientTests.swift */; };
 		IM100000000000000000AA01 /* ImportParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA01 /* ImportParser.swift */; };
 		IM100000000000000000AA02 /* ExerciseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA02 /* ExerciseMapper.swift */; };
 		IM100000000000000000AA03 /* ImportOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA03 /* ImportOrchestrator.swift */; };
@@ -481,6 +483,8 @@
 		RM2000001000000000000004 /* ReminderNotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderNotificationDelegate.swift; sourceTree = "<group>"; };
 		BL2000001000000000000001 /* BehavioralLearningStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStore.swift; sourceTree = "<group>"; };
 		BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStoreTests.swift; sourceTree = "<group>"; };
+		CC2000001000000000000001 /* CohortPriorClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohortPriorClient.swift; sourceTree = "<group>"; };
+		CC200000000000000000AT01 /* CohortPriorClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohortPriorClientTests.swift; sourceTree = "<group>"; };
 		NP200000000000000000VW01 /* NotificationPermissionPrimingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionPrimingView.swift; sourceTree = "<group>"; };
 		IT200000000000000000TS01 /* ImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportTests.swift; sourceTree = "<group>"; };
 		CFG000000000000000000001 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -733,6 +737,7 @@
 				RM2000001000000000000003 /* ReminderTriggers.swift */,
 				RM2000001000000000000004 /* ReminderNotificationDelegate.swift */,
 				BL2000001000000000000001 /* BehavioralLearningStore.swift */,
+				CC2000001000000000000001 /* CohortPriorClient.swift */,
 			);
 			path = Reminders;
 			sourceTree = "<group>";
@@ -979,6 +984,7 @@
 				RS200000000000000000AT01 /* ReminderSchedulerTests.swift */,
 				RA200000000000000000AT01 /* ReminderAnalyticsTests.swift */,
 				BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */,
+				CC200000000000000000AT01 /* CohortPriorClientTests.swift */,
 				OB200000000000000000AT01 /* OfflineBehaviourTests.swift */,
 				OR200000000000000000AT01 /* AIOrchestratorTests.swift */,
 				VR200000000000000000AT01 /* ValidatedRecommendationTests.swift */,
@@ -1414,6 +1420,7 @@
 				RM1000001000000000000003 /* ReminderTriggers.swift in Sources */,
 				RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */,
 				BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */,
+				CC1000001000000000000001 /* CohortPriorClient.swift in Sources */,
 				NT1000001000000000000001 /* NotificationService.swift in Sources */,
 				NT1000001000000000000002 /* NotificationPreferencesStore.swift in Sources */,
 				NT1000001000000000000003 /* NotificationContentBuilder.swift in Sources */,
@@ -1463,6 +1470,7 @@
 				RS100000000000000000AT01 /* ReminderSchedulerTests.swift in Sources */,
 				RA100000000000000000AT01 /* ReminderAnalyticsTests.swift in Sources */,
 				BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */,
+				CC100000000000000000AT01 /* CohortPriorClientTests.swift in Sources */,
 				OB100000000000000000AT01 /* OfflineBehaviourTests.swift in Sources */,
 				OR100000000000000000AT01 /* AIOrchestratorTests.swift in Sources */,
 				VR100000000000000000AT01 /* ValidatedRecommendationTests.swift in Sources */,

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -240,6 +240,8 @@
 		RM1000001000000000000002 /* ReminderScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000002 /* ReminderScheduler.swift */; };
 		RM1000001000000000000003 /* ReminderTriggers.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000003 /* ReminderTriggers.swift */; };
 		RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = RM2000001000000000000004 /* ReminderNotificationDelegate.swift */; };
+		BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL2000001000000000000001 /* BehavioralLearningStore.swift */; };
+		BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */; };
 		IM100000000000000000AA01 /* ImportParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA01 /* ImportParser.swift */; };
 		IM100000000000000000AA02 /* ExerciseMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA02 /* ExerciseMapper.swift */; };
 		IM100000000000000000AA03 /* ImportOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = IM200000000000000000AA03 /* ImportOrchestrator.swift */; };
@@ -477,6 +479,8 @@
 		RM2000001000000000000002 /* ReminderScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduler.swift; sourceTree = "<group>"; };
 		RM2000001000000000000003 /* ReminderTriggers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderTriggers.swift; sourceTree = "<group>"; };
 		RM2000001000000000000004 /* ReminderNotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderNotificationDelegate.swift; sourceTree = "<group>"; };
+		BL2000001000000000000001 /* BehavioralLearningStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStore.swift; sourceTree = "<group>"; };
+		BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStoreTests.swift; sourceTree = "<group>"; };
 		NP200000000000000000VW01 /* NotificationPermissionPrimingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionPrimingView.swift; sourceTree = "<group>"; };
 		IT200000000000000000TS01 /* ImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportTests.swift; sourceTree = "<group>"; };
 		CFG000000000000000000001 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -728,6 +732,7 @@
 				RM2000001000000000000002 /* ReminderScheduler.swift */,
 				RM2000001000000000000003 /* ReminderTriggers.swift */,
 				RM2000001000000000000004 /* ReminderNotificationDelegate.swift */,
+				BL2000001000000000000001 /* BehavioralLearningStore.swift */,
 			);
 			path = Reminders;
 			sourceTree = "<group>";
@@ -973,6 +978,7 @@
 				KH200000000000000000AT01 /* KeychainHelperTests.swift */,
 				RS200000000000000000AT01 /* ReminderSchedulerTests.swift */,
 				RA200000000000000000AT01 /* ReminderAnalyticsTests.swift */,
+				BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */,
 				OB200000000000000000AT01 /* OfflineBehaviourTests.swift */,
 				OR200000000000000000AT01 /* AIOrchestratorTests.swift */,
 				VR200000000000000000AT01 /* ValidatedRecommendationTests.swift */,
@@ -1407,6 +1413,7 @@
 				RM1000001000000000000002 /* ReminderScheduler.swift in Sources */,
 				RM1000001000000000000003 /* ReminderTriggers.swift in Sources */,
 				RM1000001000000000000004 /* ReminderNotificationDelegate.swift in Sources */,
+				BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */,
 				NT1000001000000000000001 /* NotificationService.swift in Sources */,
 				NT1000001000000000000002 /* NotificationPreferencesStore.swift in Sources */,
 				NT1000001000000000000003 /* NotificationContentBuilder.swift in Sources */,
@@ -1455,6 +1462,7 @@
 				KH100000000000000000AT01 /* KeychainHelperTests.swift in Sources */,
 				RS100000000000000000AT01 /* ReminderSchedulerTests.swift in Sources */,
 				RA100000000000000000AT01 /* ReminderAnalyticsTests.swift in Sources */,
+				BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */,
 				OB100000000000000000AT01 /* OfflineBehaviourTests.swift in Sources */,
 				OR100000000000000000AT01 /* AIOrchestratorTests.swift in Sources */,
 				VR100000000000000000AT01 /* ValidatedRecommendationTests.swift in Sources */,

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		AC1000000000000000000009 /* ConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000009 /* ConsentView.swift */; };
 		AC1000000000000000000010 /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000010 /* DeleteAccountView.swift */; };
 		AC1000000000000000000011 /* ExportDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000011 /* ExportDataView.swift */; };
+		BL1000002000000000000001 /* BehavioralLearningSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL2000002000000000000001 /* BehavioralLearningSettingsView.swift */; };
 		TP100000000000000000AA01 /* TrainingPlanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TP200000000000000000AA01 /* TrainingPlanView.swift */; };
 		TP100000000000000000AA02 /* ExerciseRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TP200000000000000000AA02 /* ExerciseRowView.swift */; };
 		TP100000000000000000AA03 /* SetRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TP200000000000000000AA03 /* SetRowView.swift */; };
@@ -340,6 +341,7 @@
 		AC2000000000000000000009 /* ConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentView.swift; sourceTree = "<group>"; };
 		AC2000000000000000000010 /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
 		AC2000000000000000000011 /* ExportDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportDataView.swift; sourceTree = "<group>"; };
+		BL2000002000000000000001 /* BehavioralLearningSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningSettingsView.swift; sourceTree = "<group>"; };
 		AI200000000000000000AAA1 /* AITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITypes.swift; sourceTree = "<group>"; };
 		AI200000000000000000AAA2 /* AIEngineClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIEngineClient.swift; sourceTree = "<group>"; };
 		AI200000000000000000AAA3 /* FoundationModelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationModelService.swift; sourceTree = "<group>"; };
@@ -1045,6 +1047,7 @@
 			isa = PBXGroup;
 			children = (
 				AC2000000000000000000010 /* DeleteAccountView.swift */,
+				BL2000002000000000000001 /* BehavioralLearningSettingsView.swift */,
 				DD000002000000000000AA02 /* DesignSystemCatalogView.swift */,
 				AC2000000000000000000011 /* ExportDataView.swift */,
 				CC000002000000000000AA0D /* SettingsView.swift */,
@@ -1376,6 +1379,7 @@
 				CC000001000000000000AA0C /* RecoverySupport.swift in Sources */,
 				AC1000000000000000000010 /* DeleteAccountView.swift in Sources */,
 				AC1000000000000000000011 /* ExportDataView.swift in Sources */,
+				BL1000002000000000000001 /* BehavioralLearningSettingsView.swift in Sources */,
 				SE100000000000000000AA01 /* SettingsView.swift in Sources */,
 				SE100000000000000000AA02 /* AccountSecuritySettingsScreen.swift in Sources */,
 				SE100000000000000000AA03 /* HealthDevicesSettingsScreen.swift in Sources */,

--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -66,6 +66,14 @@ struct FitTrackerApp: App {
     @State private var showBiometricActivation = false
     // Strong reference; iOS only retains the delegate weakly via the center.
     private let reminderNotificationDelegate = ReminderNotificationDelegate()
+    // Behavioural learning sub-feature (PR 1 ships data-collection only).
+    // Store is @MainActor — App struct itself is @MainActor in SwiftUI 6, so
+    // the init runs on the right actor. Cache + client are non-isolated.
+    @MainActor private let behavioralLearningStore = BehavioralLearningStore()
+    private let cohortPriorCache = CohortPriorCache()
+    // `let` (not `lazy var`) so the `.task` closure can capture by value.
+    // `makeAIEngineBaseURL()` is a pure function — safe to evaluate eagerly.
+    private let cohortPriorClient = CohortPriorClient(baseURL: makeAIEngineBaseURL())
     @StateObject private var aiOrchestrator: AIOrchestrator = {
         let client: any AIEngineClientProtocol = AIEngineClient(baseURL: makeAIEngineBaseURL())
         let foundationModel: any FoundationModelProtocol = {
@@ -124,6 +132,30 @@ struct FitTrackerApp: App {
                     // lifetime of the app.
                     reminderNotificationDelegate.setAnalytics(analytics)
                     ReminderScheduler.shared.analytics = analytics
+
+                    // smart-reminders-behavioral-learning Task 10:
+                    // wire the behavioral-learning store + cohort client
+                    // into the delegate. Then fire-and-forget cohort prior
+                    // fetch if the on-device cache is stale or cold.
+                    reminderNotificationDelegate.setStore(behavioralLearningStore)
+                    reminderNotificationDelegate.setCohortClient(cohortPriorClient)
+                    if cohortPriorCache.isStale {
+                        let client = cohortPriorClient
+                        let cache = cohortPriorCache
+                        Task {
+                            do {
+                                let response = try await client.fetchPriors()
+                                cache.persist(response)
+                            } catch {
+                                // Silent fallback — the resolver (PR 2) uses
+                                // static defaults when cache is empty. The
+                                // next app launch retries.
+                                #if DEBUG
+                                print("[smart-reminders] cohort prior fetch failed: \(error)")
+                                #endif
+                            }
+                        }
+                    }
                 }
                 .onChange(of: signIn.activeSession) { _, session in
                     if session != nil {

--- a/FitTracker/Services/AppSettings.swift
+++ b/FitTracker/Services/AppSettings.swift
@@ -112,6 +112,17 @@ final class AppSettings: ObservableObject {
         didSet { UserDefaults.standard.set(hasAskedForBiometricActivation, forKey: "ft.hasAskedForBiometricActivation") }
     }
 
+    // ── Smart-timing global toggle (smart-reminders-behavioral-learning PR 1) ──
+    // PR 1 ships with default OFF — toggle has no consumer yet (resolver lands
+    // in PR 2). PR 2 will flip the default to ON for new installs.
+    // When OFF, all three personalisable reminder types (Nutrition Gap, Training
+    // Day, Rest Day) keep their static fire times. When ON, the future
+    // SmartTimingResolver (PR 2) reads BehavioralLearningStore + CohortPriorCache
+    // to compute per-user fire hours.
+    @Published var smartTimingEnabled: Bool = false {
+        didSet { UserDefaults.standard.set(smartTimingEnabled, forKey: "ft.smartTimingEnabled") }
+    }
+
     init() {
         if let raw = UserDefaults.standard.string(forKey: "ft.unitSystem"),
            let v = UnitSystem(rawValue: raw) { unitSystem = v }
@@ -122,6 +133,9 @@ final class AppSettings: ObservableObject {
         }
         if UserDefaults.standard.object(forKey: "ft.hasAskedForBiometricActivation") != nil {
             hasAskedForBiometricActivation = UserDefaults.standard.bool(forKey: "ft.hasAskedForBiometricActivation")
+        }
+        if UserDefaults.standard.object(forKey: "ft.smartTimingEnabled") != nil {
+            smartTimingEnabled = UserDefaults.standard.bool(forKey: "ft.smartTimingEnabled")
         }
     }
 }

--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -819,6 +819,11 @@ final class EncryptedDataStore: ObservableObject {
                 try fm.removeItem(at: fileURL)
             }
         }
+        // smart-reminders-behavioral-learning Task 11 — extend GDPR Article 17
+        // wipe to the behavioural-learning posterior + cohort prior cache.
+        // Both surfaces are UserDefaults-backed; they don't share fileURLs above.
+        BehavioralLearningStore().deleteAllUserData()
+        CohortPriorCache().deleteAllUserData()
     }
 
     // ── CRUD ─────────────────────────────────────────────

--- a/FitTracker/Services/Reminders/BehavioralLearningStore.swift
+++ b/FitTracker/Services/Reminders/BehavioralLearningStore.swift
@@ -1,0 +1,166 @@
+// FitTracker/Services/Reminders/BehavioralLearningStore.swift
+//
+// Per-user posterior over 24 hour-of-day buckets per personalisable
+// ReminderType. The Bayesian numerator/denominator state lives in
+// UserDefaults under stable string keys so it survives relaunch and is
+// scopeable for GDPR wipe.
+//
+// Storage schema:
+//
+//   ft.reminder.posterior.<type>.h<00..23>   Int — taps observed in that hour
+//   ft.reminder.obsCount.<type>              Int — total observations for type
+//   ft.reminder.lastObservation              [String: Any] — recovery slot for
+//                                                            tap-after-show idempotence
+//
+// Recording flow:
+//
+//   1. willPresent fires:    recordObservation(type:, hour:, tapped: false)
+//                            → obsCount++; if tapped→ taps[hour]++; cache last obs
+//   2. didReceive fires:     upgradeLastObservation(type:, tapped: true)
+//                            → if last obs matches and was not yet tapped,
+//                              promote to a tap (taps[hour]++); idempotent
+//
+// Posterior:
+//
+//   posterior(type:) returns [hour: probability]; sums to 1.0 if obs>0,
+//   uniform 1/24 if obs=0. Each bucket = taps[hour] / obsCount.
+//
+// GDPR Article 17 — `deleteAllUserData()` wipes every key this store
+// owns. Called by EncryptedDataStore.deleteAllUserData() (Task 11).
+//
+// Thread isolation: @MainActor — read/write UserDefaults from the main
+// actor so we don't race with notification delegate callbacks.
+
+import Foundation
+
+@MainActor
+final class BehavioralLearningStore {
+
+    // MARK: - Stored key prefixes
+
+    private let storeKeyPrefix = "ft.reminder.posterior."
+    private let countKeyPrefix = "ft.reminder.obsCount."
+    private let lastObsKey     = "ft.reminder.lastObservation"
+
+    // MARK: - Lifecycle
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Posterior accessor
+
+    /// Per-hour probability distribution for `type`. Sums to 1.0.
+    /// When zero observations have been recorded for the type, returns a
+    /// uniform 1/24 distribution.
+    ///
+    /// This is the numerator-only component of the Bayesian posterior:
+    /// the cohort prior + observation-count weighting are applied by the
+    /// caller (`SmartTimingResolver`, PR 2).
+    func posterior(type: ReminderType) -> [Int: Double] {
+        let count = observationCount(type: type)
+        guard count > 0 else {
+            var uniform: [Int: Double] = [:]
+            for h in 0..<24 { uniform[h] = 1.0 / 24.0 }
+            return uniform
+        }
+        var dist: [Int: Double] = [:]
+        for h in 0..<24 {
+            let taps = defaults.integer(forKey: tapsKey(type: type, hour: h))
+            dist[h] = Double(taps) / Double(count)
+        }
+        return dist
+    }
+
+    /// Total observations recorded for a `type`.
+    func observationCount(type: ReminderType) -> Int {
+        defaults.integer(forKey: "\(countKeyPrefix)\(type.rawValue)")
+    }
+
+    // MARK: - Observation recording
+
+    /// Records a `shown` event (denominator). The first call for a given
+    /// (type, hour) increments `obsCount` and — if `tapped` is true —
+    /// also increments `taps[hour]` immediately.
+    ///
+    /// Caller pattern (from `ReminderNotificationDelegate`, Task 9):
+    ///
+    ///   • `willPresent` → `recordObservation(type:, hour:, tapped: false)`
+    ///   • `didReceive`  → `upgradeLastObservation(type:, tapped: true)`
+    ///
+    /// Returns a synthetic id for the observation. Caller does not need
+    /// the id today; it is provided for future per-observation tracking.
+    @discardableResult
+    func recordObservation(type: ReminderType, hour: Int, tapped: Bool) -> String {
+        precondition((0..<24).contains(hour), "hour must be in 0..<24")
+        let countKey = "\(countKeyPrefix)\(type.rawValue)"
+        defaults.set(defaults.integer(forKey: countKey) + 1, forKey: countKey)
+        if tapped {
+            let key = tapsKey(type: type, hour: hour)
+            defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+        }
+        defaults.set(
+            ["type": type.rawValue, "hour": hour, "tapped": tapped],
+            forKey: lastObsKey
+        )
+        return "\(type.rawValue):\(hour):\(Date().timeIntervalSince1970)"
+    }
+
+    /// Promotes the most recently recorded observation for `type` from
+    /// "shown only" to "shown + tapped". Idempotent: calling twice for
+    /// the same observation does NOT double-count.
+    ///
+    /// Returns silently when:
+    ///   • `tapped` is false (this method only handles tap promotion).
+    ///   • No prior observation exists in the recovery slot.
+    ///   • The recovery slot's `type` does not match the requested type.
+    ///   • The recovery slot is already marked tapped (idempotence guard).
+    func upgradeLastObservation(type: ReminderType, tapped: Bool) {
+        guard tapped else { return }
+        guard let last = defaults.dictionary(forKey: lastObsKey) else { return }
+        guard
+            let recordedTypeRaw = last["type"] as? String,
+            let recordedType    = ReminderType(rawValue: recordedTypeRaw),
+            recordedType == type,
+            let hour            = last["hour"] as? Int
+        else { return }
+        let alreadyTapped = (last["tapped"] as? Bool) ?? false
+        guard !alreadyTapped else { return }
+
+        // Promote: only the taps[hour] bucket; obsCount was already incremented
+        // by the matching recordObservation call.
+        let key = tapsKey(type: type, hour: hour)
+        defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+        defaults.set(
+            ["type": type.rawValue, "hour": hour, "tapped": true],
+            forKey: lastObsKey
+        )
+    }
+
+    // MARK: - GDPR Article 17 — right to erasure
+
+    /// Wipes every key this store owns. Called by
+    /// `EncryptedDataStore.deleteAllUserData()` (Task 11).
+    ///
+    /// After this call:
+    ///   • `observationCount(type:)` returns 0 for every type
+    ///   • `posterior(type:)` returns the uniform 1/24 distribution
+    func deleteAllUserData() {
+        for type in ReminderType.allCases {
+            defaults.removeObject(forKey: "\(countKeyPrefix)\(type.rawValue)")
+            for h in 0..<24 {
+                defaults.removeObject(forKey: tapsKey(type: type, hour: h))
+            }
+        }
+        defaults.removeObject(forKey: lastObsKey)
+    }
+
+    // MARK: - Internal
+
+    private func tapsKey(type: ReminderType, hour: Int) -> String {
+        let suffix = String(format: "%02d", hour)
+        return "\(storeKeyPrefix)\(type.rawValue).h\(suffix)"
+    }
+}

--- a/FitTracker/Services/Reminders/CohortPriorCache.swift
+++ b/FitTracker/Services/Reminders/CohortPriorCache.swift
@@ -1,0 +1,91 @@
+// FitTracker/Services/Reminders/CohortPriorCache.swift
+//
+// On-device cache of the most recent `CohortPriorResponse` from the AI
+// engine. The cache wraps the response in an `Envelope` carrying a
+// `fetchedAt: Date`, persists the envelope as a JSON blob in UserDefaults
+// under the stable key `ft.reminder.cohortPrior.json`, and exposes:
+//
+//   priors    The decoded response, or nil when cold / malformed.
+//   isStale   True when no envelope is loaded OR the load is older than
+//             `ttl` (7 days). Forces the caller to refetch via
+//             `CohortPriorClient.fetchPriors()` (Task 4).
+//
+// Failure modes that resolve to "cold cache, force fetch":
+//   • UserDefaults has no entry for the cache key (first launch).
+//   • Stored data is not valid JSON (data corruption or schema change
+//     between app versions).
+//   • Stored envelope is older than `ttl`.
+//
+// None of these crash; `loadFromDefaults` swallows decode errors so the
+// app can keep running while the next fetch repopulates the cache.
+
+import Foundation
+
+final class CohortPriorCache {
+
+    private let defaults: UserDefaults
+    private let cacheKey: String
+    private let ttl: TimeInterval
+
+    private struct Envelope: Codable {
+        let response: CohortPriorResponse
+        let fetchedAt: Date
+    }
+
+    private(set) var priors: CohortPriorResponse?
+    private var fetchedAt: Date?
+
+    /// - Parameters:
+    ///   - defaults: UserDefaults to persist into. Default `.standard`.
+    ///   - cacheKey: storage key. Default `ft.reminder.cohortPrior.json`.
+    ///   - ttl: how long a stored envelope remains fresh. Default 7 days.
+    init(
+        defaults: UserDefaults = .standard,
+        cacheKey: String = "ft.reminder.cohortPrior.json",
+        ttl: TimeInterval = 7 * 24 * 60 * 60
+    ) {
+        self.defaults = defaults
+        self.cacheKey = cacheKey
+        self.ttl = ttl
+        loadFromDefaults()
+    }
+
+    /// True when no envelope is loaded OR the loaded envelope is older
+    /// than `ttl`. The caller (PR 2 `SmartTimingResolver`) uses this to
+    /// decide whether to fetch from the AI engine before scheduling.
+    var isStale: Bool {
+        guard let fetched = fetchedAt else { return true }
+        return Date().timeIntervalSince(fetched) > ttl
+    }
+
+    /// Persist a freshly-fetched response with a synthetic timestamp.
+    /// `fetchedAt` defaults to "now"; tests override it to simulate
+    /// stale envelopes without time-travel.
+    func persist(_ response: CohortPriorResponse, fetchedAt: Date = Date()) {
+        let envelope = Envelope(response: response, fetchedAt: fetchedAt)
+        guard let data = try? JSONEncoder().encode(envelope) else { return }
+        defaults.set(data, forKey: cacheKey)
+        self.priors = response
+        self.fetchedAt = fetchedAt
+    }
+
+    /// GDPR Article 17 — wipe the cached envelope. Called by
+    /// `EncryptedDataStore.deleteAllUserData()` (Task 11).
+    func deleteAllUserData() {
+        defaults.removeObject(forKey: cacheKey)
+        priors = nil
+        fetchedAt = nil
+    }
+
+    // MARK: - Private
+
+    private func loadFromDefaults() {
+        guard let data = defaults.data(forKey: cacheKey) else { return }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else {
+            // Malformed JSON — silently treat as cold cache (priors nil + isStale true).
+            return
+        }
+        priors = envelope.response
+        fetchedAt = envelope.fetchedAt
+    }
+}

--- a/FitTracker/Services/Reminders/CohortPriorClient.swift
+++ b/FitTracker/Services/Reminders/CohortPriorClient.swift
@@ -1,0 +1,93 @@
+// FitTracker/Services/Reminders/CohortPriorClient.swift
+//
+// HTTP client for the AI-engine reminder-cohort endpoints.
+//
+// Two methods:
+//   • POST /reminder-cohort-event   — fire-and-forget write of a (type, hour, tapped)
+//                                     observation. Payload contains *only* those three
+//                                     keys; no userId, deviceId, locale, or timestamp
+//                                     leaks to the cohort surface (GDPR posture per
+//                                     spec §6).
+//   • GET  /reminder-cohort-priors  — read the population prior + kill-flag list.
+//
+// Errors are propagated to the caller (`FitTrackerApp`, Task 10) so the
+// caller can decide whether to swallow (PR 1, no UI surface) or surface
+// (PR 3, "Why this time?" affordance).
+//
+// `URLSessionProtocol` injection lets unit tests substitute a deterministic
+// mock without hitting the real network.
+
+import Foundation
+
+
+// MARK: - Session injection seam
+
+protocol URLSessionProtocol {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+
+// MARK: - Wire-format response
+
+/// Server-side response shape for `GET /reminder-cohort-priors`.
+///
+/// `priors` is a per-type histogram: `priors["nutrition_gap"]["16"] = 0.34`
+/// means the cohort taps that type at hour 16 about 34% of the time.
+/// `killFlags` is a list of `ReminderType.rawValue` strings whose per-type
+/// metric crossed the kill threshold; the client should revert those types
+/// to their static fire times until the flag clears.
+struct CohortPriorResponse: Codable {
+    let priors: [String: [String: Double]]
+    let killFlags: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case priors
+        case killFlags = "kill_flags"
+    }
+}
+
+
+// MARK: - Client
+
+final class CohortPriorClient {
+
+    private let baseURL: URL
+    private let session: URLSessionProtocol
+
+    init(baseURL: URL, session: URLSessionProtocol = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    /// POST `/reminder-cohort-event` with the minimum-PII payload.
+    ///
+    /// Per spec §6 the payload MUST contain only `{type, hour, tapped}`.
+    /// Adding any caller-identifying field here would void the cohort
+    /// surface's GDPR posture; the test `testRecordEvent_payloadContainsOnlyAllowedKeys`
+    /// asserts the keyset on every change.
+    func recordEvent(type: ReminderType, hour: Int, tapped: Bool) async throws {
+        precondition((0..<24).contains(hour), "hour must be in 0..<24")
+        let url = baseURL.appendingPathComponent("reminder-cohort-event")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let payload: [String: Any] = [
+            "type":   type.rawValue,
+            "hour":   hour,
+            "tapped": tapped,
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        _ = try await session.data(for: req)
+    }
+
+    /// GET `/reminder-cohort-priors`. Returns the population prior + kill flags.
+    func fetchPriors() async throws -> CohortPriorResponse {
+        let url = baseURL.appendingPathComponent("reminder-cohort-priors")
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        let (data, _) = try await session.data(for: req)
+        return try JSONDecoder().decode(CohortPriorResponse.self, from: data)
+    }
+}

--- a/FitTracker/Services/Reminders/ReminderNotificationDelegate.swift
+++ b/FitTracker/Services/Reminders/ReminderNotificationDelegate.swift
@@ -5,9 +5,25 @@
 //
 // Wired by FitTrackerApp at init (set as UNUserNotificationCenter.current().delegate).
 //
+// Smart-reminders behavioral-learning PR 1 (Task 9):
+// In addition to logging analytics, the delegate now records observations
+// on a BehavioralLearningStore (per-user posterior) and fires a fire-and-
+// forget POST on a CohortPriorClient (population prior). Both are weakly
+// held — the delegate participates in the recording path but does NOT own
+// the lifecycle of either store/client; FitTrackerApp does (Task 10).
+//
+// Recording semantics (per spec §6 + plan §Task 9):
+//   willPresent  →  store.recordObservation(type, hour, tapped:false)   denominator
+//                   client.recordEvent(type, hour, tapped:false)        cohort signal
+//   didReceive   →  if tap:    store.upgradeLastObservation(type, tapped:true)  numerator
+//                              client.recordEvent(type, hour, tapped:true)
+//                   if dismiss: leave observation as tapped:false (correct —
+//                              denominator without numerator)
+//
 // Isolation: the class itself is non-isolated so it can satisfy
 // UNUserNotificationCenterDelegate without Swift-6 actor warnings; calls
-// into AnalyticsService (a @MainActor type) hop to the main actor explicitly.
+// into AnalyticsService + BehavioralLearningStore (both @MainActor) hop to
+// the main actor explicitly.
 
 import Foundation
 import UserNotifications
@@ -25,7 +41,32 @@ final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDele
     /// notifications without logging.
     @MainActor weak var analytics: AnalyticsService?
 
+    /// Optional reference to BehavioralLearningStore. Records the per-user
+    /// posterior observations (denominator on willPresent, numerator on tap).
+    /// Owned by FitTrackerApp; held weakly here.
+    @MainActor weak var store: BehavioralLearningStore?
+
+    /// Optional reference to CohortPriorClient. Fires a fire-and-forget POST
+    /// to the AI engine on every show/tap so the population prior accumulates.
+    /// Owned by FitTrackerApp; held weakly here.
+    weak var cohortClient: CohortPriorClient?
+
     override init() {
+        super.init()
+    }
+
+    /// Convenience init for tests + FitTrackerApp wiring (Task 10).
+    /// All parameters are optional — passing nil leaves that surface
+    /// disconnected (the existing PR #158 behavior).
+    @MainActor
+    init(
+        analytics: AnalyticsService? = nil,
+        store: BehavioralLearningStore? = nil,
+        cohortClient: CohortPriorClient? = nil
+    ) {
+        self.analytics = analytics
+        self.store = store
+        self.cohortClient = cohortClient
         super.init()
     }
 
@@ -34,11 +75,53 @@ final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDele
         self.analytics = service
     }
 
+    @MainActor
+    func setStore(_ behavioralStore: BehavioralLearningStore?) {
+        self.store = behavioralStore
+    }
+
+    func setCohortClient(_ client: CohortPriorClient?) {
+        self.cohortClient = client
+    }
+
+    // MARK: - Test seams (also called from willPresent / didReceive)
+
+    /// Test-only seam: directly drive the willPresent recording path
+    /// without constructing a UNNotification (which has private inits).
+    /// Records the denominator (`tapped: false`) on the store and
+    /// fires-and-forgets a cohort event with the same payload.
+    ///
+    /// `@MainActor` because the store property itself is main-actor isolated.
+    /// Callers that aren't on the main actor wrap their call in
+    /// `Task { @MainActor in ... }` (this is what willPresent + didReceive
+    /// already do).
+    @MainActor
+    func recordObservationFromNotification(type: ReminderType, hour: Int) {
+        store?.recordObservation(type: type, hour: hour, tapped: false)
+        let client = cohortClient
+        Task { [client] in
+            try? await client?.recordEvent(type: type, hour: hour, tapped: false)
+        }
+    }
+
+    /// Test-only seam: directly drive the didReceive(tap) path.
+    /// Promotes the most recent observation to a tap (numerator) on the
+    /// store and emits a tapped:true cohort event.
+    @MainActor
+    func upgradeObservationFromTap(type: ReminderType, hour: Int) {
+        store?.upgradeLastObservation(type: type, tapped: true)
+        let client = cohortClient
+        Task { [client] in
+            try? await client?.recordEvent(type: type, hour: hour, tapped: true)
+        }
+    }
+
     // MARK: - Foreground presentation
 
     /// Called when a notification arrives while the app is in the foreground.
-    /// We let iOS show the banner + sound (so the reminder is still visible)
-    /// and log a `reminder_shown` analytics event.
+    /// We let iOS show the banner + sound (so the reminder is still visible),
+    /// log a `reminder_shown` analytics event, AND record the denominator on
+    /// the behavioral-learning store.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -50,6 +133,8 @@ final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDele
         Task { @MainActor in
             if let raw = typeRaw, let type = ReminderType(rawValue: raw) {
                 analytics?.logReminderShown(type: type.rawValue)
+                let hour = Calendar.current.component(.hour, from: Date())
+                recordObservationFromNotification(type: type, hour: hour)
             }
         }
         completionHandler([.banner, .sound, .list])
@@ -59,6 +144,8 @@ final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDele
 
     /// Called when the user taps OR explicitly dismisses a notification.
     /// `actionIdentifier` distinguishes the two cases.
+    /// On tap, we additionally upgrade the most recent observation to a tap
+    /// (numerator) on the behavioral-learning store.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
@@ -73,14 +160,18 @@ final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDele
                 completionHandler()
                 return
             }
+            let hour = Calendar.current.component(.hour, from: Date())
             switch actionIdentifier {
             case UNNotificationDismissActionIdentifier:
                 analytics?.logReminderDismissed(type: type.rawValue)
+                // No upgrade — observation stays tapped:false (denominator only)
             case UNNotificationDefaultActionIdentifier:
                 analytics?.logReminderTapped(type: type.rawValue)
+                upgradeObservationFromTap(type: type, hour: hour)
                 Self.postDeepLinkNotification(type: type, userInfo: userInfo)
             default:
                 analytics?.logReminderTapped(type: type.rawValue)
+                upgradeObservationFromTap(type: type, hour: hour)
                 Self.postDeepLinkNotification(type: type, userInfo: userInfo)
             }
             completionHandler()

--- a/FitTracker/Services/Reminders/ReminderType.swift
+++ b/FitTracker/Services/Reminders/ReminderType.swift
@@ -50,4 +50,43 @@ enum ReminderType: String, CaseIterable, Codable {
         case .engagement:          "fitme://home"
         }
     }
+
+    // ── Fire-time defaults (smart-reminders-behavioral-learning PR 1) ──
+    //
+    // The existing trigger evaluators in ReminderTriggers.swift gate firing
+    // on inline hour-of-day checks (nutrition gap >= 16, training day >= 10).
+    // This property exposes those static fire-time defaults as a single
+    // source of truth so the Bayesian behavioral-learning layer (PR 1+)
+    // can use them as its prior centre without re-deriving the values.
+
+    /// Static default fire hour (local time) for this reminder type.
+    /// Matches the editorial defaults baked into ReminderTriggers.swift.
+    /// Used as the centre of `defaultPriorDistribution`.
+    var defaultFireHour: Int {
+        switch self {
+        case .nutritionGap:        return 16
+        case .trainingDay:         return 10
+        case .restDay:             return 8
+        case .healthKitConnect:    return 11
+        case .accountRegistration: return 14
+        case .engagement:          return 18
+        }
+    }
+
+    /// Tight bell curve over the 24 hour-of-day buckets, centred on
+    /// `defaultFireHour`. Used as the Bayesian prior fallback when the
+    /// cohort prior cache is cold.
+    /// Sums to 1.0. σ = 1.5 hours (gives ~80% of mass within ±2 hours
+    /// of centre).
+    var defaultPriorDistribution: [Int: Double] {
+        let centre = Double(defaultFireHour)
+        let sigma  = 1.5
+        var raw: [Int: Double] = [:]
+        for h in 0..<24 {
+            let dx = Double(h) - centre
+            raw[h] = exp(-(dx * dx) / (2 * sigma * sigma))
+        }
+        let total = raw.values.reduce(0, +)
+        return raw.mapValues { $0 / total }
+    }
 }

--- a/FitTracker/Views/Settings/BehavioralLearningSettingsView.swift
+++ b/FitTracker/Views/Settings/BehavioralLearningSettingsView.swift
@@ -1,0 +1,41 @@
+// FitTracker/Views/Settings/BehavioralLearningSettingsView.swift
+//
+// PR 1 of smart-reminders-behavioral-learning (per
+// docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md):
+// a single global "Smart timing" toggle row.
+//
+// Defaults OFF — PR 1 ships zero user-visible behaviour change. The
+// resolver that consumes the priors + posterior (SmartTimingResolver,
+// PR 2) is not yet on the schedule path; this toggle has no consumer yet.
+//
+// PR 2 will flip the default to ON for new installs and wire the toggle
+// to the SmartTimingResolver. PR 3 will append per-type "Why this time?"
+// rows below this section.
+//
+// Self-contained: takes AppSettings via @EnvironmentObject. Embed via
+//   BehavioralLearningSettingsView()
+// from any host Settings screen.
+
+import SwiftUI
+
+struct BehavioralLearningSettingsView: View {
+    @EnvironmentObject private var settings: AppSettings
+
+    var body: some View {
+        SettingsSectionCard(title: "Smart Timing", eyebrow: "Reminders") {
+            Toggle(isOn: $settings.smartTimingEnabled) {
+                VStack(alignment: .leading, spacing: AppSpacing.xxxSmall) {
+                    Text("Smart timing")
+                        .font(AppText.button)
+                        .foregroundStyle(AppColor.Text.primary)
+                    Text("Learns when you're most responsive and shifts reminder times to match. Off keeps the app's static defaults.")
+                        .font(AppText.subheading)
+                        .foregroundStyle(AppColor.Text.secondary)
+                }
+            }
+            .tint(AppColor.Accent.primary)
+
+            SettingsSupportingText("Personalisation applies to Nutrition Gap, Training Day, and Rest Day reminders. The other reminder types use static fire times.")
+        }
+    }
+}

--- a/FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
@@ -49,6 +49,10 @@ struct GoalsPreferencesSettingsScreen: View {
                 }
             }
 
+            // smart-reminders-behavioral-learning PR 1 (Task 12).
+            // Self-contained section; defaults OFF, no consumer wired yet.
+            BehavioralLearningSettingsView()
+
             SettingsSectionCard(title: "Stats Carousel", eyebrow: "Preferences") {
                 SettingsSupportingText("Weight and Body Fat stay pinned on the stats screen. Choose which extra metrics appear in Track More.")
 

--- a/FitTrackerTests/BehavioralLearningStoreTests.swift
+++ b/FitTrackerTests/BehavioralLearningStoreTests.swift
@@ -1,0 +1,137 @@
+// FitTrackerTests/BehavioralLearningStoreTests.swift
+//
+// Behavioural learning store — per-user posterior + GDPR wipe.
+//
+// Test inventory (per plan §Task 3):
+//   1. testPosteriorWithZeroObservations_isUniform
+//   2. testRecordObservation_incrementsCountForType
+//   3. testUpgradeLastObservation_promotesShowToTap_andIsIdempotent
+//   4. testDeleteAllUserData_wipesAllStoreKeys
+//
+// Each test uses a clean UserDefaults snapshot via setUp/tearDown
+// removing every key the store owns. Tests are @MainActor because the
+// production type is @MainActor.
+
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class BehavioralLearningStoreTests: XCTestCase {
+
+    private let storeKeyPrefix = "ft.reminder.posterior."
+    private let countKeyPrefix = "ft.reminder.obsCount."
+    private let lastObsKey     = "ft.reminder.lastObservation"
+
+    override func setUp() {
+        super.setUp()
+        clearAllStoreDefaults()
+    }
+
+    override func tearDown() {
+        clearAllStoreDefaults()
+        super.tearDown()
+    }
+
+    // MARK: - 1) zero-obs posterior is uniform
+
+    func testPosteriorWithZeroObservations_isUniform() {
+        let store = BehavioralLearningStore()
+        let posterior = store.posterior(type: .nutritionGap)
+
+        XCTAssertEqual(posterior.count, 24, "Posterior must cover all 24 hours")
+        for h in 0..<24 {
+            XCTAssertEqual(
+                posterior[h] ?? 0,
+                1.0 / 24.0,
+                accuracy: 0.0001,
+                "Hour \(h) must be uniform 1/24 when zero observations recorded"
+            )
+        }
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 0)
+    }
+
+    // MARK: - 2) recordObservation increments count for the right type
+
+    func testRecordObservation_incrementsCountForType() {
+        let store = BehavioralLearningStore()
+
+        store.recordObservation(type: .nutritionGap, hour: 16, tapped: false)
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+        XCTAssertEqual(
+            store.observationCount(type: .trainingDay),
+            0,
+            "Per-type isolation: nutritionGap obs must not count toward trainingDay"
+        )
+    }
+
+    // MARK: - 3) upgradeLastObservation promotes show→tap, idempotently
+
+    func testUpgradeLastObservation_promotesShowToTap_andIsIdempotent() {
+        let store = BehavioralLearningStore()
+
+        store.recordObservation(type: .nutritionGap, hour: 16, tapped: false)
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+        store.upgradeLastObservation(type: .nutritionGap, tapped: true)
+        let posterior1 = store.posterior(type: .nutritionGap)
+        XCTAssertEqual(
+            posterior1[16] ?? 0,
+            1.0,
+            accuracy: 0.0001,
+            "Single observation upgraded to tap: bucket 16 must hold 100% of mass"
+        )
+
+        // Calling upgrade twice for the SAME observation must not double-count
+        store.upgradeLastObservation(type: .nutritionGap, tapped: true)
+        let posterior2 = store.posterior(type: .nutritionGap)
+        XCTAssertEqual(
+            posterior1,
+            posterior2,
+            "Idempotent upgrade — second call must not change posterior"
+        )
+        XCTAssertEqual(
+            store.observationCount(type: .nutritionGap),
+            1,
+            "obsCount must remain 1; upgrade does not increment denominator"
+        )
+    }
+
+    // MARK: - 4) deleteAllUserData wipes everything (GDPR Article 17)
+
+    func testDeleteAllUserData_wipesAllStoreKeys() {
+        let store = BehavioralLearningStore()
+
+        store.recordObservation(type: .nutritionGap, hour: 16, tapped: true)
+        store.upgradeLastObservation(type: .nutritionGap, tapped: true)
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+        store.deleteAllUserData()
+
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 0)
+
+        let posterior = store.posterior(type: .nutritionGap)
+        for h in 0..<24 {
+            XCTAssertEqual(
+                posterior[h] ?? 0,
+                1.0 / 24.0,
+                accuracy: 0.0001,
+                "After wipe, posterior must be uniform 1/24 again at hour \(h)"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func clearAllStoreDefaults() {
+        let defaults = UserDefaults.standard
+        for type in ReminderType.allCases {
+            defaults.removeObject(forKey: "\(countKeyPrefix)\(type.rawValue)")
+            for h in 0..<24 {
+                let suffix = String(format: "%02d", h)
+                defaults.removeObject(forKey: "\(storeKeyPrefix)\(type.rawValue).h\(suffix)")
+            }
+        }
+        defaults.removeObject(forKey: lastObsKey)
+    }
+}

--- a/FitTrackerTests/BehavioralLearningStoreTests.swift
+++ b/FitTrackerTests/BehavioralLearningStoreTests.swift
@@ -121,6 +121,27 @@ final class BehavioralLearningStoreTests: XCTestCase {
         }
     }
 
+    // MARK: - 5) EncryptedDataStore.deletePersistedData wipes behavioral-learning state (Task 11)
+
+    func testEncryptedDataStore_deletePersistedData_wipesBehavioralLearning() throws {
+        // Seed observation data on the standalone store.
+        let store = BehavioralLearningStore()
+        store.recordObservation(type: .nutritionGap, hour: 16, tapped: true)
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+        // Trigger the GDPR Article 17 path through EncryptedDataStore.
+        // deletePersistedData() now also wipes BehavioralLearningStore +
+        // CohortPriorCache (smart-reminders-behavioral-learning Task 11).
+        let dataStore = EncryptedDataStore()
+        try dataStore.deletePersistedData()
+
+        XCTAssertEqual(
+            store.observationCount(type: .nutritionGap),
+            0,
+            "GDPR Article 17 — deletePersistedData() must wipe BehavioralLearningStore"
+        )
+    }
+
     // MARK: - Helpers
 
     private func clearAllStoreDefaults() {

--- a/FitTrackerTests/CohortPriorCacheTests.swift
+++ b/FitTrackerTests/CohortPriorCacheTests.swift
@@ -1,0 +1,100 @@
+// FitTrackerTests/CohortPriorCacheTests.swift
+//
+// CohortPriorCache — TTL + JSON round-trip + graceful failure recovery.
+//
+// Test inventory (per plan §Task 5):
+//   1. testColdCache_isStale
+//   2. testPersistThenLoad_roundTrip       — across simulated relaunch
+//   3. testStaleAfter7Days                 — 8-days-ago timestamp → stale
+//   4. testMalformedJSON_recoversToCold    — invalid bytes → no crash
+//
+// Plus one extra:
+//   5. testDeleteAllUserData_clearsCache  — GDPR Article 17
+
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class CohortPriorCacheTests: XCTestCase {
+
+    private let cacheKey = "ft.reminder.cohortPrior.json"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: cacheKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: cacheKey)
+        super.tearDown()
+    }
+
+    // MARK: - 1) Cold cache reports stale + nil priors
+
+    func testColdCache_isStale() {
+        let cache = CohortPriorCache()
+        XCTAssertTrue(cache.isStale, "Cold cache must report stale (forces fetch)")
+        XCTAssertNil(cache.priors)
+    }
+
+    // MARK: - 2) Persist→load round-trip across simulated relaunch
+
+    func testPersistThenLoad_roundTrip() {
+        let cache = CohortPriorCache()
+        let response = CohortPriorResponse(
+            priors: ["nutrition_gap": ["16": 0.42]],
+            killFlags: ["engagement"]
+        )
+        cache.persist(response)
+
+        // Construct a fresh instance — simulates app relaunch reading the
+        // same UserDefaults key.
+        let cache2 = CohortPriorCache()
+        XCTAssertFalse(cache2.isStale, "Just-persisted cache must not be stale")
+        XCTAssertEqual(cache2.priors?.priors["nutrition_gap"]?["16"], 0.42)
+        XCTAssertEqual(cache2.priors?.killFlags, ["engagement"])
+    }
+
+    // MARK: - 3) Envelope older than 7d is stale
+
+    func testStaleAfter7Days() {
+        let cache = CohortPriorCache()
+        let response = CohortPriorResponse(priors: [:], killFlags: [])
+        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
+        cache.persist(response, fetchedAt: eightDaysAgo)
+
+        let cache2 = CohortPriorCache()
+        XCTAssertTrue(cache2.isStale, "Cache older than 7 days must be stale")
+    }
+
+    // MARK: - 4) Malformed JSON resolves to cold cache (no crash)
+
+    func testMalformedJSON_recoversToCold() {
+        UserDefaults.standard.set(
+            "not valid json".data(using: .utf8),
+            forKey: cacheKey
+        )
+        let cache = CohortPriorCache()
+        XCTAssertTrue(cache.isStale)
+        XCTAssertNil(
+            cache.priors,
+            "Malformed JSON must result in cold cache, not crash"
+        )
+    }
+
+    // MARK: - 5) deleteAllUserData clears the cache (GDPR Article 17)
+
+    func testDeleteAllUserData_clearsCache() {
+        let cache = CohortPriorCache()
+        cache.persist(CohortPriorResponse(priors: ["x": ["1": 0.5]], killFlags: []))
+        XCTAssertFalse(cache.isStale)
+        XCTAssertNotNil(cache.priors)
+
+        cache.deleteAllUserData()
+        XCTAssertTrue(cache.isStale)
+        XCTAssertNil(cache.priors)
+
+        // And UserDefaults entry must be gone
+        XCTAssertNil(UserDefaults.standard.data(forKey: cacheKey))
+    }
+}

--- a/FitTrackerTests/CohortPriorClientTests.swift
+++ b/FitTrackerTests/CohortPriorClientTests.swift
@@ -1,0 +1,107 @@
+// FitTrackerTests/CohortPriorClientTests.swift
+//
+// CohortPriorClient — three tests covering the contract:
+//   1. POST payload contains ONLY {type, hour, tapped} — no PII leak
+//   2. Network errors propagate (caller swallows / surfaces as appropriate)
+//   3. fetchPriors decodes the canonical response shape
+//
+// `MockURLSession` is the test double — captures last request, supports
+// canned responses + injected errors, never hits the network.
+
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class CohortPriorClientTests: XCTestCase {
+
+    // MARK: - 1) no-PII payload
+
+    func testRecordEvent_payloadContainsOnlyAllowedKeys() async throws {
+        let session = MockURLSession()
+        let client = CohortPriorClient(
+            baseURL: URL(string: "https://test.local")!,
+            session: session
+        )
+
+        try await client.recordEvent(type: .nutritionGap, hour: 16, tapped: true)
+
+        let request = try XCTUnwrap(session.lastRequest)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try JSONSerialization.jsonObject(with: body) as? [String: Any] ?? [:]
+
+        XCTAssertEqual(
+            Set(json.keys),
+            Set(["type", "hour", "tapped"]),
+            "Payload must contain only {type, hour, tapped} — no PII"
+        )
+        XCTAssertEqual(json["type"] as? String, "nutrition_gap")
+        XCTAssertEqual(json["hour"] as? Int, 16)
+        XCTAssertEqual(json["tapped"] as? Bool, true)
+    }
+
+    // MARK: - 2) network error propagates
+
+    func testRecordEvent_networkError_propagates() async {
+        let session = MockURLSession()
+        session.error = URLError(.notConnectedToInternet)
+        let client = CohortPriorClient(
+            baseURL: URL(string: "https://test.local")!,
+            session: session
+        )
+
+        do {
+            try await client.recordEvent(type: .nutritionGap, hour: 16, tapped: true)
+            XCTFail("Should have thrown")
+        } catch is URLError {
+            // Expected — caller (FitTrackerApp) is responsible for catch/swallow.
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - 3) fetchPriors decodes the wire format
+
+    func testFetchPriors_decodesResponse() async throws {
+        let session = MockURLSession()
+        session.canned = """
+        {
+          "priors": { "nutrition_gap": { "16": 0.34, "17": 0.41 } },
+          "kill_flags": ["engagement"]
+        }
+        """.data(using: .utf8)!
+
+        let client = CohortPriorClient(
+            baseURL: URL(string: "https://test.local")!,
+            session: session
+        )
+
+        let response = try await client.fetchPriors()
+        XCTAssertEqual(response.priors["nutrition_gap"]?["17"], 0.41)
+        XCTAssertEqual(response.priors["nutrition_gap"]?["16"], 0.34)
+        XCTAssertEqual(response.killFlags, ["engagement"])
+    }
+}
+
+
+// MARK: - Mock
+
+/// Deterministic test double — captures the most recent request, supports
+/// canned response bodies + injected errors. Never hits the network.
+private final class MockURLSession: URLSessionProtocol {
+    var lastRequest: URLRequest?
+    var error: Error?
+    var canned: Data = Data()
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        if let e = error { throw e }
+        let status = canned.isEmpty ? 204 : 200
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (canned, response)
+    }
+}

--- a/FitTrackerTests/ReminderAnalyticsTests.swift
+++ b/FitTrackerTests/ReminderAnalyticsTests.swift
@@ -199,4 +199,24 @@ final class ReminderAnalyticsTests: XCTestCase {
         delegate.setAnalytics(nil)
         XCTAssertNil(delegate.analytics)
     }
+
+    // MARK: - ReminderNotificationDelegate — behavioral learning store wiring (PR 1, Task 9)
+
+    func testWillPresent_recordsObservationOnStore() async {
+        // Per plan §Task 9 step 1: clean slate, wire a store, drive the
+        // willPresent recording path via the test seam, assert obs counts up.
+        let store = BehavioralLearningStore()
+        store.deleteAllUserData()  // clean slate (in case previous tests left state)
+
+        let delegate = ReminderNotificationDelegate(analytics: nil, store: store)
+        delegate.recordObservationFromNotification(type: .nutritionGap, hour: 16)
+
+        // The seam dispatches to a Task { @MainActor in ... }; await a tick
+        // so the store write completes before we assert. ~50ms is generous.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+        // Cleanup
+        store.deleteAllUserData()
+    }
 }

--- a/docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md
+++ b/docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md
@@ -1,0 +1,1780 @@
+# Smart Reminders — Behavioral Learning PR 1 (Data Layer + Toggle-Off) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the data-collection foundation of the behavioral-learning sub-feature with zero user-visible behaviour change. Cohort writes start accumulating in production. Resolver and automation come in PR 2 (separate plan).
+
+**Architecture:** Three new on-device Swift services (`BehavioralLearningStore`, `CohortPriorClient`, `CohortPriorCache`) record per-user observations and fetch the server-side cohort prior. The existing `ReminderNotificationDelegate` is extended to call `BehavioralLearningStore.recordObservation` alongside the existing analytics events from PR #158. A new global "Smart timing" toggle in Settings is wired up but **defaults off** — the toggle reads/writes `AppSettings.smartTimingEnabled` but has no consumer until PR 2 lands. Two new AI-engine endpoints reuse the existing Supabase `cohort_stats` table + `increment_cohort_frequency` RPC; one new migration extends the existing pg_cron retention job. No new tables, no new authentication paths.
+
+**Tech Stack:** Swift 5.9+ (iOS 17+), SwiftUI, XCTest, UserNotifications, UserDefaults; Python (Railway-hosted AI engine, FastAPI); Supabase Postgres + pg_cron; existing GA4 event taxonomy.
+
+**Predecessor PRs:** PR #98 (parent feature shipped) + PR #158 (six lifecycle analytics events; merged 2026-04-30). Both already on `main`.
+
+**Reference:** `docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md` is the source of truth for design decisions.
+
+---
+
+## File Structure
+
+### New Swift files (PR 1)
+
+| Path | Responsibility |
+|---|---|
+| `FitTracker/Services/Reminders/BehavioralLearningStore.swift` | Per-user posterior over 24 hour-of-day buckets per personalisable type. Pure logic + UserDefaults persistence. No network. |
+| `FitTracker/Services/Reminders/CohortPriorClient.swift` | HTTP client for `/reminder-cohort-event` + `/reminder-cohort-priors`. Reuses `AIEngineClient` URL pattern. |
+| `FitTracker/Services/Reminders/CohortPriorCache.swift` | On-device cache of the cohort prior (7-day TTL). Persists single JSON blob to UserDefaults. |
+| `FitTracker/Views/Settings/BehavioralLearningSettingsView.swift` | Settings → Notifications: one global "Smart timing" toggle row. Defaults off. (PR 3 will add per-type "Why?" rows below it.) |
+| `FitTrackerTests/BehavioralLearningStoreTests.swift` | Bayesian math, denominator/numerator separation, persistence, per-type isolation. |
+| `FitTrackerTests/CohortPriorClientTests.swift` | No-PII-in-payload, network-error silent catch, response shape. |
+| `FitTrackerTests/CohortPriorCacheTests.swift` | TTL, malformed-JSON recovery, round-trip. |
+
+### Modified Swift files (PR 1)
+
+| Path | Change |
+|---|---|
+| `FitTracker/Services/Reminders/ReminderType.swift` | Add `defaultPriorDistribution: [Hour: Double]` static property per case (used as Bayesian prior fallback). |
+| `FitTracker/Services/Reminders/ReminderNotificationDelegate.swift` | Extend `willPresent` to call `store.recordObservation(tapped: false)` (denominator) and `client.recordEvent`. Extend `didReceive` to upgrade observation on tap. |
+| `FitTracker/FitTrackerApp.swift` | Instantiate `BehavioralLearningStore` + `CohortPriorCache` on app launch; fire-and-forget `client.fetchPriors()` once per session (cache-TTL guarded); inject store reference into `ReminderNotificationDelegate`. |
+| `FitTracker/Services/AppSettings.swift` (or equivalent settings model) | Add `@AppStorage var smartTimingEnabled: Bool = false`. Defaults off in PR 1. |
+| `FitTracker/Services/EncryptedDataStore.swift` (or wherever GDPR delete lives) | Extend `deleteAllUserData()` to wipe `BehavioralLearningStore` keys. |
+| `FitTracker/FitTracker.xcodeproj/project.pbxproj` | Register new Swift files in Sources build phase. |
+
+### New backend artifacts (PR 1)
+
+| Path | Change |
+|---|---|
+| `backend/supabase/migrations/000009_extend_retention_for_reminders.sql` | Extend pg_cron retention job to cover `segment LIKE 'reminders.%'`. |
+| AI-engine repo (Railway): `app/api/reminder_cohort.py` (new module) | `POST /reminder-cohort-event` and `GET /reminder-cohort-priors`. |
+| AI-engine repo: `app/tests/test_reminder_cohort.py` | pytest for both endpoints. |
+
+### State + meta artifacts (PR 1)
+
+| Path | Change |
+|---|---|
+| `.claude/features/smart-reminders-behavioral-learning/state.json` | Advance `current_phase` from `research` → `tasks` (start) → `implementation` (after Task 16) → `test`/`review`/`merge` (after PR opens). |
+| `.claude/logs/smart-reminders-behavioral-learning.log.json` | Phase-transition events at each `current_phase` change. |
+
+---
+
+## Tasks
+
+### Task 1: Pre-work — advance state.json from `research` to `tasks`
+
+**Files:**
+- Modify: `.claude/features/smart-reminders-behavioral-learning/state.json`
+- Modify: `.claude/logs/smart-reminders-behavioral-learning.log.json`
+
+- [ ] **Step 1: Update state.json `current_phase` and add timing entry**
+
+```bash
+python3 -c "
+import json
+from datetime import datetime, timezone
+path = '.claude/features/smart-reminders-behavioral-learning/state.json'
+d = json.load(open(path))
+now = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+d['current_phase'] = 'tasks'
+d['updated'] = now
+d['phases']['research']['status'] = 'complete'
+d['phases']['research']['ended_at'] = now
+d['phases']['tasks'] = {'status': 'in_progress', 'started_at': now}
+d['timing']['phases']['research']['ended_at'] = now
+d['timing']['phases']['tasks'] = {'started_at': now, 'ended_at': None, 'duration_minutes': None, 'paused_minutes': 0}
+json.dump(d, open(path, 'w'), indent=2)
+"
+```
+
+- [ ] **Step 2: Append phase-transition log entry**
+
+```bash
+python3 scripts/append-feature-log.py \
+  --feature smart-reminders-behavioral-learning \
+  --event-type phase_started \
+  --phase tasks \
+  --summary "Tasks phase started 2026-05-01. Spec at docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md. Plan at docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md."
+```
+
+- [ ] **Step 3: Validate the state.json**
+
+Run: `python3 scripts/check-state-schema.py .claude/features/smart-reminders-behavioral-learning/state.json`
+Expected: `✓ All 1 state.json files pass all checks`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/features/smart-reminders-behavioral-learning/state.json .claude/logs/smart-reminders-behavioral-learning.log.json
+git commit -m "chore(smart-reminders-behavioral-learning): advance phase research → tasks"
+```
+
+---
+
+### Task 2: Add `defaultPriorDistribution` to `ReminderType`
+
+**Files:**
+- Modify: `FitTracker/Services/Reminders/ReminderType.swift`
+- Test: (covered transitively by `BehavioralLearningStoreTests` in Task 4)
+
+The existing `ReminderType` enum has a static `defaultFireHour` per case. We need a `defaultPriorDistribution: [Int: Double]` per case — a tight bell curve around the default fire hour, summing to 1.0. This is the Bayesian prior fallback when the cohort prior cache is cold.
+
+- [ ] **Step 1: Open `FitTracker/Services/Reminders/ReminderType.swift` and locate the existing `defaultFireHour` accessor**
+
+```swift
+// Existing code, for context:
+var defaultFireHour: Int {
+    switch self {
+    case .nutritionGap: return 16
+    case .trainingDay:  return 10
+    case .restDay:      return 8
+    case .healthKitConnect:    return 11
+    case .accountRegistration: return 14
+    case .engagement:          return 18
+    }
+}
+```
+
+- [ ] **Step 2: Add `defaultPriorDistribution` immediately after `defaultFireHour`**
+
+```swift
+/// Tight bell curve over the 24 hour-of-day buckets, centred on `defaultFireHour`.
+/// Used as the Bayesian prior fallback when the cohort prior cache is cold.
+/// Sums to 1.0. σ = 1.5 hours (gives ~80% of mass within ±2 hours of centre).
+var defaultPriorDistribution: [Int: Double] {
+    let centre = Double(defaultFireHour)
+    let sigma  = 1.5
+    var raw: [Int: Double] = [:]
+    for h in 0..<24 {
+        let dx = Double(h) - centre
+        raw[h] = exp(-(dx * dx) / (2 * sigma * sigma))
+    }
+    let total = raw.values.reduce(0, +)
+    return raw.mapValues { $0 / total }
+}
+```
+
+- [ ] **Step 3: Add `import Foundation` if not already present** (`exp` requires it; existing imports likely cover this — verify)
+
+```bash
+head -10 FitTracker/Services/Reminders/ReminderType.swift
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `xcodebuild build -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -quiet`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add FitTracker/Services/Reminders/ReminderType.swift
+git commit -m "feat(smart-reminders): add ReminderType.defaultPriorDistribution (Bayesian prior fallback)"
+```
+
+---
+
+### Task 3: Implement `BehavioralLearningStore` (Bayesian math + persistence)
+
+**Files:**
+- Create: `FitTracker/Services/Reminders/BehavioralLearningStore.swift`
+- Test:   `FitTrackerTests/BehavioralLearningStoreTests.swift`
+- Modify: `FitTracker/FitTracker.xcodeproj/project.pbxproj` (Sources build phase entries)
+
+This is the core data structure: per-user, per-type rolling histogram of `(hour, tap_through)` outcomes, with a posterior accessor that combines observed counts.
+
+- [ ] **Step 1: Create `FitTrackerTests/BehavioralLearningStoreTests.swift` with the 0-observations test** (write the failing test first)
+
+```swift
+// FitTrackerTests/BehavioralLearningStoreTests.swift
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class BehavioralLearningStoreTests: XCTestCase {
+
+    private let storeKeyPrefix = "ft.reminder.posterior."
+    private let countKeyPrefix = "ft.reminder.obsCount."
+
+    override func setUp() {
+        super.setUp()
+        clearAllStoreDefaults()
+    }
+
+    override func tearDown() {
+        clearAllStoreDefaults()
+        super.tearDown()
+    }
+
+    func testPosteriorWithZeroObservations_isUniform() {
+        let store = BehavioralLearningStore()
+        let posterior = store.posterior(type: .nutritionGap)
+        // With zero observations, posterior is uniform across 24 hours
+        XCTAssertEqual(posterior.count, 24)
+        for h in 0..<24 {
+            XCTAssertEqual(posterior[h] ?? 0, 1.0 / 24.0, accuracy: 0.0001)
+        }
+        XCTAssertEqual(store.observationCount(type: .nutritionGap), 0)
+    }
+
+    private func clearAllStoreDefaults() {
+        let defaults = UserDefaults.standard
+        for type in ReminderType.allCases {
+            for h in 0..<24 {
+                let suffix = String(format: "%02d", h)
+                defaults.removeObject(forKey: "\(storeKeyPrefix)\(type.rawValue).h\(suffix)")
+            }
+            defaults.removeObject(forKey: "\(countKeyPrefix)\(type.rawValue)")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create the empty `BehavioralLearningStore.swift` shell so the test compiles**
+
+```swift
+// FitTracker/Services/Reminders/BehavioralLearningStore.swift
+// Per-user posterior over 24 hour-of-day buckets per personalisable ReminderType.
+// Persistence: UserDefaults keys ft.reminder.posterior.<type>.h<00..23> + ft.reminder.obsCount.<type>.
+
+import Foundation
+
+@MainActor
+final class BehavioralLearningStore {
+
+    private let defaults: UserDefaults
+    private let storeKeyPrefix = "ft.reminder.posterior."
+    private let countKeyPrefix = "ft.reminder.obsCount."
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Returns the per-hour distribution for a type. Uniform when zero observations recorded.
+    func posterior(type: ReminderType) -> [Int: Double] {
+        var dist: [Int: Double] = [:]
+        for h in 0..<24 { dist[h] = 1.0 / 24.0 }
+        return dist
+    }
+
+    /// Number of observations recorded for a type.
+    func observationCount(type: ReminderType) -> Int {
+        return 0
+    }
+}
+```
+
+- [ ] **Step 3: Add both files to `project.pbxproj`** (so the test can find the type)
+
+The pattern (mirror what was done for `ReminderNotificationDelegate.swift`/`ReminderAnalyticsTests.swift` in PR #158):
+
+In `project.pbxproj`, in the PBXBuildFile section near other Reminder entries (around the `RM*` IDs), add:
+
+```
+		BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL2000001000000000000001 /* BehavioralLearningStore.swift */; };
+		BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */; };
+```
+
+In the PBXFileReference section, add:
+
+```
+		BL2000001000000000000001 /* BehavioralLearningStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStore.swift; sourceTree = "<group>"; };
+		BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStoreTests.swift; sourceTree = "<group>"; };
+```
+
+In the Reminders PBXGroup children list (near where `ReminderNotificationDelegate.swift` appears), add `BL2000001000000000000001 /* BehavioralLearningStore.swift */,`. In the Tests PBXGroup, add `BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */,`. In the FitTracker target's Sources PBXBuildPhase children, add `BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */,`. In the FitTrackerTests target's Sources PBXBuildPhase children, add `BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */,`.
+
+- [ ] **Step 4: Run the test to confirm it passes (the shell happens to satisfy the 0-obs case)**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests/testPosteriorWithZeroObservations_isUniform 2>&1 | tail -10`
+Expected: `Test Suite 'BehavioralLearningStoreTests' passed`
+
+- [ ] **Step 5: Add the `recordObservation` test (denominator path)**
+
+Append to `BehavioralLearningStoreTests.swift`:
+
+```swift
+func testRecordObservation_incrementsCountForType() {
+    let store = BehavioralLearningStore()
+    store.recordObservation(type: .nutritionGap, hour: 16, tapped: false)
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+    XCTAssertEqual(store.observationCount(type: .trainingDay), 0,
+                   "Per-type isolation: nutritionGap obs must NOT count toward trainingDay")
+}
+```
+
+- [ ] **Step 6: Run to confirm it FAILS** (`recordObservation` doesn't exist yet)
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests/testRecordObservation_incrementsCountForType 2>&1 | tail -10`
+Expected: build error `value of type 'BehavioralLearningStore' has no member 'recordObservation'`
+
+- [ ] **Step 7: Implement `recordObservation` (minimal — just count)**
+
+Replace `BehavioralLearningStore.swift` body methods with:
+
+```swift
+    func posterior(type: ReminderType) -> [Int: Double] {
+        let count = observationCount(type: type)
+        guard count > 0 else {
+            var uniform: [Int: Double] = [:]
+            for h in 0..<24 { uniform[h] = 1.0 / 24.0 }
+            return uniform
+        }
+        // Each bucket = (taps in that hour) / (total observations)
+        var dist: [Int: Double] = [:]
+        for h in 0..<24 {
+            let tapsKey = tapsKey(type: type, hour: h)
+            let taps = defaults.integer(forKey: tapsKey)
+            dist[h] = Double(taps) / Double(count)
+        }
+        return dist
+    }
+
+    func observationCount(type: ReminderType) -> Int {
+        defaults.integer(forKey: "\(countKeyPrefix)\(type.rawValue)")
+    }
+
+    /// Records a `shown` event (denominator). `tapped` is initially false; call
+    /// `upgradeLastObservation` after a tap to promote the same observation
+    /// to a tap (numerator). Returns the observation's stable id so callers
+    /// can pass it to `upgradeLastObservation`.
+    @discardableResult
+    func recordObservation(type: ReminderType, hour: Int, tapped: Bool) -> String {
+        precondition((0..<24).contains(hour), "hour must be 0..<24")
+        let countKey = "\(countKeyPrefix)\(type.rawValue)"
+        defaults.set(defaults.integer(forKey: countKey) + 1, forKey: countKey)
+        if tapped {
+            let tapsKey = tapsKey(type: type, hour: hour)
+            defaults.set(defaults.integer(forKey: tapsKey) + 1, forKey: tapsKey)
+        }
+        // Stash the (type, hour) of the last observation so upgrade can find it.
+        defaults.set(["type": type.rawValue, "hour": hour, "tapped": tapped],
+                     forKey: lastObsKey)
+        return "\(type.rawValue):\(hour):\(Date().timeIntervalSince1970)"
+    }
+
+    private func tapsKey(type: ReminderType, hour: Int) -> String {
+        let suffix = String(format: "%02d", hour)
+        return "\(storeKeyPrefix)\(type.rawValue).h\(suffix)"
+    }
+
+    private let lastObsKey = "ft.reminder.lastObservation"
+```
+
+- [ ] **Step 8: Run the new test plus the original — both should pass**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests 2>&1 | tail -15`
+Expected: 2 tests passed
+
+- [ ] **Step 9: Add `upgradeLastObservation` test (numerator promotion + idempotence)**
+
+```swift
+func testUpgradeLastObservation_promotesShowToTap_andIsIdempotent() {
+    let store = BehavioralLearningStore()
+    store.recordObservation(type: .nutritionGap, hour: 16, tapped: false)
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+    store.upgradeLastObservation(type: .nutritionGap, tapped: true)
+    let posterior1 = store.posterior(type: .nutritionGap)
+    XCTAssertEqual(posterior1[16] ?? 0, 1.0, accuracy: 0.0001,
+                   "Single observation upgraded to tap: bucket 16 holds 100% of mass")
+
+    // Calling upgrade twice for the SAME observation must NOT double-count
+    store.upgradeLastObservation(type: .nutritionGap, tapped: true)
+    let posterior2 = store.posterior(type: .nutritionGap)
+    XCTAssertEqual(posterior1, posterior2, "Idempotent upgrade")
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+}
+```
+
+- [ ] **Step 10: Run to confirm FAIL** (`upgradeLastObservation` doesn't exist)
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests/testUpgradeLastObservation_promotesShowToTap_andIsIdempotent 2>&1 | tail -10`
+Expected: build error `value of type 'BehavioralLearningStore' has no member 'upgradeLastObservation'`
+
+- [ ] **Step 11: Implement `upgradeLastObservation` with idempotence guard**
+
+Add to `BehavioralLearningStore.swift`:
+
+```swift
+    /// Promotes the most recent `shown` observation to a `tap`. Idempotent —
+    /// if the last observation is already marked tapped, this is a no-op.
+    /// Used by ReminderNotificationDelegate.didReceive when the user taps.
+    func upgradeLastObservation(type: ReminderType, tapped: Bool) {
+        guard tapped else { return }  // only handle "promote to tap"
+        guard let last = defaults.dictionary(forKey: lastObsKey) else { return }
+        guard let recordedTypeRaw = last["type"] as? String,
+              let recordedTypeRaw_ = ReminderType(rawValue: recordedTypeRaw),
+              recordedTypeRaw_ == type,
+              let hour = last["hour"] as? Int else { return }
+        let alreadyTapped = (last["tapped"] as? Bool) ?? false
+        guard !alreadyTapped else { return }  // idempotent
+
+        // Promote: increment taps[hour], DO NOT increment obsCount (it was already incremented at recordObservation)
+        let tapsK = tapsKey(type: type, hour: hour)
+        defaults.set(defaults.integer(forKey: tapsK) + 1, forKey: tapsK)
+        defaults.set(["type": type.rawValue, "hour": hour, "tapped": true],
+                     forKey: lastObsKey)
+    }
+```
+
+- [ ] **Step 12: Run all `BehavioralLearningStoreTests` to confirm 3/3 pass**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests 2>&1 | tail -10`
+Expected: 3 tests passed
+
+- [ ] **Step 13: Add `deleteAllUserData` test (GDPR wipe)**
+
+```swift
+func testDeleteAllUserData_wipesAllStoreKeys() {
+    let store = BehavioralLearningStore()
+    store.recordObservation(type: .nutritionGap, hour: 16, tapped: true)
+    store.upgradeLastObservation(type: .nutritionGap, tapped: true)
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+    store.deleteAllUserData()
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 0)
+    let posterior = store.posterior(type: .nutritionGap)
+    for h in 0..<24 {
+        XCTAssertEqual(posterior[h] ?? 0, 1.0 / 24.0, accuracy: 0.0001,
+                       "After wipe, posterior is uniform again")
+    }
+}
+```
+
+- [ ] **Step 14: Run to confirm FAIL**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests/testDeleteAllUserData_wipesAllStoreKeys 2>&1 | tail -10`
+Expected: `value of type 'BehavioralLearningStore' has no member 'deleteAllUserData'`
+
+- [ ] **Step 15: Implement `deleteAllUserData`**
+
+Add to `BehavioralLearningStore.swift`:
+
+```swift
+    /// GDPR Article 17 — right to erasure. Wipes all behavioural-learning
+    /// state from UserDefaults. Called by EncryptedDataStore.deleteAllUserData()
+    /// (Task 11).
+    func deleteAllUserData() {
+        for type in ReminderType.allCases {
+            defaults.removeObject(forKey: "\(countKeyPrefix)\(type.rawValue)")
+            for h in 0..<24 {
+                defaults.removeObject(forKey: tapsKey(type: type, hour: h))
+            }
+        }
+        defaults.removeObject(forKey: lastObsKey)
+    }
+```
+
+- [ ] **Step 16: Run all tests — 4/4 pass**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests 2>&1 | tail -10`
+Expected: 4 tests passed
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add FitTracker/Services/Reminders/BehavioralLearningStore.swift FitTrackerTests/BehavioralLearningStoreTests.swift FitTracker.xcodeproj/project.pbxproj
+git commit -m "feat(smart-reminders): BehavioralLearningStore — per-user posterior + GDPR wipe
+
+Pure logic + UserDefaults persistence. Records denominator (shown) on
+willPresent, upgrades to numerator (tap) on didReceive. Idempotent
+upgrade. Per-type isolation. deleteAllUserData() satisfies Article 17.
+
+Tests cover: 0-obs uniform posterior, recordObservation increments, idempotent
+upgradeLastObservation, deleteAllUserData wipes everything."
+```
+
+---
+
+### Task 4: Implement `CohortPriorClient` (HTTP client + no-PII assertion)
+
+**Files:**
+- Create: `FitTracker/Services/Reminders/CohortPriorClient.swift`
+- Test:   `FitTrackerTests/CohortPriorClientTests.swift`
+- Modify: `FitTracker.xcodeproj/project.pbxproj`
+
+The client wraps two HTTP calls: `POST /reminder-cohort-event` (fire-and-forget write) and `GET /reminder-cohort-priors` (read). Reuses `AIEngineClient`'s URL pattern.
+
+- [ ] **Step 1: Create `CohortPriorClientTests.swift` with the no-PII test (write the failing test)**
+
+```swift
+// FitTrackerTests/CohortPriorClientTests.swift
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class CohortPriorClientTests: XCTestCase {
+
+    func testRecordEvent_payloadContainsOnlyAllowedKeys() async throws {
+        let session = MockURLSession()
+        let client = CohortPriorClient(baseURL: URL(string: "https://test.local")!, session: session)
+
+        try await client.recordEvent(type: .nutritionGap, hour: 16, tapped: true)
+
+        let request = try XCTUnwrap(session.lastRequest)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try JSONSerialization.jsonObject(with: body) as? [String: Any] ?? [:]
+
+        // The ONLY allowed keys: type, hour, tapped. No userId, no deviceId, no locale, no timestamp.
+        XCTAssertEqual(Set(json.keys), Set(["type", "hour", "tapped"]),
+                       "Payload must contain only {type, hour, tapped} — no PII")
+        XCTAssertEqual(json["type"] as? String, "nutrition_gap")
+        XCTAssertEqual(json["hour"] as? Int, 16)
+        XCTAssertEqual(json["tapped"] as? Bool, true)
+    }
+}
+
+/// Test double — captures the most recent request without hitting the network.
+private final class MockURLSession: URLSessionProtocol {
+    var lastRequest: URLRequest?
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        let response = HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: nil, headerFields: nil)!
+        return (Data(), response)
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm FAIL** (`CohortPriorClient` doesn't exist)
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/CohortPriorClientTests 2>&1 | tail -10`
+Expected: build error referencing `CohortPriorClient`
+
+- [ ] **Step 3: Create `CohortPriorClient.swift` with the minimal implementation + injected URLSession**
+
+```swift
+// FitTracker/Services/Reminders/CohortPriorClient.swift
+// HTTP client for the AI-engine reminder-cohort endpoints.
+// Two methods: recordEvent (POST, fire-and-forget) and fetchPriors (GET).
+// All errors are caught and re-thrown — callers may swallow as appropriate.
+
+import Foundation
+
+protocol URLSessionProtocol {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+struct CohortPriorResponse: Codable {
+    let priors: [String: [String: Double]]   // [type: [hour: rate]]
+    let killFlags: [String]                  // ["nutrition_gap", ...]
+
+    enum CodingKeys: String, CodingKey {
+        case priors
+        case killFlags = "kill_flags"
+    }
+}
+
+final class CohortPriorClient {
+
+    private let baseURL: URL
+    private let session: URLSessionProtocol
+
+    init(baseURL: URL, session: URLSessionProtocol = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    /// POST /reminder-cohort-event with the minimum-PII payload.
+    func recordEvent(type: ReminderType, hour: Int, tapped: Bool) async throws {
+        precondition((0..<24).contains(hour), "hour must be 0..<24")
+        let url = baseURL.appendingPathComponent("reminder-cohort-event")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let payload: [String: Any] = [
+            "type":   type.rawValue,
+            "hour":   hour,
+            "tapped": tapped,
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        _ = try await session.data(for: req)
+    }
+
+    /// GET /reminder-cohort-priors. Returns the population prior + kill flags.
+    func fetchPriors() async throws -> CohortPriorResponse {
+        let url = baseURL.appendingPathComponent("reminder-cohort-priors")
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        let (data, _) = try await session.data(for: req)
+        return try JSONDecoder().decode(CohortPriorResponse.self, from: data)
+    }
+}
+```
+
+- [ ] **Step 4: Add the file to project.pbxproj** (mirror the `BehavioralLearningStore` pbxproj entries from Task 3 with new IDs `CC1*`/`CC2*`)
+
+- [ ] **Step 5: Run the no-PII test**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/CohortPriorClientTests/testRecordEvent_payloadContainsOnlyAllowedKeys 2>&1 | tail -10`
+Expected: PASS
+
+- [ ] **Step 6: Add the network-error test**
+
+```swift
+func testRecordEvent_networkError_propagates() async {
+    let session = MockURLSession()
+    session.error = URLError(.notConnectedToInternet)
+    let client = CohortPriorClient(baseURL: URL(string: "https://test.local")!, session: session)
+
+    do {
+        try await client.recordEvent(type: .nutritionGap, hour: 16, tapped: true)
+        XCTFail("Should have thrown")
+    } catch is URLError {
+        // Expected — caller (FitTrackerApp) is responsible for catching/swallowing
+    } catch {
+        XCTFail("Unexpected error type: \(error)")
+    }
+}
+```
+
+Update `MockURLSession` to support an injected error:
+
+```swift
+private final class MockURLSession: URLSessionProtocol {
+    var lastRequest: URLRequest?
+    var error: Error?
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        if let e = error { throw e }
+        let response = HTTPURLResponse(url: request.url!, statusCode: 204, httpVersion: nil, headerFields: nil)!
+        return (Data(), response)
+    }
+}
+```
+
+- [ ] **Step 7: Add the fetchPriors response-shape test**
+
+```swift
+func testFetchPriors_decodesResponse() async throws {
+    let session = MockURLSession()
+    session.canned = """
+    {
+      "priors": { "nutrition_gap": { "16": 0.34, "17": 0.41 } },
+      "kill_flags": ["engagement"]
+    }
+    """.data(using: .utf8)!
+    let client = CohortPriorClient(baseURL: URL(string: "https://test.local")!, session: session)
+
+    let response = try await client.fetchPriors()
+    XCTAssertEqual(response.priors["nutrition_gap"]?["17"], 0.41)
+    XCTAssertEqual(response.killFlags, ["engagement"])
+}
+```
+
+Update `MockURLSession`:
+
+```swift
+private final class MockURLSession: URLSessionProtocol {
+    var lastRequest: URLRequest?
+    var error: Error?
+    var canned: Data = Data()
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        if let e = error { throw e }
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        return (canned, response)
+    }
+}
+```
+
+- [ ] **Step 8: Run all `CohortPriorClientTests` (3 cases) — all pass**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/CohortPriorClientTests 2>&1 | tail -10`
+Expected: 3 tests passed
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add FitTracker/Services/Reminders/CohortPriorClient.swift FitTrackerTests/CohortPriorClientTests.swift FitTracker.xcodeproj/project.pbxproj
+git commit -m "feat(smart-reminders): CohortPriorClient — POST/GET with no-PII payload
+
+Two methods: recordEvent (fire-and-forget write) and fetchPriors (read).
+Payload contains only {type, hour, tapped} — no userId / deviceId / locale.
+URLSessionProtocol injection for testability.
+
+Tests: payload-keys assertion, network-error propagation, fetchPriors decode."
+```
+
+---
+
+### Task 5: Implement `CohortPriorCache` (TTL + JSON round-trip)
+
+**Files:**
+- Create: `FitTracker/Services/Reminders/CohortPriorCache.swift`
+- Test:   `FitTrackerTests/CohortPriorCacheTests.swift`
+- Modify: `FitTracker.xcodeproj/project.pbxproj`
+
+A thin wrapper around the `CohortPriorResponse` with a 7-day TTL and graceful JSON-failure recovery.
+
+- [ ] **Step 1: Write `CohortPriorCacheTests.swift` with the TTL + round-trip tests**
+
+```swift
+// FitTrackerTests/CohortPriorCacheTests.swift
+import XCTest
+@testable import FitTracker
+
+@MainActor
+final class CohortPriorCacheTests: XCTestCase {
+
+    private let cacheKey = "ft.reminder.cohortPrior.json"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: cacheKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: cacheKey)
+        super.tearDown()
+    }
+
+    func testColdCache_isStale() {
+        let cache = CohortPriorCache()
+        XCTAssertTrue(cache.isStale, "Cold cache must report stale (forces fetch)")
+        XCTAssertNil(cache.priors)
+    }
+
+    func testPersistThenLoad_roundTrip() {
+        let cache = CohortPriorCache()
+        let response = CohortPriorResponse(
+            priors: ["nutrition_gap": ["16": 0.42]],
+            killFlags: ["engagement"]
+        )
+        cache.persist(response)
+
+        let cache2 = CohortPriorCache()  // simulate app relaunch
+        XCTAssertFalse(cache2.isStale, "Just-persisted cache must NOT be stale")
+        XCTAssertEqual(cache2.priors?.priors["nutrition_gap"]?["16"], 0.42)
+        XCTAssertEqual(cache2.priors?.killFlags, ["engagement"])
+    }
+
+    func testStaleAfter7Days() {
+        let cache = CohortPriorCache()
+        let response = CohortPriorResponse(priors: [:], killFlags: [])
+        // Persist with a fake "fetched 8 days ago" timestamp
+        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
+        cache.persist(response, fetchedAt: eightDaysAgo)
+
+        let cache2 = CohortPriorCache()
+        XCTAssertTrue(cache2.isStale, "Cache older than 7 days must be stale")
+    }
+
+    func testMalformedJSON_recoversToCold() {
+        UserDefaults.standard.set("not valid json".data(using: .utf8), forKey: cacheKey)
+        let cache = CohortPriorCache()
+        XCTAssertTrue(cache.isStale)
+        XCTAssertNil(cache.priors, "Malformed JSON must result in cold cache, not crash")
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm FAIL** (`CohortPriorCache` doesn't exist)
+
+Expected: build error
+
+- [ ] **Step 3: Create `CohortPriorCache.swift` minimal impl**
+
+```swift
+// FitTracker/Services/Reminders/CohortPriorCache.swift
+// On-device cache of the cohort prior response. 7-day TTL.
+// Persistence: a single JSON blob in UserDefaults key ft.reminder.cohortPrior.json.
+
+import Foundation
+
+final class CohortPriorCache {
+
+    private let defaults: UserDefaults
+    private let cacheKey = "ft.reminder.cohortPrior.json"
+    private let ttl: TimeInterval = 7 * 24 * 60 * 60
+
+    private struct Envelope: Codable {
+        let response: CohortPriorResponse
+        let fetchedAt: Date
+    }
+
+    private(set) var priors: CohortPriorResponse?
+    private var fetchedAt: Date?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        loadFromDefaults()
+    }
+
+    var isStale: Bool {
+        guard let fetched = fetchedAt else { return true }
+        return Date().timeIntervalSince(fetched) > ttl
+    }
+
+    func persist(_ response: CohortPriorResponse, fetchedAt: Date = Date()) {
+        let envelope = Envelope(response: response, fetchedAt: fetchedAt)
+        guard let data = try? JSONEncoder().encode(envelope) else { return }
+        defaults.set(data, forKey: cacheKey)
+        self.priors = response
+        self.fetchedAt = fetchedAt
+    }
+
+    private func loadFromDefaults() {
+        guard let data = defaults.data(forKey: cacheKey) else { return }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else {
+            // Malformed JSON — leave priors/fetchedAt nil; isStale stays true
+            return
+        }
+        priors = envelope.response
+        fetchedAt = envelope.fetchedAt
+    }
+}
+```
+
+- [ ] **Step 4: Add to project.pbxproj** (IDs `CP1*`/`CP2*` for store + tests)
+
+- [ ] **Step 5: Run all `CohortPriorCacheTests` (4 tests)**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/CohortPriorCacheTests 2>&1 | tail -10`
+Expected: 4 tests passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add FitTracker/Services/Reminders/CohortPriorCache.swift FitTrackerTests/CohortPriorCacheTests.swift FitTracker.xcodeproj/project.pbxproj
+git commit -m "feat(smart-reminders): CohortPriorCache — 7-day TTL + graceful JSON recovery
+
+Wraps CohortPriorResponse with a fetchedAt timestamp + isStale getter.
+Cold cache and malformed-JSON both report stale (forces fetch).
+
+Tests: cold = stale, round-trip preserves data, 8d-old = stale, malformed JSON does not crash."
+```
+
+---
+
+### Task 6: AI engine — `POST /reminder-cohort-event` endpoint + pytest
+
+**Files (in the AI engine repo, separate from FT2):**
+- Create: `app/api/reminder_cohort.py` (or wherever new routers live in the existing FastAPI structure)
+- Create: `app/tests/test_reminder_cohort.py`
+- Modify: `app/main.py` (or equivalent — register the new router)
+
+> **Inspect the AI engine repo's existing structure before adding files.** The endpoint pattern, dependency injection (Supabase client), and test fixture imports follow whatever the existing endpoints (e.g., readiness, recommendations) use. Mirror those patterns.
+
+- [ ] **Step 1: Locate the existing endpoint pattern**
+
+```bash
+cd <ai-engine-repo>
+ls app/api/
+grep -rn "increment_cohort_frequency" app/
+```
+
+Note the pattern: existing endpoints accept a Pydantic model, call `supabase.rpc(...)`, return a status code. Tests use a `pytest` async client + a mocked Supabase service.
+
+- [ ] **Step 2: Write the failing pytest first**
+
+`app/tests/test_reminder_cohort.py`:
+
+```python
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_record_event_writes_two_segments_when_tapped(client: AsyncClient, mock_supabase):
+    response = await client.post(
+        "/reminder-cohort-event",
+        json={"type": "nutrition_gap", "hour": 16, "tapped": True},
+    )
+    assert response.status_code == 204
+
+    # Should have called increment_cohort_frequency twice:
+    # once for shows, once for taps
+    calls = mock_supabase.rpc_calls("increment_cohort_frequency")
+    assert len(calls) == 2
+
+    shows_call = next(c for c in calls if "shows" in c["params"]["p_segment"])
+    taps_call  = next(c for c in calls if "taps"  in c["params"]["p_segment"])
+    assert shows_call["params"] == {
+        "p_segment": "reminders.shows.nutrition_gap",
+        "p_field_name": "hour",
+        "p_field_value": "16",
+    }
+    assert taps_call["params"] == {
+        "p_segment": "reminders.taps.nutrition_gap",
+        "p_field_name": "hour",
+        "p_field_value": "16",
+    }
+
+
+@pytest.mark.asyncio
+async def test_record_event_only_writes_shows_when_not_tapped(client: AsyncClient, mock_supabase):
+    response = await client.post(
+        "/reminder-cohort-event",
+        json={"type": "nutrition_gap", "hour": 16, "tapped": False},
+    )
+    assert response.status_code == 204
+    calls = mock_supabase.rpc_calls("increment_cohort_frequency")
+    assert len(calls) == 1
+    assert "shows" in calls[0]["params"]["p_segment"]
+
+
+@pytest.mark.asyncio
+async def test_record_event_no_pii_persisted(client: AsyncClient, mock_supabase):
+    """Even with auth, the request body has no userId — and the RPC params
+    have no per-user keys."""
+    await client.post(
+        "/reminder-cohort-event",
+        json={"type": "nutrition_gap", "hour": 16, "tapped": True},
+        headers={"Authorization": "Bearer fake_jwt_with_userId_in_claims"},
+    )
+    calls = mock_supabase.rpc_calls("increment_cohort_frequency")
+    for call in calls:
+        params = call["params"]
+        assert "user_id" not in params
+        assert "userId" not in params
+        # Aggregation key is only (segment, field_name, field_value)
+        assert set(params.keys()) == {"p_segment", "p_field_name", "p_field_value"}
+```
+
+- [ ] **Step 3: Run the test, confirm it fails (endpoint doesn't exist)**
+
+```bash
+pytest app/tests/test_reminder_cohort.py -v
+```
+
+Expected: 404 or routing error.
+
+- [ ] **Step 4: Implement the endpoint**
+
+`app/api/reminder_cohort.py`:
+
+```python
+from fastapi import APIRouter, status, Depends
+from pydantic import BaseModel, Field, field_validator
+from app.dependencies import get_supabase  # whatever path the existing pattern uses
+
+router = APIRouter()
+
+class CohortEvent(BaseModel):
+    type: str = Field(..., description="ReminderType.rawValue, e.g. 'nutrition_gap'")
+    hour: int = Field(..., ge=0, le=23)
+    tapped: bool
+
+    @field_validator("type")
+    @classmethod
+    def type_must_be_known(cls, v: str) -> str:
+        allowed = {
+            "nutrition_gap", "training_day", "rest_day",
+            "healthkit_connect", "account_registration", "engagement",
+        }
+        if v not in allowed:
+            raise ValueError(f"type must be one of {allowed}")
+        return v
+
+
+@router.post("/reminder-cohort-event", status_code=status.HTTP_204_NO_CONTENT)
+async def record_cohort_event(event: CohortEvent, supabase = Depends(get_supabase)):
+    hour_str = f"{event.hour:02d}"
+
+    # Always write shows
+    supabase.rpc("increment_cohort_frequency", {
+        "p_segment":     f"reminders.shows.{event.type}",
+        "p_field_name":  "hour",
+        "p_field_value": hour_str,
+    }).execute()
+
+    # Conditionally write taps
+    if event.tapped:
+        supabase.rpc("increment_cohort_frequency", {
+            "p_segment":     f"reminders.taps.{event.type}",
+            "p_field_name":  "hour",
+            "p_field_value": hour_str,
+        }).execute()
+```
+
+- [ ] **Step 5: Register the router in `app/main.py`**
+
+```python
+from app.api.reminder_cohort import router as reminder_cohort_router
+app.include_router(reminder_cohort_router)
+```
+
+- [ ] **Step 6: Run tests — 3/3 pass**
+
+```bash
+pytest app/tests/test_reminder_cohort.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 7: Commit (in the AI engine repo)**
+
+```bash
+git add app/api/reminder_cohort.py app/tests/test_reminder_cohort.py app/main.py
+git commit -m "feat(reminder-cohort): POST /reminder-cohort-event endpoint
+
+Writes anonymised cohort observations to Supabase via
+increment_cohort_frequency RPC. Uses two segments per event
+(shows + taps) so tap-through rate = taps[h] / shows[h] is
+computable at read time.
+
+Payload validates type ∈ known ReminderTypes; hour ∈ [0, 23].
+No PII in request body or persisted RPC params."
+```
+
+---
+
+### Task 7: AI engine — `GET /reminder-cohort-priors` endpoint + pytest
+
+**Files (AI engine repo):**
+- Modify: `app/api/reminder_cohort.py`
+- Modify: `app/tests/test_reminder_cohort.py`
+
+The read endpoint reads `cohort_stats` for `segment LIKE 'reminders.%'`, computes per-type per-hour `tap-through = taps[h] / shows[h]`, suppresses cells with `shows < 50`, and surfaces kill flags.
+
+- [ ] **Step 1: Add the failing test for the response shape**
+
+```python
+@pytest.mark.asyncio
+async def test_priors_returns_per_type_per_hour_rates(client: AsyncClient, mock_supabase):
+    # Seed: nutrition_gap at hour 16 has 80 shows and 32 taps → rate 0.4
+    mock_supabase.seed_cohort_stats([
+        {"segment": "reminders.shows.nutrition_gap", "field_name": "hour", "field_value": "16", "frequency": 80},
+        {"segment": "reminders.taps.nutrition_gap",  "field_name": "hour", "field_value": "16", "frequency": 32},
+    ])
+    response = await client.get("/reminder-cohort-priors")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["priors"]["nutrition_gap"]["16"] == pytest.approx(0.4)
+    assert data["kill_flags"] == []
+
+@pytest.mark.asyncio
+async def test_priors_suppresses_low_volume_cells(client: AsyncClient, mock_supabase):
+    # 49 shows is below the privacy threshold (50)
+    mock_supabase.seed_cohort_stats([
+        {"segment": "reminders.shows.nutrition_gap", "field_name": "hour", "field_value": "16", "frequency": 49},
+        {"segment": "reminders.taps.nutrition_gap",  "field_name": "hour", "field_value": "16", "frequency": 20},
+    ])
+    response = await client.get("/reminder-cohort-priors")
+    data = response.json()
+    assert "16" not in data["priors"].get("nutrition_gap", {}), \
+        "cells with shows<50 must be suppressed in the response"
+
+@pytest.mark.asyncio
+async def test_priors_includes_kill_flags(client: AsyncClient, mock_supabase):
+    mock_supabase.seed_cohort_stats([
+        {"segment": "reminders.kill_flag", "field_name": "engagement", "field_value": "true", "frequency": 1},
+    ])
+    response = await client.get("/reminder-cohort-priors")
+    data = response.json()
+    assert data["kill_flags"] == ["engagement"]
+```
+
+- [ ] **Step 2: Run to confirm fail**
+
+Expected: 404.
+
+- [ ] **Step 3: Implement the endpoint**
+
+Append to `app/api/reminder_cohort.py`:
+
+```python
+from typing import Dict, List
+
+class CohortPriorsResponse(BaseModel):
+    priors: Dict[str, Dict[str, float]]   # {type: {hour: rate}}
+    kill_flags: List[str]
+
+
+@router.get("/reminder-cohort-priors", response_model=CohortPriorsResponse)
+async def get_cohort_priors(supabase = Depends(get_supabase)):
+    PRIVACY_THRESHOLD = 50
+
+    # Fetch all reminder cohort rows in one query
+    rows = supabase.table("cohort_stats") \
+        .select("segment, field_name, field_value, frequency") \
+        .like("segment", "reminders.%") \
+        .execute() \
+        .data
+
+    shows: Dict[str, Dict[str, int]] = {}
+    taps:  Dict[str, Dict[str, int]] = {}
+    kill_flags: List[str] = []
+
+    for row in rows:
+        segment = row["segment"]
+        if segment == "reminders.kill_flag" and row["field_value"] == "true":
+            kill_flags.append(row["field_name"])
+            continue
+        if segment.startswith("reminders.shows."):
+            type_ = segment.removeprefix("reminders.shows.")
+            shows.setdefault(type_, {})[row["field_value"]] = row["frequency"]
+        elif segment.startswith("reminders.taps."):
+            type_ = segment.removeprefix("reminders.taps.")
+            taps.setdefault(type_, {})[row["field_value"]] = row["frequency"]
+
+    priors: Dict[str, Dict[str, float]] = {}
+    for type_, hour_shows in shows.items():
+        priors[type_] = {}
+        for hour, n_shows in hour_shows.items():
+            if n_shows < PRIVACY_THRESHOLD:
+                continue  # suppress
+            n_taps = taps.get(type_, {}).get(hour, 0)
+            priors[type_][hour] = n_taps / n_shows
+        if not priors[type_]:
+            del priors[type_]  # don't return empty type entries
+
+    return CohortPriorsResponse(priors=priors, kill_flags=kill_flags)
+```
+
+- [ ] **Step 4: Run tests — all 6 (3 from Task 6 + 3 here) pass**
+
+```bash
+pytest app/tests/test_reminder_cohort.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/reminder_cohort.py app/tests/test_reminder_cohort.py
+git commit -m "feat(reminder-cohort): GET /reminder-cohort-priors endpoint
+
+Reads cohort_stats for segment LIKE 'reminders.%', computes per-type
+per-hour tap-through rate. Suppresses cells with shows < 50 (privacy
++ statistical-validity threshold). Surfaces kill flags from the
+'reminders.kill_flag' segment."
+```
+
+---
+
+### Task 8: Supabase migration — extend pg_cron retention to `reminders.%` segments
+
+**Files:**
+- Create: `backend/supabase/migrations/000009_extend_retention_for_reminders.sql`
+
+- [ ] **Step 1: Read the existing retention migration to mirror its pattern**
+
+```bash
+cat backend/supabase/migrations/000004_retention_pg_cron.sql
+```
+
+Note the existing TTL policy and pg_cron schedule. Follow exactly the same pattern.
+
+- [ ] **Step 2: Create the new migration**
+
+`backend/supabase/migrations/000009_extend_retention_for_reminders.sql`:
+
+```sql
+-- Migration 000009: extend cohort_stats retention to reminders.* segments
+-- Mirrors the policy defined in migration 000004 for the existing ai-engine
+-- segments. The reminder cohort segments use the same TTL since their data
+-- volume + sensitivity profile is identical (anonymised frequency counts).
+
+-- Re-create the existing pg_cron job's predicate to also match reminders.%
+-- (replace the original job rather than adding a second one — keeps the
+-- retention policy single-sourced.)
+
+SELECT cron.unschedule('cohort_stats_retention');
+
+SELECT cron.schedule(
+  'cohort_stats_retention',
+  '0 3 * * *',  -- daily at 03:00 UTC
+  $$
+    DELETE FROM cohort_stats
+    WHERE updated_at < NOW() - INTERVAL '90 days'
+      AND (
+        segment IN ('training', 'nutrition', 'recovery', 'stats')
+        OR segment LIKE 'reminders.%'
+      );
+  $$
+);
+
+COMMENT ON EXTENSION pg_cron IS
+  '90-day rolling retention on cohort_stats. Covers all known segments: '
+  'the original ai-engine 4 + reminders.* added 2026-05-01 (migration 000009).';
+```
+
+> **Verify the schedule + interval against migration 000004 — adjust if 000004 uses different values.** The plan above assumes 90-day TTL + 03:00 UTC daily; replace with whatever 000004 uses.
+
+- [ ] **Step 3: Apply the migration to the local Supabase (or staging)**
+
+```bash
+cd backend/supabase
+supabase db push --include-all
+# OR via the Supabase MCP if configured: mcp__claude_ai_Supabase__apply_migration
+```
+
+- [ ] **Step 4: Verify the cron job is registered**
+
+```sql
+SELECT jobname, schedule FROM cron.job WHERE jobname = 'cohort_stats_retention';
+```
+
+Expected: one row with the new schedule.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/supabase/migrations/000009_extend_retention_for_reminders.sql
+git commit -m "feat(supabase): extend cohort_stats retention to reminders.% segments
+
+Single-sources the retention policy (re-schedules the existing
+cohort_stats_retention pg_cron job rather than adding a second). Uses
+the same 90-day TTL as the original ai-engine segments. No new tables;
+reuses cohort_stats schema verbatim per the design spec."
+```
+
+---
+
+### Task 9: Wire `BehavioralLearningStore` into `ReminderNotificationDelegate`
+
+**Files:**
+- Modify: `FitTracker/Services/Reminders/ReminderNotificationDelegate.swift`
+- Modify: `FitTrackerTests/ReminderAnalyticsTests.swift` (existing file — extend with new behaviour assertion)
+
+`willPresent` records the **denominator** (`tapped: false`); `didReceive` upgrades to numerator on tap.
+
+- [ ] **Step 1: Add a failing test to `ReminderAnalyticsTests.swift`** (the existing test file from PR #158 that already exercises the delegate)
+
+```swift
+func testWillPresent_recordsObservationOnStore() async {
+    let store = BehavioralLearningStore()
+    store.deleteAllUserData()  // clean slate
+    let delegate = ReminderNotificationDelegate(analytics: nil, store: store)
+
+    // Simulate a willPresent callback (delegate is non-isolated; we exercise
+    // the store-recording branch directly via the test seam.)
+    delegate.recordObservationFromNotification(type: .nutritionGap, hour: 16)
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+}
+```
+
+(`recordObservationFromNotification` is a small internal seam we'll expose for testability — the real `willPresent` callback is hard to drive in XCTest without a UNNotification fixture.)
+
+- [ ] **Step 2: Run to confirm fail**
+
+Expected: missing init parameter `store:` and missing method `recordObservationFromNotification`.
+
+- [ ] **Step 3: Modify `ReminderNotificationDelegate.swift` to accept a store + expose the test seam**
+
+```swift
+final class ReminderNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+
+    weak var analytics: AnalyticsService?
+    weak var store: BehavioralLearningStore?
+    weak var cohortClient: CohortPriorClient?
+
+    init(analytics: AnalyticsService? = nil,
+         store: BehavioralLearningStore? = nil,
+         cohortClient: CohortPriorClient? = nil) {
+        self.analytics = analytics
+        self.store = store
+        self.cohortClient = cohortClient
+        super.init()
+    }
+
+    /// Test-only seam: directly drive the willPresent recording path
+    /// without constructing a UNNotification (which has private inits).
+    func recordObservationFromNotification(type: ReminderType, hour: Int) {
+        Task { @MainActor in
+            store?.recordObservation(type: type, hour: hour, tapped: false)
+        }
+        Task {
+            try? await cohortClient?.recordEvent(type: type, hour: hour, tapped: false)
+        }
+    }
+
+    /// Test-only seam: directly drive the didReceive(tap) path.
+    func upgradeObservationFromTap(type: ReminderType, hour: Int) {
+        Task { @MainActor in
+            store?.upgradeLastObservation(type: type, tapped: true)
+        }
+        Task {
+            try? await cohortClient?.recordEvent(type: type, hour: hour, tapped: true)
+        }
+    }
+
+    // ... existing willPresent + didReceive methods unchanged from PR #158 BUT
+    //     each now also calls the corresponding seam:
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping @Sendable (UNNotificationPresentationOptions) -> Void) {
+        let userInfo = notification.request.content.userInfo
+        let typeRaw = userInfo["type"] as? String
+
+        Task { @MainActor in
+            if let raw = typeRaw, let type = ReminderType(rawValue: raw) {
+                analytics?.logReminderShown(type: type.rawValue)
+                let hour = Calendar.current.component(.hour, from: Date())
+                recordObservationFromNotification(type: type, hour: hour)
+            }
+        }
+        completionHandler([.banner, .sound, .list])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping @Sendable () -> Void) {
+        let userInfo = response.notification.request.content.userInfo
+        let actionIdentifier = response.actionIdentifier
+        let typeRaw = userInfo["type"] as? String
+
+        Task { @MainActor in
+            guard let raw = typeRaw, let type = ReminderType(rawValue: raw) else {
+                completionHandler()
+                return
+            }
+            let hour = Calendar.current.component(.hour, from: Date())
+            switch actionIdentifier {
+            case UNNotificationDismissActionIdentifier:
+                analytics?.logReminderDismissed(type: type.rawValue)
+                // No upgrade — observation stays tapped:false
+            case UNNotificationDefaultActionIdentifier:
+                analytics?.logReminderTapped(type: type.rawValue)
+                upgradeObservationFromTap(type: type, hour: hour)
+                Self.postDeepLinkNotification(type: type, userInfo: userInfo)
+            default:
+                analytics?.logReminderTapped(type: type.rawValue)
+                upgradeObservationFromTap(type: type, hour: hour)
+                Self.postDeepLinkNotification(type: type, userInfo: userInfo)
+            }
+            completionHandler()
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the new test**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/ReminderAnalyticsTests/testWillPresent_recordsObservationOnStore 2>&1 | tail -10`
+Expected: PASS
+
+- [ ] **Step 5: Run the existing `ReminderAnalyticsTests` (12 cases from PR #158) — none regressed**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/ReminderAnalyticsTests 2>&1 | tail -10`
+Expected: 13 tests passed (12 existing + 1 new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add FitTracker/Services/Reminders/ReminderNotificationDelegate.swift FitTrackerTests/ReminderAnalyticsTests.swift
+git commit -m "feat(smart-reminders): wire BehavioralLearningStore into delegate
+
+ReminderNotificationDelegate now takes optional store + cohortClient.
+willPresent records the denominator (shown event) on the store and
+fires-and-forgets a cohort write. didReceive upgrades to numerator on
+tap. Dismissals leave observations as tapped:false (correct — denominator
+without numerator).
+
+Existing 12 PR #158 tests unchanged; +1 new assertion that exercises
+the recordObservation seam."
+```
+
+---
+
+### Task 10: Wire stores + fetch into `FitTrackerApp`
+
+**Files:**
+- Modify: `FitTracker/FitTrackerApp.swift`
+
+Bootstrap the new services + trigger a fire-and-forget cohort prior fetch on app launch.
+
+- [ ] **Step 1: Add service properties to `FitTrackerApp`**
+
+In the `@StateObject` block (around line 52, near `analytics`):
+
+```swift
+    // Behavioural learning sub-feature (PR 1 ships data-collection only)
+    private let behavioralLearningStore = BehavioralLearningStore()
+    private let cohortPriorCache        = CohortPriorCache()
+    private lazy var cohortPriorClient: CohortPriorClient = {
+        // Reuse the existing AI-engine base URL (defined elsewhere in this file).
+        CohortPriorClient(baseURL: makeAIEngineBaseURL())
+    }()
+```
+
+- [ ] **Step 2: Wire the delegate to the new services in the `init()` or `.task` modifier**
+
+Find where `reminderNotificationDelegate.setAnalytics(analytics)` is called (PR #158 pattern). Add alongside:
+
+```swift
+                .task {
+                    // ... existing analytics + delegate wiring from PR #158 ...
+                    reminderNotificationDelegate.store = behavioralLearningStore
+                    reminderNotificationDelegate.cohortClient = cohortPriorClient
+
+                    // Fire-and-forget cohort prior fetch if cache is stale or cold.
+                    if cohortPriorCache.isStale {
+                        Task {
+                            do {
+                                let response = try await cohortPriorClient.fetchPriors()
+                                cohortPriorCache.persist(response)
+                            } catch {
+                                // Silent fallback — resolver (PR 2) uses static defaults
+                                analytics.logEvent("smart_timing_fetch_failed",
+                                                   parameters: ["reason": "\(error)"])
+                            }
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `xcodebuild build -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -quiet 2>&1 | tail -3`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add FitTracker/FitTrackerApp.swift
+git commit -m "feat(smart-reminders): bootstrap BehavioralLearningStore + CohortPriorCache
+
+App-launch wiring: instantiate the three new services and inject the
+store + client into the existing ReminderNotificationDelegate. Fire-
+and-forget cohort prior fetch if cache is stale (>7d) or cold. Network
+errors caught silently — the next app launch will retry, and the
+resolver (PR 2) gracefully uses static defaults when cache is empty.
+
+PR 1's wiring stops here: the resolver in PR 2 is not yet connected."
+```
+
+---
+
+### Task 11: Extend `EncryptedDataStore.deleteAllUserData()` to wipe the store
+
+**Files:**
+- Modify: `FitTracker/Services/Encryption/EncryptedDataStore.swift` (or wherever `deleteAllUserData` lives — verify path)
+- Test: extend an existing GDPR-delete test if one exists, else add a new one to `BehavioralLearningStoreTests`
+
+GDPR Article 17 right-to-erasure must reach the new store.
+
+- [ ] **Step 1: Locate `deleteAllUserData`**
+
+```bash
+grep -rn "deleteAllUserData" FitTracker/Services/
+```
+
+Note the file + signature.
+
+- [ ] **Step 2: Add a call to `BehavioralLearningStore().deleteAllUserData()` in the existing implementation**
+
+If `deleteAllUserData` is on `EncryptedDataStore`:
+
+```swift
+func deleteAllUserData() async {
+    // ... existing cleanup ...
+    await MainActor.run {
+        BehavioralLearningStore().deleteAllUserData()
+    }
+}
+```
+
+(or non-async if the existing method is sync — match the existing signature.)
+
+- [ ] **Step 3: Add an integration test**
+
+In `FitTrackerTests/BehavioralLearningStoreTests.swift` (or a sibling test), add:
+
+```swift
+func testEncryptedDataStore_deleteAllUserData_wipesBehavioralLearning() async {
+    let store = BehavioralLearningStore()
+    store.recordObservation(type: .nutritionGap, hour: 16, tapped: true)
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 1)
+
+    let dataStore = EncryptedDataStore()  // or however it's instantiated in tests
+    await dataStore.deleteAllUserData()
+
+    XCTAssertEqual(store.observationCount(type: .nutritionGap), 0,
+                   "GDPR Article 17 — deleteAllUserData must wipe BehavioralLearningStore")
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -only-testing FitTrackerTests/BehavioralLearningStoreTests/testEncryptedDataStore_deleteAllUserData_wipesBehavioralLearning 2>&1 | tail -10`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add FitTracker/Services/Encryption/EncryptedDataStore.swift FitTrackerTests/BehavioralLearningStoreTests.swift
+git commit -m "feat(smart-reminders): extend GDPR Article 17 wipe to BehavioralLearningStore
+
+EncryptedDataStore.deleteAllUserData() now also wipes the per-user
+behavioural-learning posterior. Test asserts the wipe takes effect."
+```
+
+---
+
+### Task 12: Add the global "Smart timing" toggle (defaults OFF) to Settings
+
+**Files:**
+- Create: `FitTracker/Views/Settings/BehavioralLearningSettingsView.swift`
+- Modify: `FitTracker/Services/AppSettings.swift` (or the equivalent `@AppStorage` host)
+- Modify: `FitTracker/Views/Settings/<existing notifications view>` to embed the new view
+- Modify: `FitTracker.xcodeproj/project.pbxproj`
+
+PR 1's UI is intentionally minimal: one toggle row, defaults OFF, no consumer yet (resolver lands in PR 2).
+
+- [ ] **Step 1: Add the `@AppStorage` flag**
+
+In `AppSettings.swift` (or wherever `@AppStorage` properties live):
+
+```swift
+    @AppStorage("smartTimingEnabled") var smartTimingEnabled: Bool = false
+```
+
+- [ ] **Step 2: Create the new view**
+
+```swift
+// FitTracker/Views/Settings/BehavioralLearningSettingsView.swift
+// PR 1: single global toggle, defaults OFF.
+// PR 3 will add per-type "Why this time?" rows below this toggle.
+
+import SwiftUI
+
+struct BehavioralLearningSettingsView: View {
+
+    @AppStorage("smartTimingEnabled") private var smartTimingEnabled: Bool = false
+
+    var body: some View {
+        Section(header: Text("Smart timing")) {
+            Toggle(isOn: $smartTimingEnabled) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Smart timing")
+                    Text("Learns when you're most responsive and shifts reminder times to match. Off = static defaults.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Embed the new view in the existing notifications settings screen**
+
+Find the existing `NotificationSettingsView.swift` or whichever Settings → Notifications root. Add:
+
+```swift
+struct NotificationSettingsView: View {
+    var body: some View {
+        Form {
+            // ... existing per-type toggles ...
+            BehavioralLearningSettingsView()
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add `BehavioralLearningSettingsView.swift` to `project.pbxproj`** (mirror Task 3's pattern with new IDs)
+
+- [ ] **Step 5: Build to verify compilation**
+
+Run: `xcodebuild build -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' -quiet 2>&1 | tail -3`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add FitTracker/Views/Settings/BehavioralLearningSettingsView.swift FitTracker/Services/AppSettings.swift FitTracker/Views/Settings/NotificationSettingsView.swift FitTracker.xcodeproj/project.pbxproj
+git commit -m "feat(smart-reminders): add global 'Smart timing' toggle (defaults off, no consumer)
+
+Settings → Notifications now includes a single Smart timing toggle row.
+Defaults off — PR 1 ships zero user-visible behaviour change. PR 2 will
+flip the default to on for new installs and wire the toggle to the
+SmartTimingResolver.
+
+PR 3 will append per-type 'Why this time?' rows below this toggle."
+```
+
+---
+
+### Task 13: Run the full test suite + UI audit
+
+- [ ] **Step 1: Run the full test suite to verify no regressions**
+
+Run: `xcodebuild test -project FitTracker.xcodeproj -scheme FitTracker -destination 'generic/platform=iOS Simulator' 2>&1 | tail -10`
+Expected: all tests pass; new `BehavioralLearningStoreTests` (4) + `CohortPriorClientTests` (3) + `CohortPriorCacheTests` (4) + extended `ReminderAnalyticsTests` (13) all green.
+
+- [ ] **Step 2: Run the UI audit**
+
+Run: `make ui-audit 2>&1 | tail -10`
+Expected: P0 count unchanged from baseline (or zero new findings on the new view file).
+
+- [ ] **Step 3: Run state.json + cu_v2 validators**
+
+```bash
+python3 scripts/check-state-schema.py .claude/features/smart-reminders-behavioral-learning/state.json
+python3 scripts/validate-cu-v2.py --state .claude/features/smart-reminders-behavioral-learning/state.json
+```
+
+Expected: both ✓.
+
+- [ ] **Step 4: If any failures, fix them and commit before advancing**
+
+---
+
+### Task 14: Advance state.json to `implementation` → `test` → `review` → `merge`
+
+**Files:**
+- Modify: `.claude/features/smart-reminders-behavioral-learning/state.json`
+- Modify: `.claude/logs/smart-reminders-behavioral-learning.log.json`
+
+PR 1 is data-layer only; phases are short.
+
+- [ ] **Step 1: Advance phases as the work progresses**
+
+Each transition:
+1. Update `current_phase` and the `phases.<old>.status` to complete + `phases.<new>.status` to in_progress
+2. Append a phase-transition log entry via `scripts/append-feature-log.py`
+3. Update `timing.phases.<phase>` started_at/ended_at
+4. Validate via `scripts/check-state-schema.py`
+5. Commit
+
+- [ ] **Step 2: When all tests pass and the local build is green, set `current_phase: review`**
+
+```bash
+python3 scripts/append-feature-log.py \
+  --feature smart-reminders-behavioral-learning \
+  --event-type phase_started \
+  --phase review \
+  --summary "PR 1 ready for review. All Swift tests pass; AI-engine pytests pass; Supabase migration applied to staging."
+```
+
+- [ ] **Step 3: Commit the phase advance**
+
+```bash
+git add .claude/features/smart-reminders-behavioral-learning/state.json .claude/logs/smart-reminders-behavioral-learning.log.json
+git commit -m "chore(smart-reminders-behavioral-learning): PR 1 ready for review (phase=review)"
+```
+
+---
+
+### Task 15: Push branch + open PR 1
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push origin feature/smart-reminders-behavioral-learning
+```
+
+- [ ] **Step 2: Open PR 1 against `main`**
+
+```bash
+gh pr create --base main --head feature/smart-reminders-behavioral-learning \
+  --title "feat(smart-reminders): behavioral learning PR 1 — data layer + toggle-off" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR 1 of 3 for the smart-reminders behavioral learning sub-feature. Ships
+the data-collection foundation: per-user posterior store, cohort prior
+client + cache, AI-engine writer/reader endpoints, Supabase retention
+extension, and the global "Smart timing" Settings toggle (defaults off).
+**Zero user-visible behaviour change.** Cohort writes start accumulating
+in production for the resolver in PR 2 to consume after ~5-7 days.
+
+## Spec
+
+`docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md`
+
+## Plan
+
+`docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md` (this PR)
+
+## What's in this PR
+
+- **Swift services (3 new):** BehavioralLearningStore, CohortPriorClient, CohortPriorCache
+- **Swift wiring:** ReminderNotificationDelegate records observations on willPresent/didReceive; FitTrackerApp bootstraps stores + fire-and-forget cohort fetch
+- **GDPR:** EncryptedDataStore.deleteAllUserData() extended
+- **UI:** Settings → Notifications adds a Smart timing toggle (defaults off, no consumer)
+- **AI engine:** POST /reminder-cohort-event + GET /reminder-cohort-priors endpoints
+- **Supabase:** migration 000009 extends pg_cron retention to reminders.* segments
+
+## What's NOT in this PR
+
+- SmartTimingResolver (PR 2)
+- A/B test instrumentation (PR 2)
+- "Why this time?" UI affordance (PR 3)
+
+## Test plan
+
+- [x] All Swift tests pass (24 tests added across 3 new test files; 1 added to existing ReminderAnalyticsTests)
+- [x] AI-engine pytests pass (6 new tests)
+- [ ] Supabase migration applied to staging (verified by checking pg_cron.job table)
+- [ ] Manual smoke: install on simulator, verify the toggle renders in Settings → Notifications, verify cohort writes hit Supabase via the AI engine
+- [ ] PR-integrity gate: state.json schema valid, cu_v2 valid
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After PR is opened, advance state.json to `merge` phase (with `pr_number` filled)**
+
+```python
+# python helper inline; or via append-feature-log + manual edit
+import json, subprocess
+pr_number = int(subprocess.check_output(["gh", "pr", "view", "--json", "number", "-q", ".number"]).decode().strip())
+path = ".claude/features/smart-reminders-behavioral-learning/state.json"
+d = json.load(open(path))
+d["phases"]["merge"]["pr_number"] = pr_number
+json.dump(d, open(path, "w"), indent=2)
+```
+
+```bash
+git add .claude/features/smart-reminders-behavioral-learning/state.json
+git commit -m "chore(smart-reminders-behavioral-learning): record PR number on state.json"
+git push
+```
+
+---
+
+## Self-Review
+
+After writing this plan, run a fresh-eyes pass against the spec:
+
+**1. Spec coverage:**
+
+| Spec section | Plan task |
+|---|---|
+| §5 BehavioralLearningStore | Task 3 |
+| §5 CohortPriorClient | Task 4 |
+| §5 CohortPriorCache | Task 5 |
+| §5 SmartTimingResolver | **Deferred to PR 2 plan** (intentional — see scope check above) |
+| §5 BehavioralLearningSettingsView toggle | Task 12 |
+| §5 WhyThisTimeSheet | **Deferred to PR 3 plan** |
+| §5 ReminderType.defaultPriorDistribution | Task 2 |
+| §5 ReminderNotificationDelegate extension | Task 9 |
+| §5 FitTrackerApp wiring | Task 10 |
+| §5 EncryptedDataStore.deleteAllUserData extension | Task 11 |
+| §5 project.pbxproj registration | Tasks 3, 4, 5, 12 (per-file) |
+| §5 AI engine endpoints | Tasks 6, 7 |
+| §5 Supabase migration 000009 | Task 8 |
+| §5 Tests (PR 1 scope) | Tasks 3, 4, 5, 9, 11 |
+| §6 Flow A (App launch) | Task 10 |
+| §6 Flow C (Observation recording) | Task 9 |
+| §7 Network failures | Task 10 (silent catch in fetch) + Task 4 (network-error test) |
+| §7 GDPR Article 22 / 17 | Task 11 |
+| §7 Toggle off → revert | Task 12 (toggle exists but no consumer in PR 1; reverts naturally) |
+
+PR 2 / PR 3 scope (resolver, A/B, "Why?" UI) intentionally **not** covered here — own plans when PR 1 ships.
+
+**2. Placeholder scan:** No `TBD`, `TODO`, "implement appropriately" patterns. ✓
+
+**3. Type consistency:** `BehavioralLearningStore` API signatures match across Tasks 3, 9, 10, 11. `CohortPriorClient` matches across Tasks 4, 9, 10. `CohortPriorResponse` matches Tasks 4, 5. ✓
+
+**4. Open ambiguities:**
+
+- Task 8 step 2 contains a `verify against migration 000004` annotation rather than the exact policy. The pattern is correct (re-schedule the existing job rather than adding a second), but the executor must read 000004 first. Acceptable since the plan can't pre-fetch unknown content; flagged in the step.
+- Task 11 step 1 says "Locate `deleteAllUserData`" via `grep` rather than naming the file directly. The existing GDPR-delete entrypoint isn't fully specified in the spec; the executor will identify the correct path. Acceptable.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Good for a 15-task plan that touches multiple repos (FT2 + AI engine + Supabase) — each subagent gets a focused brief.
+
+**2. Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints for review.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md
+++ b/docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md
@@ -1,0 +1,434 @@
+# Smart Reminders — Behavioral Learning Layer (design spec)
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-01 |
+| Author | Regev (with Claude Opus 4.7) via brainstorming session |
+| Parent feature | `smart-reminders` (shipped 2026-04-16, code; PR #98 tests; case study 2026-04-20) |
+| Sub-feature scope | SR-17 (data collection) + SR-18 (smart timing automation) — both already in parent PRD as P2 |
+| Work type | Feature (full PM lifecycle — own PRD content lives in this spec) |
+| Framework version | v7.7 |
+| Branch | `feature/smart-reminders-behavioral-learning` (refreshed off `main` 2026-05-01) |
+| Status | Spec (post-brainstorm) — implementation plan pending |
+| Brainstorm artifacts | `.claude/features/smart-reminders-behavioral-learning/research/open-questions.md` (full lock record) |
+
+---
+
+## 1. Summary
+
+Adapt the existing six-type smart-reminder system (`ReminderScheduler` + `ReminderType` + `ReminderTriggerEvaluator`) to fire each personalisable reminder type at the per-user hour with the highest tap-through probability, using a Bayesian posterior weighted against a server-side cohort prior. Three of six types personalise (Nutrition Gap, Training Day, Rest Day); the other three (HealthKit Connect, Account Registration, Engagement) cap too low or fire too sparsely and keep their static fire times. Ships in three staged PRs against an A/B test that gates merge of the second PR; success threshold is +5 pp aggregate tap-through lift over a 14 ± 4 day per-user readout window. Reuses the existing Supabase `cohort_stats` table + `increment_cohort_frequency` RPC (migrations 000001–000003) — no new tables.
+
+## 2. Why this exists
+
+The parent feature ships every reminder at a globally-fixed hour: nutrition gap at 16:00, training reminder at 10:00, etc. These defaults were picked editorially. Real users have different daily rhythms — some users tap nutrition reminders 80% at 12:30 and 5% at 14:00; others are mirror-flipped. A globally-fixed hour wastes the slot for everyone whose pattern doesn't match the default.
+
+The parent PRD already explicitly lists this as future scope: SR-17 (P2) "Behavioral learning: track which reminder types drive app opens vs. dismissals per user" and SR-18 (P2) "Smart timing optimization: shift reminder fire times based on observed user-open patterns." The Phase 3 rollout sequence is locked in the parent PRD: SR-17 first (data collection only, no UI), then SR-18 (timing automation). This spec ships both together as one staged feature.
+
+PR #158 (merged 2026-04-30) shipped the six lifecycle analytics events (`reminder_scheduled / shown / tapped / dismissed / disabled / suppressed`) that supply the input signal for this feature. Without those events, no behavioral learning is possible. Their merge is what unblocks this spec.
+
+## 3. Locked decisions (from brainstorm session 2026-04-30)
+
+### OQ-1 → β (SR-17 + SR-18 both ship in v1)
+
+Picked over α (SR-17 alone — silent data collection only) and γ (SR-17 + non-PRD automation). β matches the parent PRD's Phase 3 sequence and ships visible behaviour change measurable via A/B test. α would require a follow-up release for the actual win.
+
+**Constraint surfaced:** Of the six `ReminderType` cases, only three are realistic personalisation targets:
+
+| Type | Lifetime cap | Verdict |
+|---|---|---|
+| HealthKit Connect | 3 lifetime | ❌ never enough data per user |
+| Account Registration | 3 lifetime | ❌ never enough data per user |
+| Engagement | 3 per lapse, sparse | ❌ bursty + thin |
+| **Nutrition Gap** | 5/week | ✅ ~20+ obs in 30 days |
+| **Training Day** | 1/day | ✅ ~12 obs in 30 days (5×/week training) |
+| **Rest Day** | 1/day | ✅ ~10 obs in 30 days |
+
+The three non-personalisable types keep their static fire times. SR-18 in v1 = adaptive timing for **Nutrition Gap, Training Day, Rest Day only**.
+
+### OQ-2 → Bayesian update with static-default prior
+
+Always personalise; no count-threshold cliff. The per-user posterior is weighted by observation count vs the population prior. The "prior" is the existing static fire time per type (the same `defaultFireHour` already in `ReminderType.swift`) — already in code, no bootstrap needed. Posterior weight `obs / (obs + 10)` means below ~5 observations the posterior is indistinguishable from the static default; behaviour drifts smoothly toward personal as observations accumulate. Picked over (a) hard count threshold (cliff effect) and (c) time + count hybrid (defeats the purpose for users with fast data accumulation).
+
+### OQ-3 → Hybrid (cohort prior server-side + posterior on-device)
+
+Server-side prior comes from the existing Supabase `cohort_stats` table + `increment_cohort_frequency` RPC (migrations 000001–000003), which the AI engine already writes to via service-key. On-device posterior update lives in a new Swift store (`BehavioralLearningStore`).
+
+**No new Supabase table needed** — the existing schema (`segment` / `field_name` / `field_value` / `frequency`) is generic enough to fit the new reminder cohort signal. Backend scope:
+
+- Reuse existing `cohort_stats` table with new `segment` values: `reminders.shows.<type>`, `reminders.taps.<type>`, `reminders.kill_flag`.
+- `field_name = "hour"`, `field_value = "00".."23"` for shows/taps; `field_name = "<type>"`, `field_value = "true"` for kill flags.
+- Add a **read RPC** (`/reminder-cohort-priors`) — read path doesn't exist today; existing infrastructure is write-only on the client side via service-key.
+- Add an **AI-engine writer hook** (`/reminder-cohort-event`) so each `reminder_shown`/`reminder_tapped` event also emits an anonymised cohort write via the existing `increment_cohort_frequency` path.
+- Extend the existing pg_cron retention job (migration 000004) to cover the new `reminders.*` segments.
+
+Picked over (1) pure on-device (no cross-user signal) and (2) pure server-side (violates parent PRD's "all trigger evaluation and scheduling fully local" GDPR commitment). Hybrid splits responsibilities cleanly: prior is shared, posterior + decision-making stays local.
+
+### OQ-4 → Global toggle + per-type "Why?" affordance
+
+In Settings → Notifications: one global "Smart timing" toggle row alongside the existing per-type enable/disable toggles. **On by default** (for new installs; existing users get the toggle in `on` state at first launch post-PR-2). Off → revert to static fire times across all three personalisable types. **Plus** a per-type "Why this time?" affordance: each personalisable type's row in Settings shows the current send time; tap opens a sheet that explains the personalisation. Reuses the existing `AIIntelligenceSheet` pattern. Picked over (a) no UI (fails GDPR Article 22 on automated decision-making), (b) toggle without explanation, and (c) per-type toggles (over-promises since 3 of 6 types don't personalise).
+
+### OQ-5 → Aggregate-primary + per-type kill (composite metric)
+
+| Metric | Target | Kill threshold |
+|---|---|---|
+| Aggregate tap-through lift (treatment − control) | **≥ +5 pp** at p < 0.05 | < +0 pp at end of window |
+| Per-type regression (treatment − control, per personalised type) | n/a — composite kill | **< −3 pp** on any single personalised type → per-type rollback to static |
+| Dismiss-rate change | flat or down | > +5 pp from baseline (advisory) |
+| Disable-rate change | flat or down | > +3 pp (advisory; parent PRD already kills at +25 pp/month) |
+
+**Readout window: 14 ± 4 days** (10–18 day floor / ceiling) per user, flexible to absorb non-uniform sample-accumulation rates. Earliest readout day 10 (when per-user obs count crosses Bayesian saturation point ~10 obs); latest day 18 (cap to prevent indefinite waiting). **Plus a post-population aggregation later** — once each `(type, hour)` cell has ≥ 100 cohort observations (≈ 7,200 total across the 24h × 3 personalisable types matrix), expected ~4–6 weeks post-launch, run a meta-analysis across users to produce robust per-cohort priors. The exact threshold can be tuned post-launch; 100 obs/cell is a defensible default (2× the privacy suppression threshold of 50).
+
+### OQ-6 → resolved by PR #158 merge (2026-04-30); no remaining dependency
+
+### Sequencing → Approach B (3 staged PRs)
+
+| PR | Scope | User-visible change | Rollback |
+|---|---|---|---|
+| **PR 1** | SR-17 data layer + Settings toggle (defaults *off*) + Supabase migration + AI-engine writer hook + retention extension | None — toggle is off; cohort writes accumulate silently | Single `git revert` |
+| **PR 2** | SR-18 timing automation (toggle defaults *on*; A/B test instrumentation begins) | Personalised fire times for ≥10-obs users; static for everyone else | Flip toggle default back to off; no code revert needed |
+| **PR 3** | "Why this time?" affordance + per-type transparency rows | Pure UX polish; users tap to read explanation | Single `git revert` |
+
+Picked over A (big-bang — too much novelty in one merge gate) and C (vertical slice — Nutrition Gap caps at 5/week, slowest-accumulating type, inverts the leverage).
+
+## 4. Architecture
+
+```
+┌─────────────────────────── Device (Swift) ─────────────────────────────┐
+│                                                                          │
+│  ReminderTriggerEvaluator  ──→  ReminderScheduler  ──→  UNUserNotif…     │
+│         │                              │                                 │
+│         │                              ↓                                 │
+│         │                  ┌──────────────────────────┐                  │
+│         │                  │  SmartTimingResolver     │  ← PR 2          │
+│         │                  │  picks per-user fire-time│                  │
+│         │                  └──────────┬───────────────┘                  │
+│         │                             │                                  │
+│         │                  ┌──────────▼───────────────┐                  │
+│         │                  │  BehavioralLearningStore │  ← PR 1          │
+│         │                  │  per-user posterior      │                  │
+│         │                  │  (Bayesian, 24 buckets)  │                  │
+│         │                  └──────────┬───────────────┘                  │
+│         │                             │                                  │
+│         │             ┌───────────────┴──────────┐                       │
+│         │             ↓ posterior update         ↓ prior fetch           │
+│  AnalyticsService   ReminderNotificationDelegate (existing PR #158)      │
+│     │                                                                    │
+│     │ reminder_shown / reminder_tapped events                            │
+│     ↓                                                                    │
+│  AIEngineClient ──→ POST /reminder-cohort-event   ← PR 1 (server hook)   │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
+                                     │
+                                     ↓
+┌─────────────────────────── AI Engine (Railway) ────────────────────────┐
+│  POST /reminder-cohort-event                                             │
+│    → calls increment_cohort_frequency(segment, field_name, field_value)  │
+│  GET /reminder-cohort-priors                            ← PR 1 (read RPC)│
+│    → returns per-type per-hour tap-through rates + kill flags            │
+└──────────────────────────────────────────────────────────────────────────┘
+                                     │
+                                     ↓
+┌─────────────────────────── Supabase (existing) ────────────────────────┐
+│  cohort_stats (segment, field_name, field_value, frequency)              │
+│  pg_cron retention extended to cover new "reminders.*" segments  ← PR 1  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Architectural decisions:**
+
+- **Decision-making stays on-device.** The resolver picks the send-time using the local Bayesian posterior + cached cohort prior. No round-trip per send decision. Matches parent PRD's "all trigger evaluation and scheduling fully local" rule.
+- **Cohort prior is shared, posterior is private.** Aggregated counts (no PII, no per-user values) flow to Supabase via the existing pattern. Per-user posterior lives in `UserDefaults` next to existing scheduler state.
+- **AI engine is the only writer.** Client never writes directly to Supabase — it POSTs to the new AI-engine endpoint that calls the existing `increment_cohort_frequency` RPC with service-key. Matches existing security posture.
+- **Three personalisable types only.** `SmartTimingResolver` short-circuits for HealthKit / Account / Engagement.
+- **PR boundary is the `BehavioralLearningStore` ↔ `SmartTimingResolver` seam.** PR 1 ships the store + write paths + cohort fetch (toggle-off, no resolver). PR 2 ships the resolver. PR 3 ships the "Why?" UI.
+
+## 5. Components
+
+### New Swift files
+
+| File | Responsibility | PR |
+|---|---|---|
+| `FitTracker/Services/Reminders/BehavioralLearningStore.swift` | Per-user posterior over 24 hour-of-day buckets per personalisable type. `recordObservation(type:hour:tapped:)`, `posterior(type:) -> [Hour: Double]`, `observationCount(type:)`. Persists to `UserDefaults` keys `ft.reminder.posterior.<type>.h<00..23>` and `ft.reminder.obsCount.<type>`. | PR 1 |
+| `FitTracker/Services/Reminders/CohortPriorClient.swift` | HTTP client for the two new AI-engine endpoints. `recordEvent(type:hour:tapped:) async` and `fetchPriors() async throws -> CohortPriorResponse`. Reuses existing `AIEngineClient` URL + auth pattern. | PR 1 |
+| `FitTracker/Services/Reminders/CohortPriorCache.swift` | On-device cache of cohort prior. 7-day TTL, refreshes on app launch. Falls back to hardcoded static fire times when fetch fails OR cache cold. Single JSON blob in `UserDefaults` key `ft.reminder.cohortPrior.json`. | PR 1 |
+| `FitTracker/Services/Reminders/SmartTimingResolver.swift` | Decision-maker. `firingTime(for: ReminderType) -> Hour`. Combines prior (cache) + posterior (store) via Bayesian update; short-circuits to static default for non-personalisable types AND when toggle off AND when type has a server kill_flag. | PR 2 |
+| `FitTracker/Views/Settings/BehavioralLearningSettingsView.swift` | Settings → Notifications additions. Global "Smart timing" toggle row (PR 1, defaults *off*) + per-type "Why this time?" rows (PR 3). | PR 1 (toggle) + PR 3 (rows) |
+| `FitTracker/Views/Settings/WhyThisTimeSheet.swift` | Per-type explanation: current send time, observation count, prior vs posterior breakdown, Article-22-required opt-out info. Reuses existing `AIIntelligenceSheet` pattern. | PR 3 |
+
+### Modified Swift files
+
+| File | Change | PR |
+|---|---|---|
+| `FitTracker/Services/Reminders/ReminderScheduler.swift` | Inject the resolver. `scheduleIfAllowed` consults `SmartTimingResolver.firingTime(for: type)` BEFORE building the trigger. Existing `delayMinutes` parameter remains an explicit override. | PR 2 |
+| `FitTracker/FitTrackerApp.swift` | Bootstrap: instantiate `BehavioralLearningStore` and `CohortPriorCache` on app launch; trigger fire-and-forget `CohortPriorClient.fetchPriors()` once per app session (cache-TTL guarded). PR 2 wires the resolver into the scheduler. PR 2 also assigns `smartTimingArm` user property on first launch. | PR 1 + PR 2 |
+| `FitTracker/Services/Reminders/ReminderNotificationDelegate.swift` | One-line change: `willPresent` calls `BehavioralLearningStore.recordObservation(tapped: false)` (the **denominator**); `didReceive` calls `upgradeLastObservation(tapped: true)` for taps (the **numerator**) — leaves it `false` for dismissals. Also fires `CohortPriorClient.recordEvent` on each. | PR 1 |
+| `FitTracker/Services/EncryptedDataStore.swift` (or equivalent GDPR-delete entrypoint) | `deleteAllUserData()` extended to wipe `BehavioralLearningStore` (all `ft.reminder.posterior.*` + `ft.reminder.obsCount.*` keys). | PR 1 |
+
+### AI engine (Railway, Python) — new endpoints
+
+| Endpoint | Behaviour | PR |
+|---|---|---|
+| `POST /reminder-cohort-event` | Body `{type, hour, tapped}`. Calls `increment_cohort_frequency(segment="reminders.shows.<type>", ...)` always; conditionally calls `...="reminders.taps.<type>"`. Returns `204`. No userId persisted. | PR 1 |
+| `GET /reminder-cohort-priors` | Reads `cohort_stats` for `segment LIKE 'reminders.%'`. Computes per-type per-hour rate `taps[h] / shows[h]`. Suppresses cells with `shows < 50`. Returns `{ "priors": { "<type>": { "<hour>": <rate> }, ... }, "kill_flags": ["<type>", ...] }`. | PR 1 |
+
+### Supabase — new migration
+
+| File | Change | PR |
+|---|---|---|
+| `backend/supabase/migrations/000009_extend_retention_for_reminders.sql` | Extend the existing pg_cron retention job (migration 000004) to cover `segment LIKE 'reminders.%'` with same TTL policy. **No new table** — reuses `cohort_stats` schema verbatim. | PR 1 |
+
+### Tests
+
+| Test file | Coverage focus | PR |
+|---|---|---|
+| `FitTrackerTests/BehavioralLearningStoreTests.swift` | Bayesian math, per-type isolation, UserDefaults round-trip, denominator/numerator separation | PR 1 |
+| `FitTrackerTests/SmartTimingResolverTests.swift` | Static-default short-circuits, toggle-off path, cold-cache fallback, kill-flag honoring | PR 2 |
+| `FitTrackerTests/CohortPriorCacheTests.swift` | TTL, fallback, JSON round-trip, malformed-blob recovery | PR 1 |
+| `FitTrackerTests/CohortPriorClientTests.swift` | Network-error silent catch, no-PII-in-payload, response shape | PR 1 |
+| `FitTrackerTests/ReminderSchedulerSmartTimingTests.swift` | Scheduler-resolver integration, observation recording on delegate callback | PR 2 |
+| AI-engine pytest (new file in Railway repo) | Endpoint behaviour, segment values, privacy threshold, kill-flag round-trip | PR 1 |
+
+## 6. Data flow
+
+### Flow A — App launch (PR 1)
+
+1. `FitTrackerApp.task`:
+   - `BehavioralLearningStore.loadFromUserDefaults()` (sync, ~5ms)
+   - `CohortPriorCache.loadFromUserDefaults()` (sync)
+   - If cache stale (> 7d) or cold: `Task { CohortPriorClient.fetchPriors() }` fire-and-forget
+   - PR 2 only: `ReminderScheduler.shared.resolver = SmartTimingResolver(store, cache, toggle)`; assign `smartTimingArm` user property
+
+**Latency budget:** App launch must not block on the network. If fetch hasn't completed by the time the first reminder schedules, the resolver uses the static default — that's correct degraded behaviour, not a bug.
+
+### Flow B — Scheduling decision (PR 2 onward)
+
+1. `ReminderTriggerEvaluator` detects condition.
+2. `ReminderScheduler.scheduleIfAllowed(type, body)`:
+   - `resolver.firingTime(for: type) -> Hour`
+     - If `!smartTimingEnabled` OR type ∉ {nutritionGap, trainingDay, restDay} OR type in `cache.killedTypes`: return `type.defaultFireHour`
+     - Else: combine prior + posterior via Bayesian update, return `argmax`
+   - Existing guards: quiet hours, daily cap, per-type cap, lifetime cap, min interval (unchanged)
+   - Build `UNNotificationRequest` with trigger = (today, fire at resolved Hour)
+   - `center.add(request)`
+   - `analytics.logReminderScheduled(type)` (existing)
+
+**Bayesian formula** (canonical Beta-binomial, simplified):
+
+```
+posteriorWeight = obsCount / (obsCount + 10)     # smoothing constant 10 = "10 prior pseudo-observations"
+combined[h]     = (1 - posteriorWeight) * prior[h] + posteriorWeight * posterior[h]
+```
+
+Smoothing constant `10`: at 0 observations the posterior is ignored (prior wins); at 10 obs `posteriorWeight = 0.5`; at 90 obs `0.9`.
+
+### Flow C — Observation recording (PR 1)
+
+1. `UNUserNotificationCenter` delivers the notification.
+2. `ReminderNotificationDelegate.willPresent`:
+   - `analytics.logReminderShown(type)` (existing PR #158)
+   - `store.recordObservation(type, hour: now.hour, tapped: false)` ← NEW PR 1 (records the **denominator**)
+   - `Task { CohortPriorClient.recordEvent(type, hour, tapped: false) }` ← NEW PR 1
+3. `ReminderNotificationDelegate.didReceive(response)`:
+   - If tap: `analytics.logReminderTapped(type)` (existing) + `store.upgradeLastObservation(type, tapped: true)` ← NEW PR 1 + cohort recordEvent with `tapped: true`
+   - If dismiss: `analytics.logReminderDismissed(type)` (existing); no upgrade
+
+**Two-phase observation:** `willPresent` always records the denominator. `didReceive` *upgrades* it for taps. Avoids races where a user taps before the show has been recorded.
+
+### A/B test (PR 2)
+
+```
+Assignment: deterministic hash on user UUID, sticky across launches
+  if hash(userId) % 100 < 50:
+    smartTimingArm = "treatment"   (resolver active)
+  else:
+    smartTimingArm = "control"     (resolver returns static defaults always — even though store still records observations)
+
+If user manually toggles "Smart timing" off → smartTimingArm = "opted_out" (recorded, excluded from t-test)
+
+Measurement: GA4 user property smartTimingArm + reminder_shown / reminder_tapped events
+  Per-user readout: 14 ± 4 day window once obsCount(type) >= 10 for at least one personalisable type
+  Aggregate readout: rolling 7-day window across all users in each arm
+  Per-type kill: BigQuery → write cohort_stats(segment="reminders.kill_flag", field_name="<type>", field_value="true")
+```
+
+### Privacy posture
+
+- Cohort writes carry only `{type, hour, tapped}`. No userId, no timestamp, no device, no metadata.
+- Cohort reads are unauthenticated (population data is identical for all users).
+- Cells with `shows < 50` suppressed (privacy + statistical-validity threshold).
+- Posterior never leaves the device.
+
+## 7. Error handling + opt-out
+
+### Network / fetch failures
+
+| Failure | Behaviour | Surface |
+|---|---|---|
+| `fetchPriors()` HTTP error / timeout / malformed JSON | Caught silently. Existing cache stays in place; resolver uses cached or static default. **No user-visible degradation.** | `analytics.logEvent("smart_timing_fetch_failed", reason)` + Sentry breadcrumb |
+| `recordEvent()` fails | Silently dropped. Per-user observations still recorded in `BehavioralLearningStore`. Cohort write is best-effort. | `analytics.logEvent("smart_timing_record_failed", reason)` |
+
+### Missing / thin cohort data
+
+| Case | Handling |
+|---|---|
+| Cell suppressed (`shows < 50`) | Server omits entry → resolver treats as no signal (uniform contribution) |
+| Whole type has no cohort data | `cache.priors[type]` nil → use `type.defaultPriorDistribution` (tight bell curve around static fire time) |
+| User has < 10 personal obs | Posterior weight ~0; prior dominates |
+| Empty cohort prior + ≥10 personal obs | Posterior dominates — user's pattern is the strongest signal we have for them |
+
+### Toggle off → revert
+
+- User flips global toggle off → next `scheduleIfAllowed` call short-circuits to static defaults. **Existing pending notifications are NOT rescheduled** (they fire at their already-resolved time).
+- Re-enable: store's accumulated observations preserved; learning resumes where it left off.
+- Per-type disable (existing) unchanged.
+
+### Per-type kill criterion auto-rollback
+
+| Trigger | Action |
+|---|---|
+| BigQuery aggregation detects `treatmentRate[type] − controlRate[type] < −0.03` over the 14 ± 4 day window | Server writes `cohort_stats(segment="reminders.kill_flag", field_name="<type>", field_value="true")` |
+| Client app launch | `fetchPriors()` response includes `kill_flags`; resolver short-circuits killed types **regardless of toggle** |
+| Recovery | Manual: delete kill_flag row in Supabase → next app launch picks up change |
+
+### UserDefaults corruption / first install
+
+| Case | Handling |
+|---|---|
+| Malformed JSON in `BehavioralLearningStore` | `JSONDecoder` throws → store starts empty. Logged. Resolver falls back to prior + static default. |
+| First install, no observations | Same as above |
+| Future schema change | Stored blob includes `version: Int`; mismatch → wipe + restart fresh |
+
+### GDPR / Article 22
+
+The "Why this time?" affordance is the Article 22 explanation surface:
+
+1. Current decided send-time per type
+2. Observation count (signal strength)
+3. Right to opt out (link to global toggle)
+4. Right to deletion (handled via `EncryptedDataStore.deleteAllUserData()` extended to wipe `BehavioralLearningStore`)
+
+If the sheet can't render (e.g. empty store mid-fetch), it shows a static "Smart timing is currently active. Tap below to disable." — never a blank or error state.
+
+### Migration / reversibility
+
+- PR 1: toggle-off → no behaviour change for any user.
+- PR 2: toggle defaults on for new installs; existing users keep their setting. A/B assignment is deterministic and sticky.
+- PR 3: pure UI; no code-path changes.
+- Any PR can be reverted independently. Reverting PR 2 makes the toggle inert. Reverting PR 1 takes the store + cohort writes out (resolver in PR 2 still works but only with static defaults — exactly the toggle-off behaviour). Reverting PR 3 just removes the UI.
+
+## 8. Testing + A/B instrumentation
+
+### Critical assertions per file
+
+| File | Highest-value assertions |
+|---|---|
+| `BehavioralLearningStoreTests` | `posteriorWeight = obs / (obs + 10)`; 0 obs → prior dominates ≥99%; 100 obs → posterior dominates ≥90%; per-type isolation; idempotent `upgradeLastObservation` (calling twice for the same notification id doesn't double-count); UserDefaults round-trip |
+| `SmartTimingResolverTests` | The 3 non-personalisable types ALWAYS return `defaultFireHour` regardless of state; toggle-off → static default; toggle-on with cold cache → static default; toggle-on with cache+store → `bayesianCombine.argmax`; killed type → static default even with toggle-on |
+| `CohortPriorCacheTests` | TTL: cache age >7d → `isStale == true`; malformed JSON → `loadFromUserDefaults` returns nil; persist round-trip; suppressed cells deserialize as missing entries (not zero) |
+| `CohortPriorClientTests` | Network errors caught silently (no throw across API boundary); record-event payload contains ONLY `{type, hour, tapped}` (asserted via captured request body); fetch-priors deserializes documented JSON shape |
+| `ReminderSchedulerSmartTimingTests` | Scheduler asks resolver before building trigger; `delayMinutes` still works as override; resolver result honoured even when conflicting with existing per-type default |
+
+### AI-engine pytest
+
+| Test | Asserts |
+|---|---|
+| `test_reminder_cohort_event_writes_segment` | POST `{type:"nutrition_gap", hour:16, tapped:true}` → calls `increment_cohort_frequency` twice (once for `reminders.shows.nutrition_gap`, once for `reminders.taps.nutrition_gap`) |
+| `test_reminder_cohort_event_tapped_false_only_increments_shows` | POST with `tapped:false` → only one increment (shows) |
+| `test_reminder_cohort_priors_suppresses_low_volume` | Seed `shows=49, taps=20` → no entry in response; seed `shows=50, taps=20` → response includes rate `20/50` |
+| `test_reminder_cohort_priors_returns_kill_flags` | Seed `cohort_stats(segment="reminders.kill_flag", ...)` → response includes `kill_flags: ["<type>"]` |
+| `test_no_pii_in_payload` | POST with arbitrary userId in JWT → no userId persisted |
+
+### A/B instrumentation (the novel piece)
+
+Arm assignment as a **GA4 user property** (cheaper than per-event parameter, sticky, segments natively):
+
+```swift
+// In FitTrackerApp.task, on first launch post-PR-2:
+if !UserDefaults.standard.contains(key: "ft.smart_timing.arm") {
+    let arm = computeArm(userId: signIn.userId)  // hash(userId) % 100 < 50 → "treatment"
+    UserDefaults.standard.set(arm, forKey: "ft.smart_timing.arm")
+    analytics.setUserProperty(arm, forName: AnalyticsUserProperty.smartTimingArm)
+}
+```
+
+Manual toggle-off → `arm = "opted_out"` (recorded, excluded from t-test).
+
+One new analytics user property: `AnalyticsUserProperty.smartTimingArm`. All existing reminder events automatically carry this dimension via GA4 user-property mechanism — no event-signature changes needed.
+
+### BigQuery readout queries
+
+Committed under `docs/product/analytics-queries/`:
+
+| Query | Purpose | Cadence |
+|---|---|---|
+| `smart_timing_per_user_readout.sql` | Per-user tap-through rate per type, gated on `obsCount ≥ 10 AND days_since_assignment BETWEEN 10 AND 18` | Daily |
+| `smart_timing_aggregate_lift.sql` | Aggregate `tap_through_rate` per arm: `treatment_rate − control_rate` with 95% CI via Wilson score | Daily |
+| `smart_timing_per_type_kill_check.sql` | Per-type lift; flags any `< −0.03` for kill-flag write | Daily |
+| `smart_timing_post_population_aggregation.sql` | Once each `(type, hour)` cell has ≥ 100 cohort observations (≈ 7,200 total) — meta-analysis for stable per-segment baselines | Manual trigger; expected ~4–6 weeks post-launch |
+
+### Privacy / GDPR test coverage
+
+| Test | Where | Asserts |
+|---|---|---|
+| `BehavioralLearningStoreTests.testWipedByDeleteAllUserData` | Swift unit | `EncryptedDataStore.deleteAllUserData()` clears all `ft.reminder.posterior.*` + `ft.reminder.obsCount.*` keys |
+| `CohortPriorClientTests.testNoPIIInPayload` | Swift unit | Captured POST body keys exactly `{type, hour, tapped}` — no userId / deviceId / locale |
+| `test_no_pii_persisted` | Python | Seed events for two userIds → `cohort_stats` rows have identical keys (proves aggregation) |
+| Manual smoke | Settings → Account & Data → Delete | After delete, smart-timing reverts to static for that user |
+
+### CI integration
+
+| Hook | What runs | Failure surface |
+|---|---|---|
+| Existing `xcodebuild test` (FT2 CI) | Auto-discovers new test files via Sources build phase | Standard CI pass/fail |
+| Existing `make ui-audit` | Auto-scans new view files | P0 = blocking; P1 = baseline-tracked |
+| Existing pre-commit `check-state-schema.py` | Validates state.json schema as feature advances | v7.6 enforcement |
+| AI-engine CI (Railway → GitHub Actions) | New pytest for the two endpoints | Standard pass/fail |
+| **NEW:** `make smart-timing-readout` (added in PR 2) | Runs the BigQuery queries via `bq` CLI | Manual + scheduled cron |
+
+### Manual smoke playbook
+
+New file `docs/setup/smart-timing-verification-playbook.md` (PR 2):
+
+1. Install on two simulators, force `arm=treatment` on one and `arm=control` on the other via debug menu.
+2. Trigger a nutrition reminder via debug menu → verify the resolver picks a non-default hour on treatment, default hour on control.
+3. In GA4 DebugView, confirm `smart_timing_arm` user property attached to all reminder events.
+4. Toggle "Smart timing" off in Settings → next reminder fires at static default.
+5. Toggle back on → resolver picks personalised hour.
+6. Tap "Why this time?" → explanation sheet renders with non-zero observation count after enough usage.
+
+### Coverage targets
+
+- New Swift files: **≥ 80% line coverage** (matches existing `FitTrackerTests` standard)
+- AI-engine new endpoints: **100% line coverage** (only ~50 LOC each)
+- A/B-test analysis SQL: query-by-query review against snapshot fixtures committed alongside
+
+## 9. Success metrics + kill criteria
+
+### Success metrics
+
+1. **Aggregate tap-through lift (treatment − control) ≥ +5 pp at p < 0.05** over the per-user readout window (14 ± 4 days).
+2. **Post-population aggregation** confirms the per-user signal at the cohort level once each `(type, hour)` cell has ≥ 100 cohort observations (≈ 7,200 total across the 24h × 3 personalisable types matrix; expected ~4–6 weeks post-launch).
+3. **No personalisable type regresses below its static-baseline tap-through by ≥ −3 pp** (composite kill).
+
+### Kill criteria
+
+1. **Aggregate tap-through lift < +0 pp** at end of the per-user readout window AND post-population aggregate also fails → revert PR 2.
+2. **Any single personalised type regresses by ≥ −3 pp** vs its static baseline → per-type rollback to static fire time via `kill_flag` mechanism (no PR revert required).
+3. **Disable rate increases ≥ +3 pp** from baseline OR **dismiss rate increases ≥ +5 pp** from baseline (advisory; parent PRD already kills at +25 pp/month for disable rate).
+
+### Readout cadence
+
+- **Daily** automated BigQuery query runs during the readout window.
+- **Per-user readouts** trigger when `obsCount(type) ≥ 10 AND days_since_assignment BETWEEN 10 AND 18`.
+- **Aggregate readout** rolls weekly during the window.
+- **Post-population aggregation** is a one-shot manual analysis once the per-cell threshold (≥ 100 cohort observations across the 24h × 3 types matrix) is hit; expected ~4–6 weeks post-launch.
+
+## 10. References
+
+- **Parent PRD:** [`docs/product/prd/smart-reminders.md`](../../product/prd/smart-reminders.md) — SR-17, SR-18, Phase 3 sequencing
+- **Parent case study:** [`docs/case-studies/smart-reminders-case-study.md`](../../case-studies/smart-reminders-case-study.md) — flagged this sub-feature as deferred
+- **Analytics events shipped:** PR #158 (`reminder_scheduled / shown / tapped / dismissed / disabled / suppressed`) merged 2026-04-30
+- **Brainstorm artifacts:** [`.claude/features/smart-reminders-behavioral-learning/research/open-questions.md`](../../../.claude/features/smart-reminders-behavioral-learning/research/open-questions.md)
+- **Backend infrastructure:** [`backend/supabase/migrations/000001_cohort_stats.sql`](../../../backend/supabase/migrations/000001_cohort_stats.sql), [`000002_increment_cohort_frequency.sql`](../../../backend/supabase/migrations/000002_increment_cohort_frequency.sql), [`000003_rls_cohort_stats.sql`](../../../backend/supabase/migrations/000003_rls_cohort_stats.sql), [`000004_retention_pg_cron.sql`](../../../backend/supabase/migrations/000004_retention_pg_cron.sql)
+- **Related enhancement (PR #162):** E-1 Readiness-Aware Training Alert — explicitly notes "[the] behavioral-learning sub-feature would further personalize the threshold tuning per user"
+- **Framework version:** v7.7 (validity closure shipped 2026-04-27 via PR #144)


### PR DESCRIPTION
## Summary

PR 1 of 3 for the smart-reminders behavioral learning sub-feature per
[`docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md`](docs/superpowers/specs/2026-05-01-smart-reminders-behavioral-learning-design.md).

**Ships:** the iOS data-collection foundation (per-user posterior store,
cohort prior client + cache, delegate wiring, GDPR Article 17 extension,
Settings Smart Timing toggle defaulting OFF). **Zero user-visible
behaviour change** — toggle has no consumer yet (resolver lands in PR 2).

**Defers to a follow-up commit:** AI-engine endpoints (Tasks 6 + 7) and
Supabase migration (Task 8). Both blocked on this session's env (no
ai-engine `.venv`, supabase MCP disconnected). Tracked in
`state.json.known_followups`.

## Plan reference

[`docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md`](docs/superpowers/plans/2026-05-01-smart-reminders-behavioral-learning-pr1.md) — 15 tasks total; 12 shipped here (T1-T5, T9-T13, T14).

## What's in this PR

### Swift services (3 new)

- `BehavioralLearningStore` — per-user Bayesian posterior over 24 hour-of-day buckets, UserDefaults-backed, GDPR Article 17 wipe.
- `CohortPriorClient` — HTTP client with strict no-PII payload assertion (`{type, hour, tapped}` only); `URLSessionProtocol` injection seam for testability.
- `CohortPriorCache` — 7-day TTL on cached `CohortPriorResponse`, graceful JSON-failure recovery.

### Wiring

- `ReminderNotificationDelegate` records observations on `willPresent` + upgrades on tap. `@MainActor` test seams (`recordObservationFromNotification`, `upgradeObservationFromTap`) drive both real callbacks and unit tests.
- `FitTrackerApp` bootstraps the 3 services + fires fire-and-forget `cohortPriorClient.fetchPriors()` when `cohortPriorCache.isStale`.
- `EncryptedDataStore.deletePersistedData()` extended to wipe both the store and the cache (GDPR Article 17 follows the existing right-to-erasure path).

### UI

- `BehavioralLearningSettingsView.swift` — single Smart Timing toggle, embedded in `GoalsPreferencesSettingsScreen`. **Defaults OFF** for new + existing users. PR 2 will flip the default to ON for new installs and wire the toggle to `SmartTimingResolver`.
- `AppSettings.smartTimingEnabled` (`@Published` + UserDefaults persistence).

### State + meta

- `.claude/features/smart-reminders-behavioral-learning/state.json` advanced research → tasks → implementation across this session. `framework_version` fixed `7.7` → `v7.7` (the v7.7 honesty-fixes gate caught it on its first new-feature interaction post-deployment).
- `known_followups[]` tracks the 3 deferred backend tasks (T6/T7/T8).

## What's NOT in this PR (deferred to a follow-up commit)

- **T6** — AI engine `POST /reminder-cohort-event` endpoint + pytest
- **T7** — AI engine `GET /reminder-cohort-priors` endpoint + pytest
- **T8** — Supabase migration `000009` — extend `pg_cron` retention to `reminders.*` segments

Each is blocked on local env state (no ai-engine `.venv` set up; supabase MCP needs reauth). The iOS half ships independently because the runtime path is fault-tolerant: when the cohort fetch fails (because the endpoints don't exist yet), `CohortPriorCache.isStale` stays true, and the future `SmartTimingResolver` (PR 2) will fall back to static defaults — exactly the documented degraded behaviour from spec §6.

## Verification

| Step | Result |
|---|---|
| `xcodebuild build ... iPhone 17 OS 26.4.1` | ✅ ** BUILD SUCCEEDED ** |
| 4 PR-1 test suites + extended `ReminderAnalyticsTests` | ✅ 23 / 23 cases pass |
| `make ui-audit` | ✅ P0 = 0 (clean baseline; no new findings on `BehavioralLearningSettingsView.swift`) |
| `python3 scripts/check-state-schema.py` | ✅ pass |

## Test plan

- [ ] CI `pm-framework/pr-integrity` green
- [ ] CI `Build and Test` green (or env-flake accepted per FIT-59)
- [ ] No state.json regression on existing features
- [ ] Settings → Goals & Preferences shows the new "Smart Timing" toggle row at the bottom; toggling it persists across launch

## Co-authoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context)