### PR TITLE
v7.8.3 Phase 1 D-3 — unified cross-repo PR cite cache + 63/63 calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ Config/Local/*.xcconfig
 # (docs/case-studies/hadf-phase2-cloud-fingerprinting-case-study.md cites
 # both files at commit 61964d3 as "the assessable inputs").
 .claude/shared/hadf/phase2-fingerprint-raw*.jsonl
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-snapshot schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-snapshot schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -378,3 +378,11 @@ snapshot-phase:
 # Auto-install on first run
 node_modules:
 	npm install --silent
+
+# v7.8.3 D-3: unified cross-repo PR cite cache (per spec §5)
+refresh-pr-cache:
+	python3 scripts/refresh-pr-cache.py
+
+validate-existing-cites: refresh-pr-cache
+	@echo "Validating PR cites in all docs/case-studies/*.md against unified cache…"
+	@python3 scripts/check-case-study-preflight.py docs/case-studies/*.md

--- a/scripts/check-case-study-preflight.py
+++ b/scripts/check-case-study-preflight.py
@@ -71,9 +71,26 @@ FIELDS_CUTOFF_DATE = "2026-04-28"
 REQUIRED_FRONTMATTER_FIELDS = ["work_type", "success_metrics", "kill_criteria", "dispatch_pattern"]
 
 # Same regex shape as integrity-check.py (kept in sync intentionally).
+# v7.8.3 D-3: updated to 3-alternation form for cross-repo cite routing.
+#
+# Groups:
+#   group(1)        — FT2 default form:       PR #N  or  PR#N
+#   group(2)+3      — cross-repo short form:  [fitme-story#42]  (brackets required
+#                     to avoid false positives on "PRs #96", "issue #140", etc.)
+#   group(4)+5+6    — URL form:               github.com/owner/repo/pull/N
 _PR_CITATION_PAT = re.compile(
-    r'(?:[Pp][Rr]\s*#?|github\.com/[^/\s]+/[^/\s]+/pull/)(\d+)'
+    r"(?:[Pp][Rr]\s*#(\d+))"                              # group 1: FT2 default
+    r"|(?:\[([\w-]+)\s*#(\d+)\])(?!\()"                   # groups 2+3: cross-repo short (brackets, NOT markdown link)
+    r"|(?:github\.com/([\w-]+)/([\w-]+)/pull/(\d+))"     # groups 4+5+6: URL form
 )
+
+# Whitelist mapping repo short names → full "owner/repo" identifiers.
+# Used by resolve_pr_cite() to route cross-repo short-form cites.
+REPO_MAP: dict[str, str] = {
+    "fitme-story": "Regevba/fitme-story",
+    "FitTracker2": "Regevba/FitTracker2",
+    "ft2": "Regevba/FitTracker2",
+}
 _DATE_WRITTEN_PAT = re.compile(
     r"(?im)^\*\*Date written:\*\*\s*(\d{4}-\d{2}-\d{2})|^>\s*\*\*Date:\*\*\s*(\d{4}-\d{2}-\d{2})"
 )
@@ -183,29 +200,109 @@ def check_case_study_missing_fields(path: Path) -> list[dict]:
     }]
 
 
-_PR_CACHE: set[int] | None = None
+_PR_CACHE: dict | None = None
 _PR_CACHE_LOADED: bool = False
 
 
-def _load_pr_cache() -> set[int] | None:
-    """Single `gh pr list` call, cached for the script's lifetime. Graceful
-    degradation: returns None if gh is unavailable, and the BROKEN_PR_CITATION
-    check is skipped rather than failing the hook."""
+def _load_pr_cache() -> dict | None:
+    """Load multi-repo cached PR data; refresh via refresh-pr-cache.py if stale.
+
+    v7.8.3 D-3 morph: was set[int] | None (FT2-only); now returns the
+    multi-repo dict shape matching .cache/gh-pr-cache.json:
+      {"schema_version": 1, "last_refreshed_at": "...",
+       "repos": {"Regevba/FitTracker2": {open,merged,closed}, ...}}
+
+    Returns None if gh is unavailable AND no stale cache exists — caller
+    skips the BROKEN_PR_CITATION check gracefully (never block a commit on
+    missing network access).
+    """
     global _PR_CACHE, _PR_CACHE_LOADED
     if _PR_CACHE_LOADED:
         return _PR_CACHE
     _PR_CACHE_LOADED = True
+
+    cache_file = REPO_ROOT / ".cache" / "gh-pr-cache.json"
+    if not cache_file.exists():
+        # Try to refresh via the Task 1.1 refresh script.
+        refresh_script = Path(__file__).parent / "refresh-pr-cache.py"
+        if refresh_script.exists():
+            try:
+                subprocess.run(
+                    [sys.executable, str(refresh_script)],
+                    check=False, timeout=60,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                pass
+
+    if not cache_file.exists():
+        _PR_CACHE = None
+        return _PR_CACHE
+
     try:
-        out = subprocess.check_output(
-            ["gh", "pr", "list", "--state", "all", "--limit", "500",
-             "--json", "number"],
-            text=True, stderr=subprocess.DEVNULL,
-        )
-        _PR_CACHE = {p["number"] for p in json.loads(out)}
-    except (subprocess.CalledProcessError, FileNotFoundError,
-            json.JSONDecodeError):
+        _PR_CACHE = json.loads(cache_file.read_text())
+    except Exception as e:
+        print(f"WARN: PR cache load failed: {e}", file=sys.stderr)
         _PR_CACHE = None
     return _PR_CACHE
+
+
+def resolve_pr_cite(match: re.Match, cache: dict | None) -> str | None:
+    """Resolve a single _PR_CITATION_PAT match against the multi-repo PR cache.
+
+    Returns None if the cite is valid (PR found in cache).
+    Returns a human-readable error string if the cite is broken or unresolvable.
+    Returns None when cache is None (gh unavailable — caller skips gracefully).
+
+    Routing logic:
+      group(1)    → FT2 default       → repo "Regevba/FitTracker2"
+      group(2+3)  → cross-repo short  → REPO_MAP lookup → full repo name
+      group(4+6)  → URL form          → "{group4}/{group5}" as full repo name
+    """
+    if cache is None:
+        return None  # gh unavailable; caller already noted this, skip gracefully
+
+    if match.group(1):
+        repo = "Regevba/FitTracker2"
+        pr_num = int(match.group(1))
+    elif match.group(2):
+        repo_short = match.group(2)
+        repo = REPO_MAP.get(repo_short)
+        if repo is None:
+            return (
+                f"BROKEN_PR_CITATION: unknown repo short name '{repo_short}' — "
+                f"valid names: {sorted(REPO_MAP.keys())}. "
+                f"Add to REPO_MAP in check-case-study-preflight.py if intentional."
+            )
+        pr_num = int(match.group(3))
+    elif match.group(4):
+        repo = f"{match.group(4)}/{match.group(5)}"
+        pr_num = int(match.group(6))
+    else:
+        return None  # no group matched — regex logic error; skip silently
+
+    repos = cache.get("repos", {})
+    if repo not in repos:
+        return (
+            f"BROKEN_PR_CITATION: no cache entry for repo '{repo}'. "
+            f"Run scripts/refresh-pr-cache.py to rebuild, or add repo to REPO_MAP."
+        )
+
+    repo_cache = repos[repo]
+    all_prs = (
+        repo_cache.get("open", [])
+        + repo_cache.get("merged", [])
+        + repo_cache.get("closed", [])
+    )
+    if not any(pr["number"] == pr_num for pr in all_prs):
+        refreshed_at = cache.get("last_refreshed_at", "unknown")
+        return (
+            f"BROKEN_PR_CITATION: PR #{pr_num} not found in {repo} "
+            f"(cache last refreshed {refreshed_at}). "
+            f"Verify the number or run scripts/refresh-pr-cache.py to refresh."
+        )
+
+    return None
 
 
 def _is_exempt(path: Path) -> bool:
@@ -235,18 +332,12 @@ def validate_file(path: Path) -> list[str]:
         errors.append(f"{path}: cannot read ({e})")
         return errors
 
-    # Check 1c: BROKEN_PR_CITATION at write-time
-    cited = {int(m.group(1)) for m in _PR_CITATION_PAT.finditer(text)}
-    if cited:
-        pr_cache = _load_pr_cache()
-        if pr_cache is not None:
-            broken = sorted(n for n in cited if n not in pr_cache)
-            for n in broken:
-                errors.append(
-                    f"{path}: cites PR #{n} which does not resolve on GitHub. "
-                    f"Verify the number, fix the citation, or use issue-citation "
-                    f"syntax (`issue #{n}`, `repo#{n}`) if it's an issue not a PR."
-                )
+    # Check 1c: BROKEN_PR_CITATION at write-time (v7.8.3 D-3: multi-repo routing)
+    pr_cache = _load_pr_cache()
+    for m in _PR_CITATION_PAT.finditer(text):
+        finding = resolve_pr_cite(m, pr_cache)
+        if finding is not None:
+            errors.append(f"{path}: {finding}")
 
     # Check 1d: CASE_STUDY_MISSING_TIER_TAGS at write-time
     date_match = _DATE_WRITTEN_PAT.search(text)
@@ -331,7 +422,13 @@ def main() -> int:
 
     pr_note = ""
     if _PR_CACHE is not None:
-        pr_note = f" (PR-resolution: {len(_PR_CACHE)} known PRs)"
+        # Count total PRs across all repos in the multi-repo cache.
+        total_prs = sum(
+            len(r.get("open", [])) + len(r.get("merged", [])) + len(r.get("closed", []))
+            for r in _PR_CACHE.get("repos", {}).values()
+        )
+        repos_str = ", ".join(_PR_CACHE.get("repos", {}).keys())
+        pr_note = f" (PR-resolution: {total_prs} PRs across [{repos_str}])"
     elif _PR_CACHE_LOADED:
         pr_note = " (PR-resolution skipped — gh unavailable)"
     print(f"✓ All {len(eligible)} case study files pass all checks "

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -257,7 +257,9 @@ def audit_feature(feat_dir: Path) -> tuple[dict, list[dict]]:
     if isinstance(merge_obj, dict):
         pr_number = merge_obj.get("pr_number")
         if isinstance(pr_number, int) and _PR_CACHE is not None:
-            if pr_number not in _PR_CACHE:
+            # v7.8.3: _PR_CACHE is now multi-repo dict; check FT2 repo specifically.
+            _ft2_prs = _CACHE_FT2_NUMBERS(_PR_CACHE)
+            if pr_number not in _ft2_prs:
                 findings.append({
                     "feature": feat,
                     "severity": "INCONSISTENT",
@@ -294,40 +296,134 @@ def audit_feature(feat_dir: Path) -> tuple[dict, list[dict]]:
 
 # Module-level PR cache. Populated by build_snapshot() once per run so
 # per-feature audit_feature() calls can reuse it without repeated gh invocations.
-_PR_CACHE: set[int] | None = None
+# v7.8.3 D-3: type morphed from set[int] | None to multi-repo dict | None.
+_PR_CACHE: dict | None = None
+
+
+def _CACHE_FT2_NUMBERS(cache: dict) -> set[int]:
+    """Extract the set of FitTracker2 PR numbers from the multi-repo cache dict.
+
+    Used by PR_NUMBER_UNRESOLVED check in audit_feature() which only
+    verifies state.json::phases.merge.pr_number (always a FT2 PR).
+    """
+    ft2 = cache.get("repos", {}).get("Regevba/FitTracker2", {})
+    return {
+        pr["number"]
+        for lst in (ft2.get("open", []), ft2.get("merged", []), ft2.get("closed", []))
+        for pr in lst
+    }
 
 
 # -- Case-study citation checks (Auditor Agent extensions, 2026-04-21) ------
 
 # Match PR citations with high-precision context:
-#   "PR #123", "PR 123", "pr #123", "pr 123"
-#   "github.com/owner/repo/pull/123"
+#   "PR #123", "PR#123", "pr #123"                   → group 1 (FT2 default)
+#   "[fitme-story#42]"                               → groups 2+3 (cross-repo short)
+#   "github.com/owner/repo/pull/123"                 → groups 4+5+6 (URL form)
 # Avoids raw "#123" (too many false positives from list numbers, issues, etc.).
+# Cross-repo short form requires brackets to avoid false positives on
+# "PRs #96-#116", "issue #140", "Fix#123", etc.
+# v7.8.3 D-3: updated to 3-alternation form; kept in sync with
+#             check-case-study-preflight.py (sync invariant per A2).
 _PR_CITATION_PAT = re.compile(
-    r'(?:[Pp][Rr]\s*#?|github\.com/[^/\s]+/[^/\s]+/pull/)(\d+)'
+    r"(?:[Pp][Rr]\s*#(\d+))"                              # group 1: FT2 default
+    r"|(?:\[([\w-]+)\s*#(\d+)\])(?!\()"                   # groups 2+3: cross-repo short (brackets, NOT markdown link)
+    r"|(?:github\.com/([\w-]+)/([\w-]+)/pull/(\d+))"     # groups 4+5+6: URL form
 )
 
+# Whitelist mapping repo short names → full "owner/repo" identifiers.
+# Kept in sync with check-case-study-preflight.py REPO_MAP (A2 sync invariant).
+_CITATION_REPO_MAP: dict[str, str] = {
+    "fitme-story": "Regevba/fitme-story",
+    "FitTracker2": "Regevba/FitTracker2",
+    "ft2": "Regevba/FitTracker2",
+}
 
-def load_pr_cache() -> set[int] | None:
-    """Load all PR numbers via `gh pr list`. Return None if gh is unavailable.
 
-    Used by the Auditor Agent's BROKEN_PR_CITATION check. Graceful degradation:
-    if `gh` is missing or unauthenticated (e.g., CI without GH_TOKEN), the
-    check is skipped rather than failing the whole integrity cycle.
+def load_pr_cache() -> dict | None:
+    """Load multi-repo cached PR data from .cache/gh-pr-cache.json.
+
+    v7.8.3 D-3: was set[int] | None (FT2-only). Now returns the multi-repo
+    dict shape:
+      {"schema_version": 1, "last_refreshed_at": "...",
+       "repos": {"Regevba/FitTracker2": {open,merged,closed}, ...}}
+
+    Falls back to a legacy `gh pr list` call for backward compatibility when
+    the cache file doesn't exist.
+
+    Returns None if gh is unavailable AND no cache exists (graceful degradation:
+    check is skipped rather than failing the whole integrity cycle).
     """
+    cache_file = REPO_ROOT / ".cache" / "gh-pr-cache.json"
+    if cache_file.exists():
+        try:
+            return json.loads(cache_file.read_text())
+        except Exception:
+            pass  # fall through to live gh call
+
+    # Fallback: legacy single-repo gh call (FT2-only).
     try:
         out = subprocess.check_output(
             ["gh", "pr", "list", "--state", "all", "--limit", "500",
              "--json", "number"],
             text=True, stderr=subprocess.DEVNULL,
         )
-        return {p["number"] for p in json.loads(out)}
+        numbers = [p["number"] for p in json.loads(out)]
+        # Wrap in multi-repo shape so callers work uniformly.
+        return {
+            "schema_version": 1,
+            "last_refreshed_at": None,
+            "repos": {
+                "Regevba/FitTracker2": {
+                    "open": [{"number": n} for n in numbers],
+                    "merged": [],
+                    "closed": [],
+                }
+            },
+        }
     except (subprocess.CalledProcessError, FileNotFoundError,
             json.JSONDecodeError):
         return None
 
 
-def audit_case_study_citations(pr_cache: set[int] | None) -> list[dict]:
+def _resolve_pr_cite_integrity(match: re.Match, cache: dict) -> str | None:
+    """Resolve a _PR_CITATION_PAT match against the multi-repo cache (integrity-check variant).
+
+    Returns an error message string if broken, None if valid.
+    Internal helper for audit_case_study_citations().
+    """
+    if match.group(1):
+        repo = "Regevba/FitTracker2"
+        pr_num = int(match.group(1))
+    elif match.group(2):
+        repo_short = match.group(2)
+        repo = _CITATION_REPO_MAP.get(repo_short)
+        if repo is None:
+            return f"cites [{repo_short}#{match.group(3)}] with unknown repo short name '{repo_short}'"
+        pr_num = int(match.group(3))
+    elif match.group(4):
+        repo = f"{match.group(4)}/{match.group(5)}"
+        pr_num = int(match.group(6))
+    else:
+        return None
+
+    repos = cache.get("repos", {})
+    if repo not in repos:
+        return f"cites PR #{pr_num} in unknown repo '{repo}' (not in cache)"
+
+    repo_cache = repos[repo]
+    all_prs = (
+        repo_cache.get("open", [])
+        + repo_cache.get("merged", [])
+        + repo_cache.get("closed", [])
+    )
+    if not any(pr["number"] == pr_num for pr in all_prs):
+        return f"cites PR #{pr_num} in {repo} which does not resolve on GitHub"
+
+    return None
+
+
+def audit_case_study_citations(pr_cache: dict | None) -> list[dict]:
     """Scan every case study .md for PR citations; flag broken ones.
 
     If pr_cache is None, skip gracefully (gh not available). Returns findings
@@ -336,6 +432,8 @@ def audit_case_study_citations(pr_cache: set[int] | None) -> list[dict]:
     Excludes files under `docs/case-studies/meta-analysis/`: those documents
     discuss citations (including false positives), so any PR number appearing
     in their prose is meta-reference, not a real evidentiary claim.
+
+    v7.8.3 D-3: uses resolve_pr_cite() for cross-repo routing via REPO_MAP.
     """
     if pr_cache is None or not CASE_STUDIES_DIR.exists():
         return []
@@ -349,14 +447,15 @@ def audit_case_study_citations(pr_cache: set[int] | None) -> list[dict]:
             text = f.read_text()
         except Exception:
             continue
-        cited = {int(m.group(1)) for m in _PR_CITATION_PAT.finditer(text)}
-        for n in sorted(n for n in cited if n not in pr_cache):
-            findings.append({
-                "feature": str(f.relative_to(REPO_ROOT)),
-                "severity": "INCONSISTENT",
-                "code": "BROKEN_PR_CITATION",
-                "message": f"cites PR #{n} which does not resolve on GitHub",
-            })
+        for m in _PR_CITATION_PAT.finditer(text):
+            err = _resolve_pr_cite_integrity(m, pr_cache)
+            if err is not None:
+                findings.append({
+                    "feature": str(f.relative_to(REPO_ROOT)),
+                    "severity": "INCONSISTENT",
+                    "code": "BROKEN_PR_CITATION",
+                    "message": err,
+                })
     return findings
 
 
@@ -831,7 +930,13 @@ def build_snapshot(snapshot_trigger: str) -> dict:
         },
         "auditor_agent": {
             "citation_check_ran": citation_check_ran,
-            "known_pr_count": len(_PR_CACHE) if _PR_CACHE is not None else None,
+            "known_pr_count": (
+                sum(
+                    len(r.get("open", [])) + len(r.get("merged", [])) + len(r.get("closed", []))
+                    for r in _PR_CACHE.get("repos", {}).values()
+                )
+                if _PR_CACHE is not None else None
+            ),
         },
         "features": feature_summaries,
         "case_studies": discover_case_studies(),

--- a/scripts/refresh-pr-cache.py
+++ b/scripts/refresh-pr-cache.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Refresh the unified cross-repo PR cite cache.
+
+v7.8.3 D-3. Writes .cache/gh-pr-cache.json with PRs from both
+Regevba/FitTracker2 and Regevba/fitme-story.
+
+Schema:
+  {
+    "schema_version": 1,
+    "last_refreshed_at": "<ISO timestamp>",
+    "repos": {
+      "Regevba/FitTracker2": {"open": [...], "merged": [...], "closed": [...]},
+      "Regevba/fitme-story": {"open": [...], "merged": [...], "closed": [...]},
+    }
+  }
+
+Skips gracefully when `gh` is unavailable or auth missing (matches existing
+BROKEN_PR_CITATION skip-on-missing-gh pattern).
+"""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPOS = ["Regevba/FitTracker2", "Regevba/fitme-story"]
+CACHE_FILE = Path(".cache") / "gh-pr-cache.json"
+
+
+def fetch_repo_prs(repo: str) -> dict | None:
+    """Fetch PRs for one repo across all states. Return None on gh failure."""
+    repo_data = {}
+    for state in ["open", "merged", "closed"]:
+        try:
+            result = subprocess.check_output(
+                ["gh", "pr", "list", "--repo", repo, "--state", state,
+                 "--json", "number,title,state", "--limit", "500"],
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+            repo_data[state] = json.loads(result)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            print(f"WARN: failed to fetch {repo} {state} PRs: {e}", file=sys.stderr)
+            return None
+    return repo_data
+
+
+def main() -> int:
+    cache = {
+        "schema_version": 1,
+        "last_refreshed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "repos": {},
+    }
+    for repo in REPOS:
+        repo_data = fetch_repo_prs(repo)
+        if repo_data is None:
+            print(f"WARN: skipping {repo} (gh unavailable or auth failed)", file=sys.stderr)
+            continue
+        cache["repos"][repo] = repo_data
+
+    if not cache["repos"]:
+        print("ERROR: no repos cached; gh likely unavailable", file=sys.stderr)
+        return 1
+
+    CACHE_FILE.parent.mkdir(exist_ok=True)
+    CACHE_FILE.write_text(json.dumps(cache, indent=2) + "\n")
+    pr_count = sum(len(r.get(s, [])) for r in cache['repos'].values() for s in ['open','merged','closed'])
+    print(f"Wrote {CACHE_FILE} ({pr_count} PRs across {len(cache['repos'])} repos)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/framework/test_pr_cite_cache.py
+++ b/tests/framework/test_pr_cite_cache.py
@@ -1,0 +1,46 @@
+"""D-3 — unified cross-repo PR cite cache.
+
+Task 1.1: refresh-pr-cache.py builds correct multi-repo cache shape.
+Task 1.2 will add regex + routing tests."""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+REFRESH_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "refresh-pr-cache.py"
+
+
+def test_refresh_pr_cache_writes_correct_shape(tmp_path: Path, monkeypatch):
+    """refresh-pr-cache.py writes cache file with schema_version, last_refreshed_at, repos."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".cache").mkdir()
+
+    # Run the script. If gh is unavailable in the test env, the script should
+    # still create a cache file (possibly with empty repos) OR exit non-zero
+    # gracefully. We assert structurally on the output if the script created
+    # a file.
+    result = subprocess.run([sys.executable, str(REFRESH_SCRIPT)],
+                            capture_output=True, text=True)
+    cache_file = tmp_path / ".cache" / "gh-pr-cache.json"
+
+    if result.returncode == 0:
+        # Successful run: cache file must exist + have right shape
+        assert cache_file.exists(), f"script returned 0 but no cache file: {result.stderr}"
+        cache = json.loads(cache_file.read_text())
+        assert cache["schema_version"] == 1, f"unexpected schema_version: {cache.get('schema_version')}"
+        assert "last_refreshed_at" in cache
+        assert "repos" in cache
+        assert isinstance(cache["repos"], dict)
+        # If gh worked, both repos should be present
+        if cache["repos"]:
+            for repo_name in cache["repos"]:
+                repo_data = cache["repos"][repo_name]
+                assert "open" in repo_data
+                assert "merged" in repo_data
+                assert "closed" in repo_data
+    else:
+        # gh unavailable / auth failed — script should print to stderr
+        assert "gh" in result.stderr.lower() or "WARN" in result.stderr or "ERROR" in result.stderr, \
+            f"non-zero exit but no clear error message: {result.stderr}"

--- a/tests/framework/test_pr_cite_cache.py
+++ b/tests/framework/test_pr_cite_cache.py
@@ -1,13 +1,23 @@
 """D-3 — unified cross-repo PR cite cache.
 
 Task 1.1: refresh-pr-cache.py builds correct multi-repo cache shape.
-Task 1.2 will add regex + routing tests."""
+Task 1.2: regex + routing tests for check-case-study-preflight.py."""
 from __future__ import annotations
+import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
 import pytest
+
+PREFLIGHT = Path(__file__).resolve().parents[2] / "scripts" / "check-case-study-preflight.py"
+
+
+def load_preflight():
+    spec = importlib.util.spec_from_file_location("preflight", PREFLIGHT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 REFRESH_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "refresh-pr-cache.py"
 
@@ -44,3 +54,87 @@ def test_refresh_pr_cache_writes_correct_shape(tmp_path: Path, monkeypatch):
         # gh unavailable / auth failed — script should print to stderr
         assert "gh" in result.stderr.lower() or "WARN" in result.stderr or "ERROR" in result.stderr, \
             f"non-zero exit but no clear error message: {result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2 — regex + routing tests
+# ---------------------------------------------------------------------------
+
+def test_pr_citation_pat_matches_three_forms():
+    """Regex captures: PR #N (FT2 default), repo#N (cross-repo short), URL form."""
+    pf = load_preflight()
+    pat = pf._PR_CITATION_PAT
+
+    # FT2 default form: "PR #290"
+    m = pat.search("see PR #290")
+    assert m and m.group(1) == "290", f"FT2 default form failed, match={m}"
+
+    # Cross-repo short form: "[fitme-story#42]"
+    m = pat.search("backed by [fitme-story#42]")
+    assert m and m.group(2) == "fitme-story" and m.group(3) == "42", \
+        f"cross-repo short form failed, match={m}"
+
+    # URL form: "github.com/Regevba/fitme-story/pull/42"
+    m = pat.search("github.com/Regevba/fitme-story/pull/42")
+    assert m and m.group(4) == "Regevba" and m.group(5) == "fitme-story" and m.group(6) == "42", \
+        f"URL form failed, match={m}"
+
+
+def test_repo_map_includes_both_repos():
+    pf = load_preflight()
+    assert "fitme-story" in pf.REPO_MAP
+    assert "FitTracker2" in pf.REPO_MAP
+
+
+def test_resolve_pr_cite_finds_existing_pr():
+    """When cache contains the PR number, resolve_pr_cite returns None (no Finding)."""
+    pf = load_preflight()
+    cache = {
+        "schema_version": 1,
+        "last_refreshed_at": "2026-05-12T00:00:00Z",
+        "repos": {
+            "Regevba/FitTracker2": {
+                "open": [{"number": 290, "title": "x", "state": "OPEN"}],
+                "merged": [], "closed": [],
+            },
+            "Regevba/fitme-story": {
+                "open": [{"number": 42, "title": "y", "state": "OPEN"}],
+                "merged": [], "closed": [],
+            },
+        },
+    }
+
+    m = pf._PR_CITATION_PAT.search("PR #290")
+    assert pf.resolve_pr_cite(m, cache) is None, "FT2 PR in cache should return None"
+
+    m = pf._PR_CITATION_PAT.search("[fitme-story#42]")
+    assert pf.resolve_pr_cite(m, cache) is None, "fitme-story PR in cache should return None"
+
+
+def test_resolve_pr_cite_unknown_repo_short_name_fails():
+    pf = load_preflight()
+    cache = {"schema_version": 1, "repos": {}}
+    m = pf._PR_CITATION_PAT.search("[unknown-repo#1]")
+    assert m is not None, "regex should match unknown-repo#1"
+    finding = pf.resolve_pr_cite(m, cache)
+    assert finding is not None, "unknown repo short name should produce a finding"
+    code_str = str(finding)
+    assert "BROKEN_PR_CITATION" in code_str or "unknown" in code_str.lower(), \
+        f"finding should mention BROKEN_PR_CITATION or 'unknown': {code_str}"
+
+
+def test_resolve_pr_cite_missing_pr_fails():
+    pf = load_preflight()
+    cache = {
+        "schema_version": 1,
+        "last_refreshed_at": "2026-05-12T00:00:00Z",
+        "repos": {
+            "Regevba/FitTracker2": {"open": [], "merged": [], "closed": []},
+        },
+    }
+    m = pf._PR_CITATION_PAT.search("PR #999999")
+    finding = pf.resolve_pr_cite(m, cache)
+    assert finding is not None, "PR not in cache should produce a finding"
+    code_str = str(finding)
+    assert "BROKEN_PR_CITATION" in code_str or "999999" in code_str, \
+        f"finding should mention BROKEN_PR_CITATION or the PR number: {code_str}"


### PR DESCRIPTION
## Summary

Phase 1 D-3 deliverable per spec [`docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md`](docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md) §5 + plan [`docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md`](docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md) §6.2 (with A1-A6 adjustments shipped in commit `01b2100`).

Closes the BROKEN_PR_CITATION gate's two known bugs:
- **B1:** silent skip on cross-repo `[fitme-story#N]` short-form cites
- **B2:** URL-form `github.com/Regevba/fitme-story/pull/N` mis-routing to FT2 cache

## Calibration target — ✅ ACHIEVED

**Per A1 (plan adjustment):** all **63 cross-repo `fitme-story#N` cite occurrences** in `docs/case-studies/` validate cleanly via `make validate-existing-cites`. Original plan said 35; A1 corrected to 63 based on 2026-05-11 codebase state.

## Commits (3 total)

| # | SHA | Task |
|---|---|---|
| 1 | `f8cb45d` | Task 1.1: refresh-pr-cache.py (multi-repo cache foundation) |
| 2 | `3d7ad11` | Task 1.2: regex + REPO_MAP + resolve_pr_cite + integrity-check.py parallel update (per A2) + _load_pr_cache morph (per A3) |
| 3 | `f515bdd` | Task 1.3: Makefile targets (refresh-pr-cache + validate-existing-cites) |

## Files changed

- **NEW** `scripts/refresh-pr-cache.py` — populates `.cache/gh-pr-cache.json` for both repos
- **NEW** `tests/framework/test_pr_cite_cache.py` — 5 new tests (regex 3 forms + REPO_MAP + resolve found/missing/unknown-repo)
- **MOD** `scripts/check-case-study-preflight.py` — regex update + REPO_MAP + resolve_pr_cite + _load_pr_cache morph
- **MOD** `scripts/integrity-check.py` — parallel regex update per A2 (sync invariant comment now references both files)
- **MOD** `Makefile` — `refresh-pr-cache` + `validate-existing-cites` targets
- **MOD** `.gitignore` — `.cache/` (cache file is gitignored)

## Design decision (logged in commit 3d7ad11)

Negative lookahead `(?!\()` on cross-repo regex alternation excludes markdown link-text patterns like `[FT2#256](url)` from double-firing. Verified safe: still matches `[fitme-story#42]` style cites, doesn't break any of the 69 existing case studies.

## Test plan

- [x] `make verify-local` passes locally (build + tests + lint + integrity-check)
- [x] `make refresh-pr-cache` produces multi-repo cache (643 PRs across 2 repos)
- [x] `make validate-existing-cites` passes 63/63 retroactive cross-repo cite validation
- [x] `.venv/bin/python3 -m pytest tests/framework/ -v` — 12/12 PASS
- [ ] CI passes on PR

## Per-phase rollback (per spec §6.2)

- D-3 regex regression on existing FT2 cites → revert `check-case-study-preflight.py`
- C-4 build error → revert aggregator + remove from `/control-room/framework`
- Cache-shape change breaks downstream readers → revert `_load_pr_cache` morph

## Next sub-task

Task 1.5 starts the C-4 portion (fitme-story PR for control-room aggregator + sync extension) — needs an isolated fitme-story worktree per A4. Will start after this D-3 PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)