### PR TITLE
feat(analytics-observability): Phase 1.A.7 — refresh external-sync-status.json (Phase 1.A COMPLETE)

### DIFF
--- a/.claude/features/analytics-observability/state.json
+++ b/.claude/features/analytics-observability/state.json
@@ -212,6 +212,18 @@
         "FitTrackerTests/ImportPersistenceAndAnalyticsTests.swift",
         "FitTrackerTests/AnalyticsTests.swift"
       ]
+    },
+    {
+      "id": "1.A.7",
+      "title": "Refresh external-sync-status.json analytics block",
+      "status": "complete",
+      "phase": "implementation",
+      "started_at": "2026-05-13T17:50:08Z",
+      "completed_at": "2026-05-13T17:50:08Z",
+      "outcome": "Updated 'updated' timestamp + added new analytics_taxonomy_status block reflecting Phase 1.A reality (CSV 112/112, test coverage 100%, 0 unfired iOS events, web events status). Replaced findings array with current Phase 1.A summary. Preserved instrumentation_summary as backward-compat reference (40-metric framework \u2014 separate from event-taxonomy work).",
+      "files_touched": [
+        ".claude/shared/external-sync-status.json"
+      ]
     }
   ],
   "figma_node_ids": {},

--- a/.claude/logs/analytics-observability.log.json
+++ b/.claude/logs/analytics-observability.log.json
@@ -6,7 +6,7 @@
   "current_phase": "prd",
   "framework_version": "v7.8.5",
   "started_at": "2026-05-13T09:00:00Z",
-  "updated_at": "2026-05-13T17:04:49Z",
+  "updated_at": "2026-05-13T17:50:08Z",
   "events": [
     {
       "timestamp": "2026-05-13T09:00:00Z",
@@ -152,6 +152,25 @@
         "coverage_after_pct": 100,
         "events_total": 112,
         "events_tested_after": 112
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-13T17:50:08Z",
+      "event_type": "task_completed",
+      "phase": "prd",
+      "task_id": "1.A.7",
+      "summary": "Phase 1.A.7: refreshed external-sync-status.json analytics block. Added analytics_taxonomy_status section with current Phase 1.A numbers (iOS 112/112 CSV-aligned, 100% test coverage, 0 unfired). Updated 'updated' timestamp from 2026-04-30 to current. Phase 1.A is now COMPLETE \u2014 Phase 2 (live debugger) can begin.",
+      "artifacts": [
+        ".claude/shared/external-sync-status.json"
+      ],
+      "metrics": {
+        "previous_updated": "2026-04-30T05:17:51Z",
+        "now_updated": "2026-05-13T17:50:08Z",
+        "stale_days": 13,
+        "phase_1a_complete": true
       },
       "actor": "claude_opus_4_7",
       "status": "recorded",

--- a/.claude/shared/external-sync-status.json
+++ b/.claude/shared/external-sync-status.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-04-30T05:17:51Z",
+  "updated": "2026-05-13T17:48:36Z",
   "description": "Live external-tool sync snapshot for the FitMe PM framework. Captures the current state of GitHub, Linear, Notion, Vercel, and analytics/observability so the dashboard can compare repo truth against workspace truth without relying on narrative docs alone.",
   "aggregate": {
     "healthy": true,
@@ -330,10 +330,35 @@
         "dashboard_speed_insights_deployed": true
       },
       "findings": [
-        "40 metrics defined, 14 available now (35%). 6 funnel definitions created (onboarding, training, nutrition, home, AI, readiness).",
-        "Remaining 26 metrics blocked by Firebase runtime (GoogleService-Info.plist), Sentry (crash-free rate), and external services.",
-        "Web Analytics and Speed Insights live on Vercel. GA4 event taxonomy in place with screen-prefix naming convention."
-      ]
+        "Phase 1.A (analytics-observability) IN FLIGHT \u2014 refreshed 2026-05-13.",
+        "iOS analytics taxonomy 100% aligned: 112/112 events have CSV rows + 100% test coverage (was 58/114 CSV + 81% tested at audit baseline).",
+        "Web analytics: 7/8 dashboard_* events wired + 1 intentional stub (dashboard_kanban_drag, Wave 1 read-only Kanban). 2/4 design_system_* events wired + 2 forward-declared placeholders ([FORWARD-DECLARED] convention per master plan \u00a75.4).",
+        "GA4 MCP defined but NOT connected \u2014 runtime event firing cannot be mechanically verified. Phase 2 (live debugger) ships GA4 Realtime poll via mcp-server-ga4 + local mirror sink.",
+        "Crash-free rate + Firebase health still 'unknown' \u2014 same root cause (no GA4 MCP, no Sentry MCP wired). Tracked in Phase 2 + master plan \u00a710 risks."
+      ],
+      "analytics_taxonomy_status": {
+        "as_of": "2026-05-13T17:48:36Z",
+        "source_of_truth": "FitTracker/Services/Analytics/AnalyticsProvider.swift (iOS) + fitme-story src/lib/design-system-analytics.ts + control-room/analytics.ts (web)",
+        "ios_enum_events": 112,
+        "ios_csv_rows": 112,
+        "ios_csv_drift_count": 0,
+        "ios_event_test_coverage_pct": 100,
+        "ios_events_unfired_in_production": 0,
+        "ios_screens_in_enum": 42,
+        "ios_screens_in_csv": 42,
+        "ios_user_properties_in_enum": 7,
+        "ios_user_properties_in_csv": 7,
+        "web_dashboard_events_declared": 8,
+        "web_dashboard_events_wired": 7,
+        "web_dashboard_events_stub": 1,
+        "web_design_system_events_declared": 4,
+        "web_design_system_events_wired": 2,
+        "web_design_system_events_forward_declared": 2,
+        "ga4_mcp_connected": false,
+        "ga4_mcp_setup_runbook": "docs/setup/ga4-mcp-setup-guide.md (Phase 2 deliverable)",
+        "forward_declared_convention_spec": "docs/master-plan/analytics-master-plan-2026-05-13.md \u00a75.4"
+      },
+      "instrumentation_summary_note": "instrumentation_summary below reflects PRE-Phase-1.A baseline (40 metrics, 14 available). Phase 1.A focused on event-taxonomy completeness (see analytics_taxonomy_status). The metric-level framework count is updated separately when measurement-adoption tooling re-scans."
     }
   }
 }


### PR DESCRIPTION
## Summary

Final task of Phase 1.A. Closes the audit finding: `external-sync-status.json` was 13 days stale (last `updated: 2026-04-30T05:17:51Z`) and reported pre-Phase-1.A baseline numbers, obscuring the actual Phase 1.A progress.

After this PR, **Phase 1.A is complete**.

## Analytics block changes

### Updated
- `updated`: 2026-04-30 → current

### NEW — `analytics_taxonomy_status` block
Captures current empirical reality from Phase 1.A.1–1.A.6:

| Field | Value | Source |
|---|---|---|
| ios_enum_events | 112 | AnalyticsProvider.swift |
| ios_csv_rows | 112 | analytics-taxonomy.csv flat-scan |
| ios_csv_drift_count | **0** | (was 56 at audit) |
| ios_event_test_coverage_pct | **100** | (was 81%) |
| ios_events_unfired_in_production | **0** | (was 4) |
| ios_screens_in_csv | 42 / 42 | |
| ios_user_properties_in_csv | 7 / 7 | |
| web_dashboard_events_wired | 7 / 8 | 1 stub (kanban_drag) |
| web_design_system_events_wired | 2 / 4 | 2 forward-declared per §5.4 |
| ga4_mcp_connected | **false** | Phase 2 deliverable |

### Refreshed `findings`
3 stale entries → 5 current entries summarizing Phase 1.A status + remaining gaps.

### Preserved
- `instrumentation_summary` (40-metric framework, separate scope) — kept with note flagging pre-Phase-1.A baseline
- `runtime_health` — firebase + crash_free_rate still 'unknown' (Phase 2 work)

## Phase 1.A — COMPLETE after this PR

| Task | Status | PR |
|---|---|---|
| 1.A.1 CSV backfill (49 events + 7 screens + 1 user prop) | ✅ | [#334](https://github.com/Regevba/FitTracker2/pull/334) |
| 1.A.2 Screens + user prop | ✅ rolled into 1.A.1 | #334 |
| 1.A.3 Delete unfired iOS events | ✅ | [#335](https://github.com/Regevba/FitTracker2/pull/335) |
| 1.A.4 Forward-declared web events convention | ✅ | [#336](https://github.com/Regevba/FitTracker2/pull/336) + fitme-story [#104](https://github.com/Regevba/fitme-story/pull/104) |
| 1.A.5 iOS test coverage 100% | ✅ | [#338](https://github.com/Regevba/FitTracker2/pull/338) |
| 1.A.6 fitme-story .env.example | ✅ | fitme-story [#105](https://github.com/Regevba/fitme-story/pull/105) |
| **1.A.7 Refresh external-sync-status.json** | **🟡 this PR** | this PR |

## Phase 2 unlocks after this merges

Per master plan §6 (live debugger): local mirror sink + `/analytics watch` CLI + GA4 Realtime poll via MCP. Window: 2026-05-15 → 22 (parallel with end of Phase 1.A).

## Verification

- [x] `make schema-check` → 70/70 state.json clean
- [x] state.json: tasks[] entry for 1.A.7
- [x] log: task_completed event with `phase_1a_complete: true` flag
- [ ] CI green

## Spec reference

[`docs/master-plan/analytics-master-plan-2026-05-13.md`](docs/master-plan/analytics-master-plan-2026-05-13.md) §5.1 task 1.A.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)