### PR TITLE
chore(ucc): T35 redirect fit-tracker2 -> fitme-story/control-room (307 temporary)

### DIFF
--- a/dashboard/vercel.json
+++ b/dashboard/vercel.json
@@ -2,5 +2,12 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "astro",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://fitme-story.vercel.app/control-room",
+      "permanent": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Closes UCC **T35** (Block G cutover). Adds a 307 temporary redirect to \`dashboard/vercel.json\` so every request to \`fit-tracker2.vercel.app\` 307s to \`https://fitme-story.vercel.app/control-room\` (the new canonical operator dashboard).

## Diff

Strictly additive — the existing build config (buildCommand / outputDirectory / framework / installCommand) is preserved so the Astro dashboard still builds successfully on push. Only the \`redirects\` array is added.

## Why 307 (temporary), not 308 (permanent)

PRD §13 rollback plan keeps the legacy dashboard alive **30 days post-launch** as a safety net. A 307 lets browsers re-check after each visit, so reverting (revert this PR) restores the legacy URL immediately. Flip to 308 after the 30-day window if no rollback fires.

## Pre-flight verified

- ✅ \`fitme-story.vercel.app/control-room\` returns \`HTTP/2 401\` with \`www-authenticate: Basic realm=\"control-room\"\` (proxy gate active)
- ✅ \`DASHBOARD_USER\` + \`DASHBOARD_PASS\` re-set cleanly on Vercel Production (prior values had \\n corruption from echo/printf-pipe set; cleaned via \`vercel env rm\` + interactive \`vercel env add\` + redeploy)
- ✅ Live basic-auth login confirmed working with the new creds

## Pairs with PR #227 (T34)

PR #227 marked \`dashboard/\` HISTORICAL with a banner pointing operators at the new home. T35 is the runtime side of the same cutover.

## Verification after merge

\`\`\`
curl -sIL https://fit-tracker2.vercel.app | head -10
\`\`\`

Expected:
- \`HTTP/2 307\` with \`location: https://fitme-story.vercel.app/control-room\`
- After follow: \`HTTP/2 401\` with \`www-authenticate: Basic realm=\"control-room\"\` (the proxy gate)

## UCC progress after merge

T35 closes. Combined with T34 (already merged) and T36/T37/T38 (this session's PRs), Block G + Block H are fully shipped. **42/44 (95%)** with only T2.5 (deferred — measurement against the broken legacy dashboard was abandoned in favor of post-launch new-dashboard measurement) and T42 (Phase 8 case study) remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)