### PR TITLE
fix(ci): disable parallel UI testing to eliminate sim-clone flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,19 @@ jobs:
           echo "::endgroup::"
 
           # Test — same signing flags so the test host can hit the keychain.
+          # -parallel-testing-enabled NO: avoids iOS Simulator clone churn that
+          # produced a class of nondeterministic UI test flakes (different tests
+          # failed each run on PRs that touched zero Swift code; main itself
+          # flaked the same way). Trades ~5-10 min of serial test time for
+          # deterministic CI. PR #160's narrower XCTSkipIf quarantine in
+          # HomeReadinessUITests becomes redundant after this lands.
           echo "::group::Test"
           xcodebuild test \
             -project "$PROJECT_PATH" \
             -scheme "$SCHEME" \
             -destination "$SIM_DEST" \
             -resultBundlePath TestResults.xcresult \
+            -parallel-testing-enabled NO \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=YES 2>&1 | tee /tmp/test.log


### PR DESCRIPTION
## Summary
- Add `-parallel-testing-enabled NO` to the `xcodebuild test` invocation in `.github/workflows/ci.yml`
- Eliminates a class of nondeterministic UI test failures caused by iOS Simulator clone churn

## Diagnosis
During the 2026-05-04 v7.8 PR review session, **PRs #187, #191, #193 all failed `Build and Test`** despite touching only `scripts/`, `.githooks/`, `CLAUDE.md`, and docs — zero Swift code. Three lines of evidence pointed at the CI environment:

1. **Different tests fail each run.** PR #187 → `OnboardingUITests` + `AuthPolishV2`; PR #191 → `MealLogUITests`; PR #193 → `SignInUITests` + `AuthPolishV2` + `MealLogUITests`. Real regressions don't move targets.
2. **`main` itself was failing the same way** — last 2 main CI runs on 2026-05-03 also concluded `failure` with rotating UI test names.
3. **Logs showed parallel sim clones**: `Clone 1 of iPhone 16 Pro - FitTrackerUITests-Runner` / `Clone 2 of iPhone 16 Pro`.

`xcodebuild test` defaults to `-parallel-testing-enabled YES`, which spawns sim clones for concurrent execution. Shared keychain state, app launch races, and clone scheduling non-determinism produce the rotating failures.

## Fix
Single flag added to the test invocation. Trades ~5–10 min of serial test time for deterministic CI.

## Follow-up
- PR #160's narrower `XCTSkipIf NSUserName() == "runner"` quarantine in `HomeReadinessUITests` becomes redundant after this lands and can be removed.

## Test plan
- [ ] Build and Test passes on this PR
- [ ] After merge, observe 3+ consecutive green runs on `main` to confirm the flake class is gone
- [ ] Open follow-up to remove the `HomeReadinessUITests` `XCTSkipIf` quarantine

🤖 Generated with [Claude Code](https://claude.com/claude-code)