### PR TITLE
chore: untrack scheduled_tasks.lock + add lock-file gitignore patterns

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"a6423824-49ae-4309-a484-fb1ffa0f895a","pid":38626,"acquiredAt":1776709198701}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ Carthage/Build/
 !.claude/entrypoints/
 !.claude/entrypoints/**
 !.claude/settings.json
+# Session-specific lock files (regenerated per session, never commit)
+.claude/scheduled_tasks.lock
+.claude/logs/*.lock
+.claude/logs/*.lock.json
 .superpowers/
 .worktrees/
 FitMe-GDPR-Docs/


### PR DESCRIPTION
## Summary

- Untracks `.claude/scheduled_tasks.lock` from git (session-specific state, was tracked accidentally)
- Adds 3 `.gitignore` patterns to prevent re-tracking lock files in `.claude/`

## Background

2026-05-05 deep audit found the lock file was committed once via "chore: checkpoint workspace changes" with no `.gitignore` entry covering it. The file regenerates per session and contains a session ID + PID + timestamps — never project state.

## Changes

| File | Change |
|---|---|
| `.gitignore` | +3 lines: `.claude/scheduled_tasks.lock`, `.claude/logs/*.lock`, `.claude/logs/*.lock.json` |
| `.claude/scheduled_tasks.lock` | `git rm --cached` (file remains on disk) |

## Test plan
- [x] Pre-commit hook ran (no state.json or case study changes triggered validators)
- [ ] CI green
- [ ] PR Integrity Check green

## Source

Full-repair-mode plan PR-B (2026-05-05 deep audit). See [project_full_repair_2026_05_05.md](https://github.com/Regevba/FitTracker2/blob/main/.claude/features/) tracking memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)