### PR TITLE
fix(ios-code-connect): point .figma.swift mappings at component IDs (not frame IDs)

### DIFF
--- a/FitTracker/Views/Import/ImportPreviewView.figma.swift
+++ b/FitTracker/Views/Import/ImportPreviewView.figma.swift
@@ -1,8 +1,10 @@
 // Figma Code Connect template — Day-Assignment Editor (preview mode)
 //
-// Maps Figma node 921:2 in FitTracker-Design-System-Library
+// Maps Figma node 973:4 in FitTracker-Design-System-Library
 // (page 916:2 "Import Training Plan") to ImportPreviewView's
-// `.preview` mode.
+// `.preview` mode. Original frame 921:2 was converted to
+// component 973:4 on 2026-05-10 because Code Connect publish
+// requires the target node to be a COMPONENT or COMPONENT_SET.
 //
 // File: 0Ai7s3fCFqR5JXDW8JvgmD
 
@@ -13,7 +15,7 @@ import SwiftUI
 struct ImportPreviewView_DayAssignmentConnect: FigmaConnect {
     let component = ImportPreviewView.self
     let figmaNodeUrl: String =
-        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=921-2"
+        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=973-4"
 
     var body: some View {
         // Illustrative example — operator may substitute a real

--- a/FitTracker/Views/Notifications/NotificationPermissionRow.figma.swift
+++ b/FitTracker/Views/Notifications/NotificationPermissionRow.figma.swift
@@ -1,7 +1,10 @@
 // Figma Code Connect template — Settings notification permission row
 //
-// Maps Figma node 937:46 in FitTracker-Design-System-Library
-// (page 936:2 "Push Notifications" → "Settings Row States" frame).
+// Maps Figma node 973:6 in FitTracker-Design-System-Library
+// (page 936:2 "Push Notifications v2" → "Settings Row States" frame,
+// originally 937:46 — converted to component 973:6 on 2026-05-10
+// because Code Connect publish requires the target node to be a
+// COMPONENT or COMPONENT_SET).
 // Rendered in Settings as part of the v2 Notifications cluster.
 //
 // File: 0Ai7s3fCFqR5JXDW8JvgmD
@@ -13,7 +16,7 @@ import SwiftUI
 struct NotificationPermissionRow_SettingsRowConnect: FigmaConnect {
     let component = NotificationPermissionRow.self
     let figmaNodeUrl: String =
-        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=937-46"
+        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=973-6"
 
     var body: some View {
         NotificationPermissionRow()

--- a/FitTracker/Views/Onboarding/v2/OnboardingWelcomeView.figma.swift
+++ b/FitTracker/Views/Onboarding/v2/OnboardingWelcomeView.figma.swift
@@ -1,8 +1,13 @@
 // Figma Code Connect template — Onboarding v2 Welcome screen
 //
-// Maps onboarding v2 section 688:2 in FitTracker-Design-System-Library
-// (page 25:6 "Onboarding"). The v2 section was built 2026-04-07; v1
-// section 469:2 is preserved unchanged.
+// Maps Figma node 974:2 in FitTracker-Design-System-Library
+// (page 25:6 "Onboarding" → "I3.2 Onboarding v2 (PRD-Aligned)"
+// section 688:2 → "Screen 1 — Welcome", originally frame 688:6 —
+// converted to component 974:2 on 2026-05-10 because Code Connect
+// publish requires the target node to be a COMPONENT or
+// COMPONENT_SET. The original section 688:2 was the wrong target
+// (Code Connect can't map to a SECTION; it needs to be a single
+// COMPONENT representing the Welcome screen).
 //
 // File: 0Ai7s3fCFqR5JXDW8JvgmD
 
@@ -13,7 +18,7 @@ import SwiftUI
 struct OnboardingWelcomeView_V2Connect: FigmaConnect {
     let component = OnboardingWelcomeView.self
     let figmaNodeUrl: String =
-        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=688-2"
+        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=974-2"
 
     var body: some View {
         OnboardingWelcomeView()

--- a/FitTracker/Views/Settings/v2/Screens/ImportedPlansListScreen.figma.swift
+++ b/FitTracker/Views/Settings/v2/Screens/ImportedPlansListScreen.figma.swift
@@ -1,10 +1,13 @@
 // Figma Code Connect template — Imported Plans List screen
 //
 // Maps two screen variants in the FitTracker-Design-System-Library:
-//   - 919:2 — populated (active plan selected)
-//   - 920:2 — empty state
+//   - 973:2 — populated (active plan selected) [converted from frame 919:2 → component 2026-05-10]
+//   - 973:3 — empty state                       [converted from frame 920:2 → component 2026-05-10]
 //
 // Source-of-truth Figma file: 0Ai7s3fCFqR5JXDW8JvgmD (page 916:2 "Import Training Plan")
+// Note: original frames 919:2 + 920:2 were converted to components
+// 2026-05-10 because Code Connect publish requires the target node to
+// be a COMPONENT or COMPONENT_SET, not a FRAME.
 //
 // Note: this file is parsed by the figma CLI's Swift parser. It is NOT
 // part of the Xcode build target — operator excludes from compilation
@@ -17,7 +20,7 @@ import SwiftUI
 struct ImportedPlansListScreen_PopulatedConnect: FigmaConnect {
     let component = ImportedPlansListScreen.self
     let figmaNodeUrl: String =
-        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=919-2"
+        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=973-2"
 
     var body: some View {
         ImportedPlansListScreen()
@@ -27,7 +30,7 @@ struct ImportedPlansListScreen_PopulatedConnect: FigmaConnect {
 struct ImportedPlansListScreen_EmptyConnect: FigmaConnect {
     let component = ImportedPlansListScreen.self
     let figmaNodeUrl: String =
-        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=920-2"
+        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=973-3"
 
     var body: some View {
         ImportedPlansListScreen()

--- a/FitTracker/Views/Training/v2/TrainingPlanView.figma.swift
+++ b/FitTracker/Views/Training/v2/TrainingPlanView.figma.swift
@@ -1,9 +1,12 @@
 // Figma Code Connect template — Training tab with active-plan badge
 //
-// Maps Figma node 922:2 in FitTracker-Design-System-Library
+// Maps Figma node 973:5 in FitTracker-Design-System-Library
 // (page 916:2 "Import Training Plan") to TrainingPlanView's
 // surface displaying the "Following: My Strength Plan" active-
 // plan badge added when an imported plan is the active source.
+// Original frame 922:2 was converted to component 973:5 on
+// 2026-05-10 because Code Connect publish requires the target
+// node to be a COMPONENT or COMPONENT_SET.
 //
 // File: 0Ai7s3fCFqR5JXDW8JvgmD
 
@@ -14,7 +17,7 @@ import SwiftUI
 struct TrainingPlanView_ActivePlanBadgeConnect: FigmaConnect {
     let component = TrainingPlanView.self
     let figmaNodeUrl: String =
-        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=922-2"
+        "https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library?node-id=973-5"
 
     var body: some View {
         TrainingPlanView()


### PR DESCRIPTION
## Summary
Surfaced by 2026-05-10 CI publish run on FT2 main: all 6 mappings failed validation with **"corresponding node is not a component or component set"**. Code Connect requires the target Figma node to be a COMPONENT (or COMPONENT_SET), not a regular frame or section.

This PR converts the 6 underlying Figma frames to components and re-points the `.figma.swift` mappings.

## What changed (ID remapping)
| Swift mapping file | Old node (frame) | New node (component) |
|---|---|---|
| `ImportedPlansListScreen.figma.swift` (populated) | 919:2 | **973:2** |
| `ImportedPlansListScreen.figma.swift` (empty) | 920:2 | **973:3** |
| `ImportPreviewView.figma.swift` (day-assignment) | 921:2 | **973:4** |
| `TrainingPlanView.figma.swift` (active-plan) | 922:2 | **973:5** |
| `NotificationPermissionRow.figma.swift` (settings) | 937:46 | **973:6** |
| `OnboardingWelcomeView.figma.swift` (v2 Welcome) | 688:2 (section) | **974:2** (Welcome screen frame→component) |

## Onboarding special case
The original mapping pointed at section `688:2` — Code Connect can't map to a SECTION (organizational container). Re-targeted to frame `688:6` "Screen 1 — Welcome" which was then converted to component `974:2`.

## Conversion mechanism
Frames were converted to components programmatically via Figma Plugin API:
```js
const component = figma.createComponentFromNode(frame);
```
Captured new IDs (each conversion gets a new node ID).

## Local verification
```
$ npx --yes --package=@figma/code-connect figma connect publish \
    --dry-run --token <token> --skip-update-check
↓
Successfully connected component × 6
Files that would be published × 6 entries (973-2/3/4/5/6 + 974-2)
Validating... auth-failure with stub token (expected; real token in CI passes)
```

## Test plan
- [x] Local dry-run: 6 mappings parse cleanly with new IDs
- [x] Operator regenerated PAT with all 4 scopes; both repo secrets updated
- [ ] PR Integrity Check passes
- [ ] CI publish workflow fires on merge + reaches "Successfully published 6 connections" (NOT the previous "corresponding node is not a component" validation failure)
- [ ] Operator opens Figma Dev Mode on file `0Ai7s3fCFqR5JXDW8JvgmD`, clicks any of the 6 components (973-2/3/4/5/6, 974-2), confirms SwiftUI snippet appears in right-pane

## Cross-references
- FT2 PR #283 (merged): SPM wrapper for iOS Code Connect publish
- FT2 PR #277 (merged): ios-code-connect foundation (the .figma.swift files this PR updates)
- fitme-story PR #80 (merged): web-side parser fixes (different failure mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)