### PR TITLE
docs(claude.md): cross-reference ucc-passkey-auth setup guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,3 +471,4 @@ The rule applies prospectively from 2026-04-08. Existing events that pre-date th
 - Dashboard activation: `docs/setup/dashboard-activation.md`
 - Integrations setup: `docs/setup/integrations-setup-guide.md`
 - Auth runtime verification: `docs/setup/auth-runtime-verification-playbook.md`
+- UCC passkey auth (going-live runbook): `docs/setup/ucc-passkey-auth-setup-guide.md`


### PR DESCRIPTION
## Summary

Adds a one-line entry under Key Paths → Setup guides pointing at the going-live runbook merged via #250.

\`\`\`diff
- Auth runtime verification: \`docs/setup/auth-runtime-verification-playbook.md\`
+ Auth runtime verification: \`docs/setup/auth-runtime-verification-playbook.md\`
+ UCC passkey auth (going-live runbook): \`docs/setup/ucc-passkey-auth-setup-guide.md\`
\`\`\`

Keeps the canonical setup-guide index in CLAUDE.md complete so future agents + operators discover the runbook from the standard project-rules index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)