### PR TITLE
docs(hadf-phase2): update case-study citations to squash SHA a4b357f

### DIFF
--- a/docs/case-studies/hadf-phase2-cloud-fingerprinting-case-study.md
+++ b/docs/case-studies/hadf-phase2-cloud-fingerprinting-case-study.md
@@ -29,14 +29,14 @@ status: complete
 
 # HADF Phase 2 — Cloud Fingerprinting Measurement
 
-> **EXTERNAL AUDIT PENDING.** This case study reports the mechanical verdict from the analyzer; an independent assessment of the methodology, dataset, and conclusions has not yet been completed. The pre-registration ([`.claude/shared/hadf/phase2-preregistration.json`](../../.claude/shared/hadf/phase2-preregistration.json), authored 2026-04-29 and immutable since) and the summary artifact ([`.claude/shared/hadf/phase2-fingerprint-summary.json`](../../.claude/shared/hadf/phase2-fingerprint-summary.json), committed `61964d3`) are the assessable inputs. All quantitative claims in this document trace to one of those two files per `case_study_constraints.raw_data_citation_rule`.
+> **EXTERNAL AUDIT PENDING.** This case study reports the mechanical verdict from the analyzer; an independent assessment of the methodology, dataset, and conclusions has not yet been completed. The pre-registration ([`.claude/shared/hadf/phase2-preregistration.json`](../../.claude/shared/hadf/phase2-preregistration.json), authored 2026-04-29 and immutable since) and the summary artifact ([`.claude/shared/hadf/phase2-fingerprint-summary.json`](../../.claude/shared/hadf/phase2-fingerprint-summary.json), authored 2026-05-01 on branch tip `61964d3` and landed in main 2026-05-08 as squash commit `a4b357f` via PR #264) are the assessable inputs. All quantitative claims in this document trace to one of those two files per `case_study_constraints.raw_data_citation_rule`.
 
 ## Summary Card
 
 | Field | Value | Tier |
 |---|---|---|
 | Pre-registration | `.claude/shared/hadf/phase2-preregistration.json` (immutable, hash-verified) | T1 |
-| Summary artifact | `.claude/shared/hadf/phase2-fingerprint-summary.json` (commit `61964d3`) | T1 |
+| Summary artifact | `.claude/shared/hadf/phase2-fingerprint-summary.json` (squash commit `a4b357f` on main, originally branch tip `61964d3`) | T1 |
 | Verdict threshold | `max_silhouette_score_across_k > 0.5` | T1 |
 | Observed | `silhouette = 0.5566` at `best_k = 5` | T1 |
 | `clusters_found` | `true` | T1 |
@@ -66,7 +66,7 @@ Verdict function (pre-registered, mechanical):
 
 ## Raw Data
 
-Source: [`.claude/shared/hadf/phase2-fingerprint-summary.json`](../../.claude/shared/hadf/phase2-fingerprint-summary.json) (commit `61964d3`).
+Source: [`.claude/shared/hadf/phase2-fingerprint-summary.json`](../../.claude/shared/hadf/phase2-fingerprint-summary.json) (squash commit `a4b357f` on main, originally branch tip `61964d3`).
 
 ### Totals (T1)
 


### PR DESCRIPTION
## Summary

PR #264 squash-merged the HADF Phase 2 final summary + scripts to main. The original branch tip \`61964d3\` (cited by the case study as the "assessable inputs") is no longer reachable from main after squash. This 3-line update points the citations at the canonical squash commit \`a4b357f\` while preserving \`61964d3\` as historical provenance.

## What changes

3 lines in \`docs/case-studies/hadf-phase2-cloud-fingerprinting-case-study.md\`:

- Line 32 (External Audit Pending callout): adds "landed in main 2026-05-08 as squash commit a4b357f via PR #264"
- Line 39 (Summary Card row): "(squash commit a4b357f on main, originally branch tip 61964d3)"
- Line 69 (Raw Data section): same SHA pair

No T1 metric value changes. No state.json changes. No frontmatter changes.

## Test plan

- [x] Local: \`grep "61964d3\\|a4b357f"\` shows expected 3 references with both SHAs
- [x] Local pre-commit: case study preflight passes (1 file checked, 0 violations)
- [ ] CI: \`integrity\` + \`pm-framework/pr-integrity\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)