### PR TITLE
chore(code-connect-automation): scaffold chore feature (3-layer plan)

### DIFF
--- a/.claude/features/code-connect-automation/state.json
+++ b/.claude/features/code-connect-automation/state.json
@@ -1,0 +1,82 @@
+{
+  "feature_name": "code-connect-automation",
+  "current_phase": "implementation",
+  "created_at": "2026-05-10T05:32:33Z",
+  "updated_at": "2026-05-10T05:32:33Z",
+  "framework_version": "v7.8.1",
+  "work_type": "chore",
+  "work_subtype": "framework_tooling",
+  "parent_feature": "ios-code-connect",
+  "has_ui": false,
+  "requires_analytics": false,
+  "isolation_opt_out": true,
+  "isolation_opt_out_reason": "Cross-repo tooling chore — touches scripts/ + .claude/skills/ + .github/workflows/ in BOTH FT2 and fitme-story. Branch isolation gate's Mode B (infra paths) fires by design; opt-out lets the chore proceed without per-commit auto-isolation, but commits remain on dedicated chore/* branches per repo for review hygiene.",
+  "phases": {
+    "implementation": {
+      "status": "started",
+      "started_at": "2026-05-10T05:32:33Z",
+      "note": "3-layer automation closing the loop on ios-code-connect (PR #277) + fitme-story T20 (PR #75): A) scaffold script auto-generates mapping files from state.json::figma_node_ids; B) /design build skill calls scaffold after node ID capture; C) CI workflow auto-publishes on merge."
+    }
+  },
+  "timing": {
+    "phases": {
+      "implementation": {
+        "started_at": "2026-05-10T05:32:33Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "Layer A — scripts/scaffold-figma-mapping.py (FT2/iOS) + scripts/scaffold-figma-mapping.mjs (fitme-story/web)",
+      "status": "pending",
+      "effort_days": 1.0,
+      "scope_note": "Reads <feature>/state.json::figma_node_ids; for each node ID, scaffolds matching .figma.swift (iOS) or .figma.tsx (web) template file with the URL pre-filled + a placeholder example body the operator adjusts. Emits a report of scaffolded vs skipped (skip if file already exists). Idempotent."
+    },
+    {
+      "id": "T2",
+      "title": "Layer A docs + first PR",
+      "status": "pending",
+      "effort_days": 0.25,
+      "blocker": "T1",
+      "scope_note": "README section for both scripts + a usage example. PR ships Layer A as foundation."
+    },
+    {
+      "id": "T3",
+      "title": "Layer B — extend /design build skill to invoke scaffold-figma-mapping after node ID capture",
+      "status": "pending",
+      "effort_days": 0.5,
+      "blocker": "T1",
+      "scope_note": "Modify .claude/skills/design/SKILL.md so when /design build populates state.json::figma_node_ids, it also runs scripts/scaffold-figma-mapping.{py|mjs} (auto-detects which repo). Adds row to figma-code-sync-status.md."
+    },
+    {
+      "id": "T4",
+      "title": "Layer C — CI publish workflows (one per repo)",
+      "status": "pending",
+      "effort_days": 0.5,
+      "blocker": "T1",
+      "scope_note": "FT2: .github/workflows/figma-code-connect-publish.yml runs `figma-swift connect publish` on merge to main when *.figma.swift files change. fitme-story: equivalent runs `npx figma connect publish`. Both gated on FIGMA_ACCESS_TOKEN repo secret (operator adds via GitHub UI before workflows fire usefully)."
+    },
+    {
+      "id": "T5",
+      "title": "End-to-end test on a real new UI feature",
+      "status": "pending",
+      "effort_days": 0.25,
+      "blocker": "T2 + T3 + T4",
+      "scope_note": "Pick a near-future UI feature; verify /design build → state.json::figma_node_ids capture → scaffold script auto-runs → .figma.{swift|tsx} files appear → CI publish fires → mappings show in Figma Dev Mode. Documents any rough edges."
+    }
+  ],
+  "metrics": {
+    "primary": "manual_steps_per_new_ui_feature",
+    "baseline": 2,
+    "baseline_note": "Today (post-PR #277 + #75): operator hand-authors mapping file + manually runs publish",
+    "target": 0,
+    "target_note": "After Layer C ships: operator does nothing — mapping scaffolds + publish both fire automatically",
+    "kill_criteria": "scaffold script produces wrong/non-compiling files OR CI publish fails > 1x without obvious operator-fixable cause"
+  },
+  "_meta": {
+    "scaffolded_by": "claude_opus_4_7",
+    "scaffold_session": "1acfe748-7927-4116-a46e-c87c989a4253",
+    "scaffold_origin": "User answer to 'Automate Code Connect for new UI features?' on 2026-05-10 — chose 'All 3 layers (A + B + C)'. Surfaced as follow-up to ios-code-connect T1-T5 wrap-up + the question 'is the cmd automated when building a new ui feature' — answer was 'no' across both web + iOS, this feature closes that gap."
+  }
+}

--- a/.claude/features/code-connect-automation/tasks.md
+++ b/.claude/features/code-connect-automation/tasks.md
@@ -1,0 +1,27 @@
+# code-connect-automation — Tasks
+
+> **Status:** Implementation. ~2.0d total effort across 5 tasks.
+>
+> Closes the loop on `ios-code-connect` (PR #277) + fitme-story T20 (PR #75): both shipped Code Connect foundation, but neither auto-scaffolds mapping files for new UI features and neither auto-publishes on merge. This feature builds the 3 missing layers.
+
+## Tasks
+
+- [ ] **T1** — Layer A: build `scripts/scaffold-figma-mapping.py` (FT2/iOS) + `scripts/scaffold-figma-mapping.mjs` (fitme-story/web). Reads `<feature>/state.json::figma_node_ids`; for each node ID, scaffolds matching `.figma.swift` (iOS) or `.figma.tsx` (web) template file with the URL pre-filled + a placeholder example body. Idempotent — skips if file already exists. (~1d)
+- [ ] **T2** — Layer A docs + first PR. README section + usage example. PR ships Layer A as foundation. (~0.25d, blocked on T1)
+- [ ] **T3** — Layer B: extend `/design build` skill to invoke scaffold script after node ID capture. Modify `.claude/skills/design/SKILL.md` so when `/design build` populates `state.json::figma_node_ids`, it also runs `scripts/scaffold-figma-mapping.{py|mjs}` (auto-detects which repo). (~0.5d, blocked on T1)
+- [ ] **T4** — Layer C: CI publish workflows (one per repo). FT2: `.github/workflows/figma-code-connect-publish.yml` runs `figma-swift connect publish` on merge to main when `*.figma.swift` files change. fitme-story: equivalent runs `npx figma connect publish`. Both gated on `FIGMA_ACCESS_TOKEN` repo secret (operator adds via GitHub UI). (~0.5d, blocked on T1)
+- [ ] **T5** — End-to-end test on a real new UI feature. Verify `/design build` → state.json::figma_node_ids capture → scaffold auto-runs → mapping files appear → CI publish fires → mappings show in Figma Dev Mode. Documents rough edges. (~0.25d, blocked on T2+T3+T4)
+
+## Sequencing
+
+T1 is the foundation — T2/T3/T4 all depend on it. T5 is the integration test, depends on the other layers. Open as separate PRs:
+
+- **PR 1:** T1 + T2 (scaffold scripts in both repos + docs)
+- **PR 2:** T3 (skill extension in FT2)
+- **PR 3a:** T4 in FT2 (CI workflow + GitHub secret setup instructions for operator)
+- **PR 3b:** T4 in fitme-story (parallel CI workflow)
+- **PR 4:** T5 reconciliation after first end-to-end test
+
+## Success metric
+
+`manual_steps_per_new_ui_feature: 2 → 0`. Today operator hand-authors mapping files + manually runs publish; after Layer C operator does nothing.

--- a/.claude/logs/code-connect-automation.log.json
+++ b/.claude/logs/code-connect-automation.log.json
@@ -1,0 +1,30 @@
+{
+  "version": "1.0",
+  "feature": "code-connect-automation",
+  "title": "Code Connect Automation (3-layer)",
+  "work_type": "chore",
+  "current_phase": "implementation",
+  "framework_version": "v7.8.1",
+  "started_at": "2026-05-10T05:32:33Z",
+  "updated_at": "2026-05-10T05:32:33Z",
+  "events": [
+    {
+      "timestamp": "2026-05-10T05:32:33Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "Feature scaffolded as chore/framework_tooling. 3-layer automation closing the loop on ios-code-connect (PR #277) + fitme-story T20 (PR #75). 5 tasks T1-T5; T1 (scaffold scripts) is the foundation T3+T4 depend on. ~2.0d total estimated effort. Per user directive 2026-05-10 'is the cmd automated when building a new ui feature' (answer: no) → 'Automate Code Connect for new UI features?' (answer: All 3 layers A+B+C).",
+      "artifacts": [
+        ".claude/features/code-connect-automation/state.json",
+        ".claude/features/code-connect-automation/tasks.md"
+      ],
+      "metrics": {
+        "tasks_total": 5,
+        "tasks_pending": 5,
+        "estimated_effort_days": 2.0
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Scaffolds new chore feature `code-connect-automation` (v7.8.1-compliant placeholder)
- 5 tasks T1–T5 covering 3 automation layers; ~2.0d total estimated effort
- Closes the loop on `ios-code-connect` (PR #277) + fitme-story T20 (PR #75): both shipped Code Connect foundation but neither auto-scaffolds mapping files nor auto-publishes on merge

## Why now
Per user directive 2026-05-10 — answer to "is the cmd automated when building a new ui feature?" was no, then "Automate Code Connect for new UI features?" was "All 3 layers (A + B + C)". This PR is the placeholder; T1+T2+T3+T4 ship in subsequent PRs.

## Tasks queued (T1–T5, ~2.0d once executed)

| Task | Layer | What | Effort | Blocker |
|---|---|---|---|---|
| **T1** | A | `scripts/scaffold-figma-mapping.{py,mjs}` in both repos | 1d | none |
| **T2** | A | Docs + first PR | 0.25d | T1 |
| **T3** | B | Extend `/design build` skill to invoke scaffold script | 0.5d | T1 |
| **T4** | C | CI publish workflows (one per repo, gated on `FIGMA_ACCESS_TOKEN` repo secret) | 0.5d | T1 |
| **T5** | E2E | End-to-end test on a real new UI feature | 0.25d | T2+T3+T4 |

## Success metric
`manual_steps_per_new_ui_feature: 2 → 0`. Today operator hand-authors mapping files + manually runs publish; after Layer C operator does nothing.

## Test plan
- [x] Pre-commit framework gates pass (state.json schema-clean; phase transition logged + timing populated; isolation_opt_out has reason)
- [ ] PR Integrity Check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)