### PR TITLE
docs(planning): commit 2026-05-13 planning docs (skills-review + test-coverage master plan)

### DIFF
--- a/docs/master-plan/test-coverage-master-plan-2026-05-13.md
+++ b/docs/master-plan/test-coverage-master-plan-2026-05-13.md
@@ -1,0 +1,352 @@
+# FitMe Cross-Layer Test Coverage Master Plan — 2026-05-13
+
+> **Status:** CURRENT · Opened 2026-05-13 as a sub-doc of [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md)
+> **Scope:** Test discipline across every system layer — iOS, web (fitme-story), framework (Python gates), backend (Supabase/CloudKit/auth), AI, analytics. Forward-looking calibration of where tests exist, where they've drifted, and where they're missing.
+> **Purpose:** Answer the question the infra master plan does NOT answer: "are all current tests in spec across all layers?" The infra plan covers Theme G — Test discipline for the framework layer only (F14–F18 + F19/F20 from analytics-observability). This sub-doc widens the scope to iOS + web + backend + AI + analytics and proposes a per-layer T-series candidate docket.
+> **Authority:** Same scoping conventions as the infra master plan. T-candidates here feed the 2026-05-21 prioritization pass (T29) and may promote into v8.0/v8.1 alongside F-candidates.
+
+---
+
+## 0. TL;DR
+
+A 4-agent audit (3 internal inventories + 1 external comparison study) ran 2026-05-13 against all six system layers. Headline findings:
+
+1. **Framework layer is best-tested but has a known keying-drift blocker.** 133 Python test methods / 13 files. v7.8.5 cache_hits keying patch (§2.4 of infra plan) MUST ship before 2026-05-21 promotion. Per-gate dispatch tests still missing on 4 gates (F14); 5 zero-coverage gates (F15). Already on the infra plan.
+2. **iOS layer is partially in spec.** 549 methods / 56 files. Core services covered; Sentry has zero tests; CloudKit/Supabase sync at contract-only by design; entire View layer (~130 files) untested except via thin XCUITest (10 methods, 2 quarantined). UI test thinness is documented as intentional but no compensating snapshot-test discipline exists.
+3. **fitme-story (web) is severely under-spec'd.** 122 test cases / 17 files. 119 React components: zero tests. 27 routes: zero E2E. WebAuthn route handlers: zero tests (only library-level round-trip). CI does not run JS tests on PR — only Python gates. **Out of spec for a production-facing public site + operator control room.**
+4. **AI layer is the single biggest test debt.** 75 methods total; orchestration tested but cohort inference (3 tests), prompt assembly, ranking algorithm, and LLM behavioral regression have NO golden-set evals. `phase2bis-prompt-set.json` exists with no harness reading it.
+5. **Backend layer has a critical hole.** `SignInService.swift` (passkey/WebAuthn) has ZERO direct tests despite being on CLAUDE.md's high-risk list. Multi-device reconciliation, encryption-key rotation, sync conflict cascades all untested.
+6. **Analytics layer is taxonomy-strong, runtime-weak.** 81% event coverage by event count (93/114) but parameter-combination coverage ~40%. 4 wholly unfired events; 21 untested variants. No runtime check that emitted events match the CSV.
+7. **External comparison surfaced 7 patterns worth borrowing** — golden-set AI evals (highest leverage), Swift snapshot testing, Supabase↔iOS schema-diff gate, platform-parity state.json field, `last_fired_at` index extension, orphan-test scanner, gate stage/tier annotation.
+
+**Bottom line:** the infra master plan's Theme G (F14–F20) is necessary but NOT sufficient. It hardens the framework layer's test discipline while leaving five other layers under-spec'd. This sub-doc proposes **T-series candidates (T1–T10) covering the non-framework layers,** to be ranked alongside F-candidates at the 2026-05-21 prioritization pass.
+
+---
+
+## 1. Scope + Relationship to Infra Master Plan
+
+### 1.1 What this plan covers
+
+| Layer | Test surface | Owned by this plan? |
+|---|---|---|
+| **Framework (Python)** | `scripts/tests/` — 34 gates + 5 advisory + integrity-check cycle codes | Covered by infra plan F14–F18; this plan widens with T1 (per-gate dispatch test enforcement gate) |
+| **iOS (Swift)** | `FitTrackerTests/`, `FitTrackerUITests/` — 549 unit + 10 UI methods | **Owned here** (T2–T5) |
+| **Web (fitme-story)** | `node:test` — 17 files, 122 cases; zero React + zero E2E | **Owned here** (T6–T8) |
+| **Backend** | Swift services + Supabase Edge Functions + CloudKit sync | **Owned here** (T9) |
+| **AI** | AIOrchestrator, cohort prior, prompt assembly, LLM behavior | **Owned here** (T10 — golden-set evals) |
+| **Analytics** | Event firing, taxonomy compliance, parameter coverage | Covered partially by analytics-observability sub-doc (F19/F20); T11 here adds runtime emission audit |
+
+### 1.2 Relationship to v7.9 / v8.x docket
+
+T-candidates compete with F-candidates at the 2026-05-21 ranking pass (Phase 9 of `framework-v7-8-branch-isolation`). The top-per-theme rule (infra plan §3.3) treats this as a new theme: **Theme H — Application-layer test coverage.** Theme H items walk the same calibration protocol (§3.5 of infra plan) as Theme G items: Phase A spec → B advisory + measure → C calibration → D promote → E validate.
+
+### 1.3 What this plan does NOT cover
+
+- **Performance / load testing** — separate concern; tracked in `docs/product/backlog.md`
+- **Security penetration testing** — quarterly process; tracked via `/security-review` skill
+- **Manual QA / TestFlight** — handled by `/qa` skill + `/release` skill
+- **Accessibility audits** — handled by `/design accessibility`
+
+---
+
+## 2. Per-Layer Inventory (as of 2026-05-13)
+
+### 2.1 Framework (Python) — 133 methods / 13 files
+
+**Already on the docket via infra plan F14–F18.** Highlights:
+
+| Gate / Script | Test File | Status |
+|---|---|---|
+| `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` | test_gate_coverage.py | **KEYING DRIFT** — v7.8.5 blocker |
+| `STATE_NO_CASE_STUDY_LINK` + 3 others | test_check_state_schema.py | Missing `test_main_dispatch_*` (F14) |
+| `PHASE_TRANSITION_NO_LOG`, `PHASE_TRANSITION_NO_TIMING` | — | **ZERO COVERAGE** — F15 candidate, highest-risk (guards most-frequent state mutation) |
+| `BRANCH_ISOLATION_HISTORICAL`, `BRANCH_ISOLATION_LAUNCHD_DRIFT` | — | **ZERO COVERAGE** — advisory by design, but no regression harness |
+| `PR_CACHE_STALE` (v7.8.4) | — | **ZERO COVERAGE** — F15 candidate |
+| `integrity-check.py` (16 cycle-time codes) | partial via test_gate_coverage.py | Most codes lack dedicated tests |
+| `refresh-pr-cache.py`, `append-feature-log.py`, `ui-audit.py`, `scaffold-figma-mapping.py`, 10+ HADF scripts | — | **ZERO COVERAGE** |
+
+**Judgment:** ~30% compliance on documented gates; ~60% on auxiliary scripts. v7.8.5 is the immediate unblocker; F14/F15 are the structural fix.
+
+### 2.2 iOS (Swift) — 549 methods / 56 files
+
+| Production surface | Test file | Methods | Status |
+|---|---|---|---|
+| DomainModels.swift | EncryptionServiceTests + ImportTests (indirect) | indirect | Coverage via callers, not direct |
+| EncryptionService.swift | EncryptionServiceTests | 10 | Encrypt/decrypt only; no key-rotation |
+| SupabaseSyncService.swift | SupabaseSyncServiceTests | 6 | Basic merge; no chaos tests |
+| CloudKitSyncService.swift | CloudKitSyncServiceTests | 6 | **Contract-only by design (v7.x deferral)** |
+| **SignInService.swift (passkey/WebAuthn)** | — | **0** | **ZERO DIRECT TESTS** despite high-risk classification |
+| AuthManager.swift | AuthManagerTests + AuthPolishV2Tests | 8 + 15 | Reasonable |
+| AIOrchestrator.swift | AIOrchestratorTests + FitTrackerCoreTests | 14 + 33 | Dispatch tested; algorithm untested (see §2.5) |
+| **Sentry integration** | — | **0** | **ZERO TESTS, NO PROD REFERENCES** — CLAUDE.md silent |
+| Push Notifications v2 | NotificationTests + NotificationServiceTests + PushNotificationsReachabilityTests | 21 | Strong (UI-016 reachability lesson encoded) |
+| Import-training-plan (Phase 1) | ImportTests + ImportPersistenceAndAnalyticsTests + 3 more | 53 | Strong |
+| Home v2 | HomeAnalyticsTests + HomeRecommendationProviderTests + HomeReadinessUITests | 22 + 1 quarantined | Mixed |
+| 5 v2 screens (Stats/Settings/Nutrition/Training/Readiness) | 5 analytics files + ReadinessEngineTests + ReadinessAlertTriggerTests | analytics-only + 27 | View layer untested |
+| **DesignSystem/ (10 files)** | — | **0** | **ZERO COVERAGE** |
+| **Code Connect (.figma.swift × 5)** | — | **0** | Not XCTest-testable; drift undetectable |
+| **FitTracker/Views/Auth/ (9 files)** | — | **0 unit / 1–5 UI** | Heavy reliance on thin UITests |
+| **FitTracker/Views/AI/ (4 files)** | — | **0** | Behavior via AIAnalyticsTests only |
+
+**XCUITest:** 7 files / 10 methods total. `HomeReadinessUITests` + `OnboardingUITests` quarantined via `XCTSkipIf` (parallel-clone hang — resolved at PR #225 per memory, but quarantines never removed). `MealLogUITests` has a label-drift skip.
+
+**Judgment:** core services partially current; **3 material gaps** — (a) Sentry has zero tests, (b) two sync services at contract-only with no closure plan, (c) ~130-file View layer untested. CLAUDE.md documents UI test thinness as intentional, but no compensating snapshot-test discipline exists.
+
+### 2.3 Web (fitme-story) — 122 cases / 17 files / `node:test` runner
+
+| Surface | Coverage |
+|---|---|
+| `/control-room/framework` lib (builder.ts, reconcile.ts) | Partial — builder/reconcile tested; **commands.ts + github.ts untested** |
+| `/control-room/analytics` lib | 18 tests — full |
+| WebAuthn library (`webauthn-server.ts`) | 3 tests (round-trip happy path) |
+| **WebAuthn route handlers (`/api/auth/{authenticate,register,verify,options,devices,revoke}`)** | **0** |
+| Cross-repo sync (`sync-from-fittracker2.ts`, `gate-coverage-aggregator.ts`) | 15 — strong |
+| Figma drift detection | 6 — strong |
+| Case-study MDX (54 files + frontmatter validator) | 4 — minimal; **no schema-validator tests** |
+| Parsers (state, backlog, unified, metrics, prd) — **5 untested** | tasks.ts (26) + roadmap.ts (2) only |
+| **React components — 119 .tsx files** | **0** |
+| **Public site routes — 27 page.tsx/page.mdx** | **0 E2E / 0 snapshot** |
+
+**CI Integration:** `integrity.yml` runs Python gates only. **No JS test runner in CI on PR.** `figma-drift-weekly.yml` runs the drift script weekly. Reverse-sync workflow has no test step.
+
+**Judgment:** **Out of spec.** A production-facing public site + operator control room with zero automated validation of routes / components / auth ceremonies. Coverage is episodic (lib layers strong; surfaces absent).
+
+### 2.4 Backend — 248 methods across 22 Swift test files (Edge Functions unaudited)
+
+| Service | Test file | Methods | Status |
+|---|---|---|---|
+| SupabaseSyncService | SupabaseSyncServiceTests | 6 | Basic merge; no churn/cascade |
+| CloudKitSyncService | CloudKitSyncServiceTests | 6 | Contract-only (v7.x deferral) |
+| AuthManager | AuthManagerTests | 8 | Passkey + email |
+| **SignInService** | — | **0** | **ZERO COVERAGE** |
+| EncryptionService | EncryptionServiceTests | 10 | Encrypt/decrypt; no key-rotation |
+| KeychainStorage | KeychainHelperTests | 7 | CRUD + GDPR delete |
+| GDPR / AccountDeletion | AccountDeletionServiceTests | 7 | Deletion only |
+| 3-way merge (Supabase) | SupabaseTests/SyncMergeTests | 5 | Some edge cases |
+| OAuth/session | SupabaseTests/UserSessionMappingTests | — | Some coverage |
+| **DataExportService, ConsentManager, FoodSearchService** | — | **0** | **ZERO COVERAGE** |
+| **Supabase Edge Functions (if any)** | not audited | — | Out-of-scope this pass |
+
+**Judgment:** happy-path coverage on sync/auth/encryption is reasonable. **SignInService zero-tested** despite high-risk classification. No chaos/adversarial tests. Multi-device reconciliation untested. Encryption-key rotation untested. Edge Functions (if present) need a separate audit.
+
+### 2.5 AI — 75 methods / 5 files; zero LLM behavioral evals
+
+| Component | Test file | Methods | Status |
+|---|---|---|---|
+| AIOrchestrator | AIOrchestratorTests | 14 | Dispatch, mode selection |
+| AIAdapter (HK/training/nutrition input) | AIAdapterTests | 11 | Input shaping |
+| **CohortPriorClient** | CohortPriorClientTests | **3** | **MINIMAL** for critical inference path |
+| HomeRecommendationProvider | HomeRecommendationProviderTests | 11 | Ranking + UI state |
+| ValidatedRecommendation | ValidatedRecommendationTests | 20 | Validation rules |
+| AI Analytics | AIAnalyticsTests | 16 | Event attribution |
+| **Prompt assembly, context truncation, Bayesian inference** | — | **0** | **ZERO COVERAGE** |
+| **LLM behavioral regression (golden-set)** | — | **0** | `phase2bis-prompt-set.json` exists with no harness |
+
+**Judgment:** **Weakest layer.** Orchestration works; the model/algorithm/prompt layer has zero behavioral regression coverage. No golden-set evals. Cohort prior — the most-bayes-driven inference path — has 3 tests.
+
+### 2.6 Analytics — 147 methods / 11 files
+
+| Dimension | Coverage |
+|---|---|
+| Event firing (count) | 93/114 = **81%** |
+| Unfired events | 4 (`nutrition_hydration_updated`, `nutrition_date_changed`, `nutrition_empty_state_shown`, `onboarding_skipped`) |
+| Untested parameter variants | 21 (e.g., `training_exercise_started` × all `muscle_group` values) |
+| Parameter-combination coverage | **~40%** |
+| Screen-prefix-rule compliance | `AnalyticsEventNamingTests.swift` (5 tests) |
+| Runtime emission audit (events fired in app match CSV) | **NONE** |
+
+**Judgment:** **Taxonomy-strong, runtime-weak.** CSV-driven taxonomy is well-curated; enforcement is unit-test only. F19 (`CSV_TAXONOMY_DRIFT`) + F20 (`GA4_MCP_DISCONNECTED`) from analytics-observability sub-doc help; this plan adds T11 (runtime emission audit).
+
+---
+
+## 3. External Comparison — Top 7 Patterns Worth Borrowing
+
+Full agent report cited 10 systems; synthesis below. Each pattern is mapped to the layer it strengthens + an effort estimate.
+
+| # | Pattern | Source | Targets layer | Effort | Cadence |
+|---|---|---|---|---|---|
+| **P1** | **Golden-set + random-sweep LLM evals** ([promptfoo](https://github.com/promptfoo/promptfoo) + [Anthropic demystifying-evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)) | LLM-eval frameworks | AI | M (1–2d) | Weekly drift + PR gate on golden |
+| **P2** | **Swift snapshot testing** ([uber/ios-snapshot-test-case](https://github.com/uber/ios-snapshot-test-case), [pointfreeco/swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing)) | Airbnb/Uber/Lyft pattern | iOS View layer | M-L (3–5d initial, then per-feature) | PR gate |
+| **P3** | **Schema-diff gate** ([oasdiff](https://www.oasdiff.com/) pattern adapted to Supabase↔iOS) | Stripe/GitHub API discipline | Backend ↔ iOS | S (4–8h) | pre-commit + nightly |
+| **P4** | **Platform-parity state.json field** (`platforms_tested: {ios, web, backend, ai}`) | Linear/Lyft cross-platform pattern | Framework + cross-cutting | XS (1–2h) | pre-commit (extends FEATURE_CLOSURE_COMPLETENESS) |
+| **P5** | **`last_fired_at` + `last_failed_at` index per gate** ([AWS Config DescribeConfigRuleEvaluationStatus](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigRuleEvaluationStatus.html), [driftctl](https://github.com/snyk/driftctl)) | Gate-rich infra tools | Framework (extends F17) | S (4h) | Weekly + on-demand |
+| **P6** | **Orphan-test scanner** ([ArchDrift](https://www.archdrift.com/), [shipmonk dead-code-detector](https://github.com/shipmonk-rnd/dead-code-detector)) | Drift-detection ecosystem | iOS + Web | S (4–8h) | Weekly cron, advisory |
+| **P7** | **Test-type stratification + `stages:` declaration** ([pre-commit.com](https://pre-commit.com/) + [Next.js core testing](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md)) | Pre-commit + Next.js patterns | Framework metadata | XS-S (2–4h) | One-time schema bump |
+
+**Overkill for this context** (NOT borrowed): Pact bi-directional broker; Next.js isolated-installation-per-test; 30K-snapshot scale (Airbnb); Inspect AI as second eval framework; Muter for Swift mutation testing (deferred — low value-per-hour at current size).
+
+---
+
+## 4. T-Series Candidate Docket (Theme H — Application-Layer Test Coverage)
+
+Eleven candidates surfaced. RICE-est uses the same convention as infra plan §3.1. Effort is wall-time for a focused sub-agent dispatch (XS=≤2h, S=≤8h, M=≤2d, L=≤5d).
+
+| ID | Layer | Item | Pattern | RICE-est | Notes |
+|---|---|---|---|---|---|
+| **T1** | Framework metadata | **Per-gate dispatch test enforcement gate** — extend F14 with a meta-gate `GATE_TEST_MISSING` that fails CI when a new gate function in `scripts/check-state-schema.py` ships without a paired `test_main_dispatch_*` in `scripts/tests/`. Filename-pairing contract from Semgrep. | P7 partial | H (R=10 I=2 C=80% E=0.3w → 53.3) | Closes the drift class that produced the cache_hits keying bug. Depends on F14 being in Phase E. |
+| **T2** | iOS | **Sentry integration test pass** — wire Sentry SDK reachability tests (mirror of `PushNotificationsReachabilityTests` for `crash_free_rate`). Closes the CLAUDE.md silent-pass that Sentry has zero tests + zero prod references. | — | H (R=10 I=3 C=100% E=0.3w → 80.0) | Pre-launch crash gate. High blast radius if Sentry actually disconnected. |
+| **T3** | iOS | **SignInService passkey/WebAuthn unit tests** — 8–12 tests covering credential registration, assertion, fallback to email, error states. Closes the highest-risk zero-coverage backend service. | — | H (R=10 I=3 C=100% E=0.5w → 48.0) | Mirrors `AuthManagerTests` scope. |
+| **T4** | iOS | **Swift snapshot testing on v2 views** — add `pointfreeco/swift-snapshot-testing` SPM dep; baseline 6 v2 screens (Home/Stats/Settings/Nutrition/Training/Readiness) + 4 auth views; snapshot diff as PR gate. Covers ~130-file View layer drift. | P2 | M (R=8 I=3 C=60% E=0.5w → 28.8 initial; grows per-feature) | Replaces deferred XCUITest expansion. Single-shot deterministic — no parallel-clone hang. |
+| **T5** | iOS | **Mock-protocol drift detection** — wrap `MockKeychainStorage`, `MockSupabaseClient`, `StubAIEngineClient`, `CountingAIEngineClient` in a shared `MockValidation.swift` that fails build if protocol surface drifts beyond mock conformance. Lightweight. | — | M (R=6 I=2 C=100% E=0.3w → 40.0) | Closes the "Last audit touch: 2026-04-18" concern. |
+| **T6** | Web | **fitme-story PR test gate** — add `npm test` step to `pr-integrity-check.yml` (or new `web-tests.yml`) so the 122 existing tests gate every PR. Currently zero JS tests run on PR. | — | H (R=10 I=2 C=100% E=0.1w → 200.0) | **Highest RICE.** Single-line CI config addition. Mandatory before any T7/T8. |
+| **T7** | Web | **Critical-route smoke tests** — add Playwright (or `next test`) smoke tests on 5 critical routes: `/`, `/case-studies`, `/control-room/framework`, `/control-room/analytics`, `/api/auth/authenticate/options`. Closes the "27 routes, zero E2E" gap. | — | H (R=8 I=3 C=80% E=0.5w → 38.4) | Foundation for further E2E expansion. |
+| **T8** | Web | **WebAuthn route handler tests** — test the 7 `/api/auth/*` route handlers (currently only library-level `round-trip.test.ts` exists). Mock attestation/assertion payloads. Closes pre-cutover risk before basic-auth flip. | — | H (R=8 I=3 C=80% E=0.4w → 48.0) | Operator-blocking if cutover hits a regression. |
+| **T9** | Backend | **Backend chaos/edge tests** — multi-device sync reconciliation, encryption-key rotation, GDPR cascade across CloudKit+Supabase, network-churn auth recovery. 8–15 new tests across existing test files. | — | M (R=6 I=2 C=60% E=0.7w → 10.3) | Adversarial coverage; lower R until a user-reported incident raises it. |
+| **T10** | AI | **Golden-set LLM eval harness** — `tests/ai/golden/` with 20–50 prompt+expected-behavior pairs; `tests/ai/eval-harness.swift` (or Python wrapper) reads `phase2bis-prompt-set.json` + golden pairs; weekly promptfoo-equivalent run as advisory; PR gate on golden subset. | P1 | H (R=10 I=3 C=60% E=1.0w → 18.0) | **Biggest layer gap.** Effort dominated by golden-set authorship. |
+| **T11** | Analytics | **Runtime emission audit** — instrument a test-mode flag that captures every emitted event during integration-test runs; diff against `docs/product/analytics-taxonomy.csv` at suite-end. Catches unfired-by-test events automatically. Complements F19 (CSV drift). | — | M (R=8 I=2 C=80% E=0.4w → 32.0) | Closes the "4 unfired + 21 untested variants" gap structurally. |
+
+**Cross-cutting (lower priority):**
+
+| ID | Item | RICE-est |
+|---|---|---|
+| **T12** | Supabase↔iOS schema-diff gate (P3) — pre-commit hook diffs Supabase migration files against `DomainModels.swift` matching fields | M (R=6 I=2 C=60% E=0.4w → 18.0) |
+| **T13** | `last_fired_at` + `last_failed_at` index extension to ALL gates (P5; extends F17) | S (R=8 I=2 C=100% E=0.2w → 80.0) |
+| **T14** | Platform-parity state.json field (P4) — `platforms_tested: {ios, web, backend, ai}` extends FEATURE_CLOSURE_COMPLETENESS | XS (R=8 I=2 C=100% E=0.1w → 160.0) |
+| **T15** | Orphan-test weekly cron (P6) — advisory scanner asserts every `*Tests.swift` references ≥1 production symbol (and vice versa) | S (R=6 I=1 C=80% E=0.3w → 16.0) |
+| **T16** | Test-tier / stage annotation on all 34 gates (P7) — adds `stage:` + `tier:` to gate metadata | XS (R=6 I=1 C=100% E=0.2w → 30.0) |
+
+**Total: 16 T-candidates (T1–T16).**
+
+### 4.1 Layer distribution
+
+| Layer | T-candidates | RICE-sum |
+|---|---|---|
+| Framework metadata | T1, T13, T14, T16 | 323.3 |
+| iOS | T2, T3, T4, T5 | 196.8 |
+| Web | T6, T7, T8 | 286.4 |
+| Backend | T9, T12 | 28.3 |
+| AI | T10 | 18.0 |
+| Analytics | T11 | 32.0 |
+| Cross-cutting | T15 | 16.0 |
+
+### 4.2 Top-5 by RICE
+
+1. **T6** (Web PR test gate) — RICE 200.0 — single-line CI config; should ship as v7.9.1 ride-along.
+2. **T14** (platform-parity state.json field) — RICE 160.0 — extends an existing enforced gate; ~1h effort.
+3. **T2** (Sentry integration test) — RICE 80.0 — closes a silent zero-coverage on a high-risk surface.
+4. **T13** (`last_fired_at` extension to all gates) — RICE 80.0 — natural extension of F17 once F17 ships.
+5. **T1** (per-gate dispatch test enforcement gate) — RICE 53.3 — closes the drift class behind cache_hits keying.
+
+---
+
+## 5. Sequencing — Forward Plan
+
+Calibration protocol (§3.5 of infra plan) applies. Each T-candidate walks Phases A → B → C → D → E (22 days minimum per layer; T14 + T16 are XS metadata changes that may skip B–C).
+
+### 5.1 Earliest-eligible windows
+
+| Window | Eligible | Why |
+|---|---|---|
+| **v7.9.1 ride-along (~2026-06-04 → 2026-06-11)** | T6, T14, T16 | XS/S effort; non-gate-additive (T6, T16) or extends existing enforced gate (T14); no calibration window needed |
+| **v8.0 docket (decided 2026-05-21, ship target ~2026-07-31)** | T1, T2, T3, T6 (if not in v7.9.1), T8, T11, T13 | Top-RICE items; walk full A–E calibration |
+| **v8.1 docket (target ~2026-09)** | T4, T5, T7, T10 | Medium effort; T10 (AI golden-set) deferred to allow Phase 2-bis prompt-set to stabilize |
+| **v8.2+ (target Q4 2026)** | T9, T12, T15 | Lower-RICE; ship when telemetry signals demand |
+
+### 5.2 Dependency graph
+
+```
+T1 (per-gate dispatch enforcement)  ← depends on F14 in Phase E
+T4 (Swift snapshot testing)         ← independent (new SPM dep)
+T6 (Web PR test gate)               ← independent (CI config only)
+T7 (Web E2E smoke)                  ← depends on T6 (so the gate exists)
+T8 (WebAuthn route tests)           ← depends on T6
+T10 (AI golden-set)                 ← depends on Phase 2-bis sub-experiments closing
+                                       (~2026-06-07) so golden-set has stable prompts
+T11 (runtime emission audit)        ← depends on F19 (analytics CSV drift) in Phase B
+T13 (last_fired_at extension)       ← depends on F17 in Phase E
+T14 (platform-parity field)         ← depends on FEATURE_CLOSURE_COMPLETENESS enforced
+                                       (= v7.9 promotion 2026-05-21)
+```
+
+### 5.3 Layer stacking rule applied
+
+§3.5.2 of infra plan: **no new layer built on top of a layer that hasn't reached Phase E.** Concrete applications:
+
+- T1 cannot ship until F14 reaches Phase E (~2026-07-25 if F14 ships at v8.0 start).
+- T13 cannot ship until F17 reaches Phase E (~2026-07-25 at earliest).
+- T11 cannot ship until F19 (analytics CSV drift gate) reaches Phase B with ≥7d telemetry.
+- T14 can ship the same day FEATURE_CLOSURE_COMPLETENESS is promoted to enforced (2026-05-21 if v7.9 promotion succeeds), as it's a field extension of an already-Phase-E gate.
+
+---
+
+## 6. Calibration & Cadence
+
+### 6.1 Per-T-candidate calibration
+
+Same 5-phase protocol as F-candidates. Specific notes per layer:
+
+- **iOS T-candidates (T2–T5):** Phase B telemetry comes from `xcodebuild test` log parsing — no gate-coverage.jsonl equivalent. Manual operator review at T+7d.
+- **Web T-candidates (T6–T8):** Phase B telemetry comes from GitHub Actions run summaries. Failure ratio < 5% at T+7d to advance.
+- **AI T-candidate (T10):** Phase B = weekly cron of golden-set; failure threshold is "pass rate ≥ baseline" (calibrated during Phase A).
+- **Backend T-candidates (T9, T12):** Phase B = include in nightly integration-test sweep; Phase C exit = 14 days of green.
+
+### 6.2 Quarterly cross-layer test-discipline audit
+
+In addition to the §3.5.3 Data Freshness Audit on framework gates, propose a parallel quarterly audit for application-layer tests:
+
+- **Initial run:** 2026-08-13 (T+90d).
+- **Recurring:** 2026-11-13, 2027-02-13, 2027-05-13.
+- **Scope:** For each layer (iOS / web / backend / AI / analytics), assert: (a) test count not declining, (b) production-symbol coverage ≥ prior quarter, (c) no new "zero-coverage" production directories, (d) staleness markers (TODO / FIXME / XCTSkip / .skip / .only) trend.
+
+Output: `docs/process/cross-layer-test-audit-{date}.md` quarterly snapshot + advisory PR if regression detected.
+
+---
+
+## 7. Risk Register (sub-doc-specific)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **T6 lands but reveals 30+ failing existing JS tests (silent rot)** | Medium | Medium | Phase A: pre-flight local `npm test` audit. If failures exist, fix-first as PR before gate flips enforced. |
+| **T4 snapshot baseline captures buggy current UI as canonical** | High | Medium | Phase A: review every initial snapshot with operator + spec before merging baseline. Pair with `/ux pre-merge-review`. |
+| **T10 golden-set goes stale as AIOrchestrator evolves** | High | Medium | Quarterly audit (§6.2) includes golden-set refresh as a sub-item. Treat golden-set authorship as recurring, not one-shot. |
+| **T2 Sentry tests pass against a stub but production Sentry is misconfigured** | Medium | High | Pair T2 with manual smoke run against staging Sentry project; codify in `runtime-smoke-gates.md` profile. |
+| **T9 backend chaos tests are flaky on CI** | High | Low | Run as nightly advisory before promoting to PR gate. |
+| **Effort estimate slippage on T4 / T7 / T10 (M-L items)** | Medium | Medium | Each ships incrementally — baseline first, then per-feature additions in subsequent PRs. |
+
+---
+
+## 8. Open Questions
+
+1. **Should T6 (Web PR test gate) ship at v7.8.5 rather than v7.9.1?** RICE 200.0; effort ~1h. Argument for: closes a silent zero-CI-coverage gap that's existed since fitme-story spun up. Argument against: v7.8.5 is scoped to cache_hits keying only. Decide at 2026-05-13 morning.
+2. **Snapshot test runner choice for T4** — `pointfreeco/swift-snapshot-testing` (canonical) vs `uber/ios-snapshot-test-case` (older, broader iOS app proof). Default recommendation: pointfreeco (active maintenance, SPM-first). Decide at T4 Phase A.
+3. **Golden-set authorship for T10** — written by operator manually vs generated from production logs via Mechanism C session-attribution data? Argument for log-derived: zero hallucination risk. Argument against: privacy + production-data-handling concerns. Decide at T10 Phase A.
+4. **Should Theme H be a separate framework version bump?** A v8.x where v8.0 = Theme G + H combined vs v8.0 = Theme G only + v8.1 = Theme H. Top-per-theme rule (§3.3 of infra plan) suggests combined; this sub-doc opens the question explicitly.
+5. **Edge Functions audit** — Supabase Edge Functions (if any exist) were out-of-scope this pass. Should a follow-up audit run before T9 starts? Decide at T9 Phase A.
+6. **Mock library extraction (T5 expansion)** — should mocks live in a separate Swift Package (`FitTrackerMocks`) for cleaner versioning, or remain inline in `FitTrackerTests/`? Decide at T5 Phase A.
+7. **Analytics runtime emission audit (T11) — sample rate** — capture every event in test (100%) vs sample (10%)? 100% is simpler; sample is cheaper. Decide at T11 Phase A.
+
+---
+
+## 9. References
+
+### Source documents
+- [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) — parent plan; §3.1 Source D + §3.6.4 v8.0 docket
+- [`analytics-master-plan-2026-05-13.md`](analytics-master-plan-2026-05-13.md) — analytics-observability sub-doc with F19/F20
+- [`docs/superpowers/specs/2026-05-08-framework-v7-9-candidates.md`](../superpowers/specs/2026-05-08-framework-v7-9-candidates.md) — F14–F18 spec
+- [`docs/case-studies/m-4-xcuitest-infrastructure-case-study.md`](../case-studies/m-4-xcuitest-infrastructure-case-study.md) — XCUITest env-flake history
+- [`docs/process/runtime-smoke-gates.md`](../process/runtime-smoke-gates.md) — runtime profile system that T2 hooks into
+
+### External patterns
+- [Next.js core testing](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md) — P7 stratification source
+- [AWS Config DescribeConfigRuleEvaluationStatus](https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigRuleEvaluationStatus.html) — P5 source
+- [oasdiff](https://www.oasdiff.com/) — P3 source
+- [pre-commit.com](https://pre-commit.com/) + [try-repo](https://github.com/pre-commit/pre-commit/issues/850) — P7 + F16 source
+- [Semgrep test rules](https://semgrep.dev/docs/writing-rules/testing-rules) — T1 + F15 pairing convention
+- [promptfoo](https://github.com/promptfoo/promptfoo) + [Anthropic demystifying-evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) — P1 + T10 source
+- [pointfreeco/swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing) + [uber/ios-snapshot-test-case](https://github.com/uber/ios-snapshot-test-case) — P2 + T4 source
+- [Maestro XCTest best practices](https://maestro.dev/insights/xctest-best-practices-ios-testing) — XCUITest serialization
+- [ArchDrift](https://www.archdrift.com/) + [shipmonk dead-code-detector](https://github.com/shipmonk-rnd/dead-code-detector) — P6 + T15 source
+
+### Live state
+- [`.claude/features/framework-v7-8-branch-isolation/state.json`](../../.claude/features/framework-v7-8-branch-isolation/state.json) — T29 prioritization pass (Theme H ranking)
+- [`.claude/logs/gate-coverage.jsonl`](../../.claude/logs/gate-coverage.jsonl) — framework gate telemetry input
+- `FitTrackerTests/` + `FitTrackerUITests/` — iOS test root
+- `fitme-story/scripts/` + `fitme-story/src/lib/` + `fitme-story/src/app/` — web test root
+
+---
+
+## 10. Change Log for This Document
+
+| Date | Change |
+|---|---|
+| 2026-05-13 | Initial creation. Synthesizes 4-agent audit (iOS / web / framework+backend+AI / external comparison) + proposes T1–T16 candidate docket for Theme H (Application-Layer Test Coverage). Feeds 2026-05-21 prioritization pass. |

--- a/docs/skills/skills-review-2026-05-13.md
+++ b/docs/skills/skills-review-2026-05-13.md
@@ -1,0 +1,309 @@
+# Skills Review — FitTracker2 (`/.claude/skills/*`)
+
+**Date:** 2026-05-13 · **Framework:** v7.8.5 · **Scope:** the 11 project-owned skills under `.claude/skills/` (excludes superpowers / vercel-plugin / figma vendor skills).
+
+> Companion docs: [README.md](README.md) · [architecture.md](architecture.md) · [evolution.md](evolution.md) · [pm-hub-evolution.md](pm-hub-evolution.md)
+>
+> This review supersedes earlier ad-hoc audit notes. Next scheduled review: 2026-08-13 (90-day cadence) OR after first v8.x feature ships, whichever is earlier.
+
+---
+
+## Purpose
+
+The skills ecosystem has accreted across 5 framework majors (v1.0 → v7.8.5) and >30 PRs. Most skills were added before the integrity-cycle, branch-isolation, and observed-patterns layers existed, so the *enforcement* layer has moved on while many `SKILL.md` files still describe behavior that pre-dates it. This document is the actionable improvement queue + per-skill scorecard generated from a 2026-05-13 systematic audit, cross-referenced against Anthropic's officially published PM skill set.
+
+---
+
+## 1 · Inventory (one row per skill)
+
+| Skill | LoC | Sub-cmds | Owns (write) | External adapters | Cross-calls | Recently versioned |
+|---|---:|---:|---|---|---|---|
+| **pm-workflow** | 1688 + 4 sub-files | 1 (`/pm-workflow {feat}`) | `state.json` per feature | all (routed) | all 10 spokes + superpowers | v7.8.5 (W9 hook, observed-patterns preflight) |
+| **ux** | 525 | 9 | `design-system.json::ux_coverage`, cache | axe (MCP) | `/design` (hand-off) | v4.X (2026-05-06) + kill-criteria-resolution check (v7.8) |
+| **design** | 344 | 7 (2 deprecated) | `design-system.json`, `figma-bridge-status.json` | figma MCP, figma-use, figma-generate-design | `/ux` | v4.X+CC (2026-05-10 Code Connect bridge) |
+| **cx** | 242 | 7 | `cx-signals.json` | app-store-connect, sentry | `/marketing` `/design` `/dev` `/qa` `/pm-workflow` | base |
+| **analytics** | 232 | 5 | `metric-status.json` | ga4, mixpanel | `/marketing` `/pm-workflow` `/cx` `/qa` | v4.3 (case-study instr layer) |
+| **marketing** | 231 | 7 | `campaign-tracker.json` | app-store-connect, firecrawl, ayrshare | `/cx` (dispatches in) `/research` | base |
+| **ops** | 231 | 4 | `health-status.json`, `framework-health.json` | sentry, datadog | UCC dashboard | v4.3 (Control Room integration) |
+| **research** | 230 | 7 | `context.json`, `cx-signals.json` | firecrawl, apify | `/marketing` | base |
+| **release** | 187 | 4 | (reads only) | app-store-connect, fastlane | `/analytics` `/ops` | base |
+| **qa** | 179 | 5 | `test-coverage.json`, `health-status.json` | xcode, codecov, axe, sentry | observed-patterns catalog | v7.8.5 (observed-patterns preflight) |
+| **dev** | 173 | 5 | `health-status.json` | github CLI, security-audit | observed-patterns catalog | v7.8.5 (W1/W3/W5/W9 patterns) |
+
+**Per-skill scorecard** (5 axes, ✅ ⚠️ ❌):
+
+| Skill | Boundaries | Cross-refs current | Versioned/dated | Sub-cmds testable | Observed-patterns linked |
+|---|:---:|:---:|:---:|:---:|:---:|
+| pm-workflow | ✅ | ✅ | ✅ v6.0 + v7.8.5 | ⚠️ no dispatcher tests | ✅ |
+| ux | ✅ | ✅ | ✅ v4.X | ❌ preflight tests absent | ❌ |
+| design | ✅ | ✅ | ✅ v4.X+CC | ⚠️ Code Connect parity untested | ❌ |
+| qa | ✅ | ✅ | ✅ v7.8.5 | ❌ self-testing skills meta-gap | ✅ |
+| dev | ✅ | ✅ | ✅ v7.8.5 | ❌ no `/dev review` automation tests | ✅ |
+| analytics | ✅ | ⚠️ taxonomy CSV growing stale | ⚠️ v4.3 | ❌ | ❌ |
+| ops | ✅ | ⚠️ Datadog adapter unused | ⚠️ v4.3 | ❌ | ❌ |
+| cx | ✅ | ⚠️ dispatch handlers unverified | ❌ undated | ❌ | ❌ |
+| release | ✅ | ⚠️ Fastlane adapter unused | ❌ undated | ❌ | ❌ |
+| marketing | ✅ | ⚠️ Ayrshare adapter not wired | ❌ undated | ❌ | ❌ |
+| research | ✅ | ✅ | ❌ undated | ❌ | ❌ |
+
+---
+
+## 2 · Wiring model
+
+- **Hub-and-spoke via shared JSON.** Skills never call each other directly. They read/write 15 files under `.claude/shared/*.json`. `skill-routing.json` (`v5.0`, `load_mode: on_demand`) maps each lifecycle phase to skills + model tier (Sonnet vs Opus) + batch operations + result-forwarding + systolic chains.
+- **Validation gate** sits in front of every shared write: GREEN ≥95% / ORANGE 90–95% / RED <90% confidence; RED blocks the write until human resolves.
+- **L1/L2/L3 cache.** L1 dirs exist for every spoke (session-scoped). L2 `_shared/` promotes cross-skill patterns. L3 `_project/` holds framework-level patterns. Hits logged via [scripts/append-feature-log.py](../../scripts/append-feature-log.py) → `state.json::cache_hits[]`.
+- **Six integration adapters** live under `.claude/integrations/{ga4,app-store-connect,sentry,firecrawl,axe,security-audit}`. Each is `adapter.md` + `schema.json` + `mapping.json`. Four more adapters are referenced in SKILL.md but absent on disk: **mixpanel** (analytics), **datadog** (ops), **fastlane** (release), **ayrshare** (marketing).
+- **Four enforcement layers** run beneath the skills: pre-commit hook (16+ write-time gates), per-PR review bot, 72h integrity cycle, weekly framework-status cron. These are *gate plumbing*, not skills, but skills assume their outputs (e.g. `/ops health` reads `framework-health.json`).
+
+---
+
+## 3 · Anthropic cross-reference
+
+Anthropic publishes an official PM skill set at [`anthropics/knowledge-work-plugins/product-management/`](https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management) — **7 commands + 7 skills** live on `main`. Authoring spec at [`anthropics/skills/skill-creator/SKILL.md`](https://github.com/anthropics/skills). [PR #55](https://github.com/anthropics/knowledge-work-plugins/pull/55) (OPEN) would expand to 14 + 11.
+
+### 3A · Gap candidates from Anthropic content (don't exist in our 11 skills)
+
+| Anthropic skill | Coverage | Maps to ours? | Gap severity |
+|---|---|---|---|
+| `product-brainstorming` | 4 modes (problem/solution/assumption/strategy) + HMW / JTBD / First Principles / OST + 6 anti-patterns | `superpowers:brainstorming` is generic, NOT PM-flavored | **HIGH** |
+| `roadmap-management` | RICE + MoSCoW + Now/Next/Later + decision memos | We have a roadmap *file*, no codifying skill | **HIGH** |
+| `metrics-tracking` (business layer) | Product-metric review cadence, OKRs | Our `analytics` is instrumentation-correctness, different concern | MEDIUM |
+| `stakeholder-comms` | Update templates per audience | None (low value for solo project) | LOW |
+| PR #55 candidates: `sprint-execution`, `executive-synthesis`, `release-communication` | (passive watch) | partial overlap w/ `pm-workflow` + `release` | PASSIVE |
+
+**Not a gap:** `feature-spec` (our `pm-workflow` Phase 2 is heavier), `competitive-analysis` (covered by `research` + `marketing`).
+
+### 3B · Quality-benchmark violations against `skill-creator`
+
+1. **`pm-workflow` is 1688 lines; spec recommends <500.** Single biggest non-conformance. The Anthropic pattern is: thin orchestrator + `references/{topic}.md` files loaded on demand.
+2. **Description fields are catalog-style, not trigger-style.** Anthropic guidance: *"Claude tends to undertrigger skills — make descriptions a little 'pushy'."* Our descriptions read like a feature catalog instead of explicit triggers ("Use when X, Y, Z").
+3. **No `references/` pattern.** Anthropic skills practice progressive disclosure via reference markdown loaded on demand. Our `cache/` is for cross-session learning, not on-demand reference content. Different purpose.
+4. **Commands and skills are co-mingled.** Anthropic separates thin `commands/*.md` from framework `skills/*/SKILL.md`. We embed sub-commands inside SKILL.md. Works fine privately; matters only if we publish externally.
+5. **Anti-patterns sections missing.** Every Anthropic PM skill ends with "Do not..." lists. Our skills are light on these.
+6. **No per-skill evals.** Anthropic ships an `eval-viewer/generate_review.py`. We have nothing comparable.
+
+### 3C · What aligns with Anthropic's guidance (don't change)
+
+- **11-skill cardinality** — Anthropic's live PM plugin has 7 (11 if PR #55 merges). Same order of magnitude.
+- **Hub-and-spoke orchestration** — `pm-workflow` → 10 spokes mirrors Anthropic's command → references → skill chain.
+- **Extra phases (Code/Test/Review/Merge)** — justified for solo iOS-native shop; Anthropic's plugin assumes engineers handle these elsewhere.
+- **T1/T2/T3 tier-tagging, kill criteria, mechanical pre-commit gates, integrity-cycle, gate-coverage telemetry** — none exist in Anthropic's PM plugin. **Our edge. Keep.**
+- **Cross-repo state sync, Figma MCP + Code Connect bridge, pre-merge gates** — no Anthropic equivalent. **Keep.**
+
+---
+
+## 4 · Themes (cross-cutting findings)
+
+### T1 · Skill-content drift from framework reality
+Several SKILL.md files describe v4.x-era behavior without mentioning v7.x bridge mechanisms (A–F), observed-patterns catalog, gate-coverage telemetry, or branch-isolation. **Affected:** cx, marketing, release, research, analytics, ops. **Symptom:** a fresh agent loading the skill won't know to consult [`.claude/integrity/observed-patterns.md`](../../.claude/integrity/observed-patterns.md) before debugging, or to write `gate-coverage.jsonl` entries.
+
+### T2 · Adapter ghost-references
+SKILL.md files name external adapters that don't exist as integration packages: `mixpanel` (analytics), `datadog` (ops), `fastlane` (release), `ayrshare` (marketing). A skill instructing the agent to "dispatch to datadog MCP" with no adapter on disk is a silent dead-end. **Severity:** low for now (no one is calling them), but each is an unhonored promise.
+
+### T3 · Skills cannot test themselves
+The `qa` skill defines test density targets for the codebase but no skill tests the skills layer. SKILL.md files have no fixtures, no dry-run mode, no `make skills-check`. PR #317 (2026-05-12) exposed `BRANCH_ISOLATION_VIOLATION` Mode B was unreachable in `main()` for 5 days — same failure-mode would catch a broken `/ux preflight` instantly if a fixture existed. **Echoes** v7.9 candidates F14–F18.
+
+### T4 · Skills lack a versioning convention
+Some SKILL.md files have `v4.X (2026-05-06)` headers, some have nothing. Across the 11 skills: 5 dated/versioned, 6 undated. No `last_updated` frontmatter, no per-skill changelog.
+
+### T5 · Observed-patterns catalog isn't surfaced everywhere
+The 23-pattern catalog ([`.claude/integrity/observed-patterns.md`](../../.claude/integrity/observed-patterns.md), shipped 2026-05-13 PR #328+#341) is referenced only by **dev**, **qa**, and **pm-workflow**. The other 8 skills don't know it exists.
+
+### T6 · Sub-command testability is zero
+Across 60+ documented `/skill sub-cmd` invocations, none have unit tests, no smoke tests, no fixtures. A 1-line "does this prompt still cite a file path that exists?" check would catch ~half the cross-ref rot.
+
+### T7 · UCC / Control Room integration is hub-only
+`/ops` is the only skill that writes to `framework-health.json`, which is consumed by the UCC. The other 10 skills could surface state but don't. Specifically missing: `/qa coverage`, `/analytics adoption`, `/cx sentiment` aggregates do not feed UCC panels.
+
+### T8 · No skill governs the skills themselves
+There's no `/dev skills-audit` or equivalent. The skills system is structurally a foundational layer of the framework, yet no skill is responsible for keeping it healthy.
+
+### T9 · Conformance with Anthropic's skill-authoring spec
+See §3B. Five concrete violations vs [`skill-creator`](https://github.com/anthropics/skills): pm-workflow length (1688 vs <500), catalog-style descriptions risk under-triggering, missing `references/` progressive disclosure, no anti-patterns sections, no per-skill evals. Plus a separate concern from §3A: we have no PM-flavored brainstorming skill and no roadmap-management skill.
+
+---
+
+## 5 · Concrete proposals
+
+Ordered by leverage. Effort tags: **S** (≤1h), **M** (1–4h), **L** (4h+). Items marked **[ANTH]** were added after the Anthropic cross-reference (§3).
+
+### P0 — Worth shipping this week
+
+**P0.0 · Audit + rewrite 11 `description:` fields for trigger-richness** — **S** **[ANTH]**
+*Why:* Anthropic explicitly warns Claude undertriggers skills with vague descriptions. Our descriptions are catalog-style and likely fail to fire when relevant.
+*How:* Each description gets reshaped as `Use when {trigger A}, {trigger B}, or {trigger C}. {1-sentence "what it does"}.` Pattern modeled on Anthropic's PM plugin descriptions.
+*Files:* all 11 [.claude/skills/{skill}/SKILL.md](../../.claude/skills/) frontmatter blocks.
+*Closes:* part of T9.
+
+**P0.1 · Add `last_updated` + `framework_version` frontmatter to every SKILL.md** — **S**
+*Files:* all 11 SKILL.md.
+```yaml
+---
+name: {skill}
+description: ...
+last_updated: 2026-05-13
+framework_version: v7.8.5
+---
+```
+*Closes:* T4. Lets P0.4 audit staleness mechanically.
+
+**P0.2 · Surface observed-patterns catalog in the 8 skills that don't reference it** — **S**
+*Files:* analytics, cx, design, marketing, ops, release, research, ux SKILL.md.
+*Add stanza:* "Before debugging any gate fire or workflow anomaly: `make observed-patterns`. Append novel patterns BEFORE closing the feature (mandatory per CLAUDE.md §v7.8.5)."
+*Closes:* T5.
+
+**P0.3 · Delete adapter ghost-references** — **S**
+Strike `mixpanel`, `datadog`, `fastlane`, `ayrshare` from the four SKILL.md files where they appear. Acknowledge GA4 + Sentry + App Store Connect + Firecrawl + Axe + security-audit as the only wired adapters.
+*Closes:* T2.
+
+**P0.4 · Add `make skills-audit` mechanical check** — **M**
+*New script:* `scripts/skills-audit.py`. For each SKILL.md, verify: (1) frontmatter present (P0.1); (2) every referenced shared file exists in `.claude/shared/`; (3) every referenced adapter exists in `.claude/integrations/`; (4) every referenced script exists; (5) every cross-skill call is documented. Fail loud, exit non-zero on broken refs.
+*Wire into:* `make integrity-check` — advisory in first cycle, enforced thereafter.
+*Closes:* T3 + T6 + T8.
+
+**P0.5 · Decide qa/cx/marketing/release/research bump or sunset** — **S**
+For each of the 5 undated, base-version skills: is there backlog work that will exercise them in v8.x? If no — annotate `status: "stable, last-modified date"`. If yes — schedule a bump that brings them up to v7.x patterns. Empty `status` is the worst signal.
+
+### P1 — Worth scheduling within the v8.x window
+
+**P1.0a · Split `pm-workflow/SKILL.md` (1688 → <500) via Anthropic `references/` pattern** — **L** **[ANTH]**
+*Why:* Single biggest spec violation. 1688-line skill files are unfocused; Claude has to load all of it even when it only needs Phase 4 guidance.
+*Target shape:* SKILL.md shrinks to a phase-routing core (~400 lines) + `.claude/skills/pm-workflow/references/phase-{0..9}.md` holding per-phase choreography.
+*Risk:* Must be tested on a live `/pm-workflow` invocation to confirm Claude correctly loads the right reference. Pair with P1.3 fixtures.
+*Closes:* biggest T9 violation.
+
+**P1.0b · Add `/brainstorm-pm` skill modeled on Anthropic `product-brainstorming`** — **M** **[ANTH]**
+*Why:* `superpowers:brainstorming` is generic; Anthropic's PM variant ships 4 modes (problem / solution / assumption / strategy) + 4 PM frameworks (HMW / JTBD / First Principles / OST) + 6 anti-patterns. Maps cleanly onto our Phase 1 (Research) entry point.
+*Files:* new `.claude/skills/brainstorm-pm/SKILL.md`. Wire into `pm-workflow` Phase 1 routing.
+*Closes:* §3A Gap #1.
+
+**P1.0c · Add `/roadmap` skill (or pm-workflow roadmap sub-cmd)** — **M** **[ANTH]**
+*Why:* We maintain [docs/master-plan/master-backlog-roadmap.md](../master-plan/master-backlog-roadmap.md) ad-hoc; no skill encodes RICE / MoSCoW / Now-Next-Later. Anthropic's `roadmap-management` provides the template.
+*Recommend:* `/pm-workflow roadmap {review|prioritize|decide}` sub-cmd inside the hub (keeps cardinality at 11 per §3C).
+*Files:* extend `.claude/skills/pm-workflow/SKILL.md` + new `references/roadmap.md`.
+*Closes:* §3A Gap #2.
+
+**P1.0d · Add anti-patterns section to every SKILL.md** — **S** **[ANTH]**
+*Why:* Anthropic PM skills end with explicit "Do not..." lists. Cheap to add, big quality lift, encodes hard-won mistakes (e.g. `cx` should say "Do not infer sentiment from <50 reviews"; `release` should say "Do not promote a build that hasn't passed `make verify-local`").
+*Files:* all 11 SKILL.md, 3-5 bullets each.
+*Closes:* part of T9.
+
+**P1.1 · `/dev skills` skill-of-skills sub-command** — **M**
+*New:* `/dev skills audit | trace | freshness`. Wraps P0.4 + adds: `/dev skills trace {feature}` = print which skills fired in a feature's `state.json::cache_hits[]`. Surfaces actual usage; lets us spot zero-usage skills empirically.
+*Closes:* T8.
+
+**P1.2 · UCC panel: Skills Activity** — **M**
+*File:* `fitme-story/src/app/control-room/skills/page.tsx` (new). Aggregate per-skill: last invocation, last bump date, cross-skill dispatch counts. Data sourced from `state.json` + `gate-coverage.jsonl` + `_session-*.events.jsonl`.
+*Closes:* T7.
+
+**P1.3 · Self-test fixture for every preflight/pre-merge skill** — **M** per skill
+*Affected skills:* ux, design. *Fixture shape:* `.claude/skills/{skill}/fixtures/{scenario}.json` + 1 expected-output golden file per scenario. Wire into CI.
+*Closes:* T3.
+
+**P1.4 · Cross-link adapters to consumers** — **S**
+*File:* every `.claude/integrations/{adapter}/adapter.md`. Add a `consumed_by:` field listing SKILL.md files that reference it. Add inverse pointer (`adapters_used:`) to every SKILL.md.
+*Closes:* T2.
+
+**P1.5 · Skill-level changelog** — **S**
+*New:* `docs/skills/CHANGELOG.md`. One section per skill, append-only. Bump every time `framework_version:` in a SKILL.md changes.
+*Closes:* T4.
+
+**P1.6 · `/cx digest` + `/analytics report` cross-link to UCC** — **S**
+Both skills can write a JSON sidecar (`cx-signals.json`, `metric-status.json`) that UCC already reads. Confirm the schema match + document the contract.
+*Closes:* T7.
+
+### P2 — Defer to v8.x backlog (concrete but not urgent)
+
+**P2.1 · Promote 4 v4.X gates into 11-skill model** — **L**
+Extend the preflight/pre-merge pattern from `/ux` + `/design` to `/qa`, `/analytics`, `/release`. Aligns with FEATURE_CLOSURE_COMPLETENESS v7.9 promotion.
+
+**P2.2 · Skill boundaries enforcement test** — **M**
+Add `SKILL_OWNERSHIP_VIOLATION` to write-time gates. A skill shouldn't write to a shared file outside its `owns` list.
+
+**P2.3 · Per-skill prompt regression tests** — **L**
+Snapshot the rendered SKILL.md prompt + a canonical input scenario; assert output stability across model updates. Out-of-scope until prompt-eval tooling lands.
+
+**P2.4 · Retire/merge low-usage skills** — **L**
+After P1.1 surfaces usage, decide whether `/release` deserves to be standalone vs. folded into `/dev`. Same question for `/marketing` vs `/cx`. Don't act until empirical data shows zero-or-near-zero usage over 90 days.
+
+**P2.5 · Skill versioning convention spec** — **M**
+Document the rules: `v{major}.{minor}` bumped on sub-command add/remove/rename; `last_updated` bumped on any change; `framework_version` mirrors the host framework version at write time. Pair with P1.5.
+
+---
+
+## 6 · Out of scope
+
+- **Superpowers, vercel-plugin, figma skills** — vendor-managed.
+- **CLAUDE.md rewrites** — preserves current discipline; the doc is healthy.
+- **/pm-workflow internal phase changes** — held back until v7.9 promotion decision (2026-05-21).
+- **Anthropic PR #55 candidates** — passive watch; re-evaluate if/when [PR #55](https://github.com/anthropics/knowledge-work-plugins/pull/55) merges.
+- **Per-skill evals** — defer until prompt-eval tooling lands; P2.3 already lists this.
+
+---
+
+## 7 · Verification
+
+For each P0 item:
+
+1. **P0.0** — `grep -L '^description: Use when' .claude/skills/*/SKILL.md` → expect empty.
+2. **P0.1** — `grep -l 'last_updated:' .claude/skills/*/SKILL.md | wc -l` → expect 11.
+3. **P0.2** — grep all 11 SKILL.md for `observed-patterns` → expect 11. Today: 3 (dev, qa, pm-workflow).
+4. **P0.3** — grep all SKILL.md for `mixpanel|datadog|fastlane|ayrshare` → expect 0. Today: 4.
+5. **P0.4** — `make skills-audit` exits 0. Wire into `make verify-local`.
+6. **P0.5** — annotate frontmatter on 5 undated skills; verify via P0.4.
+
+For P1 items: ship behind one PR each, gated by P0.4 passing.
+- **P1.0a**: SKILL.md line count <500, `references/phase-*.md` files exist, live `/pm-workflow` smoke test passes.
+- **P1.0b**: new skill responds to `/brainstorm-pm`; 4 modes + 4 frameworks documented.
+- **P1.0c**: RICE/MoSCoW/Now-Next-Later docs present; decision-memo template exists.
+- **P1.0d**: every SKILL.md ends with a "Do not..." section ≥3 bullets.
+- **P1.1** unlocks empirical decision-making for P2.4.
+
+For P2 items: re-evaluate after first 90-day window of P1.1 usage data.
+
+---
+
+## 8 · Critical files (for whoever implements)
+
+- All 11 [`.claude/skills/*/SKILL.md`](../../.claude/skills/) — frontmatter, descriptions, observed-patterns stanza, anti-patterns section
+- [.claude/skills/pm-workflow/](../../.claude/skills/pm-workflow/) — split target, plus new `references/phase-{0..9}.md` + `references/roadmap.md`
+- `.claude/skills/brainstorm-pm/SKILL.md` — NEW (P1.0b)
+- [.claude/integrations/](../../.claude/integrations/) — 6 existing + 4 ghost
+- [.claude/shared/skill-routing.json](../../.claude/shared/skill-routing.json)
+- [.claude/integrity/observed-patterns.md](../../.claude/integrity/observed-patterns.md)
+- [CLAUDE.md](../../CLAUDE.md) — §Skills ecosystem block; minor reference updates only
+- [docs/skills/](.) — README + architecture + evolution; reflect new conventions after ship
+- `scripts/skills-audit.py` — NEW (P0.4)
+- [scripts/integrity-check.py](../../scripts/integrity-check.py) — wire P0.4 into cycle (advisory first)
+- [Makefile](../../Makefile) — add `skills-audit` target + chain into `integrity-check`
+- `fitme-story/src/app/control-room/skills/page.tsx` — NEW (P1.2)
+
+**Upstream reference repos** (for copying patterns, NOT vendoring):
+- [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins/tree/main/product-management) — Anthropic's 7-skill PM plugin (canonical PM templates)
+- [`anthropics/skills`](https://github.com/anthropics/skills) — skill-creator authoring spec (frontmatter + length + references/ + anti-patterns)
+
+---
+
+## TL;DR
+
+Eleven skills exist and are wired into the hub-and-spoke shared-state model. The system is **architecturally sound**. Where it has drifted is at the **content / measurement / authoring-spec-conformance** layers:
+
+- 6 of 11 SKILL.md files are undated and don't reference v7.x mechanisms.
+- 4 of 11 reference adapters that don't exist on disk.
+- 8 of 11 don't surface the observed-patterns catalog.
+- 11 of 11 have catalog-style descriptions that risk under-triggering (Anthropic spec).
+- 1 of 11 (`pm-workflow`) is 1688 lines vs. Anthropic's <500 recommendation.
+- 0 of 11 have explicit anti-patterns sections.
+- 0 of 11 are mechanically audited for cross-reference integrity.
+- 2 PM-flavored skills missing vs. Anthropic's PM plugin: `product-brainstorming`, `roadmap-management`.
+
+**Top 4 recommended moves** (≤10h total — all S/M, no L):
+1. **P0.0 + P0.1 + P0.2 + P0.3** — frontmatter + trigger-rich descriptions + observed-patterns stanza + delete ghost adapters (4 × S — ~2.5h).
+2. **P0.4** — `make skills-audit` mechanical gate (M, ~2h). Single highest-leverage change; closes T3 + T8 in one PR.
+3. **P1.0d** — anti-patterns sections on all 11 (S, ~1h). Closes part of T9.
+4. **P1.0b + P1.0c** — `/brainstorm-pm` skill + roadmap sub-cmd (M + M, ~4h). Closes both §3A high-severity gaps.
+
+**Larger, deferred to v8.x:** P1.0a (split pm-workflow, L) — biggest single conformance gap but biggest risk; needs fixture-driven verification.
+
+The rest queues into v8.x.


### PR DESCRIPTION
## Summary

Commits 2 substantial planning docs that were sitting untracked on main's working tree from earlier concurrent sessions today.

| File | Lines | Purpose |
|---|---|---|
| `docs/skills/skills-review-2026-05-13.md` | 309 | Framework v7.8.5 skills review across 11 project-owned skills; P0/P1/P2 improvement queue; next review 2026-08-13 |
| `docs/master-plan/test-coverage-master-plan-2026-05-13.md` | 352 | Sub-doc of infra-master-plan-2026-05-12.md; widens Theme G test discipline scope from framework-only to iOS+web+backend+AI+analytics; forward-looking per-layer T-series candidate docket |

Both referenced in MEMORY.md as artifacts of the 2026-05-13 day.

## Test plan

- [x] Doc-only — no code changes
- [x] No state.json or schema changes
- [x] No new gates
- [x] Calibration-window compliant
- [x] Rebased onto latest origin/main (includes #342 analytics SSE server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)