### PR TITLE
chore(unified-control-center): reconcile T24/T25/T27/T28 done — fitme-story PRs #27 + #28

### DIFF
--- a/.claude/features/unified-control-center/state.json
+++ b/.claude/features/unified-control-center/state.json
@@ -12,7 +12,7 @@
   "current_phase": "implementation",
   "status": "in_progress",
   "created_at": "2026-04-26T05:30:00Z",
-  "updated": "2026-05-05T12:05:43Z",
+  "updated": "2026-05-05T13:30:00Z",
   "branch": "main",
   "spec": "docs/case-studies/unified-control-center-case-study.md (to be created in Phase 8)",
   "has_ui": true,
@@ -483,8 +483,12 @@
         "T18",
         "T19"
       ],
-      "status": "pending",
-      "priority": "critical"
+      "status": "done",
+      "priority": "critical",
+      "completed_at": "2026-05-05T13:30:00Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/27",
+      "commit": "d356553",
+      "note": "Wave 2 supporting components ported with re-skin to fitme-story tokens per token-map.md. AlertsBanner decoupled from direct analytics import via onAcknowledge callback (T36 will wire GA4). ThemeToggle uses useSyncExternalStore (React 19 set-state-in-effect compliant). SourceHealth is RSC-compatible; the other 4 are 'use client'. tsc + eslint clean. Layout/page wiring intentionally deferred to T25/T26/T27/T29/T36."
     },
     {
       "id": "T25",

--- a/.claude/features/unified-control-center/state.json
+++ b/.claude/features/unified-control-center/state.json
@@ -12,7 +12,7 @@
   "current_phase": "implementation",
   "status": "in_progress",
   "created_at": "2026-04-26T05:30:00Z",
-  "updated": "2026-05-05T13:30:00Z",
+  "updated": "2026-05-05T13:55:00Z",
   "branch": "main",
   "spec": "docs/case-studies/unified-control-center-case-study.md (to be created in Phase 8)",
   "has_ui": true,
@@ -502,8 +502,12 @@
         "T7",
         "T19"
       ],
-      "status": "pending",
-      "priority": "high"
+      "status": "done",
+      "priority": "high",
+      "completed_at": "2026-05-05T13:55:00Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/28",
+      "commit": "d17855f",
+      "note": "DataFreshnessFooter RSC reads src/data/freshness.json; renders 'Last synced N ago · counts' under every /control-room/* page via layout.tsx; flips to red-warning state when staleness > 6h per PRD FR-8."
     },
     {
       "id": "T26",
@@ -531,8 +535,12 @@
       "depends_on": [
         "T19"
       ],
-      "status": "pending",
-      "priority": "medium"
+      "status": "done",
+      "priority": "medium",
+      "completed_at": "2026-05-05T13:55:00Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/28",
+      "commit": "d17855f",
+      "note": "PhaseLegendAndActivity RSC composes PhaseLegend (4 buckets matching FeatureCard accent colors) + RecentActivityStrip (top-5 events from src/data/shared/change-log.json, sorted desc). Wired into Overview page between Live modules and migration paragraph."
     },
     {
       "id": "T28",
@@ -545,8 +553,12 @@
       "depends_on": [
         "T18"
       ],
-      "status": "pending",
-      "priority": "medium"
+      "status": "done",
+      "priority": "medium",
+      "completed_at": "2026-05-05T13:55:00Z",
+      "pr_ref": "https://github.com/Regevba/fitme-story/pull/28",
+      "commit": "d17855f",
+      "note": "Added 'Case studies \u2192' to SECONDARY_NAV in layout.tsx; trailing arrow signals leaving /control-room. Dashboard's CaseStudiesView.jsx was already absent from Wave 1 layout port."
     },
     {
       "id": "T29",


### PR DESCRIPTION
## Summary

Reconcile UCC `state.json` for **four Wave 2 tasks** shipped via fitme-story:

| Task | Commit | PR |
|---|---|---|
| **T24** — Wave 2 supporting components (5 files) | `d356553` | [fitme-story #27](https://github.com/Regevba/fitme-story/pull/27) |
| **T25** — DataFreshnessFooter | `d17855f` | [fitme-story #28](https://github.com/Regevba/fitme-story/pull/28) |
| **T27** — PhaseLegend + RecentActivityStrip | `d17855f` | [fitme-story #28](https://github.com/Regevba/fitme-story/pull/28) |
| **T28** — Case studies nav link | `d17855f` | [fitme-story #28](https://github.com/Regevba/fitme-story/pull/28) |

Implementation-phase progress: **33/44 tasks done** (was 29/44 at the start of this session).

## Wave 2 status

- ✅ T18–T23 (layout, primitives, Hero+Numbers, Kanban, Table, Knowledge — Wave 1)
- ✅ T24 (5 supporting components)
- ✅ T25 (freshness footer)
- ✅ T27 (phase legend + recent-activity strip)
- ✅ T28 (Case Studies nav link)
- ⬜ T26 (flat TaskCard grid)
- ⬜ T29 (task-tree)
- ⬜ T30 (view persistence)
- ⬜ T30.5 (Cmd+K palette)

## Test plan

- [x] state.json passes pre-commit schema/transition gates (verified locally)
- [ ] CI green on FT2 main

🤖 Generated with [Claude Code](https://claude.com/claude-code)