### PR TITLE
fix(ci): use Swift parser via SPM wrapper for iOS Code Connect publish

### DIFF
--- a/.figma-cc-tools/Package.resolved
+++ b/.figma-cc-tools/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "code-connect",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/figma/code-connect",
+      "state" : {
+        "revision" : "b8589684b6c88efcd10c37eea5048fd6b1cc7abf",
+        "version" : "1.4.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
+        "version" : "0.61.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/.figma-cc-tools/Package.swift
+++ b/.figma-cc-tools/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.9
+//
+// SPM-isolated wrapper for the Figma Code Connect Swift toolchain.
+//
+// Why a subdirectory: the FT2 repo root has FitTracker.xcodeproj.
+// Putting Package.swift at root would tempt SPM to scan the whole
+// FT2 source tree (including iOS-app-specific sources that depend
+// on Xcode-only modules) and fail to compile.
+//
+// This subdirectory hosts ONLY the @figma/code-connect dependency,
+// so `swift run --package-path .figma-cc-tools figma-swift connect
+// publish ...` resolves cleanly without touching app sources.
+//
+// Used by:
+//   - Local operator: `swift run --package-path .figma-cc-tools
+//                     figma-swift connect publish --token "$FIGMA_ACCESS_TOKEN"`
+//   - CI: .github/workflows/figma-code-connect-publish.yml
+//
+// Companion config: ../Figma.toml (file_key + include glob for
+// FitTracker/**/*.figma.swift).
+//
+// Companion docs: ../docs/design-system/ios-code-connect-workflow.md
+
+import PackageDescription
+
+let package = Package(
+    name: "FigmaCodeConnectTools",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/figma/code-connect", from: "1.0.0"),
+    ],
+    targets: [
+        // Empty placeholder target — SPM requires at least one,
+        // but we never build it. The figma-swift binary comes
+        // from the dependency above.
+        .target(name: "FigmaCodeConnectTools", path: "Sources"),
+    ]
+)

--- a/.figma-cc-tools/Sources/FigmaCodeConnectTools/Empty.swift
+++ b/.figma-cc-tools/Sources/FigmaCodeConnectTools/Empty.swift
@@ -1,0 +1,3 @@
+// Empty placeholder file — required by SPM target rule.
+// We never compile this target; we only use the package to
+// resolve and run the figma-swift binary from @figma/code-connect.

--- a/.github/workflows/figma-code-connect-publish.yml
+++ b/.github/workflows/figma-code-connect-publish.yml
@@ -4,14 +4,15 @@ on:
     branches: [main]
     paths:
       - 'FitTracker/**/*.figma.swift'
-      - 'Figma.toml'
+      - 'figma.config.json'
+      - '.figma-cc-tools/**'
       - '.github/workflows/figma-code-connect-publish.yml'
   workflow_dispatch:
 permissions:
   contents: read
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
       - name: Skip if FIGMA_ACCESS_TOKEN not set
@@ -27,6 +28,19 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         with:
           node-version: '24'
+      - name: Cache SPM build artifacts
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            .figma-cc-tools/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-figma-cc-${{ hashFiles('.figma-cc-tools/Package.swift', '.figma-cc-tools/Package.resolved') }}
+          restore-keys: spm-figma-cc-
+      - name: Pre-resolve SPM (warms cache for npm CLI subprocess)
+        if: steps.gate.outputs.skip != 'true'
+        working-directory: .figma-cc-tools
+        run: swift package resolve
       - name: Publish Code Connect mappings
         if: steps.gate.outputs.skip != 'true'
         env:

--- a/figma.config.json
+++ b/figma.config.json
@@ -1,0 +1,8 @@
+{
+  "codeConnect": {
+    "parser": "swift",
+    "include": ["FitTracker/**/*.figma.swift"],
+    "exclude": ["FitTracker/Tests/**", "FitTracker/UITests/**", ".build/**"],
+    "swiftPackagePath": ".figma-cc-tools/Package.swift"
+  }
+}


### PR DESCRIPTION
## Summary
Surfaced by 2026-05-10 iOS dry-run on PR #277's `.figma.swift` files: the npm `@figma/code-connect@1.4.4` CLI doesn't have a built-in Swift parser. It needs to invoke an external `figma-swift` binary built from the @figma/code-connect Swift package via SPM.

This PR ships the fix. **PR #281** (already merged as `091f990`) shipped a workflow that fell back to the html parser for Swift files (catastrophic 14817-file glob runaway). This PR replaces that approach.

## What ships
| File | Purpose |
|---|---|
| `.figma-cc-tools/Package.swift` | SPM wrapper isolating Figma toolchain from FT2 app sources (subdir avoids SPM scanning Xcode app code) |
| `.figma-cc-tools/Sources/FigmaCodeConnectTools/Empty.swift` | Placeholder for SPM "needs at least one target" rule |
| `.figma-cc-tools/Package.resolved` | Pinned deps: code-connect 1.4.4 + swift-argument-parser 1.7.1 + SwiftFormat 0.61.1 + swift-syntax 602.0.0 |
| `figma.config.json` | NEW. `parser: "swift"` + `swiftPackagePath: ".figma-cc-tools/Package.swift"` directs npm CLI to use the SPM wrapper |
| `.github/workflows/figma-code-connect-publish.yml` | Updated: macos-15 runner, SPM cache, pre-resolve step before npm CLI invocation |

## How it works
The npm CLI's `getSwiftParserDir` reads `swiftPackagePath` from `figma.config.json`, then runs `swift run --package-path .figma-cc-tools figma-swift` as a subprocess. The Swift binary parses `.figma.swift` files and returns connection metadata over stdin/stdout JSON. The npm CLI then publishes via Figma API.

## Local verification (real output, with stub token to test parser)
```
Config file found, parsing /Volumes/DevSSD/FitTracker2 using specified include globs
Directory enabled for swift run command
Found Code Connect Swift package at .figma-cc-tools, building parser binary
Successfully connected component: TrainingPlanView_ActivePlanBadgeConnect
Successfully connected component: ImportedPlansListScreen_PopulatedConnect
Successfully connected component: ImportedPlansListScreen_EmptyConnect
Successfully connected component: OnboardingWelcomeView_V2Connect
Successfully connected component: NotificationPermissionRow_SettingsRowConnect
Successfully connected component: ImportPreviewView_DayAssignmentConnect
Files that would be published:
- ImportPreviewView (node-id 921-2)
- OnboardingWelcomeView (node-id 688-2)
- TrainingPlanView (node-id 922-2)
- ImportedPlansListScreen (node-id 919-2)
- ImportedPlansListScreen (node-id 920-2)
- NotificationPermissionRow (node-id 937-46)
Validating... Failed to fetch node info (403): 403 Invalid token   ← expected with stub
```

All 6 .figma.swift files (5 source files; ImportedPlansListScreen has 2 connections) parse cleanly. The 403 is the stub token failing auth — operator's real token in CI will pass.

## Why this matters now
PR #281 (merged) wired CI to a broken parser. Any push to main touching `.figma.swift` files would either:
- Skip publish gracefully if `FIGMA_ACCESS_TOKEN` not set (currently set ✅), OR
- Run the npx command which falls back to html parser, scans 14k+ files, errors out

This PR fixes the workflow before the next `.figma.swift` change hits main (which will happen when PR #277 merges).

## Test plan
- [x] Local dry-run with stub token: 6 connections enumerated, parser succeeds, only validation fails (expected with stub)
- [ ] CI green
- [ ] Operator re-runs `npx --yes --package=@figma/code-connect figma connect publish --dry-run --token "$FIGMA_ACCESS_TOKEN" --skip-update-check` from FT2 root with real token — confirms 0 errors

## Cross-references
- FT2 PR #281 (already merged `091f990`): the broken workflow this fix replaces
- FT2 PR #277: ios-code-connect T1+T2+T3+T5 (the .figma.swift files this workflow publishes)
- fitme-story PR #80: parallel fix on the web side (different issue — parser errors in .figma.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)