### PR TITLE
feat(integrity): W9 branch-drift detection + real-time alert hook

### DIFF
--- a/.claude/integrity/observed-patterns.md
+++ b/.claude/integrity/observed-patterns.md
@@ -513,6 +513,99 @@ Non-gate patterns: situations where operator action (or inaction) causes confusi
 
 ---
 
+### W9 — Branch drift from concurrent-session `git checkout` collision (DETECTED + REAL-TIME ALERTED)
+
+**Pattern:** Your session creates a chore/feature branch and starts work. Between tool calls, ANOTHER concurrent Claude session running in the **same** working directory executes `git checkout <other-branch>`. Git's working tree has a single HEAD, so YOUR session's HEAD flips silently too. Your next `git commit` lands on the wrong branch (the one the other session selected), not the one you intended.
+
+**Symptom signatures (any one is sufficient):**
+- `git log --oneline -1` after a commit shows it landed on a branch you don't recognize as yours this session.
+- `gh pr create` errors with "head branch \"main\" is the same as base branch \"main\", cannot create a pull request" because gh's default `--head` resolution disagrees with your intended branch.
+- The `gh pr merge` output says "Branch: main" but your next `git status` shows you on a `feature/<something-else>` branch.
+- You ran `git checkout main` minutes ago, did NOT run another checkout, but `git branch --show-current` now reports a different branch.
+
+**Distinguishing real signal:** Always real. There is no "false positive" interpretation — if HEAD changed and you did NOT run `git checkout` / `git switch` / `git branch -b` in YOUR Bash calls, another process flipped it. The only ambiguity is whether the other process was a concurrent Claude session OR a manual operator `git` command from a different shell.
+
+**Detection — real-time alert (added 2026-05-13, this session):**
+
+Every `PostToolUse:Bash` hook now invokes [`scripts/check-branch-drift.py`](../../scripts/check-branch-drift.py), which:
+
+1. Records the current branch in `.claude/_session-state/<CLAUDE_SESSION_ID>-branch.txt` on first invocation
+2. On every subsequent Bash, re-reads current branch + compares to recorded value
+3. If they differ → emits a LOUD warning to stderr (surfaced back to the assistant via tool output):
+
+   ```text
+   ⚠️  BRANCH DRIFT DETECTED (W9 pattern)  ⚠️
+      Expected branch: <previous>
+      Current branch:  <new>
+
+      Cause: another concurrent Claude session likely ran `git checkout`
+      in this same working directory, flipping HEAD.
+
+      Resolution:
+      1. STOP — do not commit unless you intended this branch.
+      2. To recover: git checkout <expected>
+         If you have uncommitted work: git stash push -u first
+         If you have committed on the wrong branch: cherry-pick to <expected>
+
+      Full playbook: .claude/integrity/observed-patterns.md (W9)
+   ```
+
+4. The recorded baseline is updated to the NEW branch — so the warning fires ONCE per drift event, not on every subsequent Bash.
+
+**Silence + bypass:**
+- Disable temporarily: `CLAUDE_W9_DISABLE_DRIFT_CHECK=1` in env
+- After confirming the drift was intentional (e.g., YOU ran `git checkout`): the warning fires once, then quiets down because state file is updated
+- Permanently disable: remove the `Bash` matcher block from `.claude/settings.json::hooks.PostToolUse`
+
+**Recovery playbook (when alert fires):**
+
+```bash
+# STEP 1 — STOP. Do not commit unless you intended to be on this branch.
+
+# STEP 2 — Inspect the situation:
+git status              # what's in the index?
+git log --oneline -3    # what's the recent history?
+
+# STEP 3a — If you have UNCOMMITTED work:
+git stash push -u -m "wip-recovery-$(date +%Y%m%d-%H%M)"
+git checkout <expected>
+git stash pop           # OR leave stashed if work belongs on the other branch
+
+# STEP 3b — If you ALREADY committed on the wrong branch:
+# Find your commit SHA via: git log --oneline -1
+git checkout <expected>
+git cherry-pick <wrong-branch-commit-SHA>
+# Optionally reset the wrong branch to drop your commit:
+git branch -f <wrong-branch> <wrong-branch>~1
+
+# STEP 4 — Push + open PR with explicit --head to bypass any gh default mismatch:
+git push -u origin <expected>
+gh pr create --head <expected> --base main --title "..." --body "..."
+```
+
+**Prevention — strongly recommended for multi-agent operators:**
+
+The ONLY robust prevention is to give each concurrent session its own git worktree. Sharing one working directory across N concurrent Claude sessions is a footgun.
+
+```bash
+# Each agent session does this on startup instead of working in the shared tree:
+git worktree add ../FitTracker2-<unique-task-slug>
+cd ../FitTracker2-<unique-task-slug>
+# Now your HEAD is independent of the main tree's HEAD
+```
+
+The framework already supports this via `scripts/create-isolated-worktree.py` (used by `BRANCH_ISOLATION_VIOLATION` Mode C auto-isolation). Multi-agent operators should make worktree creation the default for any session that intends to commit.
+
+**First observed:** 2026-05-13 across three separate sessions today (analytics spec completion → spec planning batch → this very session creating W9). Hit the same pattern three times in one day. Detection script + real-time alert hook shipped this session to ensure it never costs investigative time again.
+
+**Files involved:**
+- Detection script: [`scripts/check-branch-drift.py`](../../scripts/check-branch-drift.py)
+- Hook registration: [`.claude/settings.json`](../../.claude/settings.json) (PostToolUse:Bash matcher)
+- Session state (gitignored): `.claude/_session-state/<SESSION_ID>-branch.txt`
+- Worktree prevention: [`scripts/create-isolated-worktree.py`](../../scripts/create-isolated-worktree.py)
+
+---
+
 ## Pattern submission template
 
 When you discover a NEW pattern (gate fires + no matching entry above), add it here.
@@ -572,6 +665,7 @@ Commit the new entry on a `chore/document-pattern-<slug>` branch + open PR + mer
 | W6 Measurement impartiality | W6 | — |
 | W7 Approval gates multi-part | W7 | — |
 | W8 Audit status is UI marker | W8 | — |
+| W9 Branch-drift from concurrent-session collision (DETECTED via PostToolUse:Bash hook) | W9 | 2026-05-13 |
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -201,6 +201,16 @@
             "command": "[ -f scripts/observe-cache-hit.py ] && python3 scripts/observe-cache-hit.py || true"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "_comment": "W9 pattern (added 2026-05-13): branch-drift detection. Catches the active-feature checkout-collision pattern where another concurrent Claude session sharing this working directory runs `git checkout` and flips THIS session's HEAD. Emits loud stderr warning on drift; surfaces back to assistant via tool output → assistant can flag to user in real time. Silent no-op when script absent (cross-repo guard). Disable with CLAUDE_W9_DISABLE_DRIFT_CHECK=1. Full pattern + playbook: .claude/integrity/observed-patterns.md W9.",
+            "command": "[ -f scripts/check-branch-drift.py ] && python3 scripts/check-branch-drift.py || true"
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/pm-workflow/SKILL.md
+++ b/.claude/skills/pm-workflow/SKILL.md
@@ -17,6 +17,18 @@ When investigation surfaces a NEW pattern not yet in the catalog, **document it 
 
 CLI: `make observed-patterns` prints the catalog. Cross-referenced from `.claude/integrity/README.md` § Expected false-positives.
 
+### Branch-drift safety (W9, added 2026-05-13) — real-time alert wired
+
+A `PostToolUse:Bash` hook ([`scripts/check-branch-drift.py`](../../../scripts/check-branch-drift.py)) detects when the current git branch has changed unexpectedly between tool calls within a session — typically caused by **another concurrent Claude session sharing the same working directory** running `git checkout`. The hook emits a LOUD stderr warning on drift; the warning is surfaced back to the assistant via tool output so it can be flagged to the operator in real time.
+
+**When the alert fires during this protocol run:**
+
+1. STOP. Do not commit until you've decided whether the drift was intentional.
+2. If the drift was unintentional → follow the W9 recovery playbook in [`observed-patterns.md`](../../integrity/observed-patterns.md) §W9 (stash + checkout-back + cherry-pick if needed).
+3. If the drift was intentional (you actually wanted to switch) → no action; the hook's internal state has already re-baselined to the new branch.
+
+**Prevention for multi-agent operators:** use isolated git worktrees (`scripts/create-isolated-worktree.py`) — each concurrent session gets its own HEAD so they cannot collide. This is the only robust prevention.
+
 ## Skill Loading Protocol (v5.1 — On-Demand + Model Tiering)
 
 Before starting any phase, check `.claude/shared/skill-routing.json` → `phase_skills` for the current phase. Load ONLY the listed SKILL.md files — do NOT load all 11 skills.

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ Config/Local/*.xcconfig
 # (which IS committed for path stability).
 .claude/shared/hadf/phase2bis-deploy-verification/
 .cache/
+.claude/_session-state/

--- a/scripts/check-branch-drift.py
+++ b/scripts/check-branch-drift.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Branch-drift detector — W9 pattern from `.claude/integrity/observed-patterns.md`.
+
+Runs as a PostToolUse:Bash hook. Detects when the current git branch has
+changed unexpectedly between tool invocations within a single Claude session.
+
+Root cause this catches:
+    Another concurrent Claude session sharing the same git working directory
+    runs `git checkout`, flipping THIS session's HEAD. The current session's
+    next `git commit` lands on the wrong branch.
+
+How it works:
+    1. On first invocation, record current branch to a session-state file.
+    2. On subsequent invocations, compare current branch to the recorded one.
+    3. If they differ:
+       - emit a LOUD warning to stderr (which the harness surfaces back to
+         the assistant via tool output), so the assistant can flag to the
+         user IN REAL TIME
+       - update the recorded baseline to the NEW branch, so subsequent
+         intentional operations on the new branch don't keep re-firing
+    4. Exit 0 always — this is informational, never blocks the tool call.
+
+Output format (stderr):
+    ⚠️ BRANCH DRIFT DETECTED ⚠️
+    Expected: <prev>
+    Current:  <new>
+    Recovery: see W9 in .claude/integrity/observed-patterns.md
+
+Resolution recipe (printed at every fire):
+    1. STOP — do NOT commit on the new branch unless you intended to be there.
+    2. SAVE your work-in-progress:
+         git stash push -u -m "wip-recovery-<date>"
+       OR commit on the current (wrong) branch and cherry-pick out later.
+    3. Switch back to the expected branch:
+         git checkout <expected>
+    4. If you committed already, cherry-pick from the wrong branch:
+         git cherry-pick <wrong-branch-tip-SHA>
+       then reset the wrong branch:
+         git checkout <wrong-branch> && git reset --hard <pre-collision-SHA>
+
+Prevention recipe:
+    Each concurrent session should use its own git worktree:
+      git worktree add ../FitTracker2-w9-test feature/my-work
+    See .claude/integrity/observed-patterns.md W9 for full prevention rules.
+
+Configuration:
+    - Disabled when CLAUDE_W9_DISABLE_DRIFT_CHECK=1 in env
+    - Session state stored at .claude/_session-state/<sessionid>-branch.txt
+      (gitignored; pruned per session)
+
+Exit codes:
+    0 = always (do not block tool calls; this is observational telemetry)
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SESSION_STATE_DIR = REPO_ROOT / ".claude" / "_session-state"
+SESSION_ID = os.environ.get("CLAUDE_SESSION_ID", "default")
+STATE_FILE = SESSION_STATE_DIR / f"{SESSION_ID}-branch.txt"
+
+
+def current_branch() -> str | None:
+    """Return current branch name, or None if not in a git repo / detached."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+        branch = result.stdout.strip()
+        return branch if branch else None
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+
+
+def main() -> int:
+    if os.environ.get("CLAUDE_W9_DISABLE_DRIFT_CHECK") == "1":
+        return 0
+
+    branch = current_branch()
+    if not branch:
+        # Detached HEAD or not in a repo — nothing useful to compare
+        return 0
+
+    SESSION_STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not STATE_FILE.exists():
+        STATE_FILE.write_text(branch + "\n")
+        return 0
+
+    expected = STATE_FILE.read_text().strip()
+    if expected == branch:
+        return 0
+
+    # DRIFT DETECTED — emit loud warning to stderr.
+    # The harness surfaces stderr to the assistant via tool result output.
+    print("", file=sys.stderr)
+    print("⚠️  BRANCH DRIFT DETECTED (W9 pattern)  ⚠️", file=sys.stderr)
+    print(f"   Expected branch: {expected}", file=sys.stderr)
+    print(f"   Current branch:  {branch}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("   Cause: another concurrent Claude session likely ran `git checkout`", file=sys.stderr)
+    print("   in this same working directory, flipping HEAD.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("   Resolution:", file=sys.stderr)
+    print("   1. STOP — do not commit unless you intended this branch.", file=sys.stderr)
+    print(f"   2. To recover: git checkout {expected}", file=sys.stderr)
+    print(f"      If you have uncommitted work: git stash push -u first", file=sys.stderr)
+    print(f"      If you have committed on the wrong branch: cherry-pick to {expected}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("   Full playbook: .claude/integrity/observed-patterns.md (W9)", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    # Update the state to current to avoid spamming on subsequent calls
+    STATE_FILE.write_text(branch + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the **active-feature checkout-collision pattern** that hit this session **3 times today** (analytics spec completion + spec planning batch + this very session's branch creation). Ships a real-time detector that fires a loud warning on stderr the moment drift happens — surfaced back to the assistant via tool output so it can be flagged to the operator in real time.

## Root cause

Multiple concurrent Claude sessions share the same git working directory. When session B runs `git checkout feature/X`, session A's HEAD flips silently too (git working-tree HEAD is shared). Session A's next `git commit` lands on `feature/X` not its intended branch.

## Deliverables

| File | What |
|---|---|
| `scripts/check-branch-drift.py` | PostToolUse:Bash detector — records baseline per session, emits LOUD warning on drift, updates baseline after firing once (no spam) |
| `.claude/settings.json` | New PostToolUse:Bash hook matcher invokes the detector (cwd-guarded for cross-repo asymmetry) |
| `.claude/integrity/observed-patterns.md` | New W9 entry — trigger / symptoms / detection / 4-step recovery / prevention via worktrees |
| `.claude/skills/pm-workflow/SKILL.md` | Preflight section extended with W9 alert decision tree |
| `.gitignore` | `.claude/_session-state/` ephemeral per-session state |

## How the real-time alert works

```text
session A: git checkout chore/A     # state file records "chore/A"
session A: <Edit some file>
session B (different terminal/agent): git checkout feature/B
session A: <Bash any command>       # hook fires:
                                    # ⚠️ BRANCH DRIFT DETECTED ⚠️
                                    # Expected: chore/A
                                    # Current:  feature/B
                                    # + 4-step recovery instructions
```

The warning goes to stderr, which the harness surfaces in the next tool result. The assistant sees it and can flag to the operator immediately, before the wrong-branch commit happens.

## Smoke-test results

- ✅ First invocation on chore branch → silent + records baseline
- ✅ Second invocation same branch → silent
- ✅ Simulated drift (state file edit) → LOUD warning + 4-step recovery
- ✅ State file updated post-warning → no repeat on next Bash
- ✅ Exit code 0 always (never blocks)
- ✅ Disable via `CLAUDE_W9_DISABLE_DRIFT_CHECK=1`

## Calibration-window compliance

- ❌ No new write-time gates
- ❌ No state.json schema changes
- ❌ No telemetry-affecting code
- ✅ Purely observational hook + workflow pattern documentation
- ✅ No impact on 2026-05-21 v7.9 promotion data

## Test plan

- [x] Detector script syntax-valid + executable
- [x] Settings.json parses + new hook registered alongside existing Read hook
- [x] integrity-check still passes (0 findings + 4 advisories)
- [x] Pattern catalog updated with full playbook + cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)