### PR TITLE
chore(fitme-story-public-enhancements): reconcile T20 → done (23/24)

### DIFF
--- a/.claude/features/fitme-story-public-enhancements/state.json
+++ b/.claude/features/fitme-story-public-enhancements/state.json
@@ -12,11 +12,11 @@
   "outlier_to_protocol": {
     "is_outlier": true,
     "tier": "midstream_invocation",
-    "reason": "Feature was created 2026-05-08 as a rollup of 23 audit-driven enhancements; 7 sub-tasks shipped same-day via PR #59 + #61 BEFORE v7.8.1 protocol was formally invoked on this rollup. Subsequent sub-tasks (T10/T15/T16/T17/T21/T24/T18/T19) shipped over multiple sessions across 2026-05-08 → 2026-05-09 with partial logging. Per user directive 2026-05-09: invoke v7.8.1 retroactively, fill in gaps honestly, mark as outlier. Subsequent sub-tasks from 2026-05-09 forward follow full protocol; pre-2026-05-09 sub-tasks carry partial timing/log coverage.",
+    "reason": "Feature was created 2026-05-08 as a rollup of 23 audit-driven enhancements; 7 sub-tasks shipped same-day via PR #59 + #61 BEFORE v7.8.1 protocol was formally invoked on this rollup. Subsequent sub-tasks (T10/T15/T16/T17/T21/T24/T18/T19) shipped over multiple sessions across 2026-05-08 \u2192 2026-05-09 with partial logging. Per user directive 2026-05-09: invoke v7.8.1 retroactively, fill in gaps honestly, mark as outlier. Subsequent sub-tasks from 2026-05-09 forward follow full protocol; pre-2026-05-09 sub-tasks carry partial timing/log coverage.",
     "honest_gaps": [
       "timing.phases lacks per-sub-task started_at/ended_at (only rollup-level timestamps present)",
-      "Tier 2.2 contemporaneous log coverage: ~50% — entries exist for major sub-tasks but not all 17",
-      "Mechanism A gate-coverage.jsonl coverage: NOT applicable — most sub-task commits landed in fitme-story repo where Mechanism A is not yet ported (Phase B of this 2026-05-09 directive)",
+      "Tier 2.2 contemporaneous log coverage: ~50% \u2014 entries exist for major sub-tasks but not all 17",
+      "Mechanism A gate-coverage.jsonl coverage: NOT applicable \u2014 most sub-task commits landed in fitme-story repo where Mechanism A is not yet ported (Phase B of this 2026-05-09 directive)",
       "Some sub-task PR descriptions are terse and don't reference back to T-IDs",
       "kill_criteria_resolution: deferred until current_phase=complete (currently implementation; 17/24 done)"
     ],
@@ -36,7 +36,7 @@
     "research": {
       "status": "skipped",
       "approved_at": null,
-      "reason": "work_type:enhancement; B_medium tier latitude (per F6 v7.9 candidate). Audit synthesis at docs/research/2026-05-08-fitme-story-audit-synthesis.md serves as the research-equivalent — 3,100-word broad audit + 28-finding case-study deep-dive + 6-P0 / 12-quick-wins synthesis.",
+      "reason": "work_type:enhancement; B_medium tier latitude (per F6 v7.9 candidate). Audit synthesis at docs/research/2026-05-08-fitme-story-audit-synthesis.md serves as the research-equivalent \u2014 3,100-word broad audit + 28-finding case-study deep-dive + 6-P0 / 12-quick-wins synthesis.",
       "sources": [
         "docs/research/2026-05-08-fitme-story-public-site-audit.md",
         "docs/research/2026-05-08-case-study-readability-deep-dive.md",
@@ -48,18 +48,18 @@
       "approved_at": null,
       "reason": "work_type:enhancement; PRD-equivalent lives in the audit synthesis (success metrics + scope + sequencing) and the website-enhancement-queue spec (per-item scope + class). Per-sub-task PRs carry their own scope statements in PR description.",
       "analytics_spec_complete": true,
-      "analytics_spec_note": "No new analytics events — enhancements are mechanical (a11y, perf, schema, layout). Re-evaluate when SEARCH-1 ships (search analytics may warrant new events)."
+      "analytics_spec_note": "No new analytics events \u2014 enhancements are mechanical (a11y, perf, schema, layout). Re-evaluate when SEARCH-1 ships (search analytics may warrant new events)."
     },
     "tasks": {
       "status": "approved",
       "approved_at": "2026-05-08T05:50:00Z",
       "count": 24,
-      "approved_note": "24 tasks (T24 mobile-readiness added 2026-05-09 per user; T1-T23 from rollup creation 2026-05-08). 19 done as of 2026-05-09: T1-T7 via fitme-story PR #59 + #61; T9 via PR #67; T11+T14 via PR #63; T15 via PR #66; T16 via PR #62; T17 via PR #65; T21 via FT2 PR #261; T22+T23 via FT2 PR #258 (v7.8.2 documented exemption — now superseded by Phase B port); T18 (Figma file fsjHfFLAHELACZHku8Rfcl) + T19 (33 token vars Light+Dark) created 2026-05-09 via Figma MCP; T24 (mobile-readiness fitme-story PR #71 squash e675fe9). 5 pending: T8 (dual-outlet pattern, ready), T10 (site-wide search, shipped via PR #70 — pending state.json update next session), T12 (22 wireframes built but not state-marked-done), T13 (v7.9 mirror, date-gated 2026-05-21), T20 (Code Connect, depends on Figma components). See tasks.md."
+      "approved_note": "24 tasks (T24 mobile-readiness added 2026-05-09 per user; T1-T23 from rollup creation 2026-05-08). 19 done as of 2026-05-09: T1-T7 via fitme-story PR #59 + #61; T9 via PR #67; T11+T14 via PR #63; T15 via PR #66; T16 via PR #62; T17 via PR #65; T21 via FT2 PR #261; T22+T23 via FT2 PR #258 (v7.8.2 documented exemption \u2014 now superseded by Phase B port); T18 (Figma file fsjHfFLAHELACZHku8Rfcl) + T19 (33 token vars Light+Dark) created 2026-05-09 via Figma MCP; T24 (mobile-readiness fitme-story PR #71 squash e675fe9). 5 pending: T8 (dual-outlet pattern, ready), T10 (site-wide search, shipped via PR #70 \u2014 pending state.json update next session), T12 (22 wireframes built but not state-marked-done), T13 (v7.9 mirror, date-gated 2026-05-21), T20 (Code Connect, depends on Figma components). See tasks.md."
     },
     "ux_or_integration": {
       "status": "skipped",
       "approved_at": null,
-      "reason": "work_type:enhancement; per-sub-task UX dispatched in-line. Most items are mechanical (a11y, perf, schema, MDX pipeline). Larger UI items (P-MOBNAV, P-CALLOUTS, ArticleNav) dispatch /ux + /design when picked up — T7 (ArticleNav) already shipped this way via PR #61 with the audit synthesis serving as ux-spec equivalent.",
+      "reason": "work_type:enhancement; per-sub-task UX dispatched in-line. Most items are mechanical (a11y, perf, schema, MDX pipeline). Larger UI items (P-MOBNAV, P-CALLOUTS, ArticleNav) dispatch /ux + /design when picked up \u2014 T7 (ArticleNav) already shipped this way via PR #61 with the audit synthesis serving as ux-spec equivalent.",
       "type": null,
       "preflight_passed": null
     },
@@ -118,7 +118,7 @@
           "name": "fitme-story public site Lighthouse score",
           "baseline": "95+/100/100/100 (per 2026-04-21 framework-story-site case study)",
           "target": "Maintain or improve",
-          "current": "TBD — measure at next audit (suggest week-1 after each major ship)"
+          "current": "TBD \u2014 measure at next audit (suggest week-1 after each major ship)"
         },
         {
           "name": "Case-study reader navigation aids present",
@@ -129,8 +129,8 @@
       ],
       "guardrails": [
         "JS error rate per Vercel Speed Insights < 0.5%",
-        "Cumulative Layout Shift on /case-studies/[slug] ≤ 0.1",
-        "Largest Contentful Paint p75 ≤ 2.5s on case-study pages"
+        "Cumulative Layout Shift on /case-studies/[slug] \u2264 0.1",
+        "Largest Contentful Paint p75 \u2264 2.5s on case-study pages"
       ],
       "instrumentation_ready": true,
       "first_review_date": "2026-05-15",
@@ -151,7 +151,11 @@
       "pr_number": 59,
       "merge_commit": "95cb4d1",
       "completed_at": "2026-05-08T05:09:55Z",
-      "closes_findings": ["A-001 P0", "A-002 P0", "A-018 P0"]
+      "closes_findings": [
+        "A-001 P0",
+        "A-002 P0",
+        "A-018 P0"
+      ]
     },
     {
       "id": "T2",
@@ -166,12 +170,18 @@
       "pr_number": 59,
       "merge_commit": "95cb4d1",
       "completed_at": "2026-05-08T05:09:55Z",
-      "closes_findings": ["A-003 P1", "V-003 P1", "A-008 P1", "V-007 P1", "CS-015 P1"]
+      "closes_findings": [
+        "A-003 P1",
+        "V-003 P1",
+        "A-008 P1",
+        "V-007 P1",
+        "CS-015 P1"
+      ]
     },
     {
       "id": "T3",
       "audit_id": "P-MDX-HEADINGS",
-      "title": "rehype-slug + rehype-autolink-headings — every heading becomes a deep-link target",
+      "title": "rehype-slug + rehype-autolink-headings \u2014 every heading becomes a deep-link target",
       "type": "infra",
       "skill": "dev",
       "status": "done",
@@ -181,12 +191,14 @@
       "pr_number": 59,
       "merge_commit": "95cb4d1",
       "completed_at": "2026-05-08T05:09:55Z",
-      "closes_findings": ["CS-007 P1"]
+      "closes_findings": [
+        "CS-007 P1"
+      ]
     },
     {
       "id": "T4",
       "audit_id": "P-MDX-TABLE",
-      "title": ".prose table display:block + overflow-x:auto — fixes mobile table overflow corpus-wide",
+      "title": ".prose table display:block + overflow-x:auto \u2014 fixes mobile table overflow corpus-wide",
       "type": "ui",
       "skill": "dev",
       "status": "done",
@@ -196,7 +208,11 @@
       "pr_number": 59,
       "merge_commit": "95cb4d1",
       "completed_at": "2026-05-08T05:09:55Z",
-      "closes_findings": ["CS-006 P1", "CS-020 P0", "R-009 P2"]
+      "closes_findings": [
+        "CS-006 P1",
+        "CS-020 P0",
+        "R-009 P2"
+      ]
     },
     {
       "id": "T5",
@@ -211,12 +227,14 @@
       "pr_number": 59,
       "merge_commit": "95cb4d1",
       "completed_at": "2026-05-08T05:09:55Z",
-      "closes_findings": ["CS-008 P0"]
+      "closes_findings": [
+        "CS-008 P0"
+      ]
     },
     {
       "id": "T6",
       "audit_id": "P-TIMELINENAV",
-      "title": "Wire <TimelineNav> at template level — prev/next derived from sorted getAllCaseStudies()",
+      "title": "Wire <TimelineNav> at template level \u2014 prev/next derived from sorted getAllCaseStudies()",
       "type": "ui",
       "skill": "dev",
       "status": "done",
@@ -226,27 +244,40 @@
       "pr_number": 59,
       "merge_commit": "95cb4d1",
       "completed_at": "2026-05-08T05:09:55Z",
-      "closes_findings": ["R-003 P1", "CS-002 P1", "CS-016 P0"]
+      "closes_findings": [
+        "R-003 P1",
+        "CS-002 P1",
+        "CS-016 P0"
+      ]
     },
     {
       "id": "T7",
       "audit_id": "P-ARTICLENAV",
-      "title": "<ArticleNav> sticky sidebar — TOC scraped from heading tree + scroll progress + active-section IntersectionObserver",
+      "title": "<ArticleNav> sticky sidebar \u2014 TOC scraped from heading tree + scroll progress + active-section IntersectionObserver",
       "type": "ui",
       "skill": "dev",
       "status": "done",
       "priority": "high",
       "effort_days": 0.5,
-      "depends_on": ["T3"],
+      "depends_on": [
+        "T3"
+      ],
       "pr_number": 61,
       "merge_commit": "a548e5f",
       "completed_at": "2026-05-08T05:31:20Z",
-      "closes_findings": ["CS-001 P1", "CS-010 P2", "CS-013 P1", "R-001 P1", "R-002 P3", "A-020 P2"]
+      "closes_findings": [
+        "CS-001 P1",
+        "CS-010 P2",
+        "CS-013 P1",
+        "R-001 P1",
+        "R-002 P3",
+        "A-020 P2"
+      ]
     },
     {
       "id": "T8",
       "audit_id": "G3",
-      "title": "Dual-outlet pattern doc — FT2 long-form vs fitme-story slot MDX contract",
+      "title": "Dual-outlet pattern doc \u2014 FT2 long-form vs fitme-story slot MDX contract",
       "type": "docs",
       "skill": "research",
       "status": "done",
@@ -261,13 +292,15 @@
     {
       "id": "T9",
       "audit_id": "G5",
-      "title": "Timeline frontmatter audit — backfill consistency across 47 showcase MDX files",
+      "title": "Timeline frontmatter audit \u2014 backfill consistency across 47 showcase MDX files",
       "type": "data",
       "skill": "dev",
       "status": "done",
       "priority": "medium",
       "effort_days": 1.5,
-      "depends_on": ["T8"],
+      "depends_on": [
+        "T8"
+      ],
       "pr_number": 67,
       "merge_commit": "e79bc8c",
       "completed_at": "2026-05-08T09:33:35Z",
@@ -282,7 +315,10 @@
       "status": "done",
       "priority": "high",
       "effort_days": 2.0,
-      "depends_on": ["T8", "T9"],
+      "depends_on": [
+        "T8",
+        "T9"
+      ],
       "pr_number": 70,
       "merge_commit": "809a709",
       "completed_at": "2026-05-09",
@@ -297,7 +333,9 @@
       "status": "done",
       "priority": "medium",
       "effort_days": 1.0,
-      "depends_on": ["T14"],
+      "depends_on": [
+        "T14"
+      ],
       "pr_number": 63,
       "merge_commit": "83b1a89",
       "completed_at": "2026-05-08T18:16:46Z",
@@ -312,17 +350,20 @@
       "status": "done",
       "priority": "low",
       "effort_days": 5.0,
-      "depends_on": ["T18", "T19"],
+      "depends_on": [
+        "T18",
+        "T19"
+      ],
       "pr_number": null,
       "merge_commit": null,
       "completed_at": "2026-05-09",
       "completion_scope": "reduced",
-      "scope_note": "Closed 2026-05-09 with REDUCED SCOPE: 22 representative wireframe frames built (3-col grid, 1280×1024 each) on the Screens page of Figma file fsjHfFLAHELACZHku8Rfcl, vs the original 35-frame target. Reduction is intentional — the 35 target was 26 case studies + 9 chrome routes, but case studies all use the same template (Standard or Flagship), so 1 template + 3 exemplars covers the full case-study surface. Total coverage: home + /about + /case-studies (index + compare + operations-layer + [slug] template + 3 exemplars) + /pm-flow + /framework (+ dev-guide + dispatch) + /design-system + /research + /search + /timeline/[version] + /trust (+ audits/2026-04-21-gemini) + /glossary + /control-room/sign-in (+ recover) = 22 frames. Each frame uses the FitMe Tokens collection (T19) so a token edit re-themes every frame at once. Built via Figma MCP use_figma calls — no PR (Figma cloud is the artifact store). Per-route node IDs not captured to figma_node_ids dict (forward-only T20 work)."
+      "scope_note": "Closed 2026-05-09 with REDUCED SCOPE: 22 representative wireframe frames built (3-col grid, 1280\u00d71024 each) on the Screens page of Figma file fsjHfFLAHELACZHku8Rfcl, vs the original 35-frame target. Reduction is intentional \u2014 the 35 target was 26 case studies + 9 chrome routes, but case studies all use the same template (Standard or Flagship), so 1 template + 3 exemplars covers the full case-study surface. Total coverage: home + /about + /case-studies (index + compare + operations-layer + [slug] template + 3 exemplars) + /pm-flow + /framework (+ dev-guide + dispatch) + /design-system + /research + /search + /timeline/[version] + /trust (+ audits/2026-04-21-gemini) + /glossary + /control-room/sign-in (+ recover) = 22 frames. Each frame uses the FitMe Tokens collection (T19) so a token edit re-themes every frame at once. Built via Figma MCP use_figma calls \u2014 no PR (Figma cloud is the artifact store). Per-route node IDs not captured to figma_node_ids dict (forward-only T20 work)."
     },
     {
       "id": "T13",
       "audit_id": "V79-DOC",
-      "title": "Mirror v7.9 promotion outcome to /framework/dev-guide (new gates, advisory→enforced flips, breaking changes)",
+      "title": "Mirror v7.9 promotion outcome to /framework/dev-guide (new gates, advisory\u2192enforced flips, breaking changes)",
       "type": "docs",
       "skill": "dev",
       "status": "blocked",
@@ -332,13 +373,16 @@
       "pr_number": null,
       "merge_commit": null,
       "completed_at": null,
-      "scheduled_after": {"date": "2026-05-21", "reason": "Date-gated: post-v7.9 promotion decision; nothing to mirror until v7.9 ships."},
+      "scheduled_after": {
+        "date": "2026-05-21",
+        "reason": "Date-gated: post-v7.9 promotion decision; nothing to mirror until v7.9 ships."
+      },
       "scope_note": "Will pull v7.9 candidate flips (10 candidates F1-F10 from docs/superpowers/specs/2026-05-08-framework-v7-9-candidates.md) and mirror to fitme-story/content/framework/dev-guide.md."
     },
     {
       "id": "T14",
       "audit_id": "P-SEO-META",
-      "title": "buildMetadata() helper — per-page openGraph + Twitter + JSON-LD",
+      "title": "buildMetadata() helper \u2014 per-page openGraph + Twitter + JSON-LD",
       "type": "infra",
       "skill": "dev",
       "status": "done",
@@ -353,7 +397,7 @@
     {
       "id": "T15",
       "audit_id": "P-CALLOUTS",
-      "title": "Callout component family — <HonestDisclosure>, <TriggerIncident>, <MemoryRef>, <PredecessorChain>, <KillCriterionResolution>",
+      "title": "Callout component family \u2014 <HonestDisclosure>, <TriggerIncident>, <MemoryRef>, <PredecessorChain>, <KillCriterionResolution>",
       "type": "ui",
       "skill": "dev",
       "status": "done",
@@ -368,7 +412,7 @@
     {
       "id": "T16",
       "audit_id": "P-MOBNAV",
-      "title": "<MobileNav> hamburger — focus-trapped Dialog with full nav + theme toggle",
+      "title": "<MobileNav> hamburger \u2014 focus-trapped Dialog with full nav + theme toggle",
       "type": "ui",
       "skill": "dev",
       "status": "done",
@@ -378,7 +422,7 @@
       "pr_number": 62,
       "merge_commit": "d560500",
       "completed_at": "2026-05-08T08:16:40Z",
-      "scope_note": "P0 still OPEN from today's audit. Below 768px nav is hidden md:flex with NO fallback — all 7 items disappear. Mobile readers can navigate ~75 routes only via in-content links + 5-link footer. Closes audit V-004 P0."
+      "scope_note": "P0 still OPEN from today's audit. Below 768px nav is hidden md:flex with NO fallback \u2014 all 7 items disappear. Mobile readers can navigate ~75 routes only via in-content links + 5-link footer. Closes audit V-004 P0."
     },
     {
       "id": "T17",
@@ -398,7 +442,7 @@
     {
       "id": "T18",
       "audit_id": "FIG-W1",
-      "title": "Create new Figma file under team Regev - My apps named 'FitMe Story Web — Design System'",
+      "title": "Create new Figma file under team Regev - My apps named 'FitMe Story Web \u2014 Design System'",
       "type": "design",
       "skill": "design",
       "status": "done",
@@ -421,29 +465,36 @@
       "status": "done",
       "priority": "medium",
       "effort_days": 1.0,
-      "depends_on": ["T18"],
+      "depends_on": [
+        "T18"
+      ],
       "pr_number": null,
       "merge_commit": null,
       "completed_at": "2026-05-09",
-      "scope_note": "brand-indigo/coral, neutral 50–900, skill palette × 11, editorial type scale. Foundational for component frames.",
+      "scope_note": "brand-indigo/coral, neutral 50\u2013900, skill palette \u00d7 11, editorial type scale. Foundational for component frames.",
       "figma_collection_name": "FitMe Tokens",
-      "figma_modes": ["Light", "Dark"],
-      "figma_variable_summary": "23 color (4 brand × 2 modes for indigo/coral, 8 neutral with neutral-500/700 dark overrides, 11 skill) + 8 numeric (3 measures, 5 type-scale + line-height) + 2 font strings = 33 variables. Pages: Cover · Tokens (with visual swatch preview) · Components · Screens."
+      "figma_modes": [
+        "Light",
+        "Dark"
+      ],
+      "figma_variable_summary": "23 color (4 brand \u00d7 2 modes for indigo/coral, 8 neutral with neutral-500/700 dark overrides, 11 skill) + 8 numeric (3 measures, 5 type-scale + line-height) + 2 font strings = 33 variables. Pages: Cover \u00b7 Tokens (with visual swatch preview) \u00b7 Components \u00b7 Screens."
     },
     {
       "id": "T20",
       "audit_id": "FIG-W5",
-      "title": "Code Connect integration — /design build pushes web screens via Figma MCP",
+      "title": "Code Connect integration \u2014 /design build pushes web screens via Figma MCP",
       "type": "design",
       "skill": "design",
-      "status": "ready",
+      "status": "done",
       "priority": "medium",
       "effort_days": 0.5,
-      "depends_on": ["T12"],
-      "pr_number": null,
-      "merge_commit": null,
-      "completed_at": null,
-      "scope_note": "T18 + T19 + T12 + Component-library bootstrap shipped 2026-05-09. Library has 17 components on the Components page (per figma_node_ids.components). Remaining work: per-component → src/components/* path mappings via add_code_connect_map MCP tool. Effort revised down 1.5 → 0.5 days since the heavy lifting (file + tokens + components) is done. Mapping list (best-fit): button_primary→Button.tsx (none yet — would need component creation in fitme-story); tag_flagship→TimelineNode.tsx (or new Tag.tsx); callout_*→src/components/mdx/callouts/{HonestDisclosure,TriggerIncident,MemoryRef,PredecessorChain,KillCriterionResolution}.tsx; card_case_study→src/components/case-study/Card.tsx (or new); search_*→src/components/SearchInput.tsx; layout_site_header→src/components/SiteHeader.tsx; layout_site_footer→src/components/SiteFooter.tsx. 5 callouts + SiteHeader + SiteFooter + SearchInput map cleanly to existing fitme-story files; the rest would require new component files in fitme-story or the mapping would point at a parent component."
+      "depends_on": [
+        "T12"
+      ],
+      "pr_number": 75,
+      "merge_commit": "pending_merge_fitme_story_75",
+      "completed_at": "2026-05-09T20:18:25Z",
+      "scope_note": "Shipped 2026-05-09 via fitme-story PR #75 (feat/web-code-connect-t20). Created 4 new primitive components (Button + Tag + CaseStudyCard + FrameworkVersionCard) per user-chosen \"create primitives\" path during plan approval. Authored 12 .figma.tsx mapping files covering all 17 captured node IDs (Button\u00d73, Tag\u00d73, CaseStudyCard, FrameworkVersionCard, SearchInput\u00d72, SiteHeader, SiteFooter, 5 callouts). figma connect publish step deferred to operator (requires FIGMA_ACCESS_TOKEN). tsconfig excludes **/*.figma.tsx from tsc since Figma CLI parses them with its own compiler."
     },
     {
       "id": "T21",
@@ -474,7 +525,7 @@
       "merge_commit": "02e3d8d",
       "completed_at": "2026-05-08T13:02:49Z",
       "resolution": "documented_exemption",
-      "scope_note": "v7.9 candidate. Closed via v7.8.2 documented exemption — see docs/superpowers/specs/2026-05-08-cross-repo-gate-asymmetry.md (7 sections explaining the asymmetry decision + 3 re-eval triggers). PR #258 also shipped the operability fix (PostToolUse:Read hook short-circuit for missing observe-cache-hit.py in fitme-story cwd)."
+      "scope_note": "v7.9 candidate. Closed via v7.8.2 documented exemption \u2014 see docs/superpowers/specs/2026-05-08-cross-repo-gate-asymmetry.md (7 sections explaining the asymmetry decision + 3 re-eval triggers). PR #258 also shipped the operability fix (PostToolUse:Read hook short-circuit for missing observe-cache-hit.py in fitme-story cwd)."
     },
     {
       "id": "T23",
@@ -490,12 +541,12 @@
       "merge_commit": "02e3d8d",
       "completed_at": "2026-05-08T13:02:49Z",
       "resolution": "documented_exemption_then_superseded_by_phase_b_port",
-      "resolution_note": "Originally closed 2026-05-08 via FT2 PR #258 as documented exemption (v7.8.2 §1-7). Per user directive 2026-05-09, the exemption was reversed: fitme-story PR #72 vendored the framework gates, closing the asymmetry the exemption acknowledged. T23 stays in done state; the v7.8.2 spec carries a §8 reversal addendum.",
+      "resolution_note": "Originally closed 2026-05-08 via FT2 PR #258 as documented exemption (v7.8.2 \u00a71-7). Per user directive 2026-05-09, the exemption was reversed: fitme-story PR #72 vendored the framework gates, closing the asymmetry the exemption acknowledged. T23 stays in done state; the v7.8.2 spec carries a \u00a78 reversal addendum.",
       "scope_note": "v7.9 candidate. Cross-repo telemetry parity. Closed initially via documented exemption (PR #258), then superseded by Phase B port (fitme-story PR #72)."
     },
     {
       "id": "T24",
-      "title": "Mobile-readiness audit + fix pass — every public route readable + usable at 360/390/430px",
+      "title": "Mobile-readiness audit + fix pass \u2014 every public route readable + usable at 360/390/430px",
       "type": "ux",
       "skill": "ux",
       "status": "done",
@@ -505,16 +556,16 @@
       "pr_number": 71,
       "merge_commit": "e675fe9",
       "completed_at": "2026-05-09",
-      "scope_note": "Two-phase: (1) audit every public route at 3 mobile widths (360/iPhone-mini, 390/iPhone-15, 430/iPhone-15-Pro-Max) — capture findings (overflow, line-length > 75ch, sub-44px tap targets, non-scrollable code/table blocks, image overflow, sticky-header cropping, font-size < 16px on body); (2) fix pass — address each finding with utility-first Tailwind responsive prefixes. Audit surfaced 22 findings; PR #71 fixed top 8 (responsive type scale on Hero/PmFlowHero/Flagship/Standard h1, 3-col grids collapse to 1-col on phones for BeforeAfter/RankedBars/ParallelGantt, CopyButton tap-target 32→44, .prose code overflow-wrap:anywhere, case-study container px-6→px-4 sm:px-6). Intentionally not changed: long-form prose containers (preserves 65-75ch), horizontal-scroll components already using overflow-x-auto. Audit findings remaining: 14 documented but lower-priority (e.g., milestone strip min-w-[640px] is intentional UX)."
+      "scope_note": "Two-phase: (1) audit every public route at 3 mobile widths (360/iPhone-mini, 390/iPhone-15, 430/iPhone-15-Pro-Max) \u2014 capture findings (overflow, line-length > 75ch, sub-44px tap targets, non-scrollable code/table blocks, image overflow, sticky-header cropping, font-size < 16px on body); (2) fix pass \u2014 address each finding with utility-first Tailwind responsive prefixes. Audit surfaced 22 findings; PR #71 fixed top 8 (responsive type scale on Hero/PmFlowHero/Flagship/Standard h1, 3-col grids collapse to 1-col on phones for BeforeAfter/RankedBars/ParallelGantt, CopyButton tap-target 32\u219244, .prose code overflow-wrap:anywhere, case-study container px-6\u2192px-4 sm:px-6). Intentionally not changed: long-form prose containers (preserves 65-75ch), horizontal-scroll components already using overflow-x-auto. Audit findings remaining: 14 documented but lower-priority (e.g., milestone strip min-w-[640px] is intentional UX)."
     }
   ],
   "figma_node_ids": {
     "_meta": {
       "file_key": "fsjHfFLAHELACZHku8Rfcl",
       "file_url": "https://www.figma.com/design/fsjHfFLAHELACZHku8Rfcl",
-      "file_name": "FitMe Story Web — Design System",
+      "file_name": "FitMe Story Web \u2014 Design System",
       "captured_at": "2026-05-09",
-      "source_task": "T20 (Code Connect bootstrap) — components live on the Components page; screens live on the Screens page. T18 created the file; T19 imported the tokens; T12 built the wireframes; this entry captures component node IDs for T20 Code Connect mappings."
+      "source_task": "T20 (Code Connect bootstrap) \u2014 components live on the Components page; screens live on the Screens page. T18 created the file; T19 imported the tokens; T12 built the wireframes; this entry captures component node IDs for T20 Code Connect mappings."
     },
     "components": {
       "button_primary": "5:4",
@@ -537,7 +588,7 @@
     }
   },
   "figma_build_status": "library_seeded",
-  "figma_build_status_note": "fitme-story Figma library bootstrap shipped 2026-05-09 in this single rollup: T18 created file fsjHfFLAHELACZHku8Rfcl (Cover · Tokens · Components · Screens pages); T19 imported 33 token variables (23 colors w/ Light+Dark modes + 8 numeric + 2 strings); T12 built 22 representative wireframe screens; T20 (this entry) bootstrapped the component library: 17 components — 3 Buttons (Primary/Secondary/Ghost), 3 Tags (Flagship/Standard/Tier T1), 5 Callouts (HonestDisclosure/TriggerIncident/MemoryRef/PredecessorChain/KillCriterionResolution), 2 Cards (CaseStudy/FrameworkVersion), 2 Search (Icon/Expanded), 2 Layouts (SiteHeader/SiteFooter). All components use the FitMe Tokens collection via setBoundVariableForPaint so a token edit re-themes the library. Per-component node IDs captured above for upcoming Code Connect mappings (T20 follow-up: per-component → fitme-story src/components/* paths via add_code_connect_map MCP tool).",
+  "figma_build_status_note": "fitme-story Figma library bootstrap shipped 2026-05-09 in this single rollup: T18 created file fsjHfFLAHELACZHku8Rfcl (Cover \u00b7 Tokens \u00b7 Components \u00b7 Screens pages); T19 imported 33 token variables (23 colors w/ Light+Dark modes + 8 numeric + 2 strings); T12 built 22 representative wireframe screens; T20 (this entry) bootstrapped the component library: 17 components \u2014 3 Buttons (Primary/Secondary/Ghost), 3 Tags (Flagship/Standard/Tier T1), 5 Callouts (HonestDisclosure/TriggerIncident/MemoryRef/PredecessorChain/KillCriterionResolution), 2 Cards (CaseStudy/FrameworkVersion), 2 Search (Icon/Expanded), 2 Layouts (SiteHeader/SiteFooter). All components use the FitMe Tokens collection via setBoundVariableForPaint so a token edit re-themes the library. Per-component node IDs captured above for upcoming Code Connect mappings (T20 follow-up: per-component \u2192 fitme-story src/components/* paths via add_code_connect_map MCP tool).",
   "pre_merge_review": {
     "ux": null,
     "design": null,
@@ -578,7 +629,7 @@
       "to": "implementation",
       "timestamp": "2026-05-08T05:50:00Z",
       "approved_by": "user",
-      "note": "Implementation already in progress — 7 of 23 tasks done. Auto-advance to current state."
+      "note": "Implementation already in progress \u2014 7 of 23 tasks done. Auto-advance to current state."
     },
     {
       "from": "implementation",
@@ -616,7 +667,7 @@
       "skill": "pm-workflow",
       "cache_key": "audit-pattern-v7-7",
       "hit_type": "adapted",
-      "task_context": "Reused audit-driven enhancement pattern from v7.7 validity closure (broad audit → synthesis → quick-wins bundle → strategic recommendations → per-PR ship). Pattern adapted to public-site context."
+      "task_context": "Reused audit-driven enhancement pattern from v7.7 validity closure (broad audit \u2192 synthesis \u2192 quick-wins bundle \u2192 strategic recommendations \u2192 per-PR ship). Pattern adapted to public-site context."
     },
     {
       "timestamp": "2026-05-08T04:39:00Z",

--- a/.claude/logs/fitme-story-public-enhancements.log.json
+++ b/.claude/logs/fitme-story-public-enhancements.log.json
@@ -6,7 +6,7 @@
   "current_phase": null,
   "framework_version": null,
   "started_at": "2026-05-08T06:36:08Z",
-  "updated_at": "2026-05-09T07:18:59Z",
+  "updated_at": "2026-05-09T20:18:25Z",
   "events": [
     {
       "timestamp": "2026-05-08T05:53:53Z",
@@ -204,6 +204,28 @@
       "summary": "Component library bootstrap (17 components) shipped 2026-05-09 via Figma MCP use_figma calls \u2014 no PR (Figma cloud is the artifact store). 3 Buttons (Primary/Secondary/Ghost) \u00b7 3 Tags (Flagship/Standard/Tier-T1) \u00b7 5 Callouts (HonestDisclosure/TriggerIncident/MemoryRef/PredecessorChain/KillCriterionResolution) \u00b7 2 Cards (CaseStudy/FrameworkVersion) \u00b7 2 Search (Icon/Expanded) \u00b7 2 Layouts (SiteHeader/SiteFooter). All bound to FitMe Tokens collection via setBoundVariableForPaint. Per-component node IDs captured in state.json::figma_node_ids.components. Unblocks T20 Code Connect (status: blocked \u2192 ready, effort 1.5 \u2192 0.5 days).",
       "artifacts": [],
       "metrics": {},
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-09T20:18:25Z",
+      "event_type": "task_done",
+      "phase": "implementation",
+      "summary": "T20 (FIG-W5) Code Connect web integration shipped via fitme-story PR #75 (feat/web-code-connect-t20). Authored 12 .figma.tsx mapping files covering all 17 captured node IDs. Created 4 new primitive components (Button + Tag + CaseStudyCard + FrameworkVersionCard) per user-chosen create-primitives path. figma connect publish deferred to operator (FIGMA_ACCESS_TOKEN required). Rollup advances 22 \u2192 23/24 done; only T13 (date-gated 2026-05-21) remains.",
+      "artifacts": [
+        "fitme-story/figma.config.json",
+        "fitme-story/src/components/ui/Button.tsx",
+        "fitme-story/src/components/ui/Tag.tsx",
+        "fitme-story/src/components/ui/CaseStudyCard.tsx",
+        "fitme-story/src/components/ui/FrameworkVersionCard.tsx"
+      ],
+      "metrics": {
+        "pr_number": 75,
+        "figma_mappings_authored": 17,
+        "new_primitive_components": 4,
+        "new_figma_tsx_files": 12
+      },
       "actor": "claude_opus_4_7",
       "status": "recorded",
       "recording_mode": "contemporaneous"


### PR DESCRIPTION
## Summary
- Reconciles rollup `state.json` after **T20 (web Code Connect)** shipped via [fitme-story PR #75](https://github.com/Regevba/fitme-story/pull/75)
- Rollup advances **22 → 23/24 done**; only T13 (date-gated 2026-05-21) remains
- Appends Tier 2.2 log event with full attribution

## What T20 delivered (in fitme-story #75)
- 12 `.figma.tsx` mapping files covering all 17 captured node IDs
- 4 new primitive components: Button, Tag, CaseStudyCard, FrameworkVersionCard (per user-chosen "create primitives" path)
- `@figma/code-connect@1.4.4` devDep + `figma.config.json`

## Out of scope
- `figma connect publish` step (operator runs manually after fitme-story #75 merges; requires FIGMA_ACCESS_TOKEN)

## Test plan
- [x] state.json schema-clean (pre-commit gates pass)
- [x] log.json appended with contemporaneous event
- [ ] PR Integrity Check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)