### PR TITLE
feat(analytics-observability): Phase 2.A.2 — `/analytics watch` CLI sub-command

### DIFF
--- a/.claude/features/analytics-observability/state.json
+++ b/.claude/features/analytics-observability/state.json
@@ -237,6 +237,20 @@
         "scripts/analytics-watch-server.py",
         "scripts/tests/test_analytics_watch_server.py"
       ]
+    },
+    {
+      "id": "2.A.2",
+      "title": " CLI sub-command + skill docs",
+      "status": "complete",
+      "phase": "implementation",
+      "started_at": "2026-05-13T18:54:50Z",
+      "completed_at": "2026-05-13T18:54:50Z",
+      "outcome": "New scripts/analytics-watch.py (CLI client for the SSE server shipped in 2.A.1). Connects to localhost:8765/stream, prints events in real time. Supports --filter (substring OR-semantics), --raw (JSON output), --no-color, --server URL. Stdlib-only. Tests at scripts/tests/test_analytics_watch.py: 12/12 pass (7 pure-function + 5 integration). Skill docs added at .claude/skills/analytics/SKILL.md.",
+      "files_touched": [
+        "scripts/analytics-watch.py",
+        "scripts/tests/test_analytics_watch.py",
+        ".claude/skills/analytics/SKILL.md"
+      ]
     }
   ],
   "figma_node_ids": {},

--- a/.claude/logs/analytics-observability.log.json
+++ b/.claude/logs/analytics-observability.log.json
@@ -6,7 +6,7 @@
   "current_phase": "implementation",
   "framework_version": "v7.8.5",
   "started_at": "2026-05-13T09:00:00Z",
-  "updated_at": "2026-05-13T18:27:35Z",
+  "updated_at": "2026-05-13T18:54:50Z",
   "events": [
     {
       "timestamp": "2026-05-13T09:00:00Z",
@@ -224,6 +224,25 @@
       "metrics": {
         "tests_pass": "7/7",
         "recovery_via": "isolated worktree"
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-13T18:54:50Z",
+      "event_type": "task_completed",
+      "phase": "implementation",
+      "task_id": "2.A.2",
+      "summary": "Phase 2.A.2: /analytics watch CLI shipped. scripts/analytics-watch.py + 12 tests + SKILL.md doc.",
+      "artifacts": [
+        "scripts/analytics-watch.py",
+        "scripts/tests/test_analytics_watch.py",
+        ".claude/skills/analytics/SKILL.md"
+      ],
+      "metrics": {
+        "tests_pass": "12/12",
+        "full_suite": "152/152"
       },
       "actor": "claude_opus_4_7",
       "status": "recorded",

--- a/.claude/skills/analytics/SKILL.md
+++ b/.claude/skills/analytics/SKILL.md
@@ -116,6 +116,53 @@ Define and track a conversion funnel.
 4. Generate GA4 funnel exploration configuration
 5. Set up monitoring for significant drop-off changes
 
+### `/analytics watch` (added 2026-05-13 — Phase 2.A.2 of analytics-observability)
+
+Tail the local analytics mirror SSE stream. Use when the iOS Simulator or
+fitme-story dev server runs locally with `DEBUG_ANALYTICS=1` (iOS scheme
+env var) or `NEXT_PUBLIC_DEBUG_ANALYTICS=1` (web `.env.local`) set —
+every event the app fires is teed to the local SSE server, and this CLI
+prints them in real time.
+
+**Prerequisite:** start the mirror server in a separate terminal first:
+
+```sh
+python3 scripts/analytics-watch-server.py
+```
+
+**Usage:**
+
+```sh
+# Default: connect to http://127.0.0.1:8765/stream
+python3 scripts/analytics-watch.py
+
+# Filter to a specific event prefix
+python3 scripts/analytics-watch.py --filter home_
+
+# Multiple filters (OR semantics)
+python3 scripts/analytics-watch.py --filter home_ --filter nutrition_
+
+# Raw JSON (one event per line) — for piping to jq / grep / file
+python3 scripts/analytics-watch.py --raw | jq '.event_name'
+
+# Connect to a server on a different port
+python3 scripts/analytics-watch.py --server http://127.0.0.1:9999
+
+# Disable color (also auto-disabled when not a TTY)
+python3 scripts/analytics-watch.py --no-color
+```
+
+**Implementation:** [`scripts/analytics-watch.py`](../../../scripts/analytics-watch.py). Stdlib-only (no pip deps). Connection-loss + bad-payload tolerant; exits 0 on Ctrl-C.
+
+**Companion:** [`scripts/analytics-watch-server.py`](../../../scripts/analytics-watch-server.py) (Phase 2.A.1).
+
+### `/analytics poll` (planned — Phase 2.B.1 of analytics-observability)
+
+Query the GA4 Realtime API via `mcp-server-ga4` to observe events firing
+against the production GA4 property (vs. the local mirror, which only
+sees events from the local dev environment). Requires GA4 MCP setup —
+see `docs/setup/ga4-mcp-setup-guide.md` (planned).
+
 ## Key References
 
 - `FitTracker/Services/Analytics/AnalyticsProvider.swift` — event/param/screen enums

--- a/scripts/analytics-watch.py
+++ b/scripts/analytics-watch.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""`/analytics watch` CLI — tail the local analytics mirror SSE stream.
+
+Phase 2.A.2 of `analytics-observability` per
+docs/master-plan/analytics-master-plan-2026-05-13.md §6.1.
+
+Connects to the SSE endpoint of `scripts/analytics-watch-server.py`
+(default http://127.0.0.1:8765/stream) and prints every event as it
+arrives. Designed for use while the iOS Simulator or fitme-story dev
+server runs locally with `DEBUG_ANALYTICS=1` env flag set.
+
+USAGE
+-----
+    python3 scripts/analytics-watch.py
+    python3 scripts/analytics-watch.py --filter home_action_tap
+    python3 scripts/analytics-watch.py --server http://localhost:9999
+    python3 scripts/analytics-watch.py --raw
+
+OPTIONS
+-------
+    --server URL        SSE server URL (default: http://127.0.0.1:8765)
+    --filter PATTERN    Only print events whose `event_name` or `name`
+                        contains PATTERN (substring match, case-sensitive).
+                        Pass multiple --filter flags to OR them together.
+    --raw               Print raw JSON dicts (no pretty-printing or colors).
+    --no-color          Disable ANSI color output (auto-detected from TTY).
+    --since N           Skip the first N seconds of events (useful for
+                        ignoring connection-time replays — not implemented
+                        in the bounded-queue v1 server; reserved for future).
+
+Ctrl-C exits cleanly.
+"""
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import signal
+import sys
+import urllib.parse
+from typing import Any
+
+
+def _is_tty() -> bool:
+    return sys.stdout.isatty()
+
+
+def _color(name: str, use_color: bool) -> tuple[str, str]:
+    """Return (start, end) ANSI codes for `name` or empty strings if disabled."""
+    if not use_color:
+        return "", ""
+    codes = {
+        "dim": "\033[2m",
+        "bold": "\033[1m",
+        "cyan": "\033[36m",
+        "green": "\033[32m",
+        "yellow": "\033[33m",
+        "magenta": "\033[35m",
+        "red": "\033[31m",
+    }
+    return codes.get(name, ""), "\033[0m" if name in codes else ""
+
+
+def _format_event(event: dict[str, Any], use_color: bool) -> str:
+    """Format an event dict as a single human-readable line."""
+    dim_s, dim_e = _color("dim", use_color)
+    cyan_s, cyan_e = _color("cyan", use_color)
+    green_s, green_e = _color("green", use_color)
+    yellow_s, yellow_e = _color("yellow", use_color)
+
+    seq = event.get("sequence", "?")
+    received_at = event.get("received_at", "")[:19]  # YYYY-MM-DDTHH:MM:SS
+    name = event.get("event_name") or event.get("name") or "<unnamed>"
+    params = event.get("params") or event.get("parameters") or {}
+
+    head = (
+        f"{dim_s}[{received_at} #{seq}]{dim_e} "
+        f"{cyan_s}{name}{cyan_e}"
+    )
+    if params:
+        kv = " ".join(
+            f"{green_s}{k}{green_e}={yellow_s}{json.dumps(v, default=str)}{yellow_e}"
+            for k, v in params.items()
+        )
+        return f"{head} {kv}"
+    return head
+
+
+def _match_filters(event: dict[str, Any], patterns: list[str]) -> bool:
+    """True iff no patterns OR event name contains any pattern."""
+    if not patterns:
+        return True
+    name = (event.get("event_name") or event.get("name") or "").lower()
+    return any(p.lower() in name for p in patterns)
+
+
+def _stream(host: str, port: int, path: str, filters: list[str], raw: bool, use_color: bool) -> int:
+    """Open SSE connection, read events forever, print matching ones.
+
+    Returns exit code (0 normal, 1 on connection error).
+    """
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=None)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+    except (ConnectionRefusedError, OSError) as exc:
+        sys.stderr.write(
+            f"error: cannot connect to http://{host}:{port}{path} — {exc}\n"
+            f"hint: start the server first:\n"
+            f"  python3 scripts/analytics-watch-server.py\n"
+        )
+        return 1
+
+    if resp.status != 200:
+        sys.stderr.write(f"error: server returned HTTP {resp.status}\n")
+        return 1
+
+    ctype = resp.getheader("Content-Type", "")
+    if "text/event-stream" not in ctype:
+        sys.stderr.write(f"error: expected text/event-stream, got '{ctype}'\n")
+        return 1
+
+    # Banner
+    sys.stderr.write(
+        f"watching events at http://{host}:{port}{path} (filters: {filters or 'none'})\n"
+        f"press Ctrl-C to stop\n"
+    )
+
+    try:
+        while True:
+            line = resp.fp.readline()
+            if not line:
+                sys.stderr.write("\nserver closed the connection\n")
+                return 0
+            line = line.decode("utf-8", errors="replace").rstrip("\n")
+            if not line.startswith("data: "):
+                continue
+            try:
+                event = json.loads(line[6:])
+            except json.JSONDecodeError as exc:
+                sys.stderr.write(f"warn: bad event payload: {exc}\n")
+                continue
+            if not isinstance(event, dict):
+                continue
+            if not _match_filters(event, filters):
+                continue
+            if raw:
+                print(json.dumps(event, default=str))
+            else:
+                print(_format_event(event, use_color))
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        sys.stderr.write("\nstopped.\n")
+        return 0
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="`/analytics watch` — tail the local analytics mirror SSE stream"
+    )
+    parser.add_argument(
+        "--server",
+        default="http://127.0.0.1:8765",
+        help="SSE server URL (default: http://127.0.0.1:8765)",
+    )
+    parser.add_argument(
+        "--filter",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="Only print events whose name contains PATTERN. Repeatable (OR semantics).",
+    )
+    parser.add_argument("--raw", action="store_true", help="Print raw JSON")
+    parser.add_argument("--no-color", action="store_true", help="Disable ANSI colors")
+    args = parser.parse_args(argv)
+
+    u = urllib.parse.urlparse(args.server)
+    if u.scheme not in ("http", ""):
+        sys.stderr.write(f"error: only http:// is supported, got '{args.server}'\n")
+        return 1
+    host = u.hostname or "127.0.0.1"
+    port = u.port or 8765
+    path = "/stream"
+
+    use_color = (not args.no_color) and _is_tty()
+
+    # Don't crash on broken pipe (e.g., piping to `head`)
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    return _stream(host, port, path, args.filter, args.raw, use_color)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_analytics_watch.py
+++ b/scripts/tests/test_analytics_watch.py
@@ -1,0 +1,282 @@
+"""Tests for `scripts/analytics-watch.py` — Phase 2.A.2 of analytics-observability.
+
+The watcher CLI connects to the live SSE server and prints events. These tests
+spin the real server up, run the watcher as a subprocess, and assert on stdout.
+"""
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+SERVER_PATH = SCRIPTS / "analytics-watch-server.py"
+WATCH_PATH = SCRIPTS / "analytics-watch.py"
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("analytics_watch_server", SERVER_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _import_watch():
+    spec = importlib.util.spec_from_file_location("analytics_watch", WATCH_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.fixture
+def server():
+    mod = _import_server()
+    mod._total_events_received = 0
+    with mod._subscribers_lock:
+        mod._subscribers.clear()
+    mod._shutdown_event.clear()
+
+    port = _free_port()
+    srv = mod._make_server("127.0.0.1", port)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    for _ in range(50):
+        try:
+            c = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+            c.request("GET", "/health")
+            r = c.getresponse()
+            r.read()
+            c.close()
+            if r.status == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(0.02)
+    else:
+        srv.shutdown()
+        srv.server_close()
+        pytest.fail("Server did not become healthy")
+
+    yield ("127.0.0.1", port)
+    srv.shutdown()
+    srv.server_close()
+    t.join(timeout=1.0)
+
+
+def _post(host: str, port: int, payload: dict) -> dict:
+    body = json.dumps(payload).encode()
+    c = http.client.HTTPConnection(host, port, timeout=2.0)
+    c.request("POST", "/event", body=body, headers={"Content-Length": str(len(body))})
+    r = c.getresponse()
+    out = json.loads(r.read())
+    c.close()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests (no subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_match_filters_empty_passes_all():
+    mod = _import_watch()
+    assert mod._match_filters({"event_name": "home_action_tap"}, []) is True
+
+
+def test_match_filters_substring_match():
+    mod = _import_watch()
+    e = {"event_name": "home_action_tap"}
+    assert mod._match_filters(e, ["home_"]) is True
+    assert mod._match_filters(e, ["action"]) is True
+    assert mod._match_filters(e, ["nutrition"]) is False
+
+
+def test_match_filters_or_semantics():
+    mod = _import_watch()
+    e = {"event_name": "home_action_tap"}
+    assert mod._match_filters(e, ["nutrition", "home_"]) is True
+
+
+def test_match_filters_case_insensitive():
+    mod = _import_watch()
+    e = {"event_name": "Home_Action_Tap"}
+    assert mod._match_filters(e, ["HOME_"]) is True
+
+
+def test_format_event_includes_name_and_params():
+    mod = _import_watch()
+    e = {
+        "sequence": 7,
+        "received_at": "2026-05-13T18:30:00",
+        "event_name": "home_action_tap",
+        "params": {"action_type": "start_workout"},
+    }
+    out = mod._format_event(e, use_color=False)
+    assert "home_action_tap" in out
+    assert "action_type" in out
+    assert "start_workout" in out
+    assert "#7" in out
+
+
+def test_format_event_no_params():
+    mod = _import_watch()
+    e = {"sequence": 1, "received_at": "2026-05-13T18:30:00", "event_name": "foo"}
+    out = mod._format_event(e, use_color=False)
+    assert "foo" in out
+
+
+def test_format_event_strips_color_when_disabled():
+    mod = _import_watch()
+    e = {"sequence": 1, "received_at": "2026-05-13T18:30:00", "event_name": "x"}
+    out = mod._format_event(e, use_color=False)
+    assert "\033[" not in out
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: real server + watcher subprocess
+# ---------------------------------------------------------------------------
+
+
+def _run_watch_until_event_seen(host: str, port: int, args: list[str], event_payload: dict) -> tuple[int, str, str]:
+    """Start the watcher in a subprocess, POST one event, return its output.
+
+    Reads stdout reactively in a thread so Python stdout buffering doesn't
+    swallow events when the subprocess is terminated.
+    """
+    # `-u` forces unbuffered stdout — critical when stdout is a pipe rather
+    # than a TTY (Python block-buffers PIPE by default).
+    proc = subprocess.Popen(
+        [sys.executable, "-u", str(WATCH_PATH), "--server", f"http://{host}:{port}", "--no-color"] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    out_lines: list[str] = []
+    err_lines: list[str] = []
+    stop = threading.Event()
+
+    def _drain(pipe, sink):
+        try:
+            for line in pipe:
+                sink.append(line)
+                if stop.is_set():
+                    break
+        except Exception:
+            pass
+
+    t_out = threading.Thread(target=_drain, args=(proc.stdout, out_lines), daemon=True)
+    t_err = threading.Thread(target=_drain, args=(proc.stderr, err_lines), daemon=True)
+    t_out.start()
+    t_err.start()
+
+    # Wait for the watcher to subscribe (banner line in err) AND for the
+    # server to register the subscriber (visible via /health)
+    for _ in range(60):
+        if any("watching events" in l for l in err_lines):
+            try:
+                c = http.client.HTTPConnection(host, port, timeout=1.0)
+                c.request("GET", "/health")
+                r = c.getresponse()
+                health = json.loads(r.read())
+                c.close()
+                if health.get("subscribers", 0) >= 1:
+                    break
+            except Exception:
+                pass
+        time.sleep(0.05)
+
+    # Small grace period after subscriber registers so the SSE handler is
+    # blocked on its queue.get() rather than mid-handshake
+    time.sleep(0.1)
+
+    # Now POST and wait for output to arrive
+    _post(host, port, event_payload)
+    for _ in range(60):
+        if out_lines:
+            break
+        time.sleep(0.05)
+
+    stop.set()
+    proc.terminate()
+    try:
+        proc.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=1.0)
+    t_out.join(timeout=1.0)
+    t_err.join(timeout=1.0)
+    return proc.returncode, "".join(out_lines), "".join(err_lines)
+
+
+def test_watch_prints_unfiltered_event(server):
+    host, port = server
+    rc, out, err = _run_watch_until_event_seen(
+        host, port, [], {"event_name": "stream_test", "params": {"v": 1}}
+    )
+    assert "stream_test" in out, f"out={out!r} err={err!r}"
+    assert "watching events" in err  # banner goes to stderr
+
+
+def test_watch_filter_includes_matching_event(server):
+    host, port = server
+    rc, out, err = _run_watch_until_event_seen(
+        host, port, ["--filter", "stream"], {"event_name": "stream_test"}
+    )
+    assert "stream_test" in out
+
+
+def test_watch_filter_excludes_non_matching_event(server):
+    host, port = server
+    rc, out, err = _run_watch_until_event_seen(
+        host, port, ["--filter", "nutrition"], {"event_name": "home_event"}
+    )
+    assert "home_event" not in out
+
+
+def test_watch_raw_mode_emits_json(server):
+    host, port = server
+    rc, out, err = _run_watch_until_event_seen(
+        host, port, ["--raw"], {"event_name": "raw_test", "params": {"k": "v"}}
+    )
+    # In raw mode, stdout should contain a parseable JSON line
+    lines = [l for l in out.splitlines() if l.strip().startswith("{")]
+    assert lines, f"expected JSON in stdout; got out={out!r}"
+    decoded = json.loads(lines[0])
+    assert decoded["event_name"] == "raw_test"
+    assert decoded["params"] == {"k": "v"}
+
+
+def test_watch_reports_connection_error_with_hint():
+    """Pointing at a non-existent server should exit non-zero with a hint."""
+    # Use a port that's almost certainly not in use
+    proc = subprocess.run(
+        [sys.executable, str(WATCH_PATH), "--server", "http://127.0.0.1:1", "--no-color"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert proc.returncode == 1
+    assert "cannot connect" in proc.stderr
+    assert "start the server first" in proc.stderr


### PR DESCRIPTION
## Summary

Companion CLI to the SSE mirror server shipped in Phase 2.A.1 ([PR #342](https://github.com/Regevba/FitTracker2/pull/342)). Tails the local server's `/stream` endpoint and prints events in real time while the iOS Simulator or fitme-story dev server runs with the debug flag set.

## What ships

### [`scripts/analytics-watch.py`](scripts/analytics-watch.py) — stdlib-only, ~165 lines

| Feature | Detail |
|---|---|
| Default target | `http://127.0.0.1:8765/stream` (the Phase 2.A.1 server) |
| `--filter PATTERN` | Show only events whose name contains PATTERN. Repeatable (OR-semantics). Case-insensitive. |
| `--raw` | JSON-per-line output for piping to `jq`, `grep`, etc. |
| `--no-color` | Disable ANSI colors (auto-disabled when stdout is not a TTY) |
| `--server URL` | Override server endpoint |
| Error handling | Clear hint when connection refused; tolerates bad payloads + dropped connections |
| Exit | Ctrl-C exits 0 |

### [`scripts/tests/test_analytics_watch.py`](scripts/tests/test_analytics_watch.py) — 12 tests, all pass

- **7 pure-function tests** for `_match_filters` (empty, substring, OR, case-insensitive) and `_format_event` (with/without params, with/without color)
- **5 integration tests** spinning up the real Phase 2.A.1 server + running the watcher in a subprocess + asserting on stdout/stderr captured reactively (avoids buffering flakes)

### `.claude/skills/analytics/SKILL.md`

- New `/analytics watch` sub-command section with full usage, prerequisites, examples
- New `/analytics poll` placeholder pointing to Phase 2.B.1 (planned)

## Usage examples

```sh
# Start server (Phase 2.A.1) in a separate terminal first
python3 scripts/analytics-watch-server.py

# Tail all events
python3 scripts/analytics-watch.py

# Filter
python3 scripts/analytics-watch.py --filter home_

# Pipe raw JSON to jq
python3 scripts/analytics-watch.py --raw | jq '.event_name'
```

## Verification

- [x] `pytest scripts/tests/test_analytics_watch.py` → **12/12 pass**
- [x] `pytest scripts/tests/` → **152/152** (was 140; +12 new)
- [x] `make schema-check` → 70/70 state.json clean
- [ ] CI green

## Phase 2 status after this PR

| Task | Status |
|---|---|
| 2.A.1 SSE mirror server | ✅ PR #342 |
| **2.A.2 `/analytics watch` CLI** | **🟡 this PR** |
| 2.A.3 iOS `DebugSinkAdapter` | next |
| 2.A.4 fitme-story web mirror function | next |
| 2.B.1 `/analytics poll` + GA4 MCP setup runbook | next |

## Spec reference

[`docs/master-plan/analytics-master-plan-2026-05-13.md`](docs/master-plan/analytics-master-plan-2026-05-13.md) §6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)