### PR TITLE
chore(ios-code-connect): scaffold placeholder chore feature

### DIFF
--- a/.claude/features/ios-code-connect/state.json
+++ b/.claude/features/ios-code-connect/state.json
@@ -1,0 +1,81 @@
+{
+  "feature_name": "ios-code-connect",
+  "current_phase": "implementation",
+  "created_at": "2026-05-09T19:27:43Z",
+  "updated_at": "2026-05-09T19:27:43Z",
+  "framework_version": "v7.8.1",
+  "work_type": "chore",
+  "work_subtype": "design_system_extension",
+  "has_ui": false,
+  "requires_analytics": false,
+  "isolation_opt_out": true,
+  "isolation_opt_out_reason": "1-phase chore scaffolding only — no current_phase mutations beyond initial creation; iOS Code Connect template files live under FitTracker/DesignSystem/ which is not in the infra-path glob list",
+  "scheduled_after": {
+    "predecessor": "fitme-story-public-enhancements",
+    "signal": "fitme-story-public-enhancements T20 phase=complete",
+    "captured_at": "2026-05-09T19:27:43Z",
+    "note": "iOS Code Connect groundwork waits for fitme-story (web) Code Connect to ship first as the learning exercise. T20 in the rollup feature captures 17 web component node IDs and authors .figma.tsx mappings for the FitMe Story Web Design System (file fsjHfFLAHELACZHku8Rfcl). Once that pattern is validated, this feature replays it for the iOS app pointing at the FitMe Design System Library (file 0Ai7s3fCFqR5JXDW8JvgmD)."
+  },
+  "phases": {
+    "implementation": {
+      "status": "scaffolded",
+      "started_at": "2026-05-09T19:27:43Z",
+      "note": "Feature scaffolded as placeholder. No implementation work started — waiting for scheduled_after.signal to fire."
+    }
+  },
+  "timing": {
+    "phases": {
+      "implementation": {
+        "started_at": "2026-05-09T19:27:43Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "Install @figma/code-connect Swift toolchain + author Figma.toml at FT2 repo root pointing at FitMe Design System Library 0Ai7s3fCFqR5JXDW8JvgmD",
+      "status": "pending",
+      "effort_days": 0.25,
+      "blocker": "scheduled_after.signal not yet fired"
+    },
+    {
+      "id": "T2",
+      "title": "Capture per-component node IDs from FitMe Design System Library — every reusable component in FitTracker/DesignSystem/AppComponents.swift (~13 components per CLAUDE.md design system reference)",
+      "status": "pending",
+      "effort_days": 0.25,
+      "blocker": "T1"
+    },
+    {
+      "id": "T3",
+      "title": "Author .figma.swift template files — one per component mapping Figma component → SwiftUI view in FitTracker/DesignSystem/",
+      "status": "pending",
+      "effort_days": 1.0,
+      "blocker": "T2"
+    },
+    {
+      "id": "T4",
+      "title": "Run figma connect publish — push iOS mappings to FitMe Design System Library; verify Code Connect snippets appear in Figma Dev Mode",
+      "status": "pending",
+      "effort_days": 0.25,
+      "blocker": "T3"
+    },
+    {
+      "id": "T5",
+      "title": "Document iOS Code Connect workflow in docs/design-system/ (companion to fitme-story-design-architecture.md from T21 of rollup feature)",
+      "status": "pending",
+      "effort_days": 0.25,
+      "blocker": "T4"
+    }
+  ],
+  "metrics": {
+    "primary": "components_with_figma_dev_mode_snippets",
+    "baseline": 0,
+    "target": 13,
+    "kill_criteria": "Code Connect publish fails for >3 components OR Figma Dev Mode shows no snippets after publish"
+  },
+  "_meta": {
+    "scaffolded_by": "claude_opus_4_7",
+    "scaffold_session": "2b1d970c-6a14-4cff-b61e-6011bdb87a68",
+    "scaffold_origin": "User directive 2026-05-09 during fitme-story-public-enhancements rollup merge session — 'add another task for code connect mapping for ios' followed by clarifying question answer choosing 'New chore feature ios-code-connect' + 'Placeholder only'."
+  }
+}

--- a/.claude/features/ios-code-connect/tasks.md
+++ b/.claude/features/ios-code-connect/tasks.md
@@ -1,0 +1,19 @@
+# ios-code-connect — Tasks
+
+> **Status:** Placeholder. No work started. Waiting on `scheduled_after.signal: fitme-story-public-enhancements T20 phase=complete`.
+>
+> Once T20 ships in the rollup feature, this feature replays the same Code Connect pattern for iOS — pointing at the FitMe Design System Library Figma file (`0Ai7s3fCFqR5JXDW8JvgmD`) instead of the FitMe Story Web file (`fsjHfFLAHELACZHku8Rfcl`).
+
+## Tasks
+
+- [ ] **T1** — Install `@figma/code-connect` Swift toolchain + author `Figma.toml` at FT2 repo root pointing at FitMe Design System Library `0Ai7s3fCFqR5JXDW8JvgmD`. (~0.25d)
+- [ ] **T2** — Capture per-component node IDs from FitMe Design System Library. Cover every reusable component in `FitTracker/DesignSystem/AppComponents.swift` (~13 components per CLAUDE.md design system reference). (~0.25d, blocked on T1)
+- [ ] **T3** — Author `.figma.swift` template files — one per component mapping Figma component → SwiftUI view in `FitTracker/DesignSystem/`. (~1d, blocked on T2)
+- [ ] **T4** — Run `figma connect publish` — push iOS mappings to FitMe Design System Library; verify Code Connect snippets appear in Figma Dev Mode. (~0.25d, blocked on T3)
+- [ ] **T5** — Document iOS Code Connect workflow in `docs/design-system/` as a companion to `fitme-story-design-architecture.md` (from T21 of the rollup feature). (~0.25d, blocked on T4)
+
+**Total estimated effort:** ~2.0 days once unblocked.
+
+## Resume signal
+
+Watch for: `fitme-story-public-enhancements/state.json::tasks[id=T20].status == "done"`. When it fires, advance this feature out of placeholder mode.

--- a/.claude/logs/ios-code-connect.log.json
+++ b/.claude/logs/ios-code-connect.log.json
@@ -1,0 +1,30 @@
+{
+  "version": "1.0",
+  "feature": "ios-code-connect",
+  "title": "iOS Code Connect mapping",
+  "work_type": "chore",
+  "current_phase": "implementation",
+  "framework_version": "v7.8.1",
+  "started_at": "2026-05-09T19:27:43Z",
+  "updated_at": "2026-05-09T19:27:43Z",
+  "events": [
+    {
+      "timestamp": "2026-05-09T19:27:43Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "Feature scaffolded as placeholder per user directive 'add another task for code connect mapping for ios' during fitme-story-public-enhancements rollup merge session. Work_type: chore (1-phase). 5 tasks (T1-T5) defined with dependency chain T1→T2→T3→T4→T5; total ~2.0 days effort. Blocked on scheduled_after.signal 'fitme-story-public-enhancements T20 phase=complete'.",
+      "artifacts": [
+        ".claude/features/ios-code-connect/state.json",
+        ".claude/features/ios-code-connect/tasks.md"
+      ],
+      "metrics": {
+        "tasks_total": 5,
+        "tasks_pending": 5,
+        "estimated_effort_days": 2.0
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/features/ios-code-connect/{state.json,tasks.md}` + `.claude/logs/ios-code-connect.log.json` as a v7.8.1-compliant chore feature scaffold
- **Placeholder only** — no implementation work. Blocked on `scheduled_after.signal: fitme-story-public-enhancements T20 phase=complete`
- Replays the web Code Connect pattern (T20, fitme-story file `fsjHfFLAHELACZHku8Rfcl`) for iOS via `.figma.swift` mappings into the FitMe Design System Library (`0Ai7s3fCFqR5JXDW8JvgmD`)

## Why now
User directive 2026-05-09 during the fitme-story-public-enhancements merge session: "add another task for code connect mapping for ios." Chosen scope: new chore feature (vs adding T25 to web rollup) for clean separation.

## Tasks queued (T1–T5, ~2.0d once unblocked)
- T1 — Install `@figma/code-connect` Swift toolchain + `Figma.toml` (~0.25d)
- T2 — Capture per-component node IDs from FitMe Design System Library (~0.25d)
- T3 — Author `.figma.swift` template files for ~13 components in `FitTracker/DesignSystem/` (~1d)
- T4 — `figma connect publish` + verify Dev Mode snippets (~0.25d)
- T5 — Document iOS Code Connect workflow in `docs/design-system/` (~0.25d)

## Test plan
- [x] Pre-commit framework gates pass (state.json schema-clean; phase transition logged + timing populated)
- [ ] PR Integrity Check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)