### PR TITLE
chore(skills): P1.1 — /dev skills sub-command (audit | trace | freshness)

### DIFF
--- a/.claude/skills/dev/SKILL.md
+++ b/.claude/skills/dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev
-description: "Use when starting a feature branch, requesting code review, checking CI status, auditing dependencies, or profiling a performance hotspot. Respects high-risk-area review policy (DomainModels, EncryptionService, SupabaseSyncService, CloudKitSyncService, SignInService, AuthManager, AIOrchestrator). Sub-commands: /dev branch {feature}, /dev review, /dev deps, /dev perf, /dev ci-status."
+description: "Use when starting a feature branch, requesting code review, checking CI status, auditing dependencies, profiling a performance hotspot, or auditing the skills layer itself (skill-of-skills meta-checks). Respects high-risk-area review policy (DomainModels, EncryptionService, SupabaseSyncService, CloudKitSyncService, SignInService, AuthManager, AIOrchestrator). Sub-commands: /dev branch {feature}, /dev review, /dev deps, /dev perf, /dev ci-status, /dev skills {audit|trace|freshness}."
 last_updated: 2026-05-14
 framework_version: v7.8.5
 status: active
@@ -91,6 +91,44 @@ Check current CI pipeline status.
 2. Check latest GitHub Actions run status
 3. Report: token-check, build, test results
 4. Update `.claude/shared/health-status.json` with current status
+
+### `/dev skills {audit|trace|freshness}`
+
+Skill-of-skills meta-checks for `.claude/skills/*`. Wraps the P0.4 audit script and adds usage tracing + freshness inspection. Per [`docs/skills/skills-review-2026-05-13.md`](../../../docs/skills/skills-review-2026-05-13.md) §5 item P1.1.
+
+#### `/dev skills audit`
+
+Run mechanical conformance checks on every SKILL.md (frontmatter present, trigger-rich descriptions, observed-patterns reference, adapter + script refs resolve on disk, freshness within window).
+
+```bash
+make skills-audit             # strict mode — exit 1 on E findings
+python3 scripts/skills-audit.py --advisory --quiet   # advisory mode (used in `make integrity-check`)
+python3 scripts/skills-audit.py --skill <name>       # single-skill scope
+```
+
+Report: per-skill PASS / E[code] / W[code] lines + summary count. Exit codes: 0 on clean, 1 on E findings. The audit also runs inside `make integrity-check` as `--advisory --quiet` (v7.8.5 → v7.9 window).
+
+#### `/dev skills trace {feature}`
+
+Surface which skills fired during a feature's lifecycle by cross-referencing three data sources:
+
+1. **`state.json::cache_hits[]`** — Read events attributed to that feature (Mechanism C). Filter for entries whose `file` field matches `.claude/skills/<name>/SKILL.md` — that's the proxy for "skill loaded into context."
+2. **`state.json::tasks[].dispatched_skills`** (if populated) — explicit skill dispatch ledger.
+3. **`.claude/logs/_session-<id>.events.jsonl`** — raw session events; filter where `active_feature == <feature>` and the Read target contains `.claude/skills/`.
+
+Output: ranked list of `<skill> — N hits` for the feature. Surfaces zero-usage skills empirically; data feeds the P2.4 retire/merge decision in the future.
+
+When `{feature}` is omitted: aggregate across all features in `.claude/features/*/state.json` and report a leaderboard.
+
+#### `/dev skills freshness`
+
+Inspect every SKILL.md frontmatter and flag those with `last_updated:` older than 90 days. Wraps the `W4` warning emitted by `scripts/skills-audit.py` (since this commit) so the operator can see the same data without running the full audit.
+
+```bash
+python3 scripts/skills-audit.py --quiet 2>&1 | grep '\[W4\]'
+```
+
+Reads `last_updated:` from each `.claude/skills/<name>/SKILL.md`. Flags any skill `>90 days` since last update (configurable via `--max-age-days <N>` to the audit script). Forces a review even if the skill is otherwise passing — stale skills accumulate quiet drift against the framework version they cite.
 
 ## Key References
 

--- a/scripts/skills-audit.py
+++ b/scripts/skills-audit.py
@@ -9,9 +9,10 @@ Per-skill checks:
   E2  description starts with "Use when " (Anthropic trigger-richness guidance)
   E3  Referenced adapters exist under .claude/integrations/
   E4  Referenced scripts (scripts/foo.py) exist on disk
-  E5  Cross-skill calls (/skill sub-cmd) reference real skills
   W1  Reference to observed-patterns catalog present (warn if missing)
   W2  Sub-commands declared in description match sub-commands documented in body
+  W3  Project cross-skill refs (/skill verb) resolve, with vendor-prefix allowlist
+  W4  Freshness — last_updated older than --max-age-days (default 90)
 
 Exit codes:
   0 — no E findings (W findings allowed)
@@ -21,8 +22,10 @@ CLI:
   --advisory        Treat E findings as W (always exit 0). Used during
                     v7.8.5 advisory window before v7.9 promotion.
   --quiet           Suppress per-skill PASS lines; print only findings + summary.
-  --skill <name>    Audit only the named skill (one of: analytics, cx, design,
-                    dev, marketing, ops, pm-workflow, qa, release, research, ux).
+  --skill <name>    Audit only the named skill (one of: analytics, brainstorm-pm,
+                    cx, design, dev, marketing, ops, pm-workflow, qa, release,
+                    research, ux).
+  --max-age-days N  Threshold for W4 freshness check (default 90).
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ import argparse
 import re
 import sys
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -283,7 +287,26 @@ def check_w2_sub_commands(sf: SkillFile) -> list[Finding]:
     return []
 
 
-def audit_one(path: Path, real_adapters: set[str], known_skills: set[str]) -> list[Finding]:
+def check_w4_freshness(sf: SkillFile, max_age_days: int, today: date) -> list[Finding]:
+    """Warn when last_updated is older than max_age_days."""
+    raw = sf.frontmatter.get("last_updated", "").strip()
+    if not raw:
+        return []  # E1 already flags missing frontmatter
+    try:
+        last = datetime.strptime(raw, "%Y-%m-%d").date()
+    except ValueError:
+        return [Finding(sf.name, "W4", "W",
+                       f"last_updated='{raw}' does not parse as YYYY-MM-DD")]
+    age = (today - last).days
+    if age > max_age_days:
+        return [Finding(sf.name, "W4", "W",
+                       f"last_updated={raw} is {age} days old "
+                       f"(>{max_age_days}); review for drift against current framework")]
+    return []
+
+
+def audit_one(path: Path, real_adapters: set[str], known_skills: set[str],
+              max_age_days: int, today: date) -> list[Finding]:
     sf = parse_skill_file(path)
     findings: list[Finding] = []
     findings.extend(check_e1_required_frontmatter(sf))
@@ -293,6 +316,7 @@ def audit_one(path: Path, real_adapters: set[str], known_skills: set[str]) -> li
     findings.extend(check_w3_cross_skill_refs(sf, known_skills))
     findings.extend(check_w1_observed_patterns(sf))
     findings.extend(check_w2_sub_commands(sf))
+    findings.extend(check_w4_freshness(sf, max_age_days, today))
     return findings
 
 
@@ -304,6 +328,8 @@ def main() -> int:
                        help="Print only findings + summary")
     parser.add_argument("--skill", default=None,
                        help="Audit only the named skill")
+    parser.add_argument("--max-age-days", type=int, default=90,
+                       help="W4 freshness threshold (default 90)")
     args = parser.parse_args()
 
     if not SKILLS_ROOT.is_dir():
@@ -322,9 +348,11 @@ def main() -> int:
     known_skills = {p.name for p in SKILLS_ROOT.iterdir()
                     if p.is_dir() and (p / "SKILL.md").is_file()}
 
+    today = date.today()
     all_findings: list[Finding] = []
     for skill_dir in skill_dirs:
-        skill_findings = audit_one(skill_dir / "SKILL.md", real_adapters, known_skills)
+        skill_findings = audit_one(skill_dir / "SKILL.md", real_adapters,
+                                    known_skills, args.max_age_days, today)
         all_findings.extend(skill_findings)
         if not args.quiet and not skill_findings:
             print(f"PASS  {skill_dir.name}")


### PR DESCRIPTION
Closes P1.1 from docs/skills/skills-review-2026-05-13.md §5. Adds skill-of-skills meta-checks to /dev. Base: PR #350; will rebase to main after #350 merges. Verbs: audit (wraps make skills-audit), trace {feature} (cross-references cache_hits + dispatched_skills + session events), freshness (flags last_updated >90d). skills-audit.py gains W4 freshness check + --max-age-days flag. 12/12 PASS.