### PR TITLE
docs(dashboard): mark Astro dashboard as HISTORICAL (UCC T34)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,8 +1,28 @@
 # FitMe Operations Control Room
 
-Internal PM dashboard and canonical live web surface at [fit-tracker2.vercel.app](https://fit-tracker2.vercel.app).
+> ## ⚠️ HISTORICAL — superseded by fitme-story `/control-room/*`
+>
+> This Astro dashboard is the **legacy implementation** of the operator control room. As of the UCC migration (Wave 2 shipped 2026-05-05), the canonical live surface is the Next.js port at `fitme-story.vercel.app/control-room/*`, with code under [`fitme-story/src/{app,components,lib}/control-room/`](https://github.com/Regevba/fitme-story/tree/main/src/components/control-room).
+>
+> **Don't ship new features here.** All dashboard work goes to fitme-story. This directory remains in the repo as a reviewable git-history reference until the UCC retention review (≥30 days post-launch — see PRD §13 rollback plan).
+>
+> **Migration provenance:**
+> - Feature: [`unified-control-center`](../.claude/features/unified-control-center/) (`current_phase: implementation` → `complete` after Block H + T42)
+> - PRD: [`prd.md`](../.claude/features/unified-control-center/prd.md) — see §13 (rollback) for the conditions under which this directory could be re-promoted to active
+> - Token map (Astro → fitme-story): [`token-map.md`](../.claude/features/unified-control-center/token-map.md)
+> - Extraction recipe (if dashboard ever needs to leave fitme-story): [`fitme-story/EXTRACTION-RECIPE.md`](https://github.com/Regevba/fitme-story/blob/main/EXTRACTION-RECIPE.md)
+>
+> **Retention policy** (matches the V2 Rule's HISTORICAL retention codified 2026-05-08): retained indefinitely by default. The first scheduled review point for any prune policy is the UCC anniversary or the post-launch decommission decision specified in PRD §13. Until then, this directory stays in the repo as on-disk reviewable reference.
+>
+> **Live URL retired:** the original `fit-tracker2.vercel.app` host redirects to `fitme-story.vercel.app/control-room` after T35 ships (per [state.json](../.claude/features/unified-control-center/state.json) Block G).
 
-## Stack
+---
+
+## (Historical context follows)
+
+Internal PM dashboard, originally hosted at [fit-tracker2.vercel.app](https://fit-tracker2.vercel.app) prior to the UCC migration.
+
+## Stack (legacy)
 
 - **Framework:** Astro 6 + React 19
 - **Styling:** Tailwind CSS v4


### PR DESCRIPTION
## Summary

UCC Block G task **T34** — marks the legacy `dashboard/` Astro implementation as HISTORICAL with a clear migration banner pointing to `fitme-story/src/{app,components,lib}/control-room/*`. T35 (DNS redirect at Vercel) follows.

## What

Prepends a HISTORICAL banner to `dashboard/README.md` covering:

- **The new home**: `fitme-story/src/components/control-room/` etc.
- **Migration provenance**: `.claude/features/unified-control-center/` PRD + token map + state.json
- **Retention policy**: indefinite by default, matching the V2 Rule HISTORICAL convention (codified 2026-05-08, scheduled review at the V2 Rule's first anniversary 2027-04-09 OR at the post-launch decommission decision per PRD §13 rollback plan — whichever surfaces first)
- **Extraction recipe**: pointer to [`fitme-story/EXTRACTION-RECIPE.md`](https://github.com/Regevba/fitme-story/blob/main/EXTRACTION-RECIPE.md) — used if the dashboard ever needs to leave fitme-story
- **Retired URL**: `fit-tracker2.vercel.app` redirects to the new home after T35 ships

The original "Stack / Features / Data Sources / Development / Tests" content is preserved below the new banner under a `(Historical context follows)` delimiter — the legacy reference stays intact for any operator who needs to inspect how the Astro version worked.

## Why now (vs. after T35)

T34 + T35 are paired in Block G but they have different dependencies. T34 is a docs-only change that the project owner can land independently. T35 requires Vercel project access (user action) to reconfigure the `fit-tracker2.vercel.app` host — not script-able from a session.

Landing T34 first lets the README state the operator-facing reality even before the DNS redirect lands; the URL line is intentionally future-tense ("redirects ... after T35 ships") to remain accurate either way.

## What's NOT in this PR

- No code deletions in `dashboard/` — that's the V2 Rule retention policy (indefinite)
- No source-file headers — the README banner is sufficient signal; per-file headers would be invasive
- No T35 work — separate user-action task

## Test plan

- [ ] CI green on this PR (docs-only change; pm-framework/pr-integrity should pass)
- [ ] Manually visit `dashboard/README.md` on GitHub → banner renders at the top with proper blockquote styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)