### PR TITLE
docs(push-notifications-v2): close last doc-debt item — rename 'Kill' → 'Kill criteria'

### DIFF
--- a/.claude/shared/documentation-debt.json
+++ b/.claude/shared/documentation-debt.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0",
-  "updated": "2026-05-07T05:16:38Z",
+  "updated": "2026-05-07T12:33:35Z",
   "description": "Baseline documentation-debt report for case-study structure, state linkage, and integrity-cycle readiness.",
   "summary": {
-    "case_studies_scanned": 61,
+    "case_studies_scanned": 62,
     "features_scanned": 53,
     "integrity_snapshot_files": 2,
     "integrity_cycle_snapshots": 1,
@@ -12,31 +12,31 @@
   },
   "coverage": {
     "date_written": {
-      "present": 61,
+      "present": 62,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "work_type": {
-      "present": 61,
+      "present": 62,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "dispatch_pattern": {
-      "present": 61,
+      "present": 62,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "success_metrics": {
-      "present": 61,
+      "present": 62,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "kill_criteria": {
-      "present": 61,
+      "present": 62,
       "missing": 0,
       "percent": 100.0,
       "examples": []

--- a/docs/case-studies/push-notifications-v2-case-study.md
+++ b/docs/case-studies/push-notifications-v2-case-study.md
@@ -64,9 +64,9 @@ It is also a case study in **how the framework caught the framework's own gaps**
 
 **Primary metric:** Notification opt-in rate ≥ 40%. Kill criterion: < 20% after 30 days. **Plus a new v2-specific metric:** Deep-link routing success rate ≥ 99% (% of reminder taps that navigate to the intended destination, vs the silent-fail today).
 
-**Success metrics (T1-instrumented at ship; 0 data until measurement window opens):**
+**Success metrics + kill criteria (T1-instrumented at ship; 0 data until measurement window opens):**
 
-| Metric | Tier | Baseline | Target | Kill |
+| Metric | Tier | Baseline | Target | Kill criteria |
 |---|---|---|---|---|
 | Notification opt-in rate | T1 | 0% (no priming surface today) | ≥ 40% | < 20% after 30d |
 | Workout reminder tap-through rate | T1 | 0% (deep links don't route) | ≥ 25% | < 10% after 30d |


### PR DESCRIPTION
Single-line cleanup. Renames the success-metrics table column header in [push-notifications-v2-case-study.md](docs/case-studies/push-notifications-v2-case-study.md) from 'Kill' to 'Kill criteria' to satisfy the documentation-debt scanner's regex `(?im)(kill criteria|^kill_criteria\s*:)`.

`make documentation-debt` open items: **2 → 1** (only cron-blocked `integrity_trend_window` remains, awaiting 2 more 72h cycle snapshots — no action available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)