### PR TITLE
feat(analytics-observability): Phase 2.A.1 — local analytics mirror SSE server

### DIFF
--- a/.claude/features/analytics-observability/state.json
+++ b/.claude/features/analytics-observability/state.json
@@ -2,7 +2,7 @@
   "name": "analytics-observability",
   "state_owner": "ft2",
   "framework_version": "v7.8.5",
-  "current_phase": "prd",
+  "current_phase": "implementation",
   "work_type": "Feature",
   "has_ui": true,
   "requires_analytics": true,
@@ -224,6 +224,19 @@
       "files_touched": [
         ".claude/shared/external-sync-status.json"
       ]
+    },
+    {
+      "id": "2.A.1",
+      "title": "Local analytics mirror SSE server (Phase 2 begins)",
+      "status": "complete",
+      "phase": "implementation",
+      "started_at": "2026-05-13T18:11:44Z",
+      "completed_at": "2026-05-13T18:11:44Z",
+      "outcome": "New scripts/analytics-watch-server.py (stdlib-only, no pip deps). HTTP/SSE design: POST /event, GET /stream (SSE), GET /health. iOS uses URLSession SSE; browser uses EventSource. Tests at scripts/tests/test_analytics_watch_server.py: 7/7 pass \u2014 health/POST/SSE/sequence/subscriber-count/404/JSON-validation. Server listens on localhost:8765 by default. Phase 2 (live debugger) begins.",
+      "files_touched": [
+        "scripts/analytics-watch-server.py",
+        "scripts/tests/test_analytics_watch_server.py"
+      ]
     }
   ],
   "figma_node_ids": {},
@@ -239,7 +252,11 @@
         "ended_at": "2026-05-13T13:00:00Z"
       },
       "prd": {
-        "started_at": "2026-05-13T13:00:00Z"
+        "started_at": "2026-05-13T13:00:00Z",
+        "ended_at": "2026-05-13T18:11:44Z"
+      },
+      "implementation": {
+        "started_at": "2026-05-13T18:11:44Z"
       }
     }
   }

--- a/.claude/logs/analytics-observability.log.json
+++ b/.claude/logs/analytics-observability.log.json
@@ -3,10 +3,10 @@
   "feature": "analytics-observability",
   "title": "Analytics Observability",
   "work_type": "Feature",
-  "current_phase": "prd",
+  "current_phase": "implementation",
   "framework_version": "v7.8.5",
   "started_at": "2026-05-13T09:00:00Z",
-  "updated_at": "2026-05-13T17:50:08Z",
+  "updated_at": "2026-05-13T18:27:35Z",
   "events": [
     {
       "timestamp": "2026-05-13T09:00:00Z",
@@ -171,6 +171,59 @@
         "now_updated": "2026-05-13T17:50:08Z",
         "stale_days": 13,
         "phase_1a_complete": true
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-13T18:27:35Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "[bumped 2026-05-13T18:27:35Z] Phase 2 (live debugger) opens. Task 2.A.1 shipped: SSE mirror server at scripts/analytics-watch-server.py + 7 tests. Stdlib-only (no pip deps). Phase transition prd -> implementation.",
+      "artifacts": [
+        "scripts/analytics-watch-server.py",
+        "scripts/tests/test_analytics_watch_server.py"
+      ],
+      "metrics": {
+        "new_scripts": 1,
+        "new_tests": 7,
+        "test_results": "7/7 pass"
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-13T18:11:44Z",
+      "event_type": "task_completed",
+      "phase": "implementation",
+      "task_id": "2.A.1",
+      "summary": "Phase 2.A.1: scripts/analytics-watch-server.py + tests merged. Stdlib HTTP+SSE; localhost:8765 default; POST /event, GET /stream, GET /health.",
+      "artifacts": [
+        "scripts/analytics-watch-server.py",
+        "scripts/tests/test_analytics_watch_server.py"
+      ],
+      "metrics": {
+        "tests_pass": "7/7"
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-13T18:26:43Z",
+      "event_type": "task_completed",
+      "phase": "implementation",
+      "task_id": "2.A.1",
+      "summary": "Phase 2.A.1: SSE mirror server + 7 tests recovered onto isolated worktree (orphan recovery from parallel-agent branch-context collision in canonical worktree). 7/7 tests pass.",
+      "artifacts": [
+        "scripts/analytics-watch-server.py",
+        "scripts/tests/test_analytics_watch_server.py"
+      ],
+      "metrics": {
+        "tests_pass": "7/7",
+        "recovery_via": "isolated worktree"
       },
       "actor": "claude_opus_4_7",
       "status": "recorded",

--- a/scripts/analytics-watch-server.py
+++ b/scripts/analytics-watch-server.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Local analytics mirror — Server-Sent Events sink for FitMe iOS + fitme-story web.
+
+Phase 2.A.1 of `analytics-observability` per
+docs/master-plan/analytics-master-plan-2026-05-13.md §6.
+
+PURPOSE
+-------
+While the iOS app (or fitme-story dev server) runs locally with the
+`DEBUG_ANALYTICS=1` env flag set, every analytics event the app fires
+is teed to this server in addition to the production path (FirebaseAnalytics
+or window.gtag). The `/analytics watch` CLI connects to the SSE stream and
+prints events in real time, eliminating the round-trip through GA4 Realtime
+for dev iteration.
+
+ARCHITECTURE
+------------
+HTTP server on localhost:8765 (configurable via --port). Three endpoints:
+
+    POST /event       — Receive a single analytics event (JSON body)
+    GET  /stream      — Server-Sent Events stream of all events
+    GET  /health      — Health JSON: {status, events_received, subscribers}
+
+Each event is a JSON dict; we add a server-side `received_at` timestamp.
+
+USAGE
+-----
+    python3 scripts/analytics-watch-server.py [--port 8765] [--bind 127.0.0.1]
+
+The server is INTENDED FOR LOCAL DEVELOPMENT ONLY. It does not authenticate
+clients, does not enforce HTTPS, and binds to loopback by default. Never
+expose to the public internet.
+
+WHY NOT WEBSOCKETS
+------------------
+The `websockets` package is not in stdlib. SSE gives real-time push using
+only stdlib `http.server`. iOS has native SSE support via URLSession with
+`text/event-stream`; browsers have `EventSource`. Plain HTTP POST for the
+event ingress keeps client code trivially small.
+
+NOT PRODUCTION CODE
+-------------------
+This server runs in the operator's local dev environment only. Events still
+go to GA4 in production via FirebaseAnalyticsAdapter / window.gtag — the
+mirror is a passive tee, not a replacement.
+"""
+from __future__ import annotations
+
+import argparse
+import http.server
+import json
+import queue
+import signal
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+
+# Global state. Single-process server; concurrency via threading.
+_event_lock = threading.Lock()
+_total_events_received = 0
+_subscribers: list[queue.Queue[dict[str, Any]]] = []
+_subscribers_lock = threading.Lock()
+_shutdown_event = threading.Event()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _broadcast(event: dict[str, Any]) -> None:
+    """Push a received event to every active SSE subscriber queue."""
+    with _subscribers_lock:
+        # Iterate over a copy so disconnects mid-loop don't break iteration
+        for q in list(_subscribers):
+            try:
+                q.put_nowait(event)
+            except queue.Full:
+                # Slow subscriber — drop the event for this subscriber rather
+                # than block all others.
+                pass
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    # Reduce default access-log noise; we'll print our own concise lines.
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+    # ------------------------------------------------------------------
+    def do_GET(self) -> None:  # noqa: N802  (BaseHTTPRequestHandler API)
+        if self.path == "/health":
+            return self._handle_health()
+        if self.path == "/stream":
+            return self._handle_stream()
+        self.send_error(404, "Not Found")
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/event":
+            return self._handle_event_post()
+        self.send_error(404, "Not Found")
+
+    # ------------------------------------------------------------------
+    def _handle_health(self) -> None:
+        with _subscribers_lock:
+            sub_count = len(_subscribers)
+        payload = json.dumps({
+            "status": "ok",
+            "events_received": _total_events_received,
+            "subscribers": sub_count,
+            "server_time_utc": _iso_now(),
+        }).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    # ------------------------------------------------------------------
+    def _handle_event_post(self) -> None:
+        global _total_events_received
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0 or length > 64 * 1024:
+            self.send_error(400, "Content-Length missing or > 64 KiB")
+            return
+        try:
+            body = self.rfile.read(length).decode("utf-8")
+            event = json.loads(body)
+            if not isinstance(event, dict):
+                raise ValueError("Event payload must be a JSON object")
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            self.send_error(400, f"Invalid JSON body: {exc}")
+            return
+
+        event.setdefault("received_at", _iso_now())
+        with _event_lock:
+            _total_events_received += 1
+            event["sequence"] = _total_events_received
+        _broadcast(event)
+
+        body_out = json.dumps({"ok": True, "sequence": event["sequence"]}).encode("utf-8")
+        self.send_response(202)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body_out)))
+        self.end_headers()
+        self.wfile.write(body_out)
+
+    # ------------------------------------------------------------------
+    def _handle_stream(self) -> None:
+        """Server-Sent Events stream. Holds the connection open until either
+        the client disconnects or the server is shut down."""
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        # Allow `EventSource` from any localhost origin
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+
+        q: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=1024)
+        with _subscribers_lock:
+            _subscribers.append(q)
+
+        # Initial comment-line so EventSource immediately sees data and opens
+        # the stream. SSE clients ignore lines starting with ":".
+        try:
+            self.wfile.write(b": connected\n\n")
+            self.wfile.flush()
+
+            while not _shutdown_event.is_set():
+                try:
+                    event = q.get(timeout=15.0)
+                except queue.Empty:
+                    # Periodic heartbeat so middleboxes don't close idle conns
+                    try:
+                        self.wfile.write(b": heartbeat\n\n")
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError):
+                        return
+                    continue
+
+                data = json.dumps(event, default=str)
+                try:
+                    self.wfile.write(f"data: {data}\n\n".encode("utf-8"))
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+        finally:
+            with _subscribers_lock:
+                if q in _subscribers:
+                    _subscribers.remove(q)
+
+
+class _ThreadingServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+
+
+def _make_server(bind: str, port: int) -> _ThreadingServer:
+    return _ThreadingServer((bind, port), _Handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Local analytics mirror SSE sink — Phase 2.A.1 (analytics-observability)"
+    )
+    parser.add_argument("--port", type=int, default=8765, help="TCP port (default: 8765)")
+    parser.add_argument("--bind", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--quiet", action="store_true", help="Suppress startup banner")
+    args = parser.parse_args(argv)
+
+    try:
+        server = _make_server(args.bind, args.port)
+    except OSError as exc:
+        sys.stderr.write(f"error: cannot bind to {args.bind}:{args.port} — {exc}\n")
+        return 1
+
+    if not args.quiet:
+        sys.stderr.write(
+            f"analytics-watch-server listening on http://{args.bind}:{args.port}\n"
+            f"  POST /event   — submit a JSON event\n"
+            f"  GET  /stream  — SSE stream of events\n"
+            f"  GET  /health  — health JSON\n"
+            f"press Ctrl-C to stop\n"
+        )
+
+    def _on_signal(_signum: int, _frame: Any) -> None:
+        _shutdown_event.set()
+        # Schedule shutdown on a separate thread; shutdown() must not be called
+        # from a handler running inside the server's own thread.
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_analytics_watch_server.py
+++ b/scripts/tests/test_analytics_watch_server.py
@@ -1,0 +1,233 @@
+"""Tests for `scripts/analytics-watch-server.py` — Phase 2.A.1 of
+analytics-observability per docs/master-plan/analytics-master-plan-2026-05-13.md.
+
+End-to-end shape: spin the server on a free port, POST an event, verify
+(a) the POST returns 202 + sequence number, (b) the SSE /stream sees the
+event, (c) /health reflects the counter.
+
+The tests use only stdlib (`http.client`, `threading`, `socket`, `pytest`).
+"""
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "analytics-watch-server.py"
+
+
+def _import_server_module():
+    """Load `analytics-watch-server.py` as a module (hyphen-safe via importlib)."""
+    spec = importlib.util.spec_from_file_location("analytics_watch_server", SCRIPT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _free_port() -> int:
+    """Return an OS-assigned free TCP port (close socket before caller binds)."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture
+def server():
+    """Start the server on a free port; tear down on test exit."""
+    mod = _import_server_module()
+    # Reset module-level counters for test isolation
+    mod._total_events_received = 0
+    with mod._subscribers_lock:
+        mod._subscribers.clear()
+    mod._shutdown_event.clear()
+
+    port = _free_port()
+    srv = mod._make_server("127.0.0.1", port)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    # Wait briefly for /health to respond — confirms ready
+    for _ in range(50):
+        try:
+            c = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+            c.request("GET", "/health")
+            r = c.getresponse()
+            r.read()
+            c.close()
+            if r.status == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(0.02)
+    else:
+        srv.shutdown()
+        srv.server_close()
+        pytest.fail("Server did not become healthy in 1s")
+
+    yield ("127.0.0.1", port, mod, srv)
+    srv.shutdown()
+    srv.server_close()
+    t.join(timeout=1.0)
+
+
+def _post_event(host: str, port: int, event: dict) -> dict:
+    body = json.dumps(event).encode("utf-8")
+    c = http.client.HTTPConnection(host, port, timeout=2.0)
+    c.request(
+        "POST",
+        "/event",
+        body=body,
+        headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+    )
+    r = c.getresponse()
+    out = json.loads(r.read().decode("utf-8"))
+    c.close()
+    assert r.status == 202, f"Expected 202, got {r.status}: {out}"
+    return out
+
+
+def _get_health(host: str, port: int) -> dict:
+    c = http.client.HTTPConnection(host, port, timeout=1.0)
+    c.request("GET", "/health")
+    r = c.getresponse()
+    body = json.loads(r.read().decode("utf-8"))
+    c.close()
+    assert r.status == 200
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_health_endpoint_initially_empty(server):
+    host, port, _mod, _srv = server
+    h = _get_health(host, port)
+    assert h["status"] == "ok"
+    assert h["events_received"] == 0
+    assert h["subscribers"] == 0
+
+
+def test_post_event_increments_sequence(server):
+    host, port, _mod, _srv = server
+    r1 = _post_event(host, port, {"event_name": "test_event", "params": {"x": 1}})
+    r2 = _post_event(host, port, {"event_name": "test_event_2"})
+    assert r1["sequence"] == 1
+    assert r2["sequence"] == 2
+    h = _get_health(host, port)
+    assert h["events_received"] == 2
+
+
+def test_post_event_rejects_non_object(server):
+    host, port, _mod, _srv = server
+    c = http.client.HTTPConnection(host, port, timeout=1.0)
+    body = b"[1, 2, 3]"
+    c.request("POST", "/event", body=body, headers={"Content-Length": str(len(body))})
+    r = c.getresponse()
+    r.read()
+    c.close()
+    assert r.status == 400
+
+
+def test_post_event_rejects_invalid_json(server):
+    host, port, _mod, _srv = server
+    c = http.client.HTTPConnection(host, port, timeout=1.0)
+    body = b"this is not json"
+    c.request("POST", "/event", body=body, headers={"Content-Length": str(len(body))})
+    r = c.getresponse()
+    r.read()
+    c.close()
+    assert r.status == 400
+
+
+def test_sse_stream_receives_posted_event(server):
+    """The end-to-end happy path: open a stream, POST an event, see it on stream."""
+    host, port, _mod, _srv = server
+
+    received: list[dict] = []
+    stop = threading.Event()
+
+    def _reader():
+        c = http.client.HTTPConnection(host, port, timeout=5.0)
+        c.request("GET", "/stream")
+        r = c.getresponse()
+        assert r.status == 200
+        assert r.getheader("Content-Type", "").startswith("text/event-stream")
+        # Read the SSE feed line-by-line until we get an event or stop
+        while not stop.is_set():
+            line = r.fp.readline().decode("utf-8")
+            if not line:
+                break
+            if line.startswith("data: "):
+                received.append(json.loads(line[6:].strip()))
+                if len(received) >= 1:
+                    break
+        c.close()
+
+    t = threading.Thread(target=_reader, daemon=True)
+    t.start()
+    # Give the reader time to register as subscriber
+    time.sleep(0.15)
+    # Verify the subscriber registered
+    h = _get_health(host, port)
+    assert h["subscribers"] >= 1
+
+    _post_event(host, port, {"event_name": "stream_test", "params": {"value": 42}})
+
+    t.join(timeout=2.0)
+    stop.set()
+
+    assert len(received) == 1
+    ev = received[0]
+    assert ev["event_name"] == "stream_test"
+    assert ev["params"] == {"value": 42}
+    assert ev["sequence"] == 1
+    assert "received_at" in ev
+
+
+def test_health_reports_active_subscriber_count(server):
+    host, port, _mod, _srv = server
+    stop = threading.Event()
+    started = threading.Event()
+
+    def _hold_stream():
+        c = http.client.HTTPConnection(host, port, timeout=5.0)
+        c.request("GET", "/stream")
+        r = c.getresponse()
+        started.set()
+        # Hold connection until stop set
+        while not stop.is_set():
+            line = r.fp.readline()
+            if not line:
+                break
+        c.close()
+
+    t = threading.Thread(target=_hold_stream, daemon=True)
+    t.start()
+    started.wait(timeout=2.0)
+    time.sleep(0.15)  # let subscriber register
+    h = _get_health(host, port)
+    assert h["subscribers"] >= 1, f"Expected at least 1 subscriber, got {h}"
+    stop.set()
+
+
+def test_unknown_endpoint_returns_404(server):
+    host, port, _mod, _srv = server
+    c = http.client.HTTPConnection(host, port, timeout=1.0)
+    c.request("GET", "/nonexistent")
+    r = c.getresponse()
+    r.read()
+    c.close()
+    assert r.status == 404


### PR DESCRIPTION
## Summary

Opens **Phase 2 (live debugger)** of analytics-observability. Phase 1.A shipped clean (CSV aligned + tests 100% + sync-status refreshed); this PR adds the local-mirror sink so the operator can observe events in real time while iOS / fitme-story runs locally.

## What ships

### [`scripts/analytics-watch-server.py`](scripts/analytics-watch-server.py) — ~245 lines, stdlib-only
HTTP + Server-Sent Events server. Binds 127.0.0.1:8765 by default.

| Endpoint | Purpose |
|---|---|
| `POST /event` | Accept one JSON event per request |
| `GET /stream` | SSE stream of all events |
| `GET /health` | JSON: `{status, events_received, subscribers, server_time_utc}` |

**Design:**
- Stdlib only — no `websockets` pip dep. `http.server.ThreadingHTTPServer` + manual SSE (`text/event-stream`).
- iOS clients: native SSE via `URLSession`. Browsers: native `EventSource`.
- Each subscriber gets a bounded queue (1024) — slow subscribers drop their own events but don't block others.
- 15-second heartbeat (`: heartbeat`) keeps idle streams alive past middlebox timeouts.
- Loopback-only bind; never exposes to public internet.
- SIGINT/SIGTERM → graceful shutdown.

### [`scripts/tests/test_analytics_watch_server.py`](scripts/tests/test_analytics_watch_server.py) — 7 tests, all pass

| Test | Validates |
|---|---|
| `test_health_endpoint_initially_empty` | Fresh server: 0 events / 0 subscribers |
| `test_post_event_increments_sequence` | Server assigns monotonic sequence numbers |
| `test_post_event_rejects_non_object` | JSON arrays/primitives → 400 |
| `test_post_event_rejects_invalid_json` | Malformed JSON → 400 |
| `test_sse_stream_receives_posted_event` | End-to-end: POST → SSE stream sees event |
| `test_health_reports_active_subscriber_count` | Stream connection bumps subscriber count |
| `test_unknown_endpoint_returns_404` | Bad path → 404 |

## Why no WebSocket

Original spec mentioned WebSockets. SSE chosen because:
1. Python stdlib has no WebSocket implementation; SSE works with `http.server`.
2. iOS `URLSession` + browser `EventSource` both natively support SSE.
3. Plain HTTP POST for ingress = trivial client code in any language.
4. No new third-party dependency for the project.

## Verification

- [x] `pytest scripts/tests/test_analytics_watch_server.py` → **7/7 pass**
- [x] `make schema-check` → 70/70 state.json clean
- [x] state.json: `tasks[]` entry for 2.A.1; `current_phase` prd → implementation
- [x] log: phase_started + task_completed events for 2.A.1
- [ ] CI green

## Recovery note (transparency)

Initial commit was authored on the canonical worktree but landed on `chore/a2-a4-spec-planning-2026-05-13` due to parallel-agent branch-context collision in the shared working directory. PR #340 then shipped the operator's planning batch independently. This PR was recovered onto an isolated worktree at `/Volumes/DevSSD/FitTracker2-phase2a1-mirror/` to avoid further collisions. Cherry-pick merged log.json events from HEAD + cherry-pick source.

## Next in Phase 2

- 2.A.2 `/analytics watch` CLI sub-command in skill SKILL.md
- 2.A.3 iOS `DebugSinkAdapter` + `DEBUG_ANALYTICS=1` scheme wiring
- 2.A.4 fitme-story web mirror function + `NEXT_PUBLIC_DEBUG_ANALYTICS` gating
- 2.B.1 `/analytics poll` sub-command + GA4 MCP setup runbook

## Spec reference

[`docs/master-plan/analytics-master-plan-2026-05-13.md`](docs/master-plan/analytics-master-plan-2026-05-13.md) §6.1 Sub-system A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)