### PR TITLE
fix(framework): BRANCH_ISOLATION_VIOLATION Mode B silent-pass on infra-only commits

### DIFF
--- a/scripts/check-state-schema.py
+++ b/scripts/check-state-schema.py
@@ -1478,10 +1478,6 @@ def main() -> int:
         files = [Path(a).resolve() for a in args]
         mode = "explicit"
 
-    if not files:
-        print(f"No state.json files to validate (mode={mode}).")
-        return 0
-
     # Phase-transition checks (1a, 1b) only fire at commit time. Full-corpus
     # scans cannot tell what's a "transition" — they just see current state.
     # Override via FORCE_TRANSITION_CHECKS=1 (used by the regression test
@@ -1506,6 +1502,13 @@ def main() -> int:
     # BRANCH_ISOLATION_VIOLATION check (Mode B — infra-path classifier).
     # Runs ONCE per script invocation in staged mode. Advisory in v7.8:
     # prints warning to stderr, does NOT add to errors list.
+    #
+    # NOTE: this block runs BEFORE the no-state-files early exit. Mode B
+    # fires on infra-path commits regardless of whether state.json is in
+    # the staged set, so scaffolding commits (scripts/, .claude/shared/,
+    # .githooks/, etc.) without a state.json must still be evaluated.
+    # Pre-2026-05-12 the early-exit was above this block, silently bypassing
+    # Mode B for ~9 commits in HADF Phase 2-bis Block A (A3–A11).
     if mode == "staged":
         all_staged = collect_all_staged_files()
         for finding in check_branch_isolation_violation_commit_level(
@@ -1526,11 +1529,6 @@ def main() -> int:
                     f"got branch={finding['got']}. {finding['remediation']}"
                 )
 
-    for p in files:
-        all_errors.extend(
-            validate_file(p, enforce_transition=enforce_transition, coverage=coverage)
-        )
-
     # Persist the coverage ledger. Failure to write must not affect the
     # exit code — Mechanism A is advisory in v7.8; the gate verdict is
     # what gates the commit. Tests opt out via GATE_COVERAGE_LEDGER_DISABLED=1.
@@ -1538,12 +1536,34 @@ def main() -> int:
     # concerned, but the longitudinal data accumulates on local + scheduled
     # cron runs (the data source for the v7.9 GATE_COVERAGE_ZERO meta-check).
     skip_ledger = os.environ.get("GATE_COVERAGE_LEDGER_DISABLED") == "1"
-    if not skip_ledger:
+
+    def _persist_coverage_ledger() -> None:
+        if skip_ledger:
+            return
         try:
             coverage.write_jsonl(GATE_COVERAGE_LEDGER)
         except OSError as e:
             print(f"warning: gate-coverage ledger write failed ({e})",
                   file=sys.stderr)
+
+    if not files:
+        _persist_coverage_ledger()
+        if all_errors:
+            print(f"✗ STATE_SCHEMA: {len(all_errors)} violation(s) "
+                  f"(mode={mode}, files scanned=0)",
+                  file=sys.stderr)
+            for err in all_errors:
+                print(f"  - {err}", file=sys.stderr)
+            return 1
+        print(f"No state.json files to validate (mode={mode}).")
+        return 0
+
+    for p in files:
+        all_errors.extend(
+            validate_file(p, enforce_transition=enforce_transition, coverage=coverage)
+        )
+
+    _persist_coverage_ledger()
 
     if all_errors:
         print(f"✗ STATE_SCHEMA: {len(all_errors)} violation(s) "

--- a/scripts/tests/test_branch_isolation_and_closure_completeness.py
+++ b/scripts/tests/test_branch_isolation_and_closure_completeness.py
@@ -170,5 +170,73 @@ def test_closure_completeness_against_real_case_study():
     assert isinstance(findings, list)
 
 
+# ─── Regression: main() must run Mode B even with no state.json staged ──
+# Pre-fix bug: main() early-returned at `if not files: return 0` BEFORE the
+# Mode B check block, so commits staging only infra-path files (scripts/,
+# .claude/shared/, .githooks/, etc.) without a state.json silently bypassed
+# the BRANCH_ISOLATION_VIOLATION gate AND the gate-coverage ledger write.
+# Witnessed empirically on HADF Phase 2-bis Block A commits A3–A11 (9
+# commits, 0 gate-coverage entries for BRANCH_ISOLATION_VIOLATION post
+# 2026-05-12T07:58:43Z). See PR for full diagnostic.
+
+def test_main_runs_mode_b_when_only_infra_files_staged(monkeypatch, tmp_path):
+    """Mode B must fire (or record skip) when infra-path files are staged
+    even if no state.json is staged."""
+    import json as _json
+
+    monkeypatch.setattr(_mod, "collect_staged_state_files", lambda: [])
+    monkeypatch.setattr(
+        _mod,
+        "collect_all_staged_files",
+        lambda: ["scripts/foo.py", ".claude/shared/bar.json"],
+    )
+    ledger_path = tmp_path / "gate-coverage.jsonl"
+    monkeypatch.setattr(_mod, "GATE_COVERAGE_LEDGER", ledger_path)
+    monkeypatch.setattr(sys, "argv", ["check-state-schema.py", "--staged"])
+
+    rc = _mod.main()
+    assert rc == 0, f"Advisory gate must not block; got rc={rc}"
+    assert ledger_path.exists(), (
+        "Coverage ledger must be written even when no state.json is staged "
+        "(Mechanism A requirement)"
+    )
+    entries = [
+        _json.loads(line)
+        for line in ledger_path.read_text().splitlines()
+        if line.strip()
+    ]
+    gate_names = {e["gate"] for e in entries}
+    assert "BRANCH_ISOLATION_VIOLATION" in gate_names, (
+        f"Mode B must record to coverage ledger; got gates: {gate_names}"
+    )
+
+
+def test_main_skips_mode_b_when_no_files_staged_at_all(monkeypatch, tmp_path):
+    """Empty staged set: Mode B records `no_staged_files` skip, exits 0."""
+    import json as _json
+
+    monkeypatch.setattr(_mod, "collect_staged_state_files", lambda: [])
+    monkeypatch.setattr(_mod, "collect_all_staged_files", lambda: [])
+    ledger_path = tmp_path / "gate-coverage.jsonl"
+    monkeypatch.setattr(_mod, "GATE_COVERAGE_LEDGER", ledger_path)
+    monkeypatch.setattr(sys, "argv", ["check-state-schema.py", "--staged"])
+
+    rc = _mod.main()
+    assert rc == 0
+    # Coverage ledger should still be written so Mechanism A can observe the
+    # candidate→skip transition (vs the pre-fix world where the gate was
+    # neither candidate nor skip — invisible to GATE_COVERAGE_ZERO meta-check).
+    assert ledger_path.exists()
+    entries = [
+        _json.loads(line)
+        for line in ledger_path.read_text().splitlines()
+        if line.strip()
+    ]
+    bi_entries = [e for e in entries if e["gate"] == "BRANCH_ISOLATION_VIOLATION"]
+    assert bi_entries, "BRANCH_ISOLATION_VIOLATION must appear as candidate+skip"
+    assert bi_entries[0]["skipped"] >= 1
+    assert "no_staged_files" in bi_entries[0]["skip_reasons"]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Bug

`scripts/check-state-schema.py:main()` early-returned at `if not files: return 0` BEFORE the BRANCH_ISOLATION_VIOLATION Mode B check block, so commits staging only infra-path files (`scripts/*`, `.claude/shared/*`, `.githooks/*`, etc.) without a state.json **silently bypassed the gate AND the gate-coverage ledger write**.

## Evidence

Empirically witnessed on HADF Phase 2-bis Block A. Commits A3–A11 (9 commits) all staged `scripts/*` and/or `.claude/shared/*` paths without a state.json. Zero `BRANCH_ISOLATION_VIOLATION` entries exist in `.claude/logs/gate-coverage.jsonl` between `2026-05-12T07:58:43Z` (A0 — the last commit that DID stage state.json) and the current diagnostic.

The gate wasn't silent-on-pass — it didn't run at all. Mechanism A's `GATE_COVERAGE_ZERO` meta-check (planned v7.9 enforcer) wouldn't catch this either, because the gate was neither candidate nor skip from its perspective.

## Fix

Reorder `main()` so the Mode B check + gate-coverage ledger write run BEFORE the no-state-files early exit. Mode B fires on infra-path commits regardless of whether state.json is in the staged set, which is the documented intent per [CLAUDE.md "BRANCH_ISOLATION_VIOLATION"](https://github.com/Regevba/FitTracker2/blob/main/CLAUDE.md) section.

- 1 file changed: [`scripts/check-state-schema.py`](scripts/check-state-schema.py) — reordered ~40 lines in `main()`. Extracted a `_persist_coverage_ledger()` closure so both exit paths (early no-files + normal post-validate) emit the ledger consistently.
- 1 file changed: [`scripts/tests/test_branch_isolation_and_closure_completeness.py`](scripts/tests/test_branch_isolation_and_closure_completeness.py) — added 2 regression tests that invoke `main()` with monkey-patched git helpers + a tmp ledger path:
  - `test_main_runs_mode_b_when_only_infra_files_staged`
  - `test_main_skips_mode_b_when_no_files_staged_at_all`

Both tests FAIL on main (pre-fix), PASS post-fix.

## Verification on this PR

The pre-commit hook on the fix commit itself recorded a fresh `BRANCH_ISOLATION_VIOLATION` entry in `gate-coverage.jsonl` at `2026-05-12T14:23:37Z` — the first such entry since `07:58:43Z` despite 10+ infra-touching commits in between. Direct demonstration that the gate now runs on the exact pattern it was silently bypassing.

## Impact

- **Advisory only in v7.8** — no commits were blocked. Functional change in current state: zero.
- **Unblocks v7.9 promotion** — without this fix, promoting BRANCH_ISOLATION_VIOLATION to *enforced* (decision 2026-05-21 per `docs/master-plan/infra-master-plan-2026-05-12.md`) would have 0% effective coverage on scaffolding-style commits, defeating the gate's purpose.
- **No regression risk for non-staged paths** — `mode == "staged"` guard is preserved on the Mode B block; `all` and `explicit` modes don't run Mode B at all (unchanged).
- **No regression for state.json-staged commits** — Mode B previously ran in this path; it still does, with identical semantics.

## Test plan

- [x] 2 new regression tests pass (`test_main_runs_mode_b_when_only_infra_files_staged` + `test_main_skips_mode_b_when_no_files_staged_at_all`)
- [x] 14 pre-existing tests in `test_branch_isolation_and_closure_completeness.py` still pass (16/16)
- [x] `make pre-commit-self-test` passes (16 declared gates all implemented + 14 implemented gates all declared)
- [x] `scripts/check-state-schema.py` full-corpus run: ✓ All 69 state.json files pass all checks
- [x] Pre-commit hook on the fix commit itself successfully invoked the new code path (ledger entry verified)

Note: 8 unrelated pre-existing test failures (`test_check_state_schema.py::test_cache_hits_empty_post_v6_blocks_when_complete`, `test_gate_coverage.py::test_cache_hits_gate_records_*`, `test_validate_tier_tags.py::test_t1_claim_without_ledger_evidence_warns`, etc.) reference the v7.8.3-renamed `CACHE_HITS_EMPTY_POST_V6` gate (now `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT`) + v7.8.4 tier-tag heuristic narrowing — these fail on main too, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)