### PR TITLE
feat(analytics-observability): Phase 2.A.3 — iOS `DebugSinkAdapter`

### DIFF
--- a/.claude/features/analytics-observability/state.json
+++ b/.claude/features/analytics-observability/state.json
@@ -251,6 +251,21 @@
         "scripts/tests/test_analytics_watch.py",
         ".claude/skills/analytics/SKILL.md"
       ]
+    },
+    {
+      "id": "2.A.3",
+      "title": "iOS DebugSinkAdapter \u2014 tee events to local SSE sink under DEBUG_ANALYTICS=1",
+      "status": "complete",
+      "phase": "implementation",
+      "started_at": "2026-05-14T03:21:11Z",
+      "completed_at": "2026-05-14T03:21:11Z",
+      "outcome": "New FitTracker/Services/Analytics/DebugSinkAdapter.swift wraps base AnalyticsProvider (Firebase/Mock); transparent passthrough when DEBUG_ANALYTICS env var unset. When set, tees logEvent + logScreenView to localhost:8765/event via fire-and-forget HTTP POST. NEVER tees user-identity APIs (PII safe). Wired into AnalyticsService.makeDefault. 14 XCTest methods at FitTrackerTests/DebugSinkAdapterTests.swift cover passthrough + tee + PII safety + env-driven sink resolution. Both files added to project.pbxproj (4 locations each).",
+      "files_touched": [
+        "FitTracker/Services/Analytics/DebugSinkAdapter.swift",
+        "FitTracker/Services/Analytics/AnalyticsService.swift",
+        "FitTrackerTests/DebugSinkAdapterTests.swift",
+        "FitTracker.xcodeproj/project.pbxproj"
+      ]
     }
   ],
   "figma_node_ids": {},

--- a/.claude/logs/analytics-observability.log.json
+++ b/.claude/logs/analytics-observability.log.json
@@ -6,7 +6,7 @@
   "current_phase": "implementation",
   "framework_version": "v7.8.5",
   "started_at": "2026-05-13T09:00:00Z",
-  "updated_at": "2026-05-13T18:54:50Z",
+  "updated_at": "2026-05-14T03:21:11Z",
   "events": [
     {
       "timestamp": "2026-05-13T09:00:00Z",
@@ -243,6 +243,27 @@
       "metrics": {
         "tests_pass": "12/12",
         "full_suite": "152/152"
+      },
+      "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-14T03:21:11Z",
+      "event_type": "task_completed",
+      "phase": "implementation",
+      "task_id": "2.A.3",
+      "summary": "Phase 2.A.3: DebugSinkAdapter shipped. Wraps base provider; tees to localhost:8765 when DEBUG_ANALYTICS=1; PII-safe (user APIs never teed). 14 XCTests + project.pbxproj wired.",
+      "artifacts": [
+        "FitTracker/Services/Analytics/DebugSinkAdapter.swift",
+        "FitTracker/Services/Analytics/AnalyticsService.swift",
+        "FitTrackerTests/DebugSinkAdapterTests.swift",
+        "FitTracker.xcodeproj/project.pbxproj"
+      ],
+      "metrics": {
+        "new_swift_files": 2,
+        "swift_test_methods": 14,
+        "pbxproj_insertions": 8
       },
       "actor": "claude_opus_4_7",
       "status": "recorded",

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		AC1000000000000000000003 /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000003 /* AnalyticsService.swift */; };
 		AC1000000000000000000004 /* ConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000004 /* ConsentManager.swift */; };
 		AC1000000000000000000005 /* FirebaseAnalyticsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000005 /* FirebaseAnalyticsAdapter.swift */; };
+		AC1000000000000000000200 /* DebugSinkAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000200 /* DebugSinkAdapter.swift */; };
 		AC1000000000000000000006 /* MockAnalyticsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000006 /* MockAnalyticsAdapter.swift */; };
 		AC1000000000000000000007 /* AccountDeletionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000007 /* AccountDeletionService.swift */; };
 		AC1000000000000000000008 /* DataExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000008 /* DataExportService.swift */; };
@@ -69,6 +70,7 @@
 		AS000001000000000000AA01 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AS000002000000000000AA01 /* Assets.xcassets */; };
 		B10000010000000000000001 /* FitTrackerCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20000010000000000000001 /* FitTrackerCoreTests.swift */; };
 		HA100000000000000000001 /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HA200000000000000000001 /* AnalyticsTests.swift */; };
+		DA100000000000000000AT01 /* DebugSinkAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA200000000000000000AT01 /* DebugSinkAdapterTests.swift */; };
 		HA100000000000000000002 /* HomeAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = HA200000000000000000002 /* HomeAnalyticsTests.swift */; };
 		TA100000000000000000001 /* TrainingAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TA200000000000000000001 /* TrainingAnalyticsTests.swift */; };
 		NA100000000000000000001 /* NutritionAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NA200000000000000000001 /* NutritionAnalyticsTests.swift */; };
@@ -351,6 +353,7 @@
 		AC2000000000000000000003 /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		AC2000000000000000000004 /* ConsentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentManager.swift; sourceTree = "<group>"; };
 		AC2000000000000000000005 /* FirebaseAnalyticsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsAdapter.swift; sourceTree = "<group>"; };
+		AC2000000000000000000200 /* DebugSinkAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSinkAdapter.swift; sourceTree = "<group>"; };
 		AC2000000000000000000006 /* MockAnalyticsAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsAdapter.swift; sourceTree = "<group>"; };
 		AC2000000000000000000007 /* AccountDeletionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletionService.swift; sourceTree = "<group>"; };
 		AC2000000000000000000008 /* DataExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExportService.swift; sourceTree = "<group>"; };
@@ -366,6 +369,7 @@
 		AS000002000000000000AA01 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B20000010000000000000001 /* FitTrackerCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitTrackerCoreTests.swift; sourceTree = "<group>"; };
 		HA200000000000000000001 /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
+		DA200000000000000000AT01 /* DebugSinkAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSinkAdapterTests.swift; sourceTree = "<group>"; };
 		HA200000000000000000002 /* HomeAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAnalyticsTests.swift; sourceTree = "<group>"; };
 		TA200000000000000000001 /* TrainingAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingAnalyticsTests.swift; sourceTree = "<group>"; };
 		NA200000000000000000001 /* NutritionAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionAnalyticsTests.swift; sourceTree = "<group>"; };
@@ -971,6 +975,7 @@
 				AC2000000000000000000003 /* AnalyticsService.swift */,
 				AC2000000000000000000004 /* ConsentManager.swift */,
 				AC2000000000000000000005 /* FirebaseAnalyticsAdapter.swift */,
+				AC2000000000000000000200 /* DebugSinkAdapter.swift */,
 				AC2000000000000000000006 /* MockAnalyticsAdapter.swift */,
 			);
 			path = Analytics;
@@ -992,6 +997,7 @@
 			isa = PBXGroup;
 			children = (
 				HA200000000000000000001 /* AnalyticsTests.swift */,
+				DA200000000000000000AT01 /* DebugSinkAdapterTests.swift */,
 				B20000010000000000000001 /* FitTrackerCoreTests.swift */,
 				HA200000000000000000002 /* HomeAnalyticsTests.swift */,
 				TA200000000000000000001 /* TrainingAnalyticsTests.swift */,
@@ -1339,6 +1345,7 @@
 				AC1000000000000000000003 /* AnalyticsService.swift in Sources */,
 				AC1000000000000000000004 /* ConsentManager.swift in Sources */,
 				AC1000000000000000000005 /* FirebaseAnalyticsAdapter.swift in Sources */,
+				AC1000000000000000000200 /* DebugSinkAdapter.swift in Sources */,
 				AC1000000000000000000006 /* MockAnalyticsAdapter.swift in Sources */,
 				AC1000000000000000000007 /* AccountDeletionService.swift in Sources */,
 				AC1000000000000000000008 /* DataExportService.swift in Sources */,
@@ -1497,6 +1504,7 @@
 			files = (
 				B10000010000000000000001 /* FitTrackerCoreTests.swift in Sources */,
 				HA100000000000000000001 /* AnalyticsTests.swift in Sources */,
+				DA100000000000000000AT01 /* DebugSinkAdapterTests.swift in Sources */,
 				HA100000000000000000002 /* HomeAnalyticsTests.swift in Sources */,
 				TA100000000000000000001 /* TrainingAnalyticsTests.swift in Sources */,
 				NA100000000000000000001 /* NutritionAnalyticsTests.swift in Sources */,

--- a/FitTracker/Services/Analytics/AnalyticsService.swift
+++ b/FitTracker/Services/Analytics/AnalyticsService.swift
@@ -48,9 +48,13 @@ final class AnalyticsService: ObservableObject {
 
     static func makeDefault() -> AnalyticsService {
         let consent = ConsentManager()
-        let provider: AnalyticsProvider = AnalyticsRuntimeConfiguration.canUseFirebase
+        let baseProvider: AnalyticsProvider = AnalyticsRuntimeConfiguration.canUseFirebase
             ? FirebaseAnalyticsAdapter()
             : MockAnalyticsAdapter()
+        // Wrap with DebugSinkAdapter — transparent passthrough unless the
+        // DEBUG_ANALYTICS=1 env var is set. Phase 2.A.3 of analytics-observability
+        // per docs/master-plan/analytics-master-plan-2026-05-13.md §6.1.
+        let provider = DebugSinkAdapter(wrapping: baseProvider)
         return AnalyticsService(provider: provider, consent: consent)
     }
 

--- a/FitTracker/Services/Analytics/DebugSinkAdapter.swift
+++ b/FitTracker/Services/Analytics/DebugSinkAdapter.swift
@@ -1,0 +1,162 @@
+// Services/Analytics/DebugSinkAdapter.swift
+// Phase 2.A.3 of analytics-observability per
+// docs/master-plan/analytics-master-plan-2026-05-13.md §6.1 Sub-system A.
+//
+// Wraps another AnalyticsProvider and TEES every event to a local
+// HTTP/SSE sink (default: http://127.0.0.1:8765/event — the server
+// shipped in Phase 2.A.1) IFF the `DEBUG_ANALYTICS=1` env var is set.
+//
+// Design properties:
+//   - PRODUCTION SAFE: when env var unset, this is a transparent passthrough
+//     to the inner adapter. Firebase/GA4 receives every event identically.
+//   - PASSIVE TEE: production path is never blocked by sink failures.
+//     POST is fire-and-forget; errors are discarded. The local debug sink
+//     is dev-only — losing events there must never affect real analytics.
+//   - DEPENDENCY-INJECTED: the AnalyticsDebugEventSink protocol abstracts
+//     the HTTP path so unit tests can verify behavior without network I/O.
+//   - PII SAFE: only logEvent + logScreenView are mirrored. setUserID and
+//     setUserProperty (which can carry per-user identifiers) are passed
+//     to the inner adapter only — never teed to the local sink.
+//
+// USAGE
+// -----
+// Wired via AnalyticsService.makeDefault() (see that file). To enable
+// during local development:
+//   1. Run the SSE server in a separate terminal:
+//        python3 scripts/analytics-watch-server.py
+//   2. In Xcode Edit Scheme → Run → Arguments → Environment Variables,
+//      add:  DEBUG_ANALYTICS = 1
+//   3. Run the app. Tail events with:
+//        python3 scripts/analytics-watch.py
+//
+// To override the sink URL, set:
+//   DEBUG_ANALYTICS_URL = http://127.0.0.1:9999/event
+
+import Foundation
+
+/// Receives an event for forwarding to the local debug sink.
+///
+/// Default impl is `URLSessionEventSink`. Tests can substitute a recording
+/// double to assert on calls without performing network I/O.
+protocol AnalyticsDebugEventSink {
+    func send(name: String, parameters: [String: Any]?)
+}
+
+/// Real network sink: fire-and-forget HTTP POST to the SSE server's `/event`
+/// endpoint. Errors are discarded (this is a dev-only mirror).
+final class URLSessionEventSink: AnalyticsDebugEventSink {
+
+    private let url: URL
+    private let session: URLSession
+
+    init(url: URL, session: URLSession? = nil) {
+        self.url = url
+        // Use ephemeral session — no caching, no persistence, no cookies.
+        self.session = session ?? URLSession(configuration: .ephemeral)
+    }
+
+    func send(name: String, parameters: [String: Any]?) {
+        var payload: [String: Any] = ["event_name": name]
+        if let parameters {
+            // Convert non-JSON-safe values to strings so JSONSerialization
+            // doesn't throw on Date / NSNumber subclasses / etc.
+            payload["params"] = parameters.mapValues(Self.jsonSafe(_:))
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+        // Fire and forget. The completion handler discards everything
+        // including errors — this sink must never block or surface anything
+        // to the production code path.
+        session.dataTask(with: request) { _, _, _ in }.resume()
+    }
+
+    /// Coerce a value into something `JSONSerialization` will accept.
+    private static func jsonSafe(_ value: Any) -> Any {
+        switch value {
+        case let v as String: return v
+        case let v as Bool: return v
+        case let v as Int: return v
+        case let v as Double: return v
+        case let v as Float: return Double(v)
+        case let v as Date: return ISO8601DateFormatter().string(from: v)
+        default: return String(describing: value)
+        }
+    }
+}
+
+/// Wraps an existing AnalyticsProvider; conditionally tees events to a
+/// local debug sink while preserving the production analytics path.
+final class DebugSinkAdapter: AnalyticsProvider {
+
+    /// Default URL for the local mirror sink (Phase 2.A.1 server default).
+    static let defaultSinkURL = URL(string: "http://127.0.0.1:8765/event")!
+
+    private let inner: AnalyticsProvider
+    private let sink: AnalyticsDebugEventSink?
+
+    init(
+        wrapping inner: AnalyticsProvider,
+        sink: AnalyticsDebugEventSink? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.inner = inner
+        // Resolve the sink:
+        //   1. Caller-provided override wins (used by tests + advanced users)
+        //   2. Otherwise: enabled iff DEBUG_ANALYTICS=1; URL from
+        //      DEBUG_ANALYTICS_URL or the default localhost:8765/event
+        if let sink {
+            self.sink = sink
+        } else if environment["DEBUG_ANALYTICS"] == "1" {
+            let urlString = environment["DEBUG_ANALYTICS_URL"]
+            let url = urlString.flatMap(URL.init(string:)) ?? Self.defaultSinkURL
+            self.sink = URLSessionEventSink(url: url)
+        } else {
+            self.sink = nil
+        }
+    }
+
+    /// True iff events are currently being teed to a sink.
+    var isTeeing: Bool { sink != nil }
+
+    // MARK: - AnalyticsProvider conformance
+
+    func configure() {
+        inner.configure()
+    }
+
+    func logEvent(_ name: String, parameters: [String: Any]?) {
+        inner.logEvent(name, parameters: parameters)
+        sink?.send(name: name, parameters: parameters)
+    }
+
+    func logScreenView(_ screenName: String, screenClass: String?) {
+        inner.logScreenView(screenName, screenClass: screenClass)
+        sink?.send(
+            name: "screen_view",
+            parameters: [
+                "screen_name": screenName,
+                "screen_class": screenClass ?? ""
+            ]
+        )
+    }
+
+    func setUserProperty(_ value: String?, forName name: String) {
+        // NEVER teed. User properties may carry per-user identifiers.
+        inner.setUserProperty(value, forName: name)
+    }
+
+    func setUserID(_ id: String?) {
+        // NEVER teed. User IDs are PII.
+        inner.setUserID(id)
+    }
+
+    func setConsent(analyticsStorage: Bool, adStorage: Bool) {
+        // NEVER teed. Operator-side state, not an analytics event.
+        inner.setConsent(analyticsStorage: analyticsStorage, adStorage: adStorage)
+    }
+}

--- a/FitTrackerTests/DebugSinkAdapterTests.swift
+++ b/FitTrackerTests/DebugSinkAdapterTests.swift
@@ -1,0 +1,173 @@
+// DebugSinkAdapterTests.swift
+// Phase 2.A.3 of analytics-observability per
+// docs/master-plan/analytics-master-plan-2026-05-13.md §6.1.
+//
+// Verifies that DebugSinkAdapter:
+//   1. Is a transparent passthrough when DEBUG_ANALYTICS env var is unset
+//      (production safety — Firebase/GA4 still receives all events identically)
+//   2. Tees logEvent + logScreenView to the sink when DEBUG_ANALYTICS=1
+//   3. NEVER tees user-identity APIs (setUserProperty / setUserID / setConsent)
+//      because those can carry per-user PII
+
+import XCTest
+@testable import FitTracker
+
+final class DebugSinkAdapterTests: XCTestCase {
+
+    // MARK: - Doubles
+
+    /// Records every event sent to the debug sink.
+    private final class RecordingSink: AnalyticsDebugEventSink {
+        struct Captured {
+            let name: String
+            let parameters: [String: Any]?
+        }
+        private(set) var captured: [Captured] = []
+
+        func send(name: String, parameters: [String: Any]?) {
+            captured.append(Captured(name: name, parameters: parameters))
+        }
+    }
+
+    // MARK: - Setup
+
+    private var inner: MockAnalyticsAdapter!
+    private var sink: RecordingSink!
+
+    override func setUp() {
+        super.setUp()
+        inner = MockAnalyticsAdapter()
+        sink = RecordingSink()
+    }
+
+    override func tearDown() {
+        inner = nil
+        sink = nil
+        super.tearDown()
+    }
+
+    // MARK: - Production safety: tee disabled by default
+
+    func testIsTeeingFalseWhenEnvUnset() {
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: [:])
+        XCTAssertFalse(adapter.isTeeing, "Sink must be nil when DEBUG_ANALYTICS env var is unset")
+    }
+
+    func testInnerReceivesEventEvenWithoutSink() {
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: [:])
+        adapter.logEvent("test_event", parameters: ["a": 1])
+        XCTAssertEqual(inner.capturedEvents.count, 1)
+        XCTAssertEqual(inner.capturedEvents[0].name, "test_event")
+    }
+
+    func testInnerReceivesScreenViewEvenWithoutSink() {
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: [:])
+        adapter.logScreenView("home", screenClass: "HomeView")
+        XCTAssertEqual(inner.capturedScreens.count, 1)
+        XCTAssertEqual(inner.capturedScreens[0], "home")
+    }
+
+    // MARK: - Tee behavior: env-gated
+
+    func testIsTeeingTrueWhenEnvSetAndExplicitSink() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        XCTAssertTrue(adapter.isTeeing)
+    }
+
+    func testLogEventTeesToSinkWhenEnabled() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        adapter.logEvent("home_action_tap", parameters: ["action_type": "start_workout"])
+
+        // Inner still receives event (passthrough preserved)
+        XCTAssertEqual(inner.capturedEvents.count, 1)
+        XCTAssertEqual(inner.capturedEvents[0].name, "home_action_tap")
+        XCTAssertEqual(inner.capturedEvents[0].parameters?["action_type"] as? String, "start_workout")
+
+        // Sink also receives the same event
+        XCTAssertEqual(sink.captured.count, 1)
+        XCTAssertEqual(sink.captured[0].name, "home_action_tap")
+        XCTAssertEqual(sink.captured[0].parameters?["action_type"] as? String, "start_workout")
+    }
+
+    func testLogEventDoesNotTeeWhenSinkNil() {
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: [:])
+        adapter.logEvent("home_action_tap", parameters: nil)
+        XCTAssertEqual(inner.capturedEvents.count, 1)
+        // sink is local to this test — we use the explicit-sink path elsewhere;
+        // here we just verify production-safe behavior under default env.
+    }
+
+    func testLogScreenViewTeesAsScreenViewEvent() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        adapter.logScreenView("training_session", screenClass: "ActiveTrainingSessionView")
+
+        XCTAssertEqual(inner.capturedScreens.count, 1)
+        XCTAssertEqual(inner.capturedScreens[0], "training_session")
+
+        XCTAssertEqual(sink.captured.count, 1)
+        XCTAssertEqual(sink.captured[0].name, "screen_view")
+        XCTAssertEqual(sink.captured[0].parameters?["screen_name"] as? String, "training_session")
+        XCTAssertEqual(sink.captured[0].parameters?["screen_class"] as? String, "ActiveTrainingSessionView")
+    }
+
+    func testLogScreenViewWithNilClassUsesEmptyString() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        adapter.logScreenView("home", screenClass: nil)
+        XCTAssertEqual(sink.captured[0].parameters?["screen_class"] as? String, "")
+    }
+
+    // MARK: - PII safety: user-identity APIs NEVER tee
+
+    func testSetUserPropertyNeverTees() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        adapter.setUserProperty("intermediate", forName: "training_level")
+
+        XCTAssertEqual(sink.captured.count, 0,
+                       "setUserProperty must NEVER tee — user properties may carry PII")
+    }
+
+    func testSetUserIDNeverTees() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        adapter.setUserID("user-12345")
+
+        XCTAssertEqual(sink.captured.count, 0,
+                       "setUserID must NEVER tee — user IDs are PII")
+    }
+
+    func testSetConsentNeverTees() {
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: ["DEBUG_ANALYTICS": "1"])
+        adapter.setConsent(analyticsStorage: true, adStorage: false)
+
+        XCTAssertEqual(sink.captured.count, 0,
+                       "setConsent must NEVER tee — operator state, not analytics event")
+    }
+
+    // MARK: - Env-driven sink resolution
+
+    func testEnvVarUnsetMeansNoSink() {
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: ["FOO": "bar"])
+        XCTAssertFalse(adapter.isTeeing)
+    }
+
+    func testEnvVarValueOtherThan1MeansNoSink() {
+        // Only "1" enables — "true", "yes", "0", etc. all disable
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: ["DEBUG_ANALYTICS": "true"])
+        XCTAssertFalse(adapter.isTeeing,
+                       "Only DEBUG_ANALYTICS=1 enables; other truthy strings are conservative-disabled")
+    }
+
+    func testEnvVarSetTo1AutoConstructsURLSessionSink() {
+        // No explicit sink override → constructor builds URLSessionEventSink
+        let adapter = DebugSinkAdapter(wrapping: inner, environment: ["DEBUG_ANALYTICS": "1"])
+        XCTAssertTrue(adapter.isTeeing,
+                      "DEBUG_ANALYTICS=1 with no explicit sink override should auto-construct URLSessionEventSink")
+    }
+
+    func testExplicitSinkOverrideWinsOverEnv() {
+        // Even with env unset, an explicit sink turns on teeing — for tests
+        let adapter = DebugSinkAdapter(wrapping: inner, sink: sink, environment: [:])
+        XCTAssertTrue(adapter.isTeeing)
+        adapter.logEvent("forced_tee", parameters: nil)
+        XCTAssertEqual(sink.captured.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary

Wires the iOS app to the local SSE mirror server (Phase 2.A.1) + CLI watcher (Phase 2.A.2) to close the iOS half of Phase 2 (live debugger). Production safe by default — only activates under `DEBUG_ANALYTICS=1` Xcode scheme env var.

## What ships

### [`FitTracker/Services/Analytics/DebugSinkAdapter.swift`](FitTracker/Services/Analytics/DebugSinkAdapter.swift) (~155 lines)

| Type | Purpose |
|---|---|
| `AnalyticsDebugEventSink` protocol | Abstracts the network path so tests verify behavior without HTTP I/O |
| `URLSessionEventSink` | Default impl; fire-and-forget POST to `http://127.0.0.1:8765/event` (override via `DEBUG_ANALYTICS_URL`) |
| `DebugSinkAdapter` | Wraps inner `AnalyticsProvider`; tees `logEvent` + `logScreenView` when sink is set; **NEVER tees** `setUserProperty` / `setUserID` / `setConsent` (PII safe) |

**Design properties:**
- **Production safe** — env unset → transparent passthrough. Firebase/GA4 receives every event identically.
- **Passive tee** — fire-and-forget POST; sink failures discarded; production analytics path never blocked or affected.
- **Dependency-injected** — protocol-based sink for testability.
- **PII safe** — only event/screen APIs are mirrored.

### [`FitTracker/Services/Analytics/AnalyticsService.swift`](FitTracker/Services/Analytics/AnalyticsService.swift) (1 method change)
`makeDefault()` now wraps the base provider with `DebugSinkAdapter`. Effect at runtime:
- `DEBUG_ANALYTICS` unset → identical behavior to before this PR
- `DEBUG_ANALYTICS=1` → events also POST to local mirror server

### [`FitTrackerTests/DebugSinkAdapterTests.swift`](FitTrackerTests/DebugSinkAdapterTests.swift) (14 XCTest methods)

| Test | Validates |
|---|---|
| `testIsTeeingFalseWhenEnvUnset` | Sink nil when DEBUG_ANALYTICS env unset |
| `testInnerReceivesEventEvenWithoutSink` | Production passthrough preserved |
| `testInnerReceivesScreenViewEvenWithoutSink` | Same for screen views |
| `testIsTeeingTrueWhenEnvSetAndExplicitSink` | Sink activates under env=1 |
| `testLogEventTeesToSinkWhenEnabled` | Events tee + inner still receives |
| `testLogScreenViewTeesAsScreenViewEvent` | Screen views tee as `screen_view` event |
| `testLogScreenViewWithNilClassUsesEmptyString` | Nil screen class → empty string |
| `testSetUserPropertyNeverTees` | **PII safety** |
| `testSetUserIDNeverTees` | **PII safety** |
| `testSetConsentNeverTees` | **PII safety** |
| `testEnvVarUnsetMeansNoSink` | Env discrimination |
| `testEnvVarValueOtherThan1MeansNoSink` | Conservative env parsing (only "1") |
| `testEnvVarSetTo1AutoConstructsURLSessionSink` | Auto-construction works |
| `testExplicitSinkOverrideWinsOverEnv` | Test ergonomics |

### `FitTracker.xcodeproj/project.pbxproj`
Both new Swift files added at 4 standard locations each (PBXBuildFile + PBXFileReference + PBXGroup + PBXSourcesBuildPhase) — same pattern as `FirebaseAnalyticsAdapter.swift` was added.

## Operator usage

```sh
# Terminal 1 — start the SSE server (Phase 2.A.1)
python3 scripts/analytics-watch-server.py

# Terminal 2 — tail the events (Phase 2.A.2)
python3 scripts/analytics-watch.py
```

In Xcode: Edit Scheme → Run → Arguments → Environment Variables → add `DEBUG_ANALYTICS = 1`. Build + run. Every event the iOS app fires is now teed to the local mirror.

## Verification

- [x] `pytest scripts/tests/` → 152/152 (no Python regression)
- [x] `make schema-check` → 70/70 state.json clean
- [x] state.json: `tasks[]` entry for 2.A.3
- [x] log.json: `task_completed` event for 2.A.3
- [ ] CI Build and Test will validate Swift compilation + 14 XCTests

## Phase 2 status after this PR

| Task | Status |
|---|---|
| 2.A.1 SSE mirror server | ✅ PR #342 |
| 2.A.2 `/analytics watch` CLI | ✅ PR #345 |
| **2.A.3 iOS DebugSinkAdapter** | **🟡 this PR** |
| 2.A.4 fitme-story web mirror function | next |
| 2.B.1 `/analytics poll` + GA4 MCP setup runbook | next |

## Spec reference

[`docs/master-plan/analytics-master-plan-2026-05-13.md`](docs/master-plan/analytics-master-plan-2026-05-13.md) §6.1 Sub-system A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)