### PR TITLE
docs(framework-meta): retroactive specs/plans for v7.5, v7.6, v7.8

### DIFF
--- a/docs/superpowers/plans/2026-05-02-framework-v7-8-bridge.md
+++ b/docs/superpowers/plans/2026-05-02-framework-v7-8-bridge.md
@@ -1,0 +1,170 @@
+# Framework v7.8 — Bridge to v7.9 Implementation Plan
+
+> **THIS IS A RETROACTIVE PLAN.** v7.8 shipped between 2026-05-02 and 2026-05-04 across 9 PRs (#173, #185-189, #191-194, #195). The **spec** existed (`2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`); this **plan** was authored 2026-05-05 as part of the chain-of-custody initiative (full-repair-mode plan PR-H), reconciling the as-shipped PR sequence against the spec's intended milestone structure. Sourced from the spec, the v7.8 case study, and the merged-PR git log; nothing fabricated.
+>
+> **Backfill type:** framework_meta_retroactive
+> **Backfill source:** `docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md` (spec) · `docs/case-studies/framework-v7-8-bridge-case-study.md` (live journal) · `git log --grep="framework-v7.8"` (PR sequence)
+
+**Goal:** Close the v7.7 silent-pass on `CACHE_HITS_EMPTY_POST_V6` (gate fired every commit but skipped 46/46 features due to a `created`/`created_at` schema field-name drift) and ship the meta-layer (Mechanisms A–F) that prevents future silent-pass failures.
+
+**Architecture:** 9 PRs across 2 days. Six new framework mechanisms (A–F) all ship advisory in v7.8; v7.9 promotes the writer-path (Mechanism C) to enforced once 7+ days of session-ledger data calibrates the threshold (window opens 2026-05-11).
+
+**Tech stack:** Python 3.11 (hooks + scripts + Mechanism C observer), Bash + GitHub Actions (CI), git custom merge driver (Mechanism E `union-dedup-by-key`), `.claude/settings.json` PostToolUse:Read hook (Mechanism C), git pre-commit hook self-test (Mechanism D), advisory smartlog (Mechanism F).
+
+**Spec:** [`docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`](../specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md)
+
+**Predecessor case studies:** v7.5 → v7.6 → v7.7 → **v7.8 bridge**
+
+---
+
+## Executive Summary
+
+**As-shipped sequence (chronological by merge date):**
+
+| PR | Merge date | Title | Closes |
+|---|---|---|---|
+| #173 | 2026-05-02 | M-C scaffold + dual-read parser | Mechanism C scaffolding + Mechanism B start |
+| #185 | 2026-05-03 | PR-2 schema bridges A — backfill `framework_version` on 5 post-v6 features | Mechanism B schema reconciliation |
+| #186 | 2026-05-03 | PR-3 framework_version backfill on 34 pre-v6 features + ui-audit dates | Mechanism B completion (47/47 features have canonical `framework_version`) |
+| #187 | 2026-05-03 | PR-4 Mechanism A coverage gates | Mechanism A — every gate emits per-run coverage stats to `gate-coverage.jsonl` |
+| #188 | 2026-05-03 | PR-5 Mechanism C session attribution | Mechanism C — `/pm-workflow` writes `.claude/active-feature`; SessionStart surfaces it; advisory `CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE` flag |
+| #189 | 2026-05-03 | PR-6 Mechanism E git merge driver | `scripts/merge-driver-dedup.py` + `.gitattributes` opt-in for ledger files |
+| #193 | 2026-05-03 | PR-6 Mechanisms D + F | `pre-commit-self-test` + `membrane-status` advisory smartlog |
+| #194 | 2026-05-04 | PR-7 cold-start entrypoint + honesty ledger | `.claude/entrypoints/framework-v7-8.md` + first FT2-FH-001 entry |
+| #195 | 2026-05-04 | CI fix — disable parallel UI testing | sim-clone flake mitigation (env-flake unrelated to v7.8 mechanism work) |
+
+**6 mechanisms (A-F) shipped advisory:**
+
+| Mechanism | Purpose | Spec section |
+|---|---|---|
+| A | Coverage-asserting gates emit `{candidates, checked, skipped, skip_reasons}` to `.claude/logs/gate-coverage.jsonl` | §4.1 |
+| B | Schema field-rename detection + dual-read for `created` ∪ `created_at`; canonical `framework_version` on 47/47 features | §4.2 |
+| C | `PostToolUse:Read` hook + `scripts/observe-cache-hit.py` — auto-captures Read events to `.claude/logs/_session-<id>.events.jsonl` | §4.3 |
+| D | `scripts/pre-commit-self-test.py` — pre-commit hook validates its own header on each run | §4.4 |
+| E | `scripts/merge-driver-dedup.py` + `.gitattributes` — auto-resolves merge conflicts on append-only ledgers via union-dedup-by-key | §4.5 |
+| F | `scripts/membrane-status.py` — advisory smartlog joining active feature + recent gate firings + dispatch-blocker state | §4.6 |
+
+**Outcome at synthesis time (2026-05-04):**
+
+| Dimension | Pre-v7.8 | Post-v7.8 |
+|---|---|---|
+| `framework_version` field coverage | 7/47 features had values; 40/47 missing | **47/47** with canonical `vX.Y` form |
+| `CACHE_HITS_EMPTY_POST_V6` effective coverage | 0/46 (silent-pass; gate read `created_at` but 43/46 used `created`) | dual-read fix; 1 effective post-Mechanism-C feature flagged correctly |
+| Per-gate coverage observability | None | `gate-coverage.jsonl` ledger, 189+ entries by 2026-05-05 |
+| `cache_hits[]` writer-path adoption | Class B (agent-attention) | Class B → A advisory (auto-collected via Mechanism C) |
+| Ledger merge conflicts | Manual resolution | Auto-resolved (Mechanism E driver) |
+| Pre-commit hook header drift | Silent | Mechanism D self-test catches |
+| Inter-agent context handoff | Stranded across sessions | Mechanism F membrane-status advisory readout |
+| Total framework mechanisms | 25 gates + 1 advisory (v7.7) | **27 mechanical gates + 2 advisories + observability layer** |
+
+---
+
+## Milestone Breakdown (reconciled to as-shipped sequence)
+
+### M0 — Schema reconciliation (PR #173 + #185 + #186)
+
+**Goal:** Close the v7.7 silent-pass via the field-name drift fix.
+
+- T1 (PR #173): Add dual-read parser for `created` ∪ `created_at` to `check-state-schema.py`. Migrate 43 of 46 state.json files from `created` → `created_at`.
+- T2 (PR #185): Backfill `framework_version` to canonical `vX.Y` on 5 post-v6 features.
+- T3 (PR #186): Backfill `framework_version` on 34 pre-v6 features (`pre-vX.Y` form) + ui-audit dates.
+
+**Outcome:** 47/47 features have canonical `framework_version`. `CACHE_HITS_EMPTY_POST_V6` gate now fires correctly.
+
+### M1 — Mechanism A coverage gates (PR #187)
+
+**Goal:** Make silent-pass impossible to ship undetected going forward.
+
+- T4: Add `scripts/gate_coverage.py` — emits `{candidates, checked, skipped, skip_reasons}` per gate per run.
+- T5: Wire every gate function in `check-state-schema.py` to accept `coverage` kwarg.
+- T6: Append per-run summary to `.claude/logs/gate-coverage.jsonl`.
+- T7: Document at `.claude/integrity/README.md` "Mechanism A — coverage tracking".
+
+**Outcome:** every commit produces a row in `gate-coverage.jsonl`; v7.9 promotion gate `GATE_COVERAGE_ZERO` becomes promotable once 7+ days of stats accumulate.
+
+### M2 — Mechanism C auto-instrumentation (PR #188)
+
+**Goal:** Move `cache_hits[]` writer-path from Class B (agent-attention) to Class A advisory (auto-collected).
+
+- T8: Add `scripts/observe-cache-hit.py` (PostToolUse:Read handler).
+- T9: Wire `.claude/settings.json` `hooks.PostToolUse[].Read` → `observe-cache-hit.py`.
+- T10: `/pm-workflow` writes `.claude/active-feature` on entry; SessionStart surfaces it.
+- T11: Add advisory check `CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE` (15th cycle-time check code) — flags features where session events show Reads but state.json::cache_hits[] is empty.
+
+**Outcome:** auto-instrumentation captures Read events to `.claude/logs/_session-<id>.events.jsonl`; cycle check surfaces features where the writer-path didn't engage.
+
+### M3 — Mechanism E ledger merge driver (PR #189)
+
+**Goal:** Auto-resolve merge conflicts on append-only ledgers.
+
+- T12: Add `scripts/merge-driver-dedup.py` (`union-dedup-by-key` implementation).
+- T13: Add `scripts/install-merge-drivers.sh` registration.
+- T14: `.gitattributes` opt-in: `measurement-adoption-history.json` + `documentation-debt.json` use `merge=union-dedup-by-key`.
+- T15: Wire `make install-hooks` to call `install-merge-drivers.sh`.
+
+**Outcome:** future merge conflicts on the two append-only ledgers auto-resolve via union-dedup-by-date-key. Manual resolution no longer required.
+
+### M4 — Mechanisms D + F (PR #193)
+
+**Goal:** Self-test the gate infrastructure + advisory inter-agent membrane status.
+
+- T16 (Mechanism D): `scripts/pre-commit-self-test.py` validates header parity between declared gates + implemented gates.
+- T17: Wire pre-commit hook to invoke self-test.
+- T18 (Mechanism F): `scripts/membrane-status.py` joins active feature + recent gate firings + dispatch-blocker state.
+- T19: Wire SessionStart hook to surface membrane status.
+- T20: Add `make membrane-status` target.
+
+**Outcome:** D catches header drift between hook + script; F gives a single readout for "what is the framework doing right now."
+
+### M5 — Cold-start entrypoint + honesty ledger (PR #194)
+
+**Goal:** Make v7.8 mechanism state legible for fresh agent sessions.
+
+- T21: `.claude/entrypoints/framework-v7-8.md` — one-page summary of mechanisms A-F + their advisory/enforced state.
+- T22: `docs/case-studies/framework-honesty-ledger.md` — ongoing record of "claim vs reality" findings.
+- T23: First entry FT2-FH-001 documenting the v7.7 `CACHE_HITS_EMPTY_POST_V6` silent-pass + v7.8 closure.
+
+**Outcome:** new agent sessions land with a v7.8-aware cold-start prompt; honesty norm institutionalized.
+
+### M6 — CI fix (PR #195)
+
+**Goal:** Mitigate the parallel-clone simulator flake observed during v7.8 mechanism PRs.
+
+- T24: Disable parallel UI testing in `.github/workflows/ci.yml` (`-parallel-testing-enabled NO`).
+- T25: Document the change at backlog entry "CI parallel-clone simulator hang — root cause investigation".
+
+**Outcome:** Build-and-Test step stops failing on env-flake (different test fails each run on PRs that touch zero Swift code). Permanent root-cause investigation deferred to a separate backlog task.
+
+---
+
+## Gating Status as of 2026-05-05
+
+**Mechanism A (coverage gates):** Shipped advisory. 189+ entries in `gate-coverage.jsonl`. `GATE_COVERAGE_ZERO` meta-check shipped advisory; v7.9 promotes to enforced once 7+ days of data accumulate (window opens 2026-05-11).
+
+**Mechanism B (schema bridges):** Fully shipped. 47/47 features have canonical `framework_version`. `created` ∪ `created_at` dual-read in place for the migration window.
+
+**Mechanism C (auto-instrumentation):** Shipped advisory. PostToolUse:Read hook captures session events. v7.9 promotes writer-path to enforced once threshold calibrated.
+
+**Mechanism D (self-test):** Shipped enforced (pre-commit invocation).
+
+**Mechanism E (merge driver):** Shipped enforced (auto-resolves on installed hooks).
+
+**Mechanism F (membrane status):** Shipped advisory.
+
+## Cross-version chain
+
+v7.5 (data integrity framework) → v7.6 (mechanical enforcement) → v7.7 (validity closure) → **v7.8 (bridge to v7.9)** → v7.9 (measurement window opens 2026-05-11)
+
+## Known limitations of this retroactive plan
+
+1. **Task-level granularity is reconstructed from the spec + as-shipped PR boundaries.** The original `feature/framework-v7-8-bridge` branch did not have a per-task tracker analogous to v7.7's 42-task plan. Tasks T1-T25 above are inferred from the spec sections + PR diffs; the original ship was more fluid.
+2. **No Linear/Notion sync trail recorded for individual tasks.** Propagation was at the PR level, not task level.
+3. **PR #195 (CI fix) was tactically bundled but not logically part of the mechanism architecture.** It's listed as M6 here for as-shipped completeness; it's not part of the "6 mechanisms" framing.
+
+## Links
+
+- **Spec:** [`docs/superpowers/specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`](../specs/2026-05-02-framework-v7-8-and-v7-9-bridge-design.md)
+- **Case study:** [`docs/case-studies/framework-v7-8-bridge-case-study.md`](../../case-studies/framework-v7-8-bridge-case-study.md)
+- **Honesty ledger (FT2-FH-001 et seq.):** [`docs/case-studies/framework-honesty-ledger.md`](../../case-studies/framework-honesty-ledger.md)
+- **Cold-start entrypoint:** [`.claude/entrypoints/framework-v7-8.md`](../../../.claude/entrypoints/framework-v7-8.md)
+- **Predecessor specs:** [v7.7](../specs/2026-04-27-framework-v7-7-validity-closure-design.md), [v7.6 (retroactive)](../specs/2026-04-25-framework-v7-6-mechanical-enforcement-design.md), [v7.5 (retroactive)](../specs/2026-04-24-framework-v7-5-data-integrity-design.md)

--- a/docs/superpowers/specs/2026-04-24-framework-v7-5-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-04-24-framework-v7-5-data-integrity-design.md
@@ -1,0 +1,137 @@
+---
+title: Framework v7.5 — Data Integrity Framework
+date_written: 2026-05-05  # RETROACTIVE BACKFILL — original framework version shipped 2026-04-24
+ship_date: 2026-04-24
+backfill_type: framework_meta_retroactive
+backfill_source:
+  - docs/case-studies/data-integrity-framework-v7.5-case-study.md  # primary narrative source
+  - trust/audits/2026-04-21-gemini/remediation-plan-2026-04-23.md  # original trigger
+  - .claude/integrity/README.md  # mechanism documentation
+  - git log --grep="v7.5\|data-integrity" between 2026-04-21 and 2026-04-25
+work_type: Feature
+dispatch_pattern: serial
+predecessor_case_studies:
+  - docs/case-studies/integrity-cycle-v7.1-case-study.md  # 72h integrity cycle (v7.1 baseline)
+  - docs/case-studies/meta-analysis-full-system-audit-v7.0-case-study.md  # v7.0 audit infrastructure
+status: shipped_pre_spec_discipline
+---
+
+# Framework v7.5 — Data Integrity Framework (Retroactive Spec)
+
+> **THIS IS A RETROACTIVE SPEC.** v7.5 shipped on 2026-04-24, before the project established formal spec discipline at v7.7 (2026-04-27). This document was authored 2026-05-05 as part of the chain-of-custody initiative (full-repair-mode plan PR-H) and is sourced entirely from existing artifacts — the v7.5 case study, the Gemini audit remediation plan, the integrity README, and git log. Nothing in this spec is fabricated; every claim is traceable to a pre-2026-05-05 source file.
+
+## 0. One-line summary
+
+v7.5 introduces an **eight-defense data-integrity framework** triggered by the 2026-04-21 Gemini independent audit, converting silent state.json drift from a Class C agent-attention problem into a write-time + cycle-time + readout-time gated discipline.
+
+## 1. Genesis & Why Now
+
+The 2026-04-21 Gemini 2.5 Pro independent audit (`trust/audits/2026-04-21-gemini/`) identified that the project had shipped extensive measurement infrastructure (v6.0 measurement framework, v7.1 integrity cycle, v7.0 meta-analysis) without measuring its own measurement adoption. The audit surfaced two patterns:
+
+1. **State.json drift:** 7+ features had been sitting in "shipped but state.json unreconciled" limbo for 3-14 days before the 2026-04-20 audit caught them.
+2. **Measurement-without-self-measurement:** the project tracked feature DVs (wall time, cache hits, cu_v2) but had no rollup of "how many features actually adopted the measurement framework."
+
+v7.5 closes both loops by introducing eight cooperating defenses across three temporal tiers (write-time, cycle-time, readout-time).
+
+## 2. Scope (as shipped)
+
+**In scope (closed by v7.5):**
+
+- **W1** `SCHEMA_DRIFT` write-time gate — pre-commit hook rejects legacy `phase` key (canonical: `current_phase`).
+- **W2** `PR_NUMBER_UNRESOLVED` write-time gate — pre-commit hook verifies `phases.merge.pr_number` against cached `gh pr list`.
+- **C1** `PHASE_LIE` cycle-time check — flags terminal phase with non-terminal sub-phases.
+- **C2** `TASK_LIE` cycle-time check — flags terminal phase with open tasks.
+- **C3** `NO_CS_LINK` cycle-time check — flags terminal phase without case_study or exempt tag.
+- **C4** `V2_FILE_MISSING` cycle-time check — flags `v2_file_path` claim without disk file.
+- **C5** `PARTIAL_SHIP_TERMINAL` cycle-time check — flags `partial_ship: true` with terminal phase.
+- **R1-R3** Readout dashboards — `make integrity-check`, `make integrity-snapshot`, `make documentation-debt`, `make measurement-adoption`.
+
+**Tier 2.3 data-quality convention introduced in same window** (forward-only from 2026-04-21): every quantitative metric in case studies, PRDs, and meta-analyses must carry T1 (Instrumented), T2 (Declared), or T3 (Narrative) tags.
+
+**Out of scope (deferred to v7.6+):**
+- Mechanical promotion of agent-attention checks to write-time (closed by v7.6 Mechanical Enforcement).
+- Per-PR review bot (closed by v7.6).
+- Weekly framework-status cron (closed by v7.6).
+- Five Class B unclosable-by-design gaps documented at `docs/case-studies/meta-analysis/unclosable-gaps.md`.
+
+## 3. Architecture
+
+### 3.1 Three temporal tiers
+
+```
+Write-time          ┃ Cycle-time           ┃ Readout-time
+(pre-commit hook)   ┃ (72h GitHub Actions) ┃ (any-time make targets)
+─────────────────── ┃ ─────────────────── ┃ ────────────────────
+SCHEMA_DRIFT        ┃ PHASE_LIE           ┃ make integrity-check
+PR_NUMBER_UNRESOLVED┃ TASK_LIE            ┃ make integrity-snapshot
+                    ┃ NO_CS_LINK          ┃ make documentation-debt
+                    ┃ V2_FILE_MISSING     ┃ make measurement-adoption
+                    ┃ PARTIAL_SHIP_TERMINAL┃ make framework-status
+                    ┃ NO_STATE / INVALID_JSON ┃
+                    ┃ NO_PHASE              ┃
+```
+
+**Tier hierarchy rationale:** write-time gates catch errors at commit; cycle-time gates catch slow drift across multiple commits; readout-time dashboards surface state to operators on demand. Each tier has a different failure mode (commit fails, cycle issue opens, dashboard reflects truth).
+
+### 3.2 Snapshot ledger
+
+`.claude/integrity/snapshots/<timestamp>.json` is the canonical ledger. Each 72h cycle produces one snapshot. Snapshots are append-only. Diff between consecutive snapshots is the "did anything regress" signal.
+
+### 3.3 Backfill exemption
+
+Features tagged `case_study_type: "pre_pm_workflow_backfill"` or `"roundup"` bypass the sub-phase vocabulary check (use legacy phase vocabulary). Documented at `.claude/integrity/README.md` "Expected false-positives".
+
+## 4. Implementation summary (as shipped 2026-04-24)
+
+| File | Purpose |
+|---|---|
+| `scripts/integrity-check.py` | Cycle-time auditor (PHASE_LIE, TASK_LIE, NO_CS_LINK, V2_FILE_MISSING, PARTIAL_SHIP_TERMINAL, SCHEMA_DRIFT, NO_STATE, INVALID_JSON, NO_PHASE) |
+| `scripts/check-state-schema.py` | Write-time pre-commit hook (SCHEMA_DRIFT, PR_NUMBER_UNRESOLVED) |
+| `.githooks/pre-commit` | Hook installer — `make install-hooks` wires it |
+| `.github/workflows/integrity-cycle.yml` | 72h GitHub Actions cron |
+| `.claude/integrity/snapshots/` | Append-only snapshot ledger |
+| `scripts/measurement-adoption-report.py` | Tier 1.1 readout |
+| `scripts/documentation-debt-report.py` | Tier 3.2 readout |
+| `Makefile` targets | `make integrity-check`, `make integrity-snapshot`, `make documentation-debt`, `make measurement-adoption`, `make install-hooks` |
+
+## 5. What v7.5 explicitly DID NOT close
+
+The v7.5 case study explicitly enumerates 5 gaps it did not close, documented at `docs/case-studies/meta-analysis/unclosable-gaps.md`:
+
+1. `cache_hits[]` writer-path adoption — agent-attention based (closed in v7.7+v7.8 via Mechanism C)
+2. `cu_v2` factor magnitude correctness — judgment-based (presence-only check)
+3. T1/T2/T3 tag correctness — heuristic-only (advisory check shipped v7.7 C1)
+4. Tier 2.1 real-provider auth checklist — human-required
+5. Tier 3.3 external replication — structurally-required
+
+Documenting these as unclosable was itself a v7.5 deliverable — "a system that knows what it cannot check is more trustworthy than one that pretends every check is a check."
+
+## 6. Outcomes (verified at v7.5 ship + ongoing)
+
+| Tier | Status at ship | Status as of 2026-05-05 |
+|---|---|---|
+| 1.1 measurement adoption | partial (13/40 events) | partial (Tier 1.1 trend mode unlocked via v7.7 B1; cache_hits gate fixed via v7.8) |
+| 1.3 schema | gated ✅ | gated ✅ (extended in v7.7 + v7.8) |
+| 2.1 runtime smoke | pilot | pilot (still requires human at simulator) |
+| 2.2 contemporaneous logs | gated forward ✅ | gated forward ✅ |
+| 2.3 tier tags | presence-gated | presence-gated (correctness check shipped v7.7 C1 advisory) |
+| 3.1 cycle audit | shipped ✅ | shipped ✅ (cron persistence fixed in PR #203) |
+| 3.2 documentation debt | baseline only | trend mode unlocking via v7.7 B2 (3rd snapshot ETA 2026-05-12) |
+| 3.3 external replication | 0 audits | 0 audits (issue #142 filed) |
+
+## 7. Predecessor chain
+
+v7.0 (meta-analysis audit infrastructure) → v7.1 (integrity cycle, 72h cron) → **v7.5** (eight-defense data integrity framework) → v7.6 (mechanical enforcement) → v7.7 (validity closure) → v7.8 (bridge to v7.9)
+
+## 8. Known limitations of this retroactive spec
+
+1. **The MILESTONE breakdown is approximated** — v7.5 did not have the 8-PR-across-N-milestones structure that v7.7 used. It shipped as a single coordinated push on 2026-04-24. This spec describes what shipped, not the live PM-workflow trace.
+2. **No Linear/Notion sync trail** — the live propagation infrastructure (Linear MCP, Notion MCP propagation) was not yet codified.
+3. **Tier 2.3 data-quality tags introduced in same window are NOT tagged in this retroactive spec.** Forward-only: every quantitative claim above is sourced from the case study or remediation plan; tier tags would themselves be retroactive and lose their meaning.
+
+## Links
+
+- **Case study (primary source):** [`docs/case-studies/data-integrity-framework-v7.5-case-study.md`](../../case-studies/data-integrity-framework-v7.5-case-study.md)
+- **Gemini audit (trigger):** [`trust/audits/2026-04-21-gemini/remediation-plan-2026-04-23.md`](../../../trust/audits/2026-04-21-gemini/remediation-plan-2026-04-23.md)
+- **Mechanism documentation:** [`.claude/integrity/README.md`](../../../.claude/integrity/README.md)
+- **Successor specs:** [v7.7](2026-04-27-framework-v7-7-validity-closure-design.md), [v7.8 + v7.9 bridge](2026-05-02-framework-v7-8-and-v7-9-bridge-design.md)

--- a/docs/superpowers/specs/2026-04-25-framework-v7-6-mechanical-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-25-framework-v7-6-mechanical-enforcement-design.md
@@ -1,0 +1,166 @@
+---
+title: Framework v7.6 — Mechanical Enforcement
+date_written: 2026-05-05  # RETROACTIVE BACKFILL — original framework version shipped 2026-04-25
+ship_date: 2026-04-25
+backfill_type: framework_meta_retroactive
+backfill_source:
+  - docs/case-studies/mechanical-enforcement-v7-6-case-study.md  # primary narrative source
+  - docs/superpowers/plans/2026-04-25-v7-6-mechanical-enforcement-phases-2-4.md  # original plan (existed pre-spec)
+  - docs/superpowers/plans/2026-04-25-v7-6-pending-fixes-handoff.md
+  - docs/superpowers/plans/2026-04-25-v7-6-unified-completion-plan.md
+  - PR #141 diff (v7.6 ship PR)
+  - .github/workflows/{pr-integrity-check,framework-status-weekly}.yml
+work_type: Feature
+dispatch_pattern: serial
+predecessor_case_studies:
+  - docs/case-studies/data-integrity-framework-v7.5-case-study.md  # v7.5 baseline
+status: shipped_pre_spec_discipline
+---
+
+# Framework v7.6 — Mechanical Enforcement (Retroactive Spec)
+
+> **THIS IS A RETROACTIVE SPEC.** v7.6 shipped on 2026-04-25, before the project established formal spec discipline at v7.7 (2026-04-27). v7.6 had a **plan** (3 plan documents, listed above), but no spec. This spec was authored 2026-05-05 as part of the chain-of-custody initiative (full-repair-mode plan PR-H) and is sourced entirely from existing artifacts. Nothing fabricated; every claim traceable to pre-2026-05-05 sources.
+
+## 0. One-line summary
+
+v7.6 promotes seven Class B (silent gap, agent-attention required) integrity checks to Class A (mechanically enforced) via four new write-time pre-commit hooks plus two recurring CI defenses, and explicitly documents five remaining Class B gaps as known limitations.
+
+## 1. Genesis & Why Now
+
+v7.5 (2026-04-24) shipped the eight-defense data integrity framework triggered by the Gemini audit. Within 24 hours the project surfaced four new silent-gap categories that v7.5 left agent-attention-dependent:
+
+1. Phase transitions in state.json with no matching log event (Tier 2.2 contemporaneous logging not gated)
+2. Phase transitions with no per-phase timing (Tier 1.1 measurement not gated)
+3. Broken PR citations in case studies (cycle-time only, not write-time)
+4. Tier-tag presence on case studies (no enforcement)
+
+v7.6 promotes these four to write-time gates. In the same release: per-PR review bot + weekly framework-status cron close two operational gaps.
+
+## 2. Scope (as shipped 2026-04-25 via PR #141)
+
+**In scope (closed by v7.6) — 4 new write-time gates:**
+
+- **W3** `PHASE_TRANSITION_NO_LOG` — pre-commit rejects `current_phase` change in state.json without a matching `phase_started`/`phase_approved`/`phase_transition`/etc. event in the feature's log within 15-min freshness window.
+- **W4** `PHASE_TRANSITION_NO_TIMING` — pre-commit rejects `current_phase` change without `timing.phases.<old>.ended_at` + `timing.phases.<new>.started_at`.
+- **W5** `BROKEN_PR_CITATION` (write-time) — pre-commit rejects case-study commits citing `PR #N` or `pull/N` numbers that don't resolve via cached `gh pr list`. Skipped gracefully when `gh` unavailable.
+- **W6** `CASE_STUDY_MISSING_TIER_TAGS` — pre-commit rejects scoped case-study commits (forward-only, dated ≥ 2026-04-21) when the file has no T1/T2/T3 tier tag at all.
+
+**In scope — 2 recurring CI defenses:**
+
+- **C9** Per-PR review bot — `.github/workflows/pr-integrity-check.yml` runs schema-check + integrity-check + measurement-adoption against every PR HEAD; sets `pm-framework/pr-integrity` commit status; sticky comment with marker `<!-- pm-framework-pr-integrity-bot -->`.
+- **C10** Weekly framework-status cron — `.github/workflows/framework-status-weekly.yml` fires Mondays 05:00 UTC; appends snapshot to `.claude/shared/measurement-adoption-history.json`; opens regression issue if `fully_adopted` or `any_adopted` decreases.
+
+**In scope — append-only adoption history:**
+
+- `.claude/shared/measurement-adoption-history.json` — Tier 1.1 trend ledger; trend mode unlocks after 3 snapshots accumulate. `make measurement-adoption` writes a dated snapshot.
+
+**Out of scope (explicitly documented as Class B unclosable-by-design):**
+
+Five gaps documented at `docs/case-studies/meta-analysis/unclosable-gaps.md`:
+1. `cache_hits[]` writer-path adoption (later closed in v7.8 via Mechanism C — auto-instrumentation hook)
+2. `cu_v2` factor magnitude correctness (judgment-based)
+3. T1/T2/T3 tag correctness (later partially-closed in v7.7 via C1 advisory heuristic)
+4. Tier 2.1 real-provider auth checklist (human-required)
+5. Tier 3.3 external replication (structurally-required)
+
+> "A system that knows what it cannot check is more trustworthy than one that pretends every check is a check."
+
+## 3. Architecture
+
+### 3.1 Promotion semantics
+
+v7.6's framing is **Class B → Class A promotion**:
+
+- **Class A** = Mechanically enforced (commit fails or PR fails or issue opens)
+- **Class B** = Agent-attention dependent (silent gap; relies on the agent remembering to check)
+- **Class C** = Heuristic-only (advisory; can produce false positives)
+
+v7.6 promotes 7 items B → A:
+- 4 new write-time gates (W3-W6 above)
+- 2 new recurring CI defenses (C9-C10 above)  
+- 1 new append-only ledger (measurement-adoption-history.json with dedup-by-date)
+
+### 3.2 New cycle-time check codes
+
+Total cycle-time check codes after v7.6: **13** (was 9 in v7.5):
+- v7.5 baseline: PHASE_LIE, TASK_LIE, NO_CS_LINK, V2_FILE_MISSING, PARTIAL_SHIP_TERMINAL, NO_STATE, INVALID_JSON, NO_PHASE, SCHEMA_DRIFT
+- v7.6 additions: PR_NUMBER_UNRESOLVED (cycle-time variant), BROKEN_PR_CITATION (cycle-time), CASE_STUDY_MISSING_TIER_TAGS (cycle-time)
+
+### 3.3 New write-time check codes
+
+Total write-time check codes after v7.6: **6** (was 2 in v7.5):
+- v7.5 baseline: SCHEMA_DRIFT, PR_NUMBER_UNRESOLVED
+- v7.6 additions: PHASE_TRANSITION_NO_LOG, PHASE_TRANSITION_NO_TIMING, BROKEN_PR_CITATION, CASE_STUDY_MISSING_TIER_TAGS
+
+### 3.4 Two new recurring CI workflows
+
+```yaml
+# .github/workflows/pr-integrity-check.yml
+on: pull_request
+# Runs schema-check + integrity-check + measurement-adoption against PR HEAD
+# Sets pm-framework/pr-integrity commit status
+```
+
+```yaml
+# .github/workflows/framework-status-weekly.yml
+on:
+  schedule: [{cron: "0 5 * * 1"}]  # Mondays 05:00 UTC
+# Appends snapshot to measurement-adoption-history.json
+# Opens issue on regression
+```
+
+## 4. Implementation summary (as shipped 2026-04-25 via PR #141)
+
+| File | Purpose |
+|---|---|
+| `scripts/check-state-schema.py` (extended) | New gates: PHASE_TRANSITION_NO_LOG, PHASE_TRANSITION_NO_TIMING |
+| `scripts/integrity-check.py` (extended) | New cycle checks: BROKEN_PR_CITATION, CASE_STUDY_MISSING_TIER_TAGS |
+| `.github/workflows/pr-integrity-check.yml` | NEW — per-PR review bot |
+| `.github/workflows/framework-status-weekly.yml` | NEW — weekly Tier 1.1 trend |
+| `.claude/shared/measurement-adoption-history.json` | NEW — append-only ledger |
+| `.claude/integrity/README.md` (extended) | Documents new check codes + per-PR bot |
+| `CLAUDE.md` (extended) | "Per-PR + weekly defenses" section |
+| `docs/case-studies/meta-analysis/unclosable-gaps.md` | NEW — explicit B-unclosable enumeration |
+
+## 5. Outcomes (verified at v7.6 ship + ongoing)
+
+**Promotion summary at ship:**
+
+| Item | Pre-v7.6 | Post-v7.6 |
+|---|---|---|
+| Phase-transition-without-log catch | Class B (silent) | Class A (commit fails) |
+| Phase-transition-without-timing catch | Class B (silent) | Class A (commit fails) |
+| Broken PR citations in case studies | Cycle-time only | Write-time + cycle-time |
+| Case studies without tier tags | None | Class A (commit fails for post-2026-04-21 dated docs) |
+| Per-PR integrity status | None | `pm-framework/pr-integrity` check |
+| Weekly Tier 1.1 trend | None | Mondays 05:00 UTC |
+| Total framework mechanisms | 8 (v7.5) | 18 (12 cycle + 6 write-time) |
+
+**Cron persistence note:** the per-PR bot worked at ship. The weekly cron initially attempted direct `git push origin main` which started failing 2026-04-29 when branch protection was hardened. PR #203 (2026-05-04, v7.8 era) replaced direct push with `peter-evans/create-pull-request@v6` for both the weekly cron AND the integrity-cycle cron. As of 2026-05-05 the persistence fix is shipped but unexercised (next firings: 2026-05-06 + 2026-05-11).
+
+## 6. What v7.6 explicitly DID NOT close
+
+- **`cache_hits[]` writer-path adoption** (Issue #140) — explicitly Class B in the v7.6 ship. Closed in v7.7 with `CACHE_HITS_EMPTY_POST_V6` write-time gate (which itself silently failed coverage at ship — closed in v7.8 via Mechanism C auto-instrumentation hook + dual-read schema bridge).
+- **`cu_v2` factor magnitude correctness** — judgment-based; presence/range check shipped in v7.7.
+- **T1/T2/T3 tag correctness** — heuristic-only; advisory check shipped in v7.7 C1.
+- **Tier 2.1 real-provider auth checklist** — human-required; D1 deferral.
+- **Tier 3.3 external replication** — structurally-required; D2 deferral, issue #142.
+
+## 7. Predecessor chain
+
+v7.0 (meta-analysis) → v7.1 (integrity cycle) → v7.5 (data integrity framework) → **v7.6** (mechanical enforcement) → v7.7 (validity closure) → v7.8 (bridge to v7.9)
+
+## 8. Known limitations of this retroactive spec
+
+1. **Milestone structure is approximated.** v7.6 had 3 plan documents (Phases 2-4, pending fixes handoff, unified completion plan), suggesting it was structured as a multi-phase ship. This spec collapses them into a single "as shipped" view.
+2. **No Linear/Notion sync trail.** v7.6 propagation was manual; the live MCP-driven sync infrastructure (formalized in v7.7) did not yet exist.
+3. **Some content is reconciled across the 3 source plans + the case study.** The plans differ in detail level; this spec uses the case study's "as shipped" claims as the canonical source where they conflict with earlier plan-stage drafts.
+
+## Links
+
+- **Case study (primary source):** [`docs/case-studies/mechanical-enforcement-v7-6-case-study.md`](../../case-studies/mechanical-enforcement-v7-6-case-study.md)
+- **Original plans (predecessor sources):** [Phases 2-4](../plans/2026-04-25-v7-6-mechanical-enforcement-phases-2-4.md), [Pending fixes handoff](../plans/2026-04-25-v7-6-pending-fixes-handoff.md), [Unified completion plan](../plans/2026-04-25-v7-6-unified-completion-plan.md)
+- **PR #141** ship PR (squash-merged 2026-04-25)
+- **Successor specs:** [v7.7](2026-04-27-framework-v7-7-validity-closure-design.md), [v7.8 + v7.9 bridge](2026-05-02-framework-v7-8-and-v7-9-bridge-design.md)
+- **Predecessor spec (retroactive):** [v7.5](2026-04-24-framework-v7-5-data-integrity-design.md)
+- **Unclosable gaps:** [`docs/case-studies/meta-analysis/unclosable-gaps.md`](../../case-studies/meta-analysis/unclosable-gaps.md)


### PR DESCRIPTION
## Summary

Retroactive backfill of design docs for 3 framework versions that shipped before formal spec discipline was established at v7.7. All content sourced from existing case studies, plans, PRs, and git log; **no fabrication**.

Per Decision 3 of the 2026-05-05 deep audit (full-repair-mode plan): "all of the work that we have done... will be documented and will be linked to the PRD and the feature that it built so full chain of custody and the ability to understand how matters specifically framework evolved is important."

## New docs

| File | Original ship | Source |
|---|---|---|
| `docs/superpowers/specs/2026-04-24-framework-v7-5-data-integrity-design.md` | 2026-04-24 | v7.5 case study + Gemini audit remediation plan + integrity README |
| `docs/superpowers/specs/2026-04-25-framework-v7-6-mechanical-enforcement-design.md` | 2026-04-25 | v7.6 case study + 3 existing plan docs + PR #141 + workflow files |
| `docs/superpowers/plans/2026-05-02-framework-v7-8-bridge.md` | 2026-05-02 to 05-04 | existing v7.8 spec + v7.8 case study + PR #173/#185-189/#191-194/#195 git log |

Each document is explicitly marked as RETROACTIVE BACKFILL with:
- `backfill_type: framework_meta_retroactive` (the exempt type added in PR-D / PR #206)
- `backfill_source:` enumeration of every source artifact consulted
- "Known limitations of this retroactive spec" section enumerating where the reconstruction approximates the original execution

## Pairing with previous PRs

- **Spec for v7.5** completes the `data-integrity-framework-v7.5-case-study.md` chain (case study existed; spec was missing)
- **Spec for v7.6** completes the chain alongside the existing 3 plan docs (plans existed; spec was missing)
- **Plan for v7.8** completes the chain alongside the existing v7.8 spec (spec + case study existed; plan was missing)

After this PR, every framework version v7.5+ has spec + plan + case study. v7.7 was already complete.

## What this PR does NOT do

- Does NOT retroactively write specs for v5.0/v5.1/v5.2/v6.0/v7.0/v7.1 — for these the source material is genuinely thin. The `framework_meta_retroactive` exempt type (shipped in PR #206) accommodates these going forward; backfill stops where source data stops.
- Does NOT modify state.json files — pure docs backfill. State.json chain-of-custody backfill (PR-G) is a separate workstream.

## Verification

- ✓ `make schema-check` (48/48)
- ✓ `make integrity-check` (0 findings)
- ✓ Each retro doc carries explicit RETROACTIVE BACKFILL preamble
- ✓ Each retro doc enumerates known limitations explicitly

## Source

Full-repair-mode plan PR-H (2026-05-05 deep audit, Decision 3 = A "chain of custody for past work where source data exists").

🤖 Generated with [Claude Code](https://claude.com/claude-code)