### PR TITLE
chore(dashboard): bump version 1.0.0 → 1.0.1 (FIT-59 cache-bust)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

iOS audit Tier 2 finding **G-1** — Linear FIT-59 (Dashboard tab navigation broken on production) was unresolved as of the 2026-05-01 bug retrospective. Root cause: Vercel build cache served a stale dashboard bundle missing commit `28dffcb` (the 2026-04-15 client-side tab nav fix).

## Status check (2026-05-05)

- ✓ Commit `28dffcb` present on main
- ✓ `dashboard/package.json` was modified by PR #156 (2026-04-29) — should have already invalidated Vercel's cache
- ✓ Latest production deployment triggered 5 min before this PR by PR #212 merge
- ⚠️ Production URL `https://fit-tracker2.vercel.app` is Vercel-auth-protected; direct bundle verification requires authenticated browser

This PR ships a clean cache-bust (version 1.0.0 → 1.0.1) as belt-and-suspenders to ensure FIT-59 is mechanically closed via a verifiable artifact, going through proper PR gates (per project mandate: no `vercel deploy --force` or direct push).

## Changes

- `dashboard/package.json::version`: `1.0.0` → `1.0.1`

The version bump:
- Forces Vercel to treat the dashboard subpackage as changed
- Invalidates any persistent build cache (turborepo / nx / Vercel internal)
- Is semver-meaningful (real fixes since 1.0.0: #145 + #155 + #156 + commit `28dffcb`)
- No downstream consumers (dashboard not npm-published)

## Verification post-merge

1. Vercel auto-rebuilds `fit-tracker2` project from updated main
2. New deployment URL in `vercel ls`
3. New bundle includes full main HEAD with `28dffcb`
4. Linear FIT-59 → Done

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green
- [ ] PR Integrity Check green
- [ ] Post-merge: verify new Vercel deployment via `vercel ls`

## Source

iOS audit Tier 2 — finding G-1 (2026-05-05 read-only audit). Memory: `project_bug_retrospective_2026_05_01.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)