### PR TITLE
docs(analytics): add 8 dashboard_* events to taxonomy CSV (UCC T37)

### DIFF
--- a/docs/product/analytics-taxonomy.csv
+++ b/docs/product/analytics-taxonomy.csv
@@ -111,6 +111,14 @@ workout_frequency,string,1-7,No,Updated weekly based on actual usage,,,,,,,
 subscription_status,string,free/premium/trial,No,Future: after StoreKit integration,,,,,,,
 app_version,string,(auto),Yes,Do NOT set manually — Firebase auto-collects,,,,,,,
 device_model,string,(auto),Yes,Do NOT set manually — Firebase auto-collects,,,,,,,
+Dashboard,dashboard_load,Custom,/control-room (any route),route (overview/board/table/tasks/knowledge/framework),data_freshness_minutes (int),auth_method (basic/public/extracted),,,No,event,UCC T36 — fires once per route mount via TrackPageView client island
+Dashboard,dashboard_blocker_acknowledged,Custom,AlertsBanner first expansion,feature_id (string),alert_severity (red/amber/blue/purple/info),time_since_load_ms (int),,,Yes,event,UCC T36 — TTC primary metric numerator. Conversion. Fires once on first banner expansion per session.
+Dashboard,dashboard_view_change,Custom,PRIMARY_NAV link click,from_view (overview/board/table/tasks/knowledge/external),to_view (same enum),,,,No,event,UCC T36 — operator navigation graph. Phase 2 (post-#32 merge).
+Dashboard,dashboard_filter_apply,Custom,TableViewClient search/sort,filter_field (search/sort_phase/sort_priority/...),filter_value_count (int),,,,No,event,UCC T36 — Phase 2 (after #31 lands TableViewClient).
+Dashboard,dashboard_kanban_drag,Custom,KanbanBoard drag-drop (NOT YET IMPLEMENTED),feature_id (string),from_phase (string),to_phase (string),,,No,event,UCC T36 — STUB. Helper shipped for future drag-to-update; current Wave 1 Kanban port is read-only.
+Dashboard,dashboard_knowledge_open,Custom,KnowledgeHub doc click,doc_path (string),doc_group (string),,,,No,event,UCC T36 — Phase 2.
+Dashboard,dashboard_external_link,Custom,Layout/palette external link click,link_type (github/linear/notion/vercel),target_id (string),,,,No,event,UCC T36 — Phase 2 (after #32 merges to wire layout link).
+Dashboard,dashboard_sync_warning_shown,Custom,DataFreshnessFooter staleness > 6h,staleness_hours (number),source (string),,,,No,event,UCC T36 — fires from TrackPageView when freshness.json syncedAt is > 6h old.
 os_version,string,(auto),Yes,Do NOT set manually — Firebase auto-collects,,,,,,,
 ,,,,,,,,,,
 Conversion Event,Funnel,Purpose,,,,,,,,
@@ -123,3 +131,4 @@ home_action_completed,Home Engagement,Home-to-action follow-through,,,,,,,,
 training_session_completed,Training,Full training session completion,,,,,,,,
 auth_password_reset_completed,Auth Recovery,Password reset completion rate (auth-polish-v2 A5),,,,,,,,
 auth_biometric_activated,Auth Activation,Biometric adoption (post-sign-in offer; auth-polish-v2 B4),,,,,,,,
+dashboard_blocker_acknowledged,Dashboard TTC,Time-To-Comprehension primary metric (UCC T36 — operator engages with first alert),,,,,,,,


### PR DESCRIPTION
## Summary

Adds the 8 GA4 events specified in [UCC PRD §10.1](.claude/features/unified-control-center/prd.md#10-analytics-spec) to `docs/product/analytics-taxonomy.csv`. Pairs with [fitme-story PR #33](https://github.com/Regevba/fitme-story/pull/33) (T36 Phase 1) which ships the analytics helper module + 3 of the 8 events wired in code; the remaining 5 (T36 Phase 2) wire in a follow-up after open Wave 2 PRs merge.

## Events added (Dashboard category)

| # | Event | Conversion? | Status |
|---|---|---|---|
| 1 | `dashboard_load` | No | Wired in T36 Phase 1 |
| 2 | `dashboard_blocker_acknowledged` | **Yes** (TTC) | Phase 2 |
| 3 | `dashboard_view_change` | No | Phase 2 |
| 4 | `dashboard_filter_apply` | No | Phase 2 |
| 5 | `dashboard_kanban_drag` | No | Stub (drag not implemented) |
| 6 | `dashboard_knowledge_open` | No | Phase 2 |
| 7 | `dashboard_external_link` | No | Phase 2 |
| 8 | `dashboard_sync_warning_shown` | No | Wired in T36 Phase 1 |

`dashboard_blocker_acknowledged` is also appended to the **Conversion Events** sub-table at the bottom (TTC funnel = Time-To-Comprehension, primary metric for the UCC migration).

## Naming compliance per CLAUDE.md "Analytics Naming Convention"

- ✅ All 8 events use the `dashboard_` screen-prefix
- ✅ 1 conversion event flagged
- ✅ PII-free parameter values
- ✅ All event names ≤ 40 chars
- ✅ All snake_case + lowercase
- ✅ No reserved prefixes (`ga_`, `firebase_`, `google_`)

## Test plan

- [ ] CI green on this PR (docs-only change; pm-framework/pr-integrity should pass)
- [ ] (Manual) `/analytics validate` future audit confirms no naming violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)