### PR TITLE
fix(v7.8.5): cache_hits gate-coverage test fixture rot — calibration data verified clean

### DIFF
--- a/scripts/tests/test_gate_coverage.py
+++ b/scripts/tests/test_gate_coverage.py
@@ -158,6 +158,43 @@ def test_write_jsonl_with_no_gates_returns_zero(tmp_path):
 # T3 — gate functions populate coverage on each early-return path
 # ---------------------------------------------------------------------------
 
+# NOTE: the gate function `check_cache_hits_empty_post_v6` retains its legacy
+# Python name (it pre-dates the v7.8.3 rename from CACHE_HITS_EMPTY_POST_V6 →
+# CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT), but its Mechanism A emission key is
+# the canonical NEW name. Tests below assert against the canonical emission key
+# — v7.8.5 fix (2026-05-12) to close the keying-drift suspicion flagged in
+# PR #318 §"Pre-promotion remediation". Production telemetry has been clean
+# since v7.8.3; only the test fixtures referenced the obsolete key.
+
+CACHE_HITS_GATE_KEY = "CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT"
+
+
+def test_cache_hits_gate_emits_canonical_key():
+    """REGRESSION (v7.8.5): the gate function MUST emit to gate-coverage under
+    the canonical CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT key — never the legacy
+    CACHE_HITS_EMPTY_POST_V6 key — regardless of which call path triggers it.
+
+    Catches future rename drift between function-name and emission-key (the
+    class of bug suspected by PR #318 §Pre-promotion remediation, ruled out
+    in v7.8.5 diagnostic).
+    """
+    cov = GateCoverage()
+    state = {
+        "feature_name": "regression",
+        "current_phase": "complete",
+        "created_at": "2026-05-03T00:00:00Z",  # post-Mechanism-C, hits main predicate
+        "cache_hits": [{"key": "x"}],
+    }
+    check_cache_hits_empty_post_v6(state, coverage=cov)
+    assert CACHE_HITS_GATE_KEY in cov.gates, (
+        f"Gate must emit under canonical key {CACHE_HITS_GATE_KEY!r}; "
+        f"got keys: {list(cov.gates.keys())}"
+    )
+    assert "CACHE_HITS_EMPTY_POST_V6" not in cov.gates, (
+        "Legacy key CACHE_HITS_EMPTY_POST_V6 must NOT appear — was renamed in v7.8.3"
+    )
+
+
 def test_cache_hits_gate_records_pre_v6_skip():
     """Pre-v6 feature: skip reason 'pre_v6'."""
     cov = GateCoverage()
@@ -168,7 +205,7 @@ def test_cache_hits_gate_records_pre_v6_skip():
         "cache_hits": [],
     }
     check_cache_hits_empty_post_v6(state, coverage=cov)
-    stats = cov.gates["CACHE_HITS_EMPTY_POST_V6"]
+    stats = cov.gates[CACHE_HITS_GATE_KEY]
     assert stats["candidates"] == 1
     assert stats["checked"] == 0
     assert stats["skipped"] == 1
@@ -185,7 +222,7 @@ def test_cache_hits_gate_records_pre_mechanism_c_skip():
         "cache_hits": [],
     }
     check_cache_hits_empty_post_v6(state, coverage=cov)
-    stats = cov.gates["CACHE_HITS_EMPTY_POST_V6"]
+    stats = cov.gates[CACHE_HITS_GATE_KEY]
     assert stats["skipped"] == 1
     assert stats["skip_reasons"] == {"pre_mechanism_c": 1}
 
@@ -200,7 +237,7 @@ def test_cache_hits_gate_records_not_complete_skip():
         "cache_hits": [],
     }
     check_cache_hits_empty_post_v6(state, coverage=cov)
-    stats = cov.gates["CACHE_HITS_EMPTY_POST_V6"]
+    stats = cov.gates[CACHE_HITS_GATE_KEY]
     assert stats["skipped"] == 1
     assert stats["skip_reasons"] == {"not_complete": 1}
 
@@ -215,7 +252,7 @@ def test_cache_hits_gate_records_checked_when_predicate_runs():
         "cache_hits": [{"key": "x"}],
     }
     check_cache_hits_empty_post_v6(state, coverage=cov)
-    stats = cov.gates["CACHE_HITS_EMPTY_POST_V6"]
+    stats = cov.gates[CACHE_HITS_GATE_KEY]
     assert stats["checked"] == 1
     assert stats["skipped"] == 0
 


### PR DESCRIPTION
## TL;DR

**Diagnostic outcome: case (2) — fixture rot only.** The v7.8 → v7.9 calibration data feeding the 2026-05-21 promotion decision is **NOT corrupted**. PR #318's pre-promotion remediation concern is resolved without further action on the gate or its emission logic.

## Bug class (from PR #318 §Pre-promotion remediation)

`test_gate_coverage.py::test_cache_hits_gate_records_*` (4 tests) raise `KeyError: 'CACHE_HITS_EMPTY_POST_V6'` on origin/main. Three possible causes:

1. **Rename incomplete** — gate function renamed but `coverage.candidate(GATE)` key not updated → emission keyed wrong → calibration data corrupted.
2. **Fixture rot only** — emission fine, tests reference the obsolete key in their assertions.
3. **Coverage instrumentation deleted entirely** — `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` records no Mechanism A telemetry.

## Diagnostic evidence

Read of [`scripts/check-state-schema.py`](scripts/check-state-schema.py):

- L281: gate function is named `check_cache_hits_empty_post_v6()` (legacy Python identifier, retained).
- L308: `GATE = \"CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT\"` — canonical NEW key used for `coverage.candidate(GATE)`.
- L343: finding code `\"CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT\"` — canonical key on emission.

Inspection of [`.claude/logs/gate-coverage.jsonl`](.claude/logs/gate-coverage.jsonl):

- **5 entries** for `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` in the last 7 days (most recent: `2026-05-12T14:22:33Z`, `mode=all`, `candidates=69, checked=14, skipped=55`).
- 175 entries for `CACHE_HITS_EMPTY_POST_V6` are **all historical** (pre-v7.8.3 rename) in the append-only ledger.

**Conclusion: case (2) confirmed.** Production has emitted under the canonical key since v7.8.3 ship. Only the 4 test fixtures referenced the obsolete key.

## Fix

Single file: [`scripts/tests/test_gate_coverage.py`](scripts/tests/test_gate_coverage.py).

- **NEW** `CACHE_HITS_GATE_KEY = \"CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT\"` module constant. Future renames touch one line.
- **4 tests fixed:** `cov.gates[\"CACHE_HITS_EMPTY_POST_V6\"]` → `cov.gates[CACHE_HITS_GATE_KEY]`.
- **NEW** regression test `test_cache_hits_gate_emits_canonical_key` asserts:
  - canonical key IS in `cov.gates` after invoking the gate function
  - legacy `CACHE_HITS_EMPTY_POST_V6` key is NEVER in `cov.gates`
  - catches future drift between Python function-name and Mechanism A emission-key

## Verification

| Surface | Before | After |
|---|---|---|
| `test_gate_coverage.py` | 11 pass / 4 fail | **15/15 pass** (incl. new regression test) |
| `scripts/tests/` full suite | 123 pass / 8 fail | 127 pass / 4 fail (-4 failures) |
| `pre-commit-self-test.py` (Mechanism D) | ✓ | ✓ |
| `gate-coverage.jsonl` canonical key emission | clean | clean (now regression-guarded) |

The 4 remaining failures are unrelated to v7.8.5: 3× `STATE_OWNER_MISSING` fixture-rot from v7.8.3 (synthetic state dicts need `state_owner` added) + 1× intentional v7.8.4 `TIER_TAG_LIKELY_INCORRECT` heuristic narrowing. Tracked separately; not blocking v7.9 promotion.

## Impact on 2026-05-21 promotion decision

**RESOLVED concern from [PR #318](https://github.com/Regevba/FitTracker2/pull/318) §Pre-promotion remediation:** the v7.9 promotion-decision criterion #1 (\"Coverage emitted\") for `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` is honestly evaluable. The 7-day calibration window starting 2026-05-14 will operate on clean data.

**No telemetry backfill needed.** Production emission has been keyed correctly since v7.8.3 ship (2026-05-11). The 5 entries already present cover the period from then through today (2026-05-12).

## What this PR does NOT touch

- Gate function and emission logic — unchanged.
- The 3 `STATE_OWNER_MISSING` + 1 `TIER_TAG` test fixture-rot failures — separate scope (potential v7.8.6 patch or bundle with v7.9).
- The infra master plan §2.4 v7.8.5 description (lives on [PR #319](https://github.com/Regevba/FitTracker2/pull/319) awaiting merge; follow-up to flip \"Case (1)/(2)/(3) triage\" → \"Case (2) confirmed, fix shipped via PR #320\" once #319 lands).

## Test plan

- [x] All 15 `test_gate_coverage.py` tests pass (was 11/15)
- [x] No NEW failures introduced in `scripts/tests/` broader suite (4 → 4 unrelated)
- [x] `pre-commit-self-test.py` Mechanism D check ✓
- [x] Pre-commit hook passes on this commit (canonical key emission recorded in `gate-coverage.jsonl` post-commit)
- [x] Branch isolation gate fires correctly per PR #317's fix (this commit touches `scripts/tests/*`, which matches no infra-path glob — Mode B records skip cleanly)

## Linear

To be filed under FIT-72 v7.9-promotion epic when that's created 2026-05-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)