### PR TITLE
docs(hadf): label Framework Version v7.0 (was v6.0) — match user-facing card

### DIFF
--- a/docs/case-studies/hadf-hardware-aware-dispatch-case-study.md
+++ b/docs/case-studies/hadf-hardware-aware-dispatch-case-study.md
@@ -10,7 +10,7 @@
 **Kill Criteria:** WAU drops ≥ 3% in HADF cohort at 90% confidence. Expected duration: 2 sprints
 
 
-> **Framework Version:** v6.0 (HADF extends v6.0 with hardware awareness)
+> **Framework Version:** v7.0 (HADF extends v6.0 dispatch with hardware awareness; ships as framework version 7.0)
 > **Date:** 2026-04-16
 > **Author:** PM Workflow (subagent-driven execution)
 


### PR DESCRIPTION
## Summary

HADF case study source said \"Framework Version: v6.0\" while the public-site card on fitme-story labels it V7.0. Aligning to V7.0.

\`Framework Version: v6.0 (HADF extends v6.0 with hardware awareness)\` →
\`Framework Version: v7.0 (extends v6.0 dispatch with hardware awareness; ships as framework version 7.0)\`

The architectural note about extending v6.0 dispatch is preserved in parens.

## Companion fitme-story PR

[#73](https://github.com/Regevba/fitme-story/pull/73) — changes \`12-hadf.mdx\` \`timeline_position.version\` from \`'6.1'\` to \`'7.0'\` and updates the era-grouping comment.

## Test plan

- [x] Pre-commit gate: case-study preflight passes (PR-resolution 212/212)
- [ ] CI integrity passes
- [ ] After merge: visit fitme-story.vercel.app/case-studies and verify the HADF card shows V7.0 / V7.0 (title and version both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)