### PR TITLE
chore(onboarding-v2-retroactive): reconcile state.json + add log.json

### DIFF
--- a/.claude/features/onboarding-v2-retroactive/state.json
+++ b/.claude/features/onboarding-v2-retroactive/state.json
@@ -1,9 +1,9 @@
 {
   "feature": "onboarding-v2-retroactive",
   "created_at": "2026-04-09T18:00:00Z",
-  "updated": "2026-04-09T18:00:00Z",
+  "updated": "2026-05-05T05:46:24Z",
   "branch": "feature/onboarding-v2-retroactive",
-  "current_phase": "tasks",
+  "current_phase": "complete",
   "framework_version": "v5.0",
   "agent_manifest": {
     "reads": [],
@@ -34,7 +34,14 @@
       "to": "tasks",
       "timestamp": "2026-04-09T18:00:00Z",
       "approved_by": "user",
-      "note": "Enhancement work type \u2014 skipped Research, PRD, UX. Parent feature: onboarding (PR #59, shipped 2026-04-06). Starting at Phase 2 (Tasks)."
+      "note": "Enhancement work type — skipped Research, PRD, UX. Parent feature: onboarding (PR #59, shipped 2026-04-06). Starting at Phase 2 (Tasks)."
+    },
+    {
+      "from": "tasks",
+      "to": "complete",
+      "timestamp": "2026-05-05T05:46:24Z",
+      "approved_by": "user",
+      "note": "State.json reconciliation: PR #63 (2026-04-09 file-move-only enhancement) shipped without state.json phase advancement. Reconciled retroactively to match shipped reality. Closes iOS audit finding H-2."
     }
   ],
   "phases": {
@@ -48,32 +55,43 @@
       "parent_prd": ".claude/features/onboarding/prd.md"
     },
     "tasks": {
-      "status": "in_progress",
-      "started_at": "2026-04-09T18:00:00Z"
+      "status": "approved",
+      "started_at": "2026-04-09T18:00:00Z",
+      "note": "Tasks were the file-move plan; executed within the single PR #63 commit."
     },
     "ux_or_integration": {
       "status": "skipped",
       "reason": "work_type:enhancement"
     },
     "implementation": {
-      "status": "pending",
-      "commits": []
+      "status": "complete",
+      "note": "Single commit on feature branch shipped 8 file moves + pbxproj surgery + HISTORICAL annotations.",
+      "commits": [
+        "6f38ee9"
+      ],
+      "started_at": "2026-04-09T12:33:44Z",
+      "ended_at": "2026-04-09T12:33:44Z"
     },
     "testing": {
-      "status": "pending",
-      "ci_passed": false,
-      "tests_added": 0
+      "status": "skipped",
+      "reason": "No functional changes — existing onboarding tests cover behavior. Build verified via xcodebuild."
     },
     "review": {
-      "status": "pending",
-      "risks": []
+      "status": "complete",
+      "note": "PR #63 review approved + merged.",
+      "started_at": "2026-04-09T12:33:44Z",
+      "ended_at": "2026-04-09T12:33:44Z"
     },
     "merge": {
-      "status": "pending",
-      "pr_number": null
+      "status": "complete",
+      "pr_number": 63,
+      "merged_at": "2026-04-09T12:33:44Z",
+      "merge_commit": "e500360c73237b2ca2db828152411a8c1936051d"
     },
     "documentation": {
-      "status": "pending"
+      "status": "complete",
+      "note": "V2 Rule documented in CLAUDE.md and validated by this multi-screen application.",
+      "ended_at": "2026-04-09T12:33:44Z"
     }
   },
   "case_study": "docs/case-studies/onboarding-v2-retroactive-case-study.md",
@@ -94,5 +112,20 @@
   },
   "_meta": {
     "deprecation_warnings": []
+  },
+  "case_study_type": "pre_pm_workflow_backfill",
+  "case_study_exempt_reason": "Enhancement work_type — retroactive v2/ subdirectory move shipped via PR #63 (2026-04-09). No functional changes (file move + project.pbxproj surgery only). Existing onboarding-v2-auth-flow case study + onboarding case study cover the user-facing surface.",
+  "timing": {
+    "phases": {
+      "complete": {
+        "started_at": "2026-05-05T05:46:24Z",
+        "note": "State reconciliation 2026-05-08 via PR-T1-H2 (iOS audit finding H-2). Original PR #63 shipped 2026-04-09; state.json was never advanced past phases.tasks=in_progress."
+      },
+      "tasks": {
+        "started_at": "2026-04-09T18:00:00Z",
+        "ended_at": "2026-05-05T05:48:10Z",
+        "note": "Tasks phase opened retroactively after PR #63 merged; closed via PR-T1-H2 reconciliation (iOS audit finding H-2)."
+      }
+    }
   }
 }

--- a/.claude/logs/onboarding-v2-retroactive.log.json
+++ b/.claude/logs/onboarding-v2-retroactive.log.json
@@ -1,0 +1,34 @@
+{
+  "version": "1.0",
+  "feature": "onboarding-v2-retroactive",
+  "title": "Onboarding v2 — Retroactive subdirectory refactor",
+  "work_type": "enhancement",
+  "current_phase": "complete",
+  "framework_version": "v5.0",
+  "started_at": "2026-04-09T18:00:00Z",
+  "updated_at": "2026-05-05T05:46:41Z",
+  "events": [
+    {
+      "timestamp": "2026-04-09T18:00:00Z",
+      "event_type": "phase_started",
+      "phase": "tasks",
+      "summary": "State.json initialized (retroactively, after PR #63 had already merged at 12:33:44Z). Enhancement work type — Research/PRD/UX skipped per parent feature linkage.",
+      "actor": "claude",
+      "status": "recorded",
+      "recording_mode": "retroactive"
+    },
+    {
+      "timestamp": "2026-05-05T05:46:41Z",
+      "event_type": "phase_started",
+      "phase": "complete",
+      "summary": "State reconciliation via PR-T1-H2 (iOS audit finding H-2, 2026-05-05 read-only audit). PR #63 shipped 2026-04-09T12:33:44Z (commit e500360c) but state.json was never advanced past phases.tasks=in_progress. Reconciliation flips state to match shipped reality: 8 v1 files moved to FitTracker/Views/Onboarding/v2/ + project.pbxproj surgery + HISTORICAL header annotations on v1. No functional changes; existing onboarding-v2-auth-flow tests cover behavior.",
+      "artifacts": [
+        ".claude/features/onboarding-v2-retroactive/state.json",
+        "FitTracker/Views/Onboarding/v2/"
+      ],
+      "actor": "claude-opus-4-7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

iOS audit Tier 1 finding **H-2** — `onboarding-v2-retroactive/state.json` was at `phases.tasks: in_progress` even though PR #63 (the actual ship PR for the v2/ subdirectory move) merged **2026-04-09T12:33:44Z** at commit `e500360c`.

The work IS shipped (verified):
- All 8 v1 files have HISTORICAL header annotations
- `FitTracker/Views/Onboarding/v2/` exists with 9 files (8 v1 equivalents + OnboardingAuthView.swift added by onboarding-v2-auth-flow PR #80)
- All v2 files referenced in `project.pbxproj` build sources
- v1 files are file-references only (not in build)

State.json was never advanced because the work was small (file move + pbxproj surgery + HISTORICAL annotations, single commit, no functional changes per PR #63 body). This PR closes the reconciliation gap.

## Changes

### state.json field deltas

- `current_phase`: `tasks` → `complete`
- `case_study_type`: (none) → `pre_pm_workflow_backfill`
- `phases.implementation.status`: `pending` → `complete` (commit `6f38ee9`)
- `phases.testing.status`: `pending` → `skipped` (no functional changes)
- `phases.review.status`: `pending` → `complete`
- `phases.merge.status`: `pending` → `complete` + `pr_number: 63` + `merge_commit: e500360c`
- `phases.documentation.status`: `pending` → `complete`
- `timing.phases.tasks.{started_at,ended_at}` + `timing.phases.complete.started_at`: recorded
- `transitions[]`: +1 reconciliation entry

### NEW: `.claude/logs/onboarding-v2-retroactive.log.json`

2 events: original retroactive `phase_started: tasks` (2026-04-09T18:00:00Z, recording_mode=retroactive) + current contemporaneous `phase_started: complete` (satisfies `PHASE_TRANSITION_NO_LOG` within 15-min freshness).

## Why `case_study_type: pre_pm_workflow_backfill`

Enhancement of parent `onboarding` feature; no separate case study warranted. The V2 Rule itself is documented in CLAUDE.md "UI Refactoring & V2 Rule" section, and the user-facing narrative lives in `onboarding-v2-auth-flow-v5.1-case-study.md`. Adding a dedicated case study for "moved 8 files into v2/ subdirectory" would be doc-bloat. The exempt tag is the honest record.

## Verification

- ✓ `make schema-check` (53/53)
- ✓ `make integrity-check` (0 findings)
- ✓ All v7.6+ pre-commit gates satisfied (`STATE_NO_CASE_STUDY_LINK`, `PHASE_TRANSITION_NO_LOG`, `PHASE_TRANSITION_NO_TIMING`)
- ✓ Filesystem reality matches state.json claims (8 v1 HISTORICAL + v2 directory + pbxproj)

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green
- [ ] PR Integrity Check green

## Source

iOS audit Tier 1 — finding H-2 (2026-05-05 read-only audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)