### PR TITLE
chore(ucc): mark T20-T23 done in state.json (Wave 1 complete)

### DIFF
--- a/.claude/features/unified-control-center/state.json
+++ b/.claude/features/unified-control-center/state.json
@@ -411,8 +411,11 @@
         "T18",
         "T19"
       ],
-      "status": "pending",
-      "priority": "critical"
+      "status": "done",
+      "priority": "critical",
+      "completed_at": "2026-05-05T12:49:03Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/23",
+      "commit": "425506c"
     },
     {
       "id": "T21",
@@ -426,8 +429,11 @@
         "T18",
         "T19"
       ],
-      "status": "pending",
-      "priority": "critical"
+      "status": "done",
+      "priority": "critical",
+      "completed_at": "2026-05-05T12:49:03Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/24",
+      "commit": "425506c"
     },
     {
       "id": "T22",
@@ -441,8 +447,11 @@
         "T18",
         "T19"
       ],
-      "status": "pending",
-      "priority": "critical"
+      "status": "done",
+      "priority": "critical",
+      "completed_at": "2026-05-05T12:49:03Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/25",
+      "commit": "79f522c"
     },
     {
       "id": "T23",
@@ -456,8 +465,11 @@
         "T18",
         "T19"
       ],
-      "status": "pending",
-      "priority": "high"
+      "status": "done",
+      "priority": "high",
+      "completed_at": "2026-05-05T12:49:03Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/26",
+      "commit": "4009133"
     },
     {
       "id": "T24",

--- a/.claude/logs/unified-control-center.log.json
+++ b/.claude/logs/unified-control-center.log.json
@@ -6,7 +6,7 @@
   "current_phase": "research",
   "framework_version": "7.6",
   "started_at": "2026-04-26T05:02:44Z",
-  "updated_at": "2026-04-27T05:17:58Z",
+  "updated_at": "2026-05-05T14:02:52Z",
   "events": [
     {
       "timestamp": "2026-04-26T05:02:44Z",
@@ -292,6 +292,13 @@
         "type": "adapted",
         "skill": "qa"
       }
+    },
+    {
+      "timestamp": "2026-05-05T14:02:52Z",
+      "event_type": "tasks_completed",
+      "phase": "implementation",
+      "summary": "Wave 1 (Block E main views) complete: T20 ControlRoom Hero+NumbersPanel, T21 KanbanBoard, T22 TableView, T23 KnowledgeHub all ported as Next.js pages on fitme-story. fitme-story PRs #23-#26 merged. /control-room layout nav: 4 of 5 primary routes now active (Tasks remains placeholder). Deferred to T24+: @dnd-kit drag-and-drop, @tanstack/react-table sort+search, knowledgeHub.featuredDocs+groups seed wiring.",
+      "agent": "claude-opus-4-7-1m"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Reconciles the unified-control-center state.json + log to match fitme-story Wave 1 ship reality.

## Wave 1 ports (all merged on fitme-story)

| Task | View | Route | PR |
|---|---|---|---|
| T20 | ControlRoom Hero + NumbersPanel | `/control-room` | [fitme-story#23](https://github.com/Regevba/fitme-story/pull/23) |
| T21 | KanbanBoard | `/control-room/board` | [fitme-story#24](https://github.com/Regevba/fitme-story/pull/24) |
| T22 | TableView | `/control-room/table` | [fitme-story#25](https://github.com/Regevba/fitme-story/pull/25) |
| T23 | KnowledgeHub | `/control-room/knowledge` | [fitme-story#26](https://github.com/Regevba/fitme-story/pull/26) |

**29/44 tasks done (66%).** Phase stays `implementation` — Wave 2 (T24–T30.5: supporting components, freshness footer, view persistence, Cmd+K palette) is next, plus T36–T38 (GA4 wiring) and T34/T35 (decommission), all gated behind T2.5 (user GA4 extraction).

## Test plan

- [x] `make schema-check` passes (verified at commit time)
- [x] state.json: T20–T23 status flipped `pending → done` with PR refs + commit SHAs + completed_at
- [x] log.json: new `tasks_completed` event appended; 20 events total

🤖 Generated with [Claude Code](https://claude.com/claude-code)