### PR TITLE
chore(workflows): bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Full CI pipeline
         shell: bash
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload build log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build-log
           path: /tmp/build.log
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results
           path: TestResults.xcresult
@@ -132,7 +132,7 @@ jobs:
 
       - name: Comment error summary on PR
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/framework-status-weekly.yml
+++ b/.github/workflows/framework-status-weekly.yml
@@ -41,12 +41,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Open PR with weekly snapshot
         if: steps.stage.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         env:
           REGRESSION: ${{ steps.compare.outputs.regression }}
         with:
@@ -209,7 +209,7 @@ jobs:
 
       - name: Open digest issue
         if: steps.compare.outputs.regression == 'true' || inputs.open_issue_on_no_regression == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           REGRESSION: ${{ steps.compare.outputs.regression }}
         with:

--- a/.github/workflows/integrity-cycle.yml
+++ b/.github/workflows/integrity-cycle.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Open PR with snapshot
         if: steps.stage.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
@@ -141,7 +141,7 @@ jobs:
 
       - name: Open issue on regression
         if: steps.check.outputs.regression == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           NEW_SNAPSHOT: ${{ steps.paths.outputs.new }}
           TIMESTAMP: ${{ steps.paths.outputs.timestamp }}

--- a/.github/workflows/pr-integrity-check.yml
+++ b/.github/workflows/pr-integrity-check.yml
@@ -31,12 +31,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout PR HEAD
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -127,7 +127,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set commit status check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           STATUS: ${{ steps.delta.outputs.status }}
           SUMMARY: ${{ steps.delta.outputs.summary }}
@@ -156,7 +156,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Sticky-comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           STATUS: ${{ steps.delta.outputs.status }}
           SUMMARY: ${{ steps.delta.outputs.summary }}

--- a/.github/workflows/ucc-audit-log-sync.yml
+++ b/.github/workflows/ucc-audit-log-sync.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 actions. From **2026-06-02** the runner forces Node 24; from **2026-09-16** Node 20 is removed entirely. Currently surfaced as a warning in every workflow run (most recently [integrity-cycle run 25541015945](https://github.com/Regevba/FitTracker2/actions/runs/25541015945)).

## Bumps

Minimum-risk approach: each action moves to its **immediate-next major** that introduces Node 24 support. Deferred jumping to absolute-latest to keep behavioral diff minimal — that's a separate PR if/when warranted.

| Action | Was | Now | Latest available |
|---|---|---|---|
| \`actions/checkout\` | v4 | **v5** | v6.0.2 |
| \`actions/setup-python\` | v5 | **v6** | v6.2.0 |
| \`actions/github-script\` | v7 | **v8** | v9.0.0 |
| \`actions/upload-artifact\` | v4 | **v5** | v7.0.1 |
| \`peter-evans/create-pull-request\` | v6 | **v7** | v8.1.1 |

## Files

5 workflows touched, 16 action references updated:

- \`.github/workflows/ci.yml\`
- \`.github/workflows/framework-status-weekly.yml\`
- \`.github/workflows/integrity-cycle.yml\`
- \`.github/workflows/pr-integrity-check.yml\`
- \`.github/workflows/ucc-audit-log-sync.yml\`

No workflow logic changes — only \`uses:\` references.

## Test plan

- [ ] CI on this PR runs successfully (validates all upgraded actions still work)
- [ ] No new Node 20 deprecation warnings in run annotations
- [ ] \`pm-framework/pr-integrity\` check passes (this is one of the affected workflows)
- [ ] \`integrity\` check passes (also affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)