### PR TITLE
feat(framework-v7.8): add framework_meta_retroactive exempt type for chain-of-custody backfill

### DIFF
--- a/.claude/integrity/README.md
+++ b/.claude/integrity/README.md
@@ -162,7 +162,9 @@ The `state_hash` field is a truncated SHA-256 of the state.json content — dete
 
 2. **Roundup-classified features** bypass the no-cs-link check via `case_study_type: "roundup"` (pointing at a shared roundup case study).
 
-3. **Features with `partial_ship: true`** are flagged via `PARTIAL_SHIP_TERMINAL` if they ALSO have a terminal phase — the policy is either "downgrade phase from complete" or "remove the partial_ship flag", pick one.
+3. **Framework-meta-retroactive features** (added v7.8) bypass phase-lie + no-cs-link checks via `case_study_type: "framework_meta_retroactive"`. Used for framework-version meta features (e.g. v5.0 SoC, v5.2 Dispatch Intelligence) whose framework version itself shipped before spec discipline was established. The case study + git history are the source of truth; there is no spec/plan/PRD chain to backfill, and the legacy phase model doesn't apply. Pairs with the v7.8 chain-of-custody initiative — going forward, all new framework versions (v7.9+) carry full spec→plan→PRD→PR→case-study→showcase chains and CANNOT use this exemption.
+
+4. **Features with `partial_ship: true`** are flagged via `PARTIAL_SHIP_TERMINAL` if they ALSO have a terminal phase — the policy is either "downgrade phase from complete" or "remove the partial_ship flag", pick one.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The 72h Integrity Cycle shipped at v7.1 is now one of **eight cooperating defens
 **Cycle-time gates (fire every 72h via GitHub Actions):**
 Runs [`scripts/integrity-check.py`](scripts/integrity-check.py) against every `.claude/features/*/state.json` and every `docs/case-studies/*.md`. 13 cycle-time check codes: `PHASE_LIE`, `TASK_LIE`, `NO_CS_LINK`, `V2_FILE_MISSING`, `PARTIAL_SHIP_TERMINAL`, `NO_STATE`, `INVALID_JSON`, `NO_PHASE`, `SCHEMA_DRIFT`, `PR_NUMBER_UNRESOLVED`, `BROKEN_PR_CITATION`, `CASE_STUDY_MISSING_TIER_TAGS`, `CU_V2_INVALID` (v7.7).
 
-- **Backfill exemption:** features tagged `case_study_type: "pre_pm_workflow_backfill"` or `"roundup"` bypass the sub-phase vocabulary check.
+- **Backfill exemption:** features tagged `case_study_type: "pre_pm_workflow_backfill"`, `"roundup"`, `"no_case_study_required"`, or `"framework_meta_retroactive"` bypass the sub-phase vocabulary check. The `framework_meta_retroactive` tag (added v7.8) is for framework-version meta features whose framework version itself shipped before spec discipline was established (v5.0 SoC, v5.2 dispatch intelligence, v6.0 measurement, v7.0 meta-analysis, v7.1 integrity cycle); the case study + git history are the source of truth — no spec/plan/PRD chain to backfill. Going forward (v7.9+), all new framework versions carry full chain-of-custody and CANNOT use this exemption.
 - **Local usage:** `make integrity-check` (findings only) or `make integrity-snapshot` (write + diff vs previous).
 - **Full docs:** [`.claude/integrity/README.md`](.claude/integrity/README.md).
 

--- a/scripts/check-state-schema.py
+++ b/scripts/check-state-schema.py
@@ -331,7 +331,12 @@ def check_cache_hits_empty_post_v6(
     return findings
 
 
-EXEMPT_CASE_STUDY_TYPES = {"no_case_study_required", "pre_pm_workflow_backfill", "roundup"}
+EXEMPT_CASE_STUDY_TYPES = {
+    "no_case_study_required",
+    "pre_pm_workflow_backfill",
+    "roundup",
+    "framework_meta_retroactive",
+}
 
 
 def check_state_no_case_study_link(
@@ -346,9 +351,14 @@ def check_state_no_case_study_link(
     one was waived.
 
     Exempt tags (EXEMPT_CASE_STUDY_TYPES):
-      - no_case_study_required  (new in v7.7 — operational artifacts)
-      - pre_pm_workflow_backfill (v7.6 — pre-PM-workflow features)
-      - roundup                  (v7.6 — covered by consolidation case study)
+      - no_case_study_required    (new in v7.7 — operational artifacts)
+      - pre_pm_workflow_backfill  (v7.6 — pre-PM-workflow features)
+      - roundup                   (v7.6 — covered by consolidation case study)
+      - framework_meta_retroactive (v7.8 — framework-version meta features
+                                    where the framework version itself shipped
+                                    before spec discipline was established;
+                                    case study + git history are the source of
+                                    truth, no spec/plan/PRD chain to backfill)
 
     Returns a list with one finding dict (code=STATE_NO_CASE_STUDY_LINK) if the
     check fails, or an empty list if the check passes or is not applicable.
@@ -377,8 +387,8 @@ def check_state_no_case_study_link(
             "docs/case-studies/<feature>-case-study.md, or a "
             "parent_case_study field pointing to the parent case study, OR "
             "add case_study_type: 'no_case_study_required' (or "
-            "'pre_pm_workflow_backfill' / 'roundup') with "
-            "case_study_exempt_reason."
+            "'pre_pm_workflow_backfill' / 'roundup' / "
+            "'framework_meta_retroactive') with case_study_exempt_reason."
         ),
         "severity": "failure",
     })

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -172,8 +172,11 @@ def audit_feature(feat_dir: Path) -> tuple[dict, list[dict]]:
     # Phase-lie exemptions:
     # - pre-PM-workflow backfills (use legacy phase vocabulary)
     # - roundup-classified features (covered by consolidation CS, sub-phase granularity not meaningful)
+    # - framework_meta_retroactive (v7.8) — framework-version meta features
+    #   whose framework version itself shipped before spec discipline; sub-phase
+    #   granularity not meaningful since the work predates the phase model
     cs_type = d.get("case_study_type")
-    is_phase_check_exempt = cs_type in ("pre_pm_workflow_backfill", "roundup")
+    is_phase_check_exempt = cs_type in ("pre_pm_workflow_backfill", "roundup", "framework_meta_retroactive")
 
     # Check #1: phase lie
     if is_terminal and not is_phase_check_exempt:
@@ -205,10 +208,13 @@ def audit_feature(feat_dir: Path) -> tuple[dict, list[dict]]:
             })
 
     # Check #3: missing case-study linkage (excluding roundup + backfill +
-    # no_case_study_required). Note: is_phase_check_exempt covers
-    # pre_pm_workflow_backfill and roundup; no_case_study_required is a v7.7
-    # addition for operational artifacts that warrant no narrative.
-    _NO_CS_EXEMPT_TYPES = {"roundup", "no_case_study_required"}
+    # no_case_study_required + framework_meta_retroactive). Note:
+    # is_phase_check_exempt covers pre_pm_workflow_backfill and roundup;
+    # no_case_study_required is a v7.7 addition for operational artifacts
+    # that warrant no narrative; framework_meta_retroactive is a v7.8
+    # addition for framework-version meta features whose framework version
+    # itself shipped before spec discipline was established.
+    _NO_CS_EXEMPT_TYPES = {"roundup", "no_case_study_required", "framework_meta_retroactive"}
     if is_terminal and not is_phase_check_exempt:
         has_cs = bool(d.get("case_study") or d.get("parent_case_study"))
         if not has_cs and d.get("case_study_type") not in _NO_CS_EXEMPT_TYPES:

--- a/scripts/tests/test_check_state_schema.py
+++ b/scripts/tests/test_check_state_schema.py
@@ -222,7 +222,7 @@ def test_state_no_case_study_link_passes_with_parent_link():
 
 
 def test_state_no_case_study_link_passes_with_exempt():
-    for tag in ("no_case_study_required", "pre_pm_workflow_backfill", "roundup"):
+    for tag in ("no_case_study_required", "pre_pm_workflow_backfill", "roundup", "framework_meta_retroactive"):
         state = {
             "feature_name": "test",
             "current_phase": "complete",


### PR DESCRIPTION
## Summary

Adds a new `case_study_type: framework_meta_retroactive` exempt tag for framework-version meta features whose framework version itself shipped before formal spec discipline (v5.0, v5.2, v6.0, v7.0, v7.1).

This is **backward-looking only** — v7.9 and future framework versions MUST carry full spec → plan → PRD → PR → case study → showcase chain-of-custody.

## Why

The 2026-05-05 deep audit surfaced 5 framework versions with no spec/plan source material. Decision 3 (full-repair-mode plan) chose Option A: adopt an exempt type rather than fabricate retroactive specs. This PR ships the schema/integrity-check support for that exemption.

## Changes

| File | Change |
|---|---|
| `scripts/check-state-schema.py` | +`framework_meta_retroactive` to `EXEMPT_CASE_STUDY_TYPES` |
| `scripts/integrity-check.py` | +`framework_meta_retroactive` to phase-lie + no-cs-link exempt sets |
| `scripts/tests/test_check_state_schema.py` | extends existing exempt-tag test |
| `.claude/integrity/README.md` | new §3 under "Expected false-positives" |
| `CLAUDE.md` | updated Data Integrity Framework "Backfill exemption" line |

## Forward policy (called out in CLAUDE.md + README.md)

`framework_meta_retroactive` cannot be used on v7.9+ framework features. Going forward, every framework version carries full chain of custody.

## Verification

- ✓ `make schema-check` passes (48/48)
- ✓ `make integrity-check` passes (0 findings)
- ✓ Hand-verified the 4 exempt tags + 1 negative case (pytest unavailable in this env; ran via importlib)

## Source

Full-repair-mode plan PR-D (2026-05-05 deep audit, Decision 3 outcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)