### PR TITLE
docs(v7-7): trend-mode unlocks verified — flip banner to shipped

### DIFF
--- a/.claude/shared/documentation-debt.json
+++ b/.claude/shared/documentation-debt.json
@@ -1,10 +1,10 @@
 {
   "version": "1.0",
-  "updated": "2026-05-12T07:42:03Z",
+  "updated": "2026-05-14T09:01:43Z",
   "description": "Baseline documentation-debt report for case-study structure, state linkage, and integrity-cycle readiness.",
   "summary": {
     "case_studies_scanned": 76,
-    "features_scanned": 68,
+    "features_scanned": 69,
     "integrity_snapshot_files": 5,
     "integrity_cycle_snapshots": 3,
     "trend_ready": true,
@@ -66,7 +66,7 @@
       ]
     },
     "state_case_study_linkage": {
-      "present": 68,
+      "present": 69,
       "missing": 0,
       "percent": 100.0,
       "examples": []

--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -370,7 +370,48 @@
           "post_v6_percent": 20.6
         }
       }
+    },
+    {
+      "date": "2026-05-14",
+      "generated_at": "2026-05-14T09:00:43Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 69,
+        "features_post_v6": 35,
+        "features_pre_v6": 34,
+        "fully_adopted": 3,
+        "partial_adopted": 27,
+        "zero_adopted": 39,
+        "fully_adopted_post_v6": 3,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 17,
+          "overall_percent": 24.6,
+          "post_v6_present": 17,
+          "post_v6_percent": 48.6
+        },
+        "per_phase_timing": {
+          "overall_present": 30,
+          "overall_percent": 43.5,
+          "post_v6_present": 27,
+          "post_v6_percent": 77.1
+        },
+        "cache_hits": {
+          "overall_present": 20,
+          "overall_percent": 29.0,
+          "post_v6_present": 19,
+          "post_v6_percent": 54.3
+        },
+        "cu_v2": {
+          "overall_present": 7,
+          "overall_percent": 10.1,
+          "post_v6_present": 7,
+          "post_v6_percent": 20.0
+        }
+      }
     }
   ],
-  "updated": "2026-05-12T07:24:45Z"
+  "updated": "2026-05-14T09:00:43Z"
 }

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,14 +1,14 @@
 {
   "version": "1.0",
-  "updated": "2026-05-12T07:24:45Z",
+  "updated": "2026-05-14T09:00:43Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {
-    "features_total": 68,
-    "features_post_v6": 34,
+    "features_total": 69,
+    "features_post_v6": 35,
     "features_pre_v6": 34,
     "fully_adopted": 3,
-    "partial_adopted": 26,
+    "partial_adopted": 27,
     "zero_adopted": 39,
     "fully_adopted_post_v6": 3,
     "tier_1_1_status": "partial"
@@ -16,27 +16,27 @@
   "dimension_coverage": {
     "timing_wall_time": {
       "overall_present": 17,
-      "overall_percent": 25.0,
+      "overall_percent": 24.6,
       "post_v6_present": 17,
-      "post_v6_percent": 50.0
+      "post_v6_percent": 48.6
     },
     "per_phase_timing": {
-      "overall_present": 29,
-      "overall_percent": 42.6,
-      "post_v6_present": 26,
-      "post_v6_percent": 76.5
+      "overall_present": 30,
+      "overall_percent": 43.5,
+      "post_v6_present": 27,
+      "post_v6_percent": 77.1
     },
     "cache_hits": {
-      "overall_present": 18,
-      "overall_percent": 26.5,
-      "post_v6_present": 18,
-      "post_v6_percent": 52.9
+      "overall_present": 20,
+      "overall_percent": 29.0,
+      "post_v6_present": 19,
+      "post_v6_percent": 54.3
     },
     "cu_v2": {
       "overall_present": 7,
-      "overall_percent": 10.3,
+      "overall_percent": 10.1,
       "post_v6_present": 7,
-      "post_v6_percent": 20.6
+      "post_v6_percent": 20.0
     }
   },
   "fully_adopted_features": [
@@ -158,7 +158,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       }
     },
@@ -172,11 +172,20 @@
       }
     },
     {
-      "feature": "import-training-plan",
+      "feature": "hadf-phase2bis-replication",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
         "cache_hits": false,
+        "cu_v2": false
+      }
+    },
+    {
+      "feature": "import-training-plan",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": true,
         "cu_v2": false
       }
     },
@@ -920,7 +929,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       },
       "fully_adopted": false,
@@ -983,6 +992,20 @@
       "any_adopted": true
     },
     {
+      "feature": "hadf-phase2bis-replication",
+      "created": "2026-05-12",
+      "post_v6": true,
+      "current_phase": "tasks_phase",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      },
+      "fully_adopted": false,
+      "any_adopted": true
+    },
+    {
       "feature": "home-status-goal-card",
       "created": "2026-04-09",
       "post_v6": false,
@@ -1018,7 +1041,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       },
       "fully_adopted": false,

--- a/docs/case-studies/framework-v7-7-validity-closure-case-study.md
+++ b/docs/case-studies/framework-v7-7-validity-closure-case-study.md
@@ -181,13 +181,26 @@ Fully adopted post-v6: **2/9** (data-integrity-framework-v7-6, meta-analysis-aud
 - **Status flip [T1]:** CLAUDE.md banner already updated to `v7.7, shipped 2026-04-27` by v7.8 sessions (no re-edit needed). `master-plan-2026-04-15.md` updated from "READY FOR MERGE" → "SHIPPED 2026-04-27" in this session.
 - **Tier tags applied:** snapshot count + adoption percentages + ledger commit ref T1; denominator-growth explanation T3.
 
+### 2026-05-14 09:01 UTC — B2 verified (Tier 3.2 trend mode unlocked); both B1 + B2 complete
+- **Trigger:** Scheduled verification agent run (2026-05-14). Checks B1 + B2 status per Section 99.8 post-merge checklist.
+- **B1 — Tier 1.1 trend mode: ALREADY VERIFIED 2026-05-04 [T1]** — `measurement-adoption-history.json` carries **10 snapshots [T1]** as of this run (dates: 2026-04-25 through 2026-05-14). Threshold ≥3 met; trend mode active. (First verified in the 2026-05-04 journal entry above.)
+- **B2 — Tier 3.2 trend mode: VERIFIED 2026-05-14 [T1]**
+  - `make documentation-debt` → `integrity_cycle.snapshots_available: 3 [T1]`, `trend_ready: true`, `snapshot_files_available: 5`. Threshold ≥3 met; trend mode active.
+  - `documentation-debt.json::summary.open_debt_items: 1 [T1]`, `case_studies_scanned: 76 [T1]`, `features_scanned: 69 [T1]`.
+- **`make measurement-adoption` key lines [T1]:**
+  - Features: 69 (post-v6: 35); fully adopted post-v6: 3/35 (8.6%); Tier 1.1 status: partial
+  - Per-dimension post-v6: `timing_wall_time` 48.6%, `per_phase_timing` 77.1%, `cache_hits` 54.3%, `cu_v2` 20.0%
+  - History ledger: 10 dated snapshots (2026-04-25 → 2026-05-14) [T1]
+- **Outcome:** Both B1 + B2 now verified. Section 99 status banner updated below [T2].
+- **Tier tags applied:** snapshot counts and `make` output numbers T1 (instrumented directly from ledger files and command output); banner-update declared date T2.
+
 ## Section 99 — Synthesis (written at M5 / T31, 2026-04-27)
 
-> **Status:** v7.7 work **complete and ready for merge** as of 2026-04-27. Two pieces remain time-gated and will be verified post-merge:
-> - **B1** (Tier 1.1 trend mode unlocks at 3 history snapshots) — earliest **2026-05-04** when the Monday cron appends snapshot #3.
-> - **B2** (Tier 3.2 trend mode unlocks at 3 cycle snapshots) — earliest **~2026-05-03 to -06** when the 72h cycle accumulates 3 snapshots.
+> **Status:** v7.7 work **complete and shipped 2026-05-14** [T2]. All cron-gated post-merge verifications now complete:
+> - **B1** (Tier 1.1 trend mode) — verified **2026-05-04** [T1]; `measurement-adoption-history.json` had ≥3 snapshots (10 total as of 2026-05-14).
+> - **B2** (Tier 3.2 trend mode) — verified **2026-05-14** [T1]; `documentation-debt.json::integrity_cycle.snapshots_available: 3`, `trend_ready: true`.
 >
-> The spec §6 explicitly anticipated this: "partly gated by passive cron firings." This synthesis covers everything that **did** ship; B1/B2 verification + journal entry will be appended by a +7d /schedule run.
+> Original prediction: "earliest 2026-05-03 to -06" for B2. Actual: 2026-05-14 (cron persistence fix delayed the 3rd cycle snapshot). Both unlock thresholds (≥3) confirmed met.
 
 ### 99.1 — Pre/post metrics (frozen at 2026-04-27 final read, before PR #144 merge)
 


### PR DESCRIPTION
## Summary

Scheduled verification run (2026-05-14) confirming both cron-gated post-merge items from v7.7 Section 99.8 are now complete.

**B1 — Tier 1.1 measurement-adoption trend mode** ✅ (first verified 2026-05-04)
- `measurement-adoption-history.json`: **10 snapshots** [T1] (threshold ≥3 met since 2026-05-04)
- Dates span 2026-04-25 → 2026-05-14

**B2 — Tier 3.2 documentation-debt trend mode** ✅ (verified 2026-05-14)
- `documentation-debt.json::integrity_cycle.snapshots_available: 3` [T1]
- `trend_ready: true`
- `snapshot_files_available: 5`

**Prediction vs actual for B2:** predicted "earliest 2026-05-03 to -06"; actual 2026-05-14. Delay caused by cron persistence fix (branch-protection prevented direct-push from cron; workflow updated to open PRs instead).

## Changes

- `docs/case-studies/framework-v7-7-validity-closure-case-study.md`
  - Section 2: appended journal entry for 2026-05-14 with full T1/T2/T3 tier tags
  - Section 99: flipped banner from "complete and ready for merge as of 2026-04-27" → "complete and shipped 2026-05-14" with both B1/B2 verification citations
- `.claude/shared/measurement-adoption-history.json` — 2026-05-14 snapshot appended
- `.claude/shared/measurement-adoption.json` — regenerated with current state (69 features, 35 post-v6)
- `.claude/shared/documentation-debt.json` — regenerated (76 case studies, 3 cycle snapshots, trend_ready: true)

## Test plan

- [ ] Confirm journal entry is in Section 2 after the 2026-05-04 B1 entry
- [ ] Confirm Section 99 banner no longer says "ready for merge"
- [ ] Confirm `measurement-adoption-history.json` has ≥3 snapshots (it has 10)
- [ ] Confirm `documentation-debt.json::integrity_cycle.trend_ready: true`
- [ ] Run `make integrity-check` — expect 0 findings

https://claude.ai/code/session_0157S48WWmEnTn5idccUPXQ8

---
_Generated by [Claude Code](https://claude.ai/code/session_0157S48WWmEnTn5idccUPXQ8)_