### PR TITLE
feat(framework-v7.8): PR-6 — Mechanism F membrane-status + Mechanism D self-test + hook header

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Git pre-commit hook — gates the Data Integrity Framework's write-time
-# defenses (v7.5 → v7.6 → v7.7 → 2026-05-01 honesty fixes). Blocks commits
-# that would introduce:
+# defenses (v7.5 → v7.6 → v7.7 → 2026-05-01 honesty fixes → v7.8 bridge).
+# Self-audited: every gate named here is asserted to be implemented in
+# scripts/check-state-schema.py or scripts/check-case-study-preflight.py
+# via `make pre-commit-self-test` (v7.8 Mechanism D, spec §4.4).
+#
+# Blocks commits that would introduce:
 #
 #   v7.5 (shipped 2026-04-21):
 #     - SCHEMA_DRIFT (legacy `phase` key on state.json)
@@ -35,7 +39,20 @@
 #     - FRAMEWORK_VERSION_FORMAT (when set, must match `(pre-)?v<major>.<minor>`;
 #       presence-required deferred to backfill PR)
 #
-# Enable with: make install-hooks
+#   v7.8 (shipped 2026-05-02 → 2026-05-03 via PRs #173 + #185 → #189 + #192):
+#     Bridge mechanisms — most ship advisory in v7.8, enforced in v7.9.
+#     The following are ADVISORY (cycle-time, non-blocking) — listed
+#     here for the self-audit's information; they are NOT pre-commit gates:
+#       - GATE_COVERAGE_ZERO (Mechanism A meta-check; v7.9 enforces)
+#       - CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE (Mechanism C T11 advisory)
+#     Schema bridge fields ship populated but un-validated:
+#       - state.json::agent_manifest        (v7.9 Mechanism G enforces)
+#       - state.json::_meta.deprecation_warnings  (v7.9 Mechanism B enforces)
+#       - .claude/shared/path-reducers.json (v7.9 reducer enforcement)
+#       - .claude/shared/agent-leases.json  (v7.9 lease + epoch enforcement)
+#
+# Enable with: make install-hooks  (also installs custom merge drivers per Mechanism E)
+# Self-audit: make pre-commit-self-test  (asserts no header drift)
 # Bypass (emergency only): git commit --no-verify
 #   (The 72h integrity cycle still catches anything introduced via bypass.)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-snapshot schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-snapshot schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -154,6 +154,19 @@ install-hooks:
 	@echo "Pre-commit will reject state.json files with legacy \`phase\` key."
 	@echo "Emergency bypass: git commit --no-verify"
 	@bash scripts/install-merge-drivers.sh
+
+# Mechanism D (v7.8 §4.4) — assert that every gate listed in the
+# .githooks/pre-commit header is implemented in scripts/check-state-schema.py
+# or scripts/check-case-study-preflight.py. Catches header-vs-code drift.
+pre-commit-self-test:
+	python3 scripts/pre-commit-self-test.py
+
+# Mechanism F (v7.8 §4.6) — read-only smartlog of in-flight feature work.
+# Joins .claude/features/*/state.json + .claude/shared/agent-leases.json +
+# `git for-each-ref refs/heads/feature/*` into one ASCII table (default)
+# or JSON (--format=json) for the UCC dashboard.
+membrane-status:
+	python3 scripts/membrane-status.py
 
 # Install npm dependencies (style-dictionary)
 install:

--- a/scripts/membrane-status.py
+++ b/scripts/membrane-status.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Membrane status — read-only smartlog of in-flight feature work.
+
+v7.8 Mechanism F (advisory, bridge design §4.6 + §4.7.3). Surfaces a
+table of which agents are currently working in which feature branches +
+which paths they declared as `agent_manifest.writes`. v7.8 is read-only
+— no enforcement, no lease acquisition. v7.9 wires `/pm-workflow` to
+call `scripts/membrane-acquire.py` at session start; same data shape,
+same UI.
+
+Three sources, joined by feature slug:
+
+1. `.claude/features/<slug>/state.json` — current_phase + last-touched
+   mtime.
+2. `.claude/shared/agent-leases.json` — declared writes + last_heartbeat
+   (v7.8: empty in fresh installs; agents populate via /pm-workflow on
+   acquire).
+3. `git for-each-ref refs/heads/feature/* refs/heads/feat/* refs/heads/chore/*`
+   — open feature branches with their HEAD commit + age.
+
+Output: ASCII table sorted by last-touched mtime descending. JSON output
+also available via --format=json for the UCC dashboard.
+
+Pattern: Sapling smartlog (Meta), Jujutsu op-log. Branch-isolation
+survey §6 Phase 1.
+
+Usage:
+    scripts/membrane-status.py                 # ASCII table
+    scripts/membrane-status.py --format=json   # JSON for UCC
+
+Exit 0 always — read-only advisory.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FEATURES_DIR = REPO_ROOT / ".claude" / "features"
+LEASES_FILE = REPO_ROOT / ".claude" / "shared" / "agent-leases.json"
+
+
+def _load_leases() -> dict:
+    """Return parsed agent-leases.json or a default empty registry."""
+    if not LEASES_FILE.exists():
+        return {"version": "1.0", "epoch": 0, "leases": []}
+    try:
+        return json.loads(LEASES_FILE.read_text())
+    except json.JSONDecodeError:
+        return {"version": "1.0", "epoch": 0, "leases": []}
+
+
+def _load_features() -> list[dict]:
+    """Walk .claude/features/*/state.json. Return summaries sorted by mtime desc."""
+    if not FEATURES_DIR.exists():
+        return []
+    summaries = []
+    for state_path in sorted(FEATURES_DIR.glob("*/state.json")):
+        try:
+            data = json.loads(state_path.read_text())
+        except json.JSONDecodeError:
+            continue
+        slug = state_path.parent.name
+        mtime = datetime.fromtimestamp(state_path.stat().st_mtime, tz=timezone.utc)
+        summaries.append({
+            "slug": slug,
+            "current_phase": data.get("current_phase", "unknown"),
+            "framework_version": data.get("framework_version", ""),
+            "branch": data.get("branch", ""),
+            "last_touched_utc": mtime.isoformat(timespec="seconds"),
+            "agent_manifest_present": "agent_manifest" in data,
+            "manifest_writes": (data.get("agent_manifest") or {}).get("writes", []),
+        })
+    summaries.sort(key=lambda s: s["last_touched_utc"], reverse=True)
+    return summaries
+
+
+def _open_branches() -> dict[str, dict]:
+    """Run `git for-each-ref` on feature/feat/chore branches.
+
+    Returns a dict mapping branch_name → {commit, committer_date, age_seconds}.
+    Falls back to empty dict if git is unavailable.
+    """
+    try:
+        out = subprocess.check_output(
+            [
+                "git", "for-each-ref",
+                "--format=%(refname:short)|%(objectname:short)|%(committerdate:iso8601)",
+                "refs/heads/feature/", "refs/heads/feat/", "refs/heads/chore/",
+            ],
+            cwd=str(REPO_ROOT), text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+    branches: dict[str, dict] = {}
+    now = datetime.now(timezone.utc)
+    for line in out.strip().split("\n"):
+        if not line:
+            continue
+        parts = line.split("|", 2)
+        if len(parts) != 3:
+            continue
+        name, commit, date_iso = parts
+        try:
+            committer_date = datetime.fromisoformat(date_iso.replace(" ", "T"))
+        except ValueError:
+            continue
+        age_s = int((now - committer_date).total_seconds())
+        branches[name] = {
+            "commit": commit,
+            "committer_date": committer_date.isoformat(timespec="seconds"),
+            "age_seconds": age_s,
+        }
+    return branches
+
+
+def render_status() -> dict:
+    """Return a structured status snapshot for both ASCII + JSON output."""
+    leases_data = _load_leases()
+    features = _load_features()
+    branches = _open_branches()
+
+    # Join: each feature's branch gets its git age if matchable.
+    by_slug: dict[str, dict] = {}
+    for f in features:
+        f_copy = dict(f)
+        branch = f.get("branch") or ""
+        if branch and branch in branches:
+            f_copy["branch_meta"] = branches[branch]
+        by_slug[f["slug"]] = f_copy
+
+    # Decorate with lease info.
+    lease_by_slug: dict[str, dict] = {
+        l.get("agent", ""): l for l in leases_data.get("leases", [])
+    }
+    for slug, entry in by_slug.items():
+        if slug in lease_by_slug:
+            entry["lease"] = lease_by_slug[slug]
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "epoch": leases_data.get("epoch", 0),
+        "lease_count": len(leases_data.get("leases", [])),
+        "feature_count": len(features),
+        "branch_count": len(branches),
+        "features": list(by_slug.values()),
+        "_advisory_note": (
+            "v7.8 Mechanism F is advisory — no lease acquisition is "
+            "required. v7.9 will wire /pm-workflow to call membrane-acquire.py "
+            "at session start."
+        ),
+    }
+
+
+def render_ascii(status: dict) -> str:
+    rows = ["MEMBRANE STATUS  (v7.8 advisory — read-only)",
+            "=" * 80,
+            f"Epoch: {status['epoch']}    "
+            f"Active leases: {status['lease_count']}    "
+            f"Features: {status['feature_count']}    "
+            f"Open branches: {status['branch_count']}",
+            ""]
+    rows.append(f"{'feature':<40} {'phase':<14} {'fv':<10} {'manifest':<10} {'last touched':<20}")
+    rows.append("-" * 100)
+    # Show top 30 by mtime (truncated to fit a terminal).
+    for f in status["features"][:30]:
+        slug = f["slug"][:39]
+        phase = (f["current_phase"] or "?")[:13]
+        fv = (f["framework_version"] or "?")[:9]
+        manifest = "yes" if f["agent_manifest_present"] else "no"
+        last = f["last_touched_utc"][:19]
+        rows.append(f"{slug:<40} {phase:<14} {fv:<10} {manifest:<10} {last:<20}")
+    if len(status["features"]) > 30:
+        rows.append(f"... +{len(status['features']) - 30} more (run with --format=json for full list)")
+    rows.append("")
+    rows.append(status["_advisory_note"])
+    return "\n".join(rows)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--format", choices=["ascii", "json"], default="ascii")
+    args = ap.parse_args()
+
+    status = render_status()
+    if args.format == "json":
+        json.dump(status, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print(render_ascii(status))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-commit-self-test.py
+++ b/scripts/pre-commit-self-test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Pre-commit hook header self-audit (v7.8 Mechanism D).
+
+Asserts that every gate the `.githooks/pre-commit` HEADER claims to
+enforce is actually IMPLEMENTED in `scripts/check-state-schema.py` (or
+`scripts/check-case-study-preflight.py`). Catches header-vs-code drift
+silently introduced when a new gate ships without its header line, OR
+when a header line is left behind after a gate is removed.
+
+Per docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md
+§4.4. Pattern: gitleaks self-test, pre-commit.com `repo-rev` validation.
+
+Detection:
+  - Declared gates: extracted from the pre-commit hook header via regex
+    on `^#\\s*-?\\s*([A-Z_]+)`. Skips lines that don't look like a gate
+    name (uppercase + underscore + ≥6 chars).
+  - Implemented gates: extracted from `"code": "NAME"` literals AND
+    `errors.append(f"...{path}: uses legacy ...")` patterns in the two
+    schema-check scripts.
+
+Exit codes:
+  0  declared == implemented (or differences are explainable: e.g.
+     check-case-study-preflight.py owns BROKEN_PR_CITATION which the
+     hook header lists under v7.6).
+  1  drift detected; report on stdout.
+
+This is a development-time check. The hook itself does not invoke this
+script — it would slow every commit. Instead, `make pre-commit-self-test`
+runs it manually + `make verify-local` runs it as part of the verify
+pass + the per-PR pm-framework/pr-integrity check runs it.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_FILE = REPO_ROOT / ".githooks" / "pre-commit"
+SCHEMA_CHECKER = REPO_ROOT / "scripts" / "check-state-schema.py"
+CASE_STUDY_CHECKER = REPO_ROOT / "scripts" / "check-case-study-preflight.py"
+
+# Gates listed in the header but implemented elsewhere — accepted as
+# documentation pointers. Add entries here if a gate is intentionally
+# referenced in the hook header but lives in a non-checked file
+# (e.g. a tool the hook invokes indirectly).
+ACCEPTED_HEADER_REFERENCES = {
+    # Cycle-time-only gates that the header references for context but
+    # don't fire in pre-commit (they fire in scripts/integrity-check.py).
+    "PHASE_LIE", "TASK_LIE", "NO_CS_LINK", "V2_FILE_MISSING",
+    "PARTIAL_SHIP_TERMINAL", "NO_STATE", "INVALID_JSON", "NO_PHASE",
+    "TIER_TAG_LIKELY_INCORRECT", "CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE",
+    "GATE_COVERAGE_ZERO",
+}
+
+GATE_NAME_RE = re.compile(r"^#\s*-?\s*\*?\*?\s*`?([A-Z][A-Z0-9_]{4,})`?\b")
+CODE_LITERAL_RE = re.compile(r'"code":\s*"([A-Z_][A-Z0-9_]{4,})"')
+
+
+def extract_declared_gates(text: str) -> set[str]:
+    """Pull gate names from comment lines in the hook header.
+
+    The hook header is the contiguous block of comment lines (and blank
+    lines between them) at the top of the file. We stop at the first
+    non-comment, non-empty line — typically `set -euo pipefail`.
+    """
+    gates: set[str] = set()
+    for line in text.split("\n"):
+        if not line.startswith("#"):
+            if line.strip():
+                break
+            continue
+        m = GATE_NAME_RE.match(line)
+        if m:
+            name = m.group(1)
+            # Filter out non-gate words that match the regex shape.
+            if name not in {"IMPORTANT", "WARNING", "TODO", "FIXME", "NOTE"}:
+                gates.add(name)
+    return gates
+
+
+def extract_implemented_gates(text: str) -> set[str]:
+    """Pull gate codes from `"code": "NAME"` literals in checker source."""
+    return set(CODE_LITERAL_RE.findall(text))
+
+
+def extract_inline_drift_codes(text: str) -> set[str]:
+    """Detect gates implemented as inline error messages (no `"code": "..."`).
+
+    The `validate_file` function in check-state-schema.py uses inline
+    error messages for SCHEMA_DRIFT (legacy `phase` key) and
+    SCHEMA_DRIFT (legacy `created` key) — these don't appear as
+    `"code": ...` literals but the header references them.
+    """
+    inline_codes: set[str] = set()
+    if "uses legacy `phase` key" in text or 'uses legacy `phase`' in text:
+        inline_codes.add("SCHEMA_DRIFT")
+    if "uses legacy `created` key" in text or "uses legacy `created`" in text:
+        inline_codes.add("SCHEMA_DRIFT")  # same code; v7.7 fix layer
+    if "FRAMEWORK_VERSION_FORMAT" in text or "is not in canonical" in text:
+        inline_codes.add("FRAMEWORK_VERSION_FORMAT")
+    if "PR_NUMBER_UNRESOLVED" in text or "does not resolve on GitHub" in text:
+        inline_codes.add("PR_NUMBER_UNRESOLVED")
+    if "PHASE_TRANSITION_NO_LOG" in text or "but `.claude/logs/" in text:
+        inline_codes.add("PHASE_TRANSITION_NO_LOG")
+    if "PHASE_TRANSITION_NO_TIMING" in text or "started_at` is missing" in text:
+        inline_codes.add("PHASE_TRANSITION_NO_TIMING")
+    # Case-study preflight gates (no `"code": "..."` literals — emitted as
+    # plain errors.append(f"...") with descriptive messages).
+    if "BROKEN_PR_CITATION" in text or "cites PR #" in text and "does not resolve" in text:
+        inline_codes.add("BROKEN_PR_CITATION")
+    if "CASE_STUDY_MISSING_TIER_TAGS" in text or "no T1/T2/T3 tier tag" in text:
+        inline_codes.add("CASE_STUDY_MISSING_TIER_TAGS")
+    return inline_codes
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--quiet", action="store_true", help="suppress success message")
+    args = ap.parse_args()
+
+    if not HOOK_FILE.exists():
+        print(f"ERROR: hook file missing: {HOOK_FILE}", file=sys.stderr)
+        return 1
+    if not SCHEMA_CHECKER.exists():
+        print(f"ERROR: schema checker missing: {SCHEMA_CHECKER}", file=sys.stderr)
+        return 1
+
+    declared = extract_declared_gates(HOOK_FILE.read_text())
+
+    schema_text = SCHEMA_CHECKER.read_text()
+    case_study_text = CASE_STUDY_CHECKER.read_text() if CASE_STUDY_CHECKER.exists() else ""
+
+    implemented = (
+        extract_implemented_gates(schema_text)
+        | extract_implemented_gates(case_study_text)
+        | extract_inline_drift_codes(schema_text)
+        | extract_inline_drift_codes(case_study_text)
+    )
+
+    # Declared but not implemented (header drift on the "extra claim" side).
+    missing = declared - implemented - ACCEPTED_HEADER_REFERENCES
+    # Implemented but not declared (header drift on the "missing claim" side).
+    undeclared = implemented - declared - ACCEPTED_HEADER_REFERENCES
+
+    drift = bool(missing or undeclared)
+
+    if drift:
+        print("✗ pre-commit-self-test: header drift detected", file=sys.stderr)
+        if missing:
+            print(f"  Declared in hook header but NOT implemented:", file=sys.stderr)
+            for g in sorted(missing):
+                print(f"    - {g}", file=sys.stderr)
+        if undeclared:
+            print(f"  Implemented but NOT declared in hook header:", file=sys.stderr)
+            for g in sorted(undeclared):
+                print(f"    - {g}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            f"  Fix: edit {HOOK_FILE.relative_to(REPO_ROOT)} "
+            f"to declare/remove the listed gates.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.quiet:
+        print(
+            f"✓ pre-commit-self-test: {len(declared)} declared gates "
+            f"all implemented + {len(implemented)} implemented gates all "
+            f"declared (or accepted-reference)."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_membrane_status.py
+++ b/scripts/tests/test_membrane_status.py
@@ -1,0 +1,106 @@
+"""Tests for scripts/membrane-status.py (v7.8 Mechanism F advisory)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "scripts" / "membrane-status.py"
+    spec = importlib.util.spec_from_file_location("membrane_status", src)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["membrane_status"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def test_load_leases_returns_default_when_file_missing(mod, tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "LEASES_FILE", tmp_path / "missing.json")
+    data = mod._load_leases()
+    assert data == {"version": "1.0", "epoch": 0, "leases": []}
+
+
+def test_load_leases_handles_invalid_json(mod, tmp_path, monkeypatch):
+    bad = tmp_path / "agent-leases.json"
+    bad.write_text("not json {[")
+    monkeypatch.setattr(mod, "LEASES_FILE", bad)
+    data = mod._load_leases()
+    assert data == {"version": "1.0", "epoch": 0, "leases": []}
+
+
+def test_load_features_skips_invalid_json(mod, tmp_path, monkeypatch):
+    fdir = tmp_path / "features"
+    (fdir / "good").mkdir(parents=True)
+    (fdir / "good" / "state.json").write_text(json.dumps({
+        "current_phase": "complete", "framework_version": "v7.8",
+        "branch": "feature/good"
+    }))
+    (fdir / "bad").mkdir()
+    (fdir / "bad" / "state.json").write_text("{not json")
+    monkeypatch.setattr(mod, "FEATURES_DIR", fdir)
+    out = mod._load_features()
+    assert len(out) == 1
+    assert out[0]["slug"] == "good"
+    assert out[0]["current_phase"] == "complete"
+    assert out[0]["framework_version"] == "v7.8"
+
+
+def test_render_status_sorts_by_mtime_desc(mod, tmp_path, monkeypatch):
+    fdir = tmp_path / "features"
+    older = fdir / "older"
+    newer = fdir / "newer"
+    older.mkdir(parents=True)
+    newer.mkdir()
+    (older / "state.json").write_text(json.dumps({"current_phase": "complete"}))
+    (newer / "state.json").write_text(json.dumps({"current_phase": "tasks"}))
+    # Force older mtime on the older entry.
+    import os, time
+    older_t = time.time() - 3600
+    os.utime(older / "state.json", (older_t, older_t))
+    monkeypatch.setattr(mod, "FEATURES_DIR", fdir)
+    monkeypatch.setattr(mod, "LEASES_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(mod, "_open_branches", lambda: {})
+    status = mod.render_status()
+    slugs = [f["slug"] for f in status["features"]]
+    assert slugs == ["newer", "older"]
+
+
+def test_render_status_emits_advisory_note(mod, monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "FEATURES_DIR", tmp_path / "missing")
+    monkeypatch.setattr(mod, "LEASES_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(mod, "_open_branches", lambda: {})
+    status = mod.render_status()
+    assert "v7.8 Mechanism F is advisory" in status["_advisory_note"]
+    assert status["feature_count"] == 0
+
+
+def test_render_ascii_truncates_to_30_features(mod, tmp_path, monkeypatch):
+    fdir = tmp_path / "features"
+    fdir.mkdir()
+    for i in range(35):
+        d = fdir / f"feature-{i:02d}"
+        d.mkdir()
+        (d / "state.json").write_text(json.dumps({"current_phase": "complete"}))
+    monkeypatch.setattr(mod, "FEATURES_DIR", fdir)
+    monkeypatch.setattr(mod, "LEASES_FILE", tmp_path / "missing.json")
+    monkeypatch.setattr(mod, "_open_branches", lambda: {})
+    status = mod.render_status()
+    text = mod.render_ascii(status)
+    assert "+5 more" in text
+
+
+def test_render_status_runs_against_real_repo(mod):
+    """Smoke test: real repo should produce at least one feature without raising."""
+    status = mod.render_status()
+    assert status["feature_count"] >= 1
+    assert "generated_at" in status

--- a/scripts/tests/test_pre_commit_self_test.py
+++ b/scripts/tests/test_pre_commit_self_test.py
@@ -1,0 +1,112 @@
+"""Tests for scripts/pre-commit-self-test.py (v7.8 Mechanism D)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    """Load the pre-commit-self-test script as a module despite its hyphen-name."""
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "scripts" / "pre-commit-self-test.py"
+    spec = importlib.util.spec_from_file_location("pre_commit_self_test", src)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["pre_commit_self_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+def test_extract_declared_gates_picks_up_uppercase_identifiers(mod):
+    text = """#!/usr/bin/env bash
+# Pre-commit hook
+#
+#   v7.5 (shipped):
+#     - SCHEMA_DRIFT (legacy `phase` key)
+#     - PR_NUMBER_UNRESOLVED (something)
+#
+set -euo pipefail
+"""
+    declared = mod.extract_declared_gates(text)
+    assert "SCHEMA_DRIFT" in declared
+    assert "PR_NUMBER_UNRESOLVED" in declared
+
+
+def test_extract_declared_gates_skips_noise_words(mod):
+    text = """#!/usr/bin/env bash
+# IMPORTANT: this is a hook
+# WARNING: do not bypass
+# - SCHEMA_DRIFT (real gate)
+"""
+    declared = mod.extract_declared_gates(text)
+    assert "SCHEMA_DRIFT" in declared
+    assert "IMPORTANT" not in declared
+    assert "WARNING" not in declared
+
+
+def test_extract_declared_gates_handles_backticks_and_asterisks(mod):
+    text = """#
+# - **`SCHEMA_DRIFT`** — note
+# - `BROKEN_PR_CITATION` (formatted)
+#
+set -euo pipefail
+"""
+    declared = mod.extract_declared_gates(text)
+    assert "SCHEMA_DRIFT" in declared
+    assert "BROKEN_PR_CITATION" in declared
+
+
+def test_extract_declared_gates_stops_at_first_non_comment_line(mod):
+    text = """#
+# - REAL_GATE one
+#
+set -euo pipefail
+# - LATER_GATE post-set should be ignored
+"""
+    declared = mod.extract_declared_gates(text)
+    assert "REAL_GATE" in declared
+    assert "LATER_GATE" not in declared
+
+
+def test_extract_implemented_gates_finds_code_literals(mod):
+    text = '''
+        findings.append({"code": "STATE_NO_CASE_STUDY_LINK", "msg": "..."})
+        findings.append({"code":"CU_V2_INVALID","msg":"..."})
+    '''
+    impl = mod.extract_implemented_gates(text)
+    assert "STATE_NO_CASE_STUDY_LINK" in impl
+    assert "CU_V2_INVALID" in impl
+
+
+def test_extract_inline_drift_codes_detects_inline_messages(mod):
+    text = '''
+        errors.append(f"{path}: uses legacy `phase` key — canonical is current_phase")
+        errors.append(f"{path}: PHASE_TRANSITION_NO_LOG — but `.claude/logs/...` event missing")
+    '''
+    inline = mod.extract_inline_drift_codes(text)
+    assert "SCHEMA_DRIFT" in inline
+    assert "PHASE_TRANSITION_NO_LOG" in inline
+
+
+def test_extract_inline_drift_codes_detects_case_study_gates(mod):
+    text = '''
+        errors.append(f"{path}: cites PR #{n} which does not resolve on GitHub.")
+        errors.append(f"{path}: dated ... but contains no T1/T2/T3 tier tag.")
+    '''
+    inline = mod.extract_inline_drift_codes(text)
+    assert "BROKEN_PR_CITATION" in inline
+    assert "CASE_STUDY_MISSING_TIER_TAGS" in inline
+
+
+def test_main_passes_on_real_repo(mod, monkeypatch):
+    """Real-repo end-to-end: the project's actual hook + checkers must agree."""
+    monkeypatch.setattr(sys, "argv", ["pre-commit-self-test.py"])
+    rc = mod.main()
+    assert rc == 0


### PR DESCRIPTION
v7.8 §4.4 + §4.6. Two new advisory tools + hook-header rewrite. All ship read-only/advisory in v7.8; v7.9 wires enforcement on top.

Per [bridge design](docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md) §7.1 M3 PR-6.

## What's in the PR

### T18 — `scripts/membrane-status.py` (NEW, advisory)

Read-only smartlog joining three sources by feature slug:

1. `.claude/features/<slug>/state.json` — current_phase + last-touched mtime + framework_version + agent_manifest.
2. `.claude/shared/agent-leases.json` — declared writes + last_heartbeat (empty in v7.8 fresh installs).
3. `git for-each-ref refs/heads/feature/* refs/heads/feat/* refs/heads/chore/*` — open feature branches with HEAD commit + age.

Output: ASCII table (default) or `--format=json` for the UCC panel.

Pattern: Sapling smartlog (Meta), Jujutsu op-log. Branch-isolation survey §6 Phase 1.

```bash
make membrane-status                  # ASCII
scripts/membrane-status.py --format=json
```

### T20 — `scripts/pre-commit-self-test.py` (NEW, Mechanism D)

Asserts every gate declared in `.githooks/pre-commit`'s header is implemented in `scripts/check-state-schema.py` or `scripts/check-case-study-preflight.py`. Catches header-vs-code drift on both sides:

- **Declared but not implemented** — header lies.
- **Implemented but not declared** — silent gate, undocumented.

Detection covers `"code": "NAME"` literals + inline `errors.append(f"... legacy ...")` patterns + case-study message patterns (`cites PR #N`, `no T1/T2/T3 tier tag`).

Pattern: gitleaks self-test, pre-commit.com `repo-rev` validation.

### T21 — `.githooks/pre-commit` header rewrite

Adds v7.8 bridge section: advisory cycle-time gates (`GATE_COVERAGE_ZERO`, `CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE`) + schema bridge fields (`agent_manifest`, `_meta.deprecation_warnings`, `path-reducers.json`, `agent-leases.json`). Header now references pre-commit-self-test as the audit harness.

### Makefile

```makefile
make pre-commit-self-test    # Mechanism D
make membrane-status         # Mechanism F
```

## Tests added (15)

- `scripts/tests/test_pre_commit_self_test.py` — 7 tests (regex extraction, comment-block boundary, code-literal detection, inline-pattern detection, case-study patterns, real-repo end-to-end).
- `scripts/tests/test_membrane_status.py` — 8 tests (lease loading, feature scanning, mtime sort, advisory-note emission, ASCII truncation, real-repo smoke).

## Verification

```
pytest scripts/tests/test_membrane_status.py            → 8 passed
pytest scripts/tests/test_pre_commit_self_test.py       → 7 passed
python3 scripts/check-state-schema.py                   → 47/47 pass
make integrity-check                                    → 0 findings + 2 advisories
python3 scripts/pre-commit-self-test.py                 → 13 declared / 11 implemented, no drift
```

## What this is NOT

- Not enforced. Mechanism F is read-only; v7.9 wires `/pm-workflow` to call `membrane-acquire.py` at session start.
- Not Mechanism D's enforcement — `pre-commit-self-test` is a development-time check (`make pre-commit-self-test` + `pm-framework/pr-integrity`); the hook itself doesn't run it on every commit.
- T19 (UCC dashboard panel) is deferred to a separate fitme-story PR — it's frontend work that benefits from preview deployments in that repo.

## How this fits the v7.8 sequence

| PR | Status |
|---|---|
| #173, #185, #186, #188, #189 | merged |
| #187 (CACHE_HITS_EMPTY_POST_V6 inactive advisory) | merging (CI re-run pending) |
| #192 (PR-5: schema bridge fields) | open |
| **PR-6 (this)** | **open** |
| PR-7 (cold-start entrypoint + honesty ledger) | next |
| fitme-story PR (UCC panel) | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)