### PR TITLE
feat(ci): T4 Layer C — figma-code-connect-publish workflow (FT2 half)

### DIFF
--- a/.github/workflows/figma-code-connect-publish.yml
+++ b/.github/workflows/figma-code-connect-publish.yml
@@ -1,0 +1,35 @@
+name: figma-code-connect-publish
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'FitTracker/**/*.figma.swift'
+      - 'Figma.toml'
+      - '.github/workflows/figma-code-connect-publish.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Skip if FIGMA_ACCESS_TOKEN not set
+        id: gate
+        env:
+          HAS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN != '' }}
+        run: |
+          if [ "$HAS_TOKEN" != "true" ]; then
+            echo "FIGMA_ACCESS_TOKEN repo secret not set; skipping publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/setup-node@v5
+        if: steps.gate.outputs.skip != 'true'
+        with:
+          node-version: '24'
+      - name: Publish Code Connect mappings
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
+        run: |
+          npx --yes --package=@figma/code-connect figma connect publish --token "$FIGMA_ACCESS_TOKEN" --skip-update-check


### PR DESCRIPTION
## Summary
- Closes **T4 (Layer C, FT2 half)** of `code-connect-automation` feature
- Adds `.github/workflows/figma-code-connect-publish.yml` that auto-publishes iOS Code Connect mappings to the FitTracker-Design-System-Library on every push to main when `*.figma.swift` or `Figma.toml` changes
- fitme-story half ships in a parallel PR (web `.figma.tsx` mappings + `npx figma connect publish`)

## How it works
1. Triggered by push to `main` touching `FitTracker/**/*.figma.swift` OR `Figma.toml` OR this workflow file (also `workflow_dispatch` for manual runs)
2. Pre-flight gate: skip with no-op log if `FIGMA_ACCESS_TOKEN` repo secret isn't set
3. Setup Node 24 + run `npx --yes --package=@figma/code-connect figma connect publish --token "$FIGMA_ACCESS_TOKEN"`
4. The `@figma/code-connect` CLI is parser-agnostic — `Figma.toml`'s `parser = "swift"` directs it to parse `.figma.swift` files (no Swift Package Manager setup needed on the runner)

## Operator setup (one-time)
1. Generate Figma access token at <https://www.figma.com/developers/api#access-tokens> — **scopes: File Content + Code Connect Write**
2. Add as repo secret named `FIGMA_ACCESS_TOKEN` (Settings → Secrets and variables → Actions)
3. Subsequent pushes auto-publish

Until step 1+2 are done, the workflow runs but **skips** with a clear log message — no error.

## Security
- Token never appears in logs (passed via `env:` var; used as `"$FIGMA_ACCESS_TOKEN"` in shell)
- No `github.event.*` user-controlled inputs interpolated into `run:` commands
- Only `secrets.*` and literal Figma file/URL refs

## Test plan
- [x] YAML structure clean
- [ ] PR Integrity Check passes
- [ ] CI green (workflow doesn't fire on this PR — paths-filter excludes; will fire next time `.figma.swift` changes land on main)
- [ ] Operator: add `FIGMA_ACCESS_TOKEN` secret + verify next `.figma.swift` change auto-publishes

## Cross-references
- FT2 PR #277: ios-code-connect T1+T2+T3+T5 (the .figma.swift files this workflow publishes)
- FT2 PR #279: scripts/scaffold-figma-mapping.py (Layer A)
- FT2 PR #280: /design build skill auto-scaffold (Layer B)
- FT2 PR #278: code-connect-automation chore feature scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)