### PR TITLE
chore(framework): MUST-have cadence batch — integrity-diff + weekly trends + ssh preflight + unified preflight

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -192,6 +192,11 @@
             "type": "command",
             "_comment": "Daily integrity checkpoint (added 2026-05-14). Kicks off scripts/daily-integrity-checkpoint.py in the background if today's snapshot hasn't run yet (idempotent --idempotent flag) and prints latest ledger row. Surfaces any active regression flag. Cross-repo guard: script self-skips when invoked outside FT2. Disable with CLAUDE_DISABLE_DAILY_CHECKPOINT=1. See docs/master-plan/data-integrity-and-rollback-2026-05-14.md §3 + scripts/session-start-checkpoint.sh.",
             "command": "[ -f scripts/session-start-checkpoint.sh ] && bash scripts/session-start-checkpoint.sh || true"
+          },
+          {
+            "type": "command",
+            "_comment": "W1 preflight (added 2026-05-15): SSH-agent identity check. Warns loudly when ssh-add has no loaded identities — prevents the documented W1 failure mode where `git commit -S` hangs silently on `ssh-keygen -Y sign`. Cross-repo safe (uses ssh-add command directly, no script-path dependency). Disable with CLAUDE_W1_DISABLE_SSH_CHECK=1. Full pattern: .claude/integrity/observed-patterns.md W1.",
+            "command": "[ -f scripts/check-ssh-agent.sh ] && bash scripts/check-ssh-agent.sh || true"
           }
         ]
       }

--- a/.claude/shared/documentation-debt.json
+++ b/.claude/shared/documentation-debt.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-14T21:19:19Z",
+  "updated": "2026-05-15T03:50:47Z",
   "description": "Baseline documentation-debt report for case-study structure, state linkage, and integrity-cycle readiness.",
   "summary": {
     "case_studies_scanned": 76,

--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -411,7 +411,48 @@
           "post_v6_percent": 19.4
         }
       }
+    },
+    {
+      "date": "2026-05-15",
+      "generated_at": "2026-05-15T03:50:39Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 70,
+        "features_post_v6": 36,
+        "features_pre_v6": 34,
+        "fully_adopted": 3,
+        "partial_adopted": 29,
+        "zero_adopted": 38,
+        "fully_adopted_post_v6": 3,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 17,
+          "overall_percent": 24.3,
+          "post_v6_present": 17,
+          "post_v6_percent": 47.2
+        },
+        "per_phase_timing": {
+          "overall_present": 32,
+          "overall_percent": 45.7,
+          "post_v6_present": 29,
+          "post_v6_percent": 80.6
+        },
+        "cache_hits": {
+          "overall_present": 20,
+          "overall_percent": 28.6,
+          "post_v6_present": 19,
+          "post_v6_percent": 52.8
+        },
+        "cu_v2": {
+          "overall_present": 7,
+          "overall_percent": 10.0,
+          "post_v6_present": 7,
+          "post_v6_percent": 19.4
+        }
+      }
     }
   ],
-  "updated": "2026-05-14T04:36:38Z"
+  "updated": "2026-05-15T03:50:39Z"
 }

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-14T21:19:19Z",
+  "updated": "2026-05-15T03:50:39Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {

--- a/.claude/shared/must-have-cadence-followups.md
+++ b/.claude/shared/must-have-cadence-followups.md
@@ -1,0 +1,105 @@
+# Must-have cadence follow-ups
+
+> Created 2026-05-15 from the prioritization cross-reference of [`docs/master-plan/infra-master-plan-2026-05-12.md`](../../docs/master-plan/infra-master-plan-2026-05-12.md), [`docs/master-plan/data-integrity-and-rollback-2026-05-14.md`](../../docs/master-plan/data-integrity-and-rollback-2026-05-14.md), and [`docs/master-plan/test-coverage-master-plan-2026-05-13.md`](../../docs/master-plan/test-coverage-master-plan-2026-05-13.md).
+>
+> This file tracks the MUST-HAVE items that are NOT yet wired as code (calendar-anchored verifications + feature-scope coding work). Streams A (data-health/integrity infra) and D (preflight entry points) shipped in the same batch and are NOT listed here.
+
+## Calendar-anchored verifications
+
+Surfaced daily by `scripts/daily-integrity-checkpoint.py` when the target date is ≤14 days away.
+
+| ID | Date | Event | Owner | Source |
+|---|---|---|---|---|
+| B1 | **2026-05-21** | v7.9 promotion-decision data freeze | operator | infra-plan §4.1, master-plan §2.2 |
+| B2 | **2026-05-28** | Post-v7.9 T+7d baseline snapshot | operator | data-integrity §3.2 trigger (2) |
+| B3 | **daily, starting now** | GA4 anomaly check (event volume + funnel breaks) | operator + GA4 MCP | analytics-observability epic |
+| B4 | **2026-08-13** | Quarterly cross-layer test-discipline audit (initial run) | operator | test-coverage §6.2 |
+| B5 | **2026-11-13** | Quarterly cross-layer test-discipline audit (recurring) | operator | test-coverage §6.2 |
+
+### B1 — v7.9 promotion-decision data freeze (2026-05-21)
+
+Required actions on the day:
+
+1. `make integrity-check` — must report 0 findings
+2. `make integrity-diff` — must report no regression vs 2026-05-14 anchor
+3. `make documentation-debt` — must report ≤ baseline open count
+4. `make measurement-adoption` — capture for the promotion record
+5. `python3 scripts/membrane-status.py` — capture
+6. Review last 14 days of `.claude/logs/gate-coverage.jsonl` — verify no `GATE_COVERAGE_ZERO` for any gate that previously fired
+7. Decision: flip v7.8.x advisory gates to enforced (specific list in infra-plan §4.1)
+
+### B2 — Post-v7.9 T+7d baseline (2026-05-28)
+
+```bash
+make snapshot-phase PHASE=post-v7-9-baseline FEATURE=framework-v7-8-branch-isolation
+```
+
+Compare against the 2026-05-14 pre-v7.9 baseline. Document deltas in a meta-analysis case study.
+
+### B3 — Daily GA4 anomaly check
+
+Possible since 2026-05-14 GA4 MCP connection (FIT-142, PR #362). Suggested daily query set:
+
+```
+mcp__ga4__getEvents period=last_24h
+mcp__ga4__runReport metric=screen_view dimension=date period=last_7d
+mcp__ga4__runReport metric=conversions period=last_24h
+```
+
+Flag day-over-day deltas > 30% as anomalies. No automation yet — operator runs in a session.
+
+### B4 / B5 — Quarterly cross-layer test audit
+
+Per test-coverage §6.2. Initial run 2026-08-13, then recurring every 90 days. Output: `docs/process/cross-layer-test-audit-YYYY-MM-DD.md`.
+
+Assertions:
+- Test count not declining
+- Production-symbol coverage ≥ prior quarter
+- No new zero-coverage directories
+- Staleness markers (Test Plan files older than 90 days) trending down
+
+## Feature-scope MUST items (require PM workflow)
+
+These require Plan→Implement→Test cycles and cannot be inlined into the cadence-batch PR.
+
+| ID | Title | Plan ref | RICE | Suggested work_type | Target ship |
+|---|---|---|---|---|---|
+| C1 | F14/F15 dispatch-test coverage push | test-coverage-master-plan §2.1 + §4.1 | (gates v7.9 promotion) | feature | **before 2026-05-21** |
+| C2 | T6 — Web PR JS test gate (fitme-story CI) | test-coverage-master-plan T6 | **200.0** | enhancement (on analytics-observability) | 2026-05-21 |
+| C3 | T2 — Sentry reachability test (iOS) | test-coverage-master-plan T2 | 80.0 | enhancement (test-coverage) | 2026-05-28 |
+
+### C1 — F14/F15 dispatch-test coverage push
+
+**Problem:** Mechanism A coverage telemetry is unreliable for 4 gates with zero dispatch tests + 5 zero-coverage gates. Without dispatch tests asserting each gate function fires, a keying drift (like the `created` vs `created_at` v7.8 incident) can silently zero out coverage.
+
+**Suggested approach:** Each of the 9 gates needs a 5-line unit test in `tests/test_gate_dispatch.py` asserting (a) the gate function is called for matching inputs, (b) `gate-coverage.jsonl` receives a row, (c) the row has expected `gate=` and non-zero `candidates`.
+
+**Why MUST:** v7.9 promotion criterion #1 in master plan §2.2 ("Mechanism A coverage validated for all gates"). Cannot promote on 2026-05-21 if these 9 gates remain unverified.
+
+**Open `/pm-workflow framework-f14-f15-dispatch-test-coverage`** to start.
+
+### C2 — T6 web PR JS test gate (fitme-story)
+
+**Problem:** fitme-story runs **zero JS tests on PR** despite 119 React components + 27 routes. A regression in `Card.tsx` or `ProseLayout.tsx` ships to prod unchecked.
+
+**Smallest viable shape:** add a single `npm test` step to fitme-story's `.github/workflows/ci.yml` + one smoke test asserting a representative page renders.
+
+**Why MUST:** test-coverage-master-plan RICE = 200.0 (highest leverage item in the entire plan).
+
+**Open** as enhancement on `analytics-observability` (current implementation phase) or as new feature `fitme-story-pr-test-gate`.
+
+### C3 — T2 Sentry reachability test (iOS)
+
+**Problem:** Zero tests on `SignInService.swift` + `SentryService.swift`. A pre-launch Sentry misconfiguration ships silently.
+
+**Smallest viable shape:** one `XCTestCase` that asserts `SentryService.shared` is reachable + can capture a synthetic event without crashing.
+
+**Why MUST:** test-coverage-master-plan RICE = 80.0; pre-launch crash gate.
+
+**Open** as enhancement on the eventual `test-coverage` feature.
+
+## How this file gets updated
+
+- **Adding an item:** drop a row in the right table + a short section. Keep the doc under 200 lines.
+- **Closing an item:** strike through the row + add `**Closed YYYY-MM-DD** via <PR or commit ref>`. Do NOT delete — historical visibility matters.
+- **Cron link:** daily-checkpoint surfaces upcoming dates from this file (≤14 days). Update [`scripts/daily-integrity-checkpoint.py`](../../scripts/daily-integrity-checkpoint.py) if you add new date fields not following the table schema.

--- a/.claude/skills/analytics/SKILL.md
+++ b/.claude/skills/analytics/SKILL.md
@@ -25,6 +25,8 @@ Before investigating an analytics drift, taxonomy mismatch, or unexpected gate f
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/metric-status.json` (targets, baselines), `.claude/shared/feature-registry.json` (what's launched), `.claude/shared/cx-signals.json` (qualitative context), `.claude/shared/campaign-tracker.json` (attribution)
 
 **Writes:** `.claude/shared/metric-status.json` (updated values, instrumentation status)

--- a/.claude/skills/cx/SKILL.md
+++ b/.claude/skills/cx/SKILL.md
@@ -25,6 +25,8 @@ Before investigating a CX signal anomaly, dispatch decision, or unexpected gate 
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/feature-registry.json` (launched features, original pain points), `.claude/shared/metric-status.json` (quantitative context), `.claude/shared/health-status.json` (technical context for complaints)
 
 **Writes:** `.claude/shared/cx-signals.json` (reviews, NPS, sentiment, feature requests, confusion signals, post-deployment assessments)

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -24,6 +24,8 @@ Before investigating an unexpected design-gate fire or Figma bridge anomaly, che
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/context.json` (brand, personas), `.claude/shared/design-system.json` (tokens, components), `.claude/shared/cx-signals.json` (UX confusion signals)
 
 **Writes:** `.claude/shared/design-system.json` (new tokens/components proposed)

--- a/.claude/skills/dev/SKILL.md
+++ b/.claude/skills/dev/SKILL.md
@@ -23,6 +23,8 @@ Before debugging any unexpected git, gate, or CI behavior, check [`.claude/integ
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/feature-registry.json` (features in flight), `.claude/shared/test-coverage.json` (coverage), `.claude/shared/health-status.json` (CI status)
 
 **Writes:** `.claude/shared/health-status.json` (build status, CI results)

--- a/.claude/skills/marketing/SKILL.md
+++ b/.claude/skills/marketing/SKILL.md
@@ -23,6 +23,8 @@ Before drafting any public-facing claim or campaign asset, check [`.claude/integ
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/context.json` (brand, personas, positioning, competitive landscape), `.claude/shared/cx-signals.json` (testimonials, user language, confusion signals dispatched here), `.claude/shared/metric-status.json` (conversion rates, retention), `.claude/shared/feature-registry.json` (what's launched)
 
 **Writes:** `.claude/shared/campaign-tracker.json` (campaign definitions, UTM params, attribution)

--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -25,6 +25,8 @@ Before reacting to a health alert, gate fire, or PR-cite false positive, check [
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/metric-status.json` (guardrail thresholds), `.claude/shared/health-status.json` (current status)
 
 **Writes:** `.claude/shared/health-status.json` (infra status, incidents, cost data)

--- a/.claude/skills/pm-workflow/SKILL.md
+++ b/.claude/skills/pm-workflow/SKILL.md
@@ -753,6 +753,28 @@ When `/cx analyze` or `/qa regression` detects an issue post-merge:
 
 **Goal:** Understand what we're building, why, and validate the approach before committing to a PRD.
 
+### Phase 0.0 — Unified preflight (v7.8.6+, MANDATORY first step)
+
+Before any phase-specific work, run:
+
+```bash
+make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]
+```
+
+This writes `.claude/shared/preflight-cache.json` with the data downstream skills depend on:
+
+- **W1 ssh-agent state** — prevents silent commit-signing hang
+- **PR citation cache freshness** — prevents v7.8.4 PR_CACHE_STALE false-positives
+- **Current branch + isolation status** — flags infra-path commits from main
+- **Current integrity findings + advisory count** — system-wide health
+- **Integrity diff vs 2026-05-14 anchor** — drift detection (closes 96h cron gap per data-integrity §2.1)
+- **Documentation-debt + measurement-adoption baselines** — calibration data for post-ship comparison
+- **Work-type-specific check** — feature state.json, enhancement parent, fix high-risk-touch, chore infra-path
+
+Downstream skills (`/ux`, `/design`, `/dev`, `/qa`, `/analytics`, `/cx`, `/ops`, `/release`, `/marketing`, `/research`) read this cache instead of re-collecting the data. The cache is overwritten each run; re-run when work_type or feature changes.
+
+Block phase advancement if the preflight reports `blocking > 0`.
+
 ### Phase 0 variant by work subtype
 
 | Subtype | Phase 0 primary output | Skills dispatched |

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -23,6 +23,8 @@ Before investigating a flaky test, surprising gate failure, or unexpected integr
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/feature-registry.json` (what to test), `.claude/shared/metric-status.json` (quality guardrails)
 
 **Writes:** `.claude/shared/test-coverage.json` (coverage per feature), `.claude/shared/health-status.json` (quality gate status)

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,6 +24,8 @@ Before promoting any build or drafting any release note, check [`.claude/integri
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/feature-registry.json` (what's included in release), `.claude/shared/test-coverage.json` (quality gate status), `.claude/shared/health-status.json` (CI + infrastructure ready)
 
 **Produces:** `CHANGELOG.md` updates, version bump in Xcode project, App Store submission materials

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -22,6 +22,8 @@ Before publishing any research output that will be cited downstream (PRDs, case 
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:** `.claude/shared/context.json` (positioning, personas, competitive landscape), `.claude/shared/feature-registry.json` (what's built, find gaps), `.claude/shared/cx-signals.json` (user feedback — what users ask for), `.claude/shared/campaign-tracker.json` (marketing context)
 
 **Writes:** `.claude/shared/context.json` (updated competitive landscape, market insights), `.claude/shared/cx-signals.json` (user research findings)

--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -34,6 +34,8 @@ Before validating a UX spec or gating a Phase 3 / Phase 6 transition, check [`.c
 
 ## Shared Data
 
+**Preflight cache:** `.claude/shared/preflight-cache.json` — refreshed by `make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]`. Run BEFORE any sub-command to get current work-context data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline). Cache schema: `docs/skills/preflight-cache-schema.md`.
+
 **Reads:**
 - `.claude/shared/context.json` — personas, positioning, competitors
 - `.claude/shared/design-system.json` — tokens, components available

--- a/.github/workflows/framework-status-weekly.yml
+++ b/.github/workflows/framework-status-weekly.yml
@@ -130,12 +130,20 @@ jobs:
           print(f"delta_any={delta_any}")
           PY
 
+      - name: Run weekly trend scan (A2 gate-coverage zero-drift + A4 per-dimension)
+        id: trend
+        continue-on-error: true
+        run: |
+          set +e
+          python3 scripts/weekly-trend-scan.py 2>&1 | tee /tmp/weekly-trend.txt
+
       - name: Stage history snapshot
         id: stage
         run: |
           git add .claude/shared/measurement-adoption-history.json \
                   .claude/shared/measurement-adoption.json \
-                  .claude/shared/documentation-debt.json 2>/dev/null || true
+                  .claude/shared/documentation-debt.json \
+                  .claude/shared/gate-coverage-weekly.jsonl 2>/dev/null || true
           if git diff --staged --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No snapshot changes to stage."
@@ -184,16 +192,34 @@ jobs:
           DELTA_FULLY: ${{ steps.compare.outputs.delta_fully }}
           DELTA_ANY: ${{ steps.compare.outputs.delta_any }}
           REGRESSION: ${{ steps.compare.outputs.regression }}
+          A2_REGRESSION: ${{ steps.trend.outputs.a2_gate_regression }}
+          A4_REGRESSION: ${{ steps.trend.outputs.a4_dim_regression }}
         run: |
+          # OR the new A2/A4 regression flags into the master regression flag.
+          if [ "$A2_REGRESSION" = "true" ] || [ "$A4_REGRESSION" = "true" ]; then
+            REGRESSION_COMBINED="true"
+          else
+            REGRESSION_COMBINED="$REGRESSION"
+          fi
+          echo "regression_combined=${REGRESSION_COMBINED}" >> "$GITHUB_OUTPUT"
           {
             echo "DIGEST<<DIGEST_EOF"
             echo "## Weekly framework-status digest"
             echo ""
-            echo "**Regression:** ${REGRESSION}"
+            echo "**Regression (any source):** ${REGRESSION_COMBINED}"
+            echo ""
+            echo "- Tier 1.1 fully/any adoption: ${REGRESSION}"
+            echo "- A2 gate-coverage zero-drift: ${A2_REGRESSION}"
+            echo "- A4 per-dimension trend: ${A4_REGRESSION}"
             echo ""
             echo "### Tier 1.1 measurement adoption"
             echo "- Fully adopted: ${CURRENT_FULLY} (Δ ${DELTA_FULLY} vs ${PRIOR_DATE:-baseline})"
             echo "- Any adoption: ${CURRENT_ANY} (Δ ${DELTA_ANY} vs ${PRIOR_DATE:-baseline})"
+            echo ""
+            echo "### Weekly trend scan (A2 + A4)"
+            echo '```'
+            head -c 4000 /tmp/weekly-trend.txt 2>/dev/null || echo "(no output)"
+            echo '```'
             echo ""
             echo "### Adoption report (head)"
             echo '```'
@@ -208,17 +234,26 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Open digest issue
-        if: steps.compare.outputs.regression == 'true' || inputs.open_issue_on_no_regression == 'true'
+        if: steps.compare.outputs.regression == 'true' || steps.trend.outputs.a2_gate_regression == 'true' || steps.trend.outputs.a4_dim_regression == 'true' || inputs.open_issue_on_no_regression == 'true'
         uses: actions/github-script@v8
         env:
           REGRESSION: ${{ steps.compare.outputs.regression }}
+          A2_REGRESSION: ${{ steps.trend.outputs.a2_gate_regression }}
+          A4_REGRESSION: ${{ steps.trend.outputs.a4_dim_regression }}
         with:
           script: |
-            const regression = process.env.REGRESSION === 'true';
+            const adoptionRegr = process.env.REGRESSION === 'true';
+            const a2Regr = process.env.A2_REGRESSION === 'true';
+            const a4Regr = process.env.A4_REGRESSION === 'true';
+            const regression = adoptionRegr || a2Regr || a4Regr;
             const digest = process.env.DIGEST || '(empty)';
             const today = new Date().toISOString().slice(0, 10);
+            const reasons = [];
+            if (adoptionRegr) reasons.push('measurement-adoption');
+            if (a2Regr) reasons.push('A2 gate-coverage');
+            if (a4Regr) reasons.push('A4 per-dimension');
             const title = regression
-              ? `Framework status ${today}: regression in measurement adoption`
+              ? `Framework status ${today}: regression — ${reasons.join(', ')}`
               : `Framework status ${today}: weekly digest`;
             const labels = regression
               ? ['framework-status', 'regression']

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Carthage/Build/
 .claude/logs/_session-*.events.jsonl
 .claude/active-feature
 .claude/logs/gate-coverage.jsonl
+.claude/shared/preflight-cache.json
+.claude/shared/integrity-checkpoint-regression.flag
+.claude/worktrees/
 !.claude/entrypoints/
 !.claude/entrypoints/**
 !.claude/settings.json

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-snapshot schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -80,6 +80,31 @@ integrity-check:
 	python3 scripts/integrity-check.py --findings-only
 	@python3 scripts/skills-audit.py --advisory --quiet || true
 	@python3 scripts/preflight-fixture-test.py 2>/dev/null || true
+
+# Compare current platform state vs the 2026-05-14 pre-v7.9 baseline anchor.
+# Closes the 96h drift window between weekly cron (Mon 05:00 UTC) and 72h
+# cycle, per docs/master-plan/data-integrity-and-rollback-2026-05-14.md §2.1+§2.3.
+# Override anchor: INTEGRITY_DIFF_BASELINE=<path> make integrity-diff
+# CI mode: exits 1 on regression — `make integrity-diff EXIT_ON_REGRESSION=1`.
+integrity-diff:
+	@python3 scripts/integrity-diff.py $(if $(EXIT_ON_REGRESSION),--exit-on-regression,)
+
+# Unified preflight entry point — aggregates all pre-work data checks adapted
+# by work_type (feature / enhancement / fix / chore). Writes
+# .claude/shared/preflight-cache.json that downstream skills (ux, design, dev,
+# qa, analytics, cx, ops, release, marketing, research) read instead of
+# re-collecting data. Schema: docs/skills/preflight-cache-schema.md.
+#
+#   make preflight WORK_TYPE=feature FEATURE=my-feature
+#   make preflight WORK_TYPE=chore
+#   make preflight WORK_TYPE=enhancement FEATURE=parent-feature
+#   make preflight WORK_TYPE=fix
+preflight:
+	@if [ -z "$(WORK_TYPE)" ]; then \
+		echo "ERROR: WORK_TYPE required. Usage: make preflight WORK_TYPE=<feature|enhancement|fix|chore> [FEATURE=<name>]"; \
+		exit 2; \
+	fi
+	@python3 scripts/preflight.py --work-type $(WORK_TYPE) $(if $(FEATURE),--feature $(FEATURE),)
 
 # v7.8.5: P0.4 from docs/skills/skills-review-2026-05-13.md — mechanical
 # conformance check for .claude/skills/*/SKILL.md (frontmatter present,

--- a/docs/skills/preflight-cache-schema.md
+++ b/docs/skills/preflight-cache-schema.md
@@ -1,0 +1,101 @@
+# Preflight cache schema
+
+**Path:** `.claude/shared/preflight-cache.json`
+**Producer:** `scripts/preflight.py` (invoked via `make preflight WORK_TYPE=<t> [FEATURE=<n>]`)
+**Consumers:** every skill listed in [`.claude/skills/`](../../.claude/skills) reads this file in its `## Shared Data` section.
+**Lifecycle:** overwritten each run. Cache is per-session (not committed); re-run when work_type or feature changes.
+
+## Why this file exists
+
+Before v7.8.6, every skill re-collected the same pre-work data (W1 ssh-agent, integrity findings, drift vs anchor, doc-debt, adoption baseline, branch isolation). The unified preflight runs all checks once, writes the result here, and downstream skills read instead of re-computing. Closes the per-skill duplication that the user surfaced 2026-05-15.
+
+## Top-level schema
+
+```json
+{
+  "work_type": "feature | enhancement | fix | chore",
+  "feature": "<feature-name | null>",
+  "generated_at": "<ISO-8601 UTC>",
+  "checks": [
+    {
+      "name": "<check-name>",
+      "status": "ok | warning | blocking | info",
+      "detail": "<human-readable summary>",
+      "blocking": true | false,
+      "...check-specific fields..."
+    }
+  ],
+  "summary": {
+    "total_checks": <int>,
+    "ok": <int>,
+    "warnings": <int>,
+    "blocking": <int>
+  },
+  "blocking_issues": ["<check-name>", ...]
+}
+```
+
+## Always-run checks
+
+| Name | Status semantics | Check-specific fields | Source |
+|---|---|---|---|
+| `W1_ssh_agent` | ok = ≥1 key loaded; warning = empty/unreachable | — | `ssh-add -l` exit code |
+| `pr_cache_fresh` | ok = fresh; warning = refresh failed | — | `scripts/ensure-pr-cache-fresh.py` |
+| `branch_isolation` | ok = on feature branch; warning = on `main` | `current_branch` | `git branch --show-current` |
+| `integrity_check` | ok = 0 findings; blocking = ≥1 | `findings_count`, `advisory_count` | `scripts/integrity-check.py --findings-only` |
+| `integrity_diff` | ok = no regression; warning = ≥1 regression vs 2026-05-14 anchor | `regressions: [{key, baseline, current, delta}, …]` | `scripts/integrity-diff.py --json` |
+| `documentation_debt` | info | `open_count` | `.claude/shared/documentation-debt.json` |
+| `measurement_adoption` | info | `fully_adopted_post_v6`, `features_post_v6`, `adoption_pct_post_v6` | `.claude/shared/measurement-adoption.json` |
+
+## Work-type-specific checks
+
+| Work type | Additional check | When it fires |
+|---|---|---|
+| `feature` | `feature_state_json` | If `--feature` provided. Reports current_phase; "no state.json yet" is OK at Phase 0 entry. |
+| `enhancement` | `enhancement_parent` | If `--feature` provided. **Blocking** if parent has no `prd.md` or is not in a downstream phase. |
+| `fix` | `fix_high_risk_touch` | Always. Warning if any high-risk file (DomainModels, EncryptionService, sync services, SignInService, AuthManager, AIOrchestrator) is in the working diff. |
+| `chore` | `chore_infra_paths` | Always. Warning if any infra path (`.githooks/`, `.github/workflows/`, `scripts/`, `.claude/skills/`, `.claude/shared/`, `docs/architecture/`, `Makefile`, `CLAUDE.md`) is in the working diff — indicates isolated worktree is recommended. |
+
+## Status conventions
+
+- **ok** (✓) — pass; nothing further required
+- **warning** (⚠) — advisory; review but does not block phase advancement
+- **blocking** (✗) — block phase advancement until resolved
+- **info** (·) — pure data surface; no judgment
+
+A consumer skill that finds `summary.blocking > 0` MUST refuse to advance the phase until the operator clears the blocking issues.
+
+## How skills should consume this
+
+```python
+import json
+from pathlib import Path
+
+cache = json.loads(Path(".claude/shared/preflight-cache.json").read_text())
+if cache["summary"]["blocking"] > 0:
+    raise SystemExit(f"preflight blocking: {cache['blocking_issues']}")
+
+# Specific datum lookup:
+adoption_pct = next(
+    c.get("adoption_pct_post_v6")
+    for c in cache["checks"] if c["name"] == "measurement_adoption"
+)
+```
+
+## Cache staleness
+
+The cache has no expiry mechanism — the consumer is responsible for re-running `make preflight` when:
+- Switching feature
+- Switching work_type
+- Crossing a commit boundary that touches state.json or shared ledgers
+- After a long pause (cron + 72h cycle may have fired)
+
+`scripts/preflight.py` is idempotent and fast (~5s on a clean tree). Re-run liberally.
+
+## Related
+
+- `docs/master-plan/data-integrity-and-rollback-2026-05-14.md` §2.1 — drift window this closes
+- `docs/master-plan/infra-master-plan-2026-05-12.md` §4.1 — v7.9 promotion calendar
+- `.claude/integrity/observed-patterns.md` — W1 (ssh) + W3 (CI check) + W9 (branch drift) patterns the preflight surfaces
+- `scripts/preflight.py` — producer
+- `scripts/integrity-diff.py` — drift-vs-anchor comparator the preflight invokes

--- a/scripts/check-ssh-agent.sh
+++ b/scripts/check-ssh-agent.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# W1 preflight (added 2026-05-15): SSH-agent identity check.
+#
+# Catches the documented W1 failure mode: `git commit -S` (SSH signing) hangs
+# silently on `ssh-keygen -Y sign` when the agent has no loaded identities,
+# producing no error — just an indefinite wait.
+#
+# Full pattern + playbook: .claude/integrity/observed-patterns.md W1.
+#
+# Behaviour:
+#   - 0 keys loaded → loud stderr warning + recovery hint (does NOT block)
+#   - ≥1 key loaded → silent (exit 0)
+#   - ssh-add unavailable → silent (exit 0; not all environments have it)
+#
+# Disable: set CLAUDE_W1_DISABLE_SSH_CHECK=1
+#
+# Designed for SessionStart hook invocation. Cross-repo safe.
+
+set -u
+
+if [ "${CLAUDE_W1_DISABLE_SSH_CHECK:-0}" = "1" ]; then
+  exit 0
+fi
+
+if ! command -v ssh-add >/dev/null 2>&1; then
+  exit 0
+fi
+
+# `ssh-add -l` exits 0 when ≥1 key loaded, 1 when agent reachable but empty,
+# 2 when agent unreachable. Both 1 and 2 mean the agent is unusable for
+# signing — warn identically.
+ssh-add -l >/dev/null 2>&1
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  exit 0  # at least one key loaded — silent success
+fi
+
+case "$rc" in
+  1) reason="no identities loaded" ;;
+  2) reason="agent unreachable (SSH_AUTH_SOCK invalid or agent not running)" ;;
+  *) reason="ssh-add returned $rc" ;;
+esac
+
+cat >&2 <<EOF
+
+⚠ W1 preflight: SSH agent unusable for signing ($reason).
+
+  Any planned signed commit will hang silently on \`ssh-keygen -Y sign\`.
+  Load a key BEFORE committing:
+
+      eval "\$(ssh-agent -s)"        # if no agent running
+      ssh-add ~/.ssh/id_ed25519       # or your signing key path
+
+  Verify with: ssh-add -l
+  Disable this check: export CLAUDE_W1_DISABLE_SSH_CHECK=1
+  Full pattern: .claude/integrity/observed-patterns.md W1
+
+EOF
+
+exit 0

--- a/scripts/daily-integrity-checkpoint.py
+++ b/scripts/daily-integrity-checkpoint.py
@@ -49,6 +49,8 @@ FITME_STORY_REPO = Path("/Volumes/DevSSD/fitme-story")
 LEDGER_JSONL = REPO_ROOT / ".claude" / "shared" / "integrity-checkpoint-ledger.jsonl"
 LEDGER_MD = REPO_ROOT / ".claude" / "shared" / "integrity-checkpoint-ledger.md"
 REGRESSION_FLAG = REPO_ROOT / ".claude" / "shared" / "integrity-checkpoint-regression.flag"
+FOLLOWUPS_FILE = REPO_ROOT / ".claude" / "shared" / "must-have-cadence-followups.md"
+FOLLOWUP_LOOKAHEAD_DAYS = 14
 
 
 def run(cmd: list[str], cwd: Path = REPO_ROOT, timeout: int = 300) -> tuple[int, str]:
@@ -365,6 +367,38 @@ def detect_regression(prev: dict | None, curr: dict) -> tuple[bool, dict]:
     return regression, deltas
 
 
+def upcoming_followups(today: dt.date, lookahead_days: int = FOLLOWUP_LOOKAHEAD_DAYS) -> list[dict]:
+    """Parse must-have-cadence-followups.md and return rows whose date is within lookahead_days.
+
+    Format expected: markdown table rows like
+        | B1 | **2026-05-21** | description | owner | source |
+    Returns list of {id, date, days_away, description}.
+    """
+    if not FOLLOWUPS_FILE.exists():
+        return []
+    import re
+    rows = []
+    for line in FOLLOWUPS_FILE.read_text().splitlines():
+        if not line.startswith("| ") or not "**20" in line:
+            continue
+        m = re.search(r"\| ([A-Z]\d+) \| \*\*(\d{4}-\d{2}-\d{2})\*\* \| (.+?) \|", line)
+        if not m:
+            continue
+        try:
+            d = dt.date.fromisoformat(m.group(2))
+        except ValueError:
+            continue
+        days_away = (d - today).days
+        if 0 <= days_away <= lookahead_days:
+            rows.append({
+                "id": m.group(1),
+                "date": m.group(2),
+                "days_away": days_away,
+                "description": m.group(3).strip(),
+            })
+    return sorted(rows, key=lambda r: r["days_away"])
+
+
 def load_last_ledger_row() -> dict | None:
     if not LEDGER_JSONL.exists():
         return None
@@ -528,6 +562,15 @@ def main():
     log(f"  SSD:   {ssd_dir} ({'OK' if ssd_ok else 'SKIPPED/FAILED'})")
     log(f"  Ledger: {LEDGER_JSONL} (+1 row)")
     log(f"  Human:  {LEDGER_MD}")
+
+    # Calendar reminders — surface MUST-HAVE follow-ups within 14d
+    upcoming = upcoming_followups(dt.date.today())
+    if upcoming:
+        log("\n📅 Upcoming MUST-HAVE follow-ups (≤14d):")
+        for r in upcoming:
+            days = "TODAY" if r["days_away"] == 0 else f"in {r['days_away']}d"
+            log(f"  - [{r['id']}] {r['date']} ({days}): {r['description']}")
+        log(f"  Source: {FOLLOWUPS_FILE.relative_to(REPO_ROOT)}")
 
 
 if __name__ == "__main__":

--- a/scripts/integrity-diff.py
+++ b/scripts/integrity-diff.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Integrity diff — compare current platform state vs a frozen baseline anchor.
+
+Default baseline: the 2026-05-14 pre-v7.9 platform-integrity baseline captured
+by the analytics-observability feature. Override via --baseline <path> or env
+INTEGRITY_DIFF_BASELINE.
+
+Reads identical surfaces from both sides:
+  - measurement-adoption.json  (summary + dimension_coverage)
+  - documentation-debt.json    (summary.open_debt_items)
+  - integrity-check-output.txt (parsed 'Findings: N + M advisory ()')
+
+Outputs a delta table to stdout and exits non-zero on regression. The
+regression definition matches scripts/daily-integrity-checkpoint.py:
+  - findings / blocking / debt UP   → regression
+  - fully_adopted / adoption% DOWN  → regression
+  - distinct gates DOWN             → regression
+
+Designed for two callers:
+  - `make integrity-diff` — operator-facing readout
+  - daily-integrity-checkpoint.py post-hook — regression flag complement
+    (the checkpoint already diffs vs prior row; this diffs vs anchor)
+
+Rationale (data-integrity-and-rollback-2026-05-14.md §2.1 + §2.3): the 96h
+gap between the weekly cron (Mon 05:00 UTC) and the 72h cycle can hide
+drift accumulating across multiple commits. The daily checkpoint catches
+day-over-day deltas; integrity-diff catches drift against the calibration
+anchor. Both together close the gap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASELINE = (
+    Path.home()
+    / "Documents"
+    / "FitTracker2-backups"
+    / "2026-05-14-analytics-observability-platform-integrity-baseline-2026-05-14"
+    / "platform-baseline"
+)
+
+
+def load_json(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def parse_integrity_findings(text: str) -> tuple[int, int]:
+    """Parse 'Findings: N + M advisory ()' line. Returns (findings, advisory)."""
+    for line in text.splitlines():
+        if line.strip().startswith("Findings:"):
+            try:
+                _, rhs = line.split(":", 1)
+                left = rhs.strip().split("+")[0].strip()
+                advisory_part = rhs.split("+", 1)[1] if "+" in rhs else "0"
+                adv_n = "".join(c for c in advisory_part if c.isdigit())
+                return int(left), int(adv_n or "0")
+            except (ValueError, IndexError):
+                continue
+    return -1, -1
+
+
+def collect_metrics_from_dir(d: Path) -> dict:
+    """Read metrics from a snapshot directory (baseline OR current shared/)."""
+    adopt = load_json(d / "measurement-adoption.json")
+    s = adopt.get("summary", {})
+    dim = adopt.get("dimension_coverage", {})
+
+    debt = load_json(d / "documentation-debt.json")
+    debt_open = debt.get("summary", {}).get("open_debt_items", -1)
+
+    findings_path = d / "integrity-check-output.txt"
+    if findings_path.exists():
+        findings, advisory = parse_integrity_findings(findings_path.read_text())
+    else:
+        findings, advisory = -1, -1
+
+    return {
+        "integrity_findings": findings,
+        "integrity_advisory": advisory,
+        "doc_debt_open": debt_open,
+        "features_total": s.get("features_total", -1),
+        "features_post_v6": s.get("features_post_v6", -1),
+        "fully_adopted": s.get("fully_adopted", -1),
+        "fully_adopted_post_v6": s.get("fully_adopted_post_v6", -1),
+        "adoption_pct_post_v6": round(
+            100 * s.get("fully_adopted_post_v6", 0)
+            / max(s.get("features_post_v6", 1), 1),
+            1,
+        ),
+        "timing_wall_time_pct_post_v6": dim.get("timing_wall_time", {}).get("post_v6_percent", -1),
+        "per_phase_timing_pct_post_v6": dim.get("per_phase_timing", {}).get("post_v6_percent", -1),
+        "cache_hits_pct_post_v6": dim.get("cache_hits", {}).get("post_v6_percent", -1),
+        "cu_v2_pct_post_v6": dim.get("cu_v2", {}).get("post_v6_percent", -1),
+    }
+
+
+def collect_current_metrics() -> dict:
+    """Read metrics from the live repo (shared/ ledgers + a fresh integrity check)."""
+    import subprocess
+
+    shared = REPO_ROOT / ".claude" / "shared"
+
+    adopt = load_json(shared / "measurement-adoption.json")
+    s = adopt.get("summary", {})
+    dim = adopt.get("dimension_coverage", {})
+
+    debt = load_json(shared / "documentation-debt.json")
+    debt_open = debt.get("summary", {}).get("open_debt_items", -1)
+
+    rc = subprocess.run(
+        ["python3", str(REPO_ROOT / "scripts" / "integrity-check.py"), "--findings-only"],
+        capture_output=True, text=True, timeout=300, check=False,
+    )
+    findings, advisory = parse_integrity_findings(rc.stdout + rc.stderr)
+
+    return {
+        "integrity_findings": findings,
+        "integrity_advisory": advisory,
+        "doc_debt_open": debt_open,
+        "features_total": s.get("features_total", -1),
+        "features_post_v6": s.get("features_post_v6", -1),
+        "fully_adopted": s.get("fully_adopted", -1),
+        "fully_adopted_post_v6": s.get("fully_adopted_post_v6", -1),
+        "adoption_pct_post_v6": round(
+            100 * s.get("fully_adopted_post_v6", 0)
+            / max(s.get("features_post_v6", 1), 1),
+            1,
+        ),
+        "timing_wall_time_pct_post_v6": dim.get("timing_wall_time", {}).get("post_v6_percent", -1),
+        "per_phase_timing_pct_post_v6": dim.get("per_phase_timing", {}).get("post_v6_percent", -1),
+        "cache_hits_pct_post_v6": dim.get("cache_hits", {}).get("post_v6_percent", -1),
+        "cu_v2_pct_post_v6": dim.get("cu_v2", {}).get("post_v6_percent", -1),
+    }
+
+
+HIGHER_IS_WORSE = ("integrity_findings", "doc_debt_open")
+LOWER_IS_WORSE = (
+    "fully_adopted_post_v6",
+    "adoption_pct_post_v6",
+    "timing_wall_time_pct_post_v6",
+    "per_phase_timing_pct_post_v6",
+    "cache_hits_pct_post_v6",
+    "cu_v2_pct_post_v6",
+)
+
+
+def is_regression(key: str, delta: float) -> bool:
+    if key in HIGHER_IS_WORSE and delta > 0:
+        return True
+    if key in LOWER_IS_WORSE and delta < 0:
+        return True
+    return False
+
+
+def format_row(key: str, baseline: float, current: float) -> tuple[str, bool]:
+    delta = round(current - baseline, 2) if isinstance(current, (int, float)) and isinstance(baseline, (int, float)) else 0
+    is_regr = is_regression(key, delta)
+    sign = "+" if delta > 0 else ""
+    flag = "⚠" if is_regr else " "
+    return f"| {flag} {key:<32} | {baseline:>10} | {current:>10} | {sign}{delta:>8} |", is_regr
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--baseline",
+        default=os.environ.get("INTEGRITY_DIFF_BASELINE", str(DEFAULT_BASELINE)),
+        help=f"Path to baseline snapshot dir (default: {DEFAULT_BASELINE})",
+    )
+    ap.add_argument(
+        "--exit-on-regression",
+        action="store_true",
+        help="Exit 1 if any regression detected (default: exit 0 even on regression)",
+    )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Output machine-readable JSON instead of human table",
+    )
+    args = ap.parse_args()
+
+    baseline_dir = Path(args.baseline)
+    if not baseline_dir.exists():
+        print(f"✗ Baseline not found: {baseline_dir}", file=sys.stderr)
+        print(
+            "  Override via --baseline <path> or env INTEGRITY_DIFF_BASELINE.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    baseline = collect_metrics_from_dir(baseline_dir)
+    current = collect_current_metrics()
+
+    keys = (
+        "integrity_findings",
+        "integrity_advisory",
+        "doc_debt_open",
+        "features_total",
+        "features_post_v6",
+        "fully_adopted",
+        "fully_adopted_post_v6",
+        "adoption_pct_post_v6",
+        "timing_wall_time_pct_post_v6",
+        "per_phase_timing_pct_post_v6",
+        "cache_hits_pct_post_v6",
+        "cu_v2_pct_post_v6",
+    )
+
+    rows = []
+    regressions = []
+    for k in keys:
+        b = baseline.get(k, -1)
+        c = current.get(k, -1)
+        row_text, regr = format_row(k, b, c)
+        rows.append(row_text)
+        if regr:
+            regressions.append({"key": k, "baseline": b, "current": c, "delta": round(c - b, 2)})
+
+    if args.json:
+        print(json.dumps({
+            "baseline_dir": str(baseline_dir),
+            "baseline": baseline,
+            "current": current,
+            "regressions": regressions,
+            "has_regression": bool(regressions),
+        }, indent=2))
+    else:
+        print(f"=== Integrity diff vs {baseline_dir.name} ===\n")
+        print(f"| {'⚠':1} {'Metric':<32} | {'Baseline':>10} | {'Current':>10} | {'Delta':>9} |")
+        print(f"|---|{'-'*34}|{'-'*12}|{'-'*12}|{'-'*11}|")
+        for r in rows:
+            print(r)
+        print()
+        if regressions:
+            print(f"⚠ {len(regressions)} regression(s) vs baseline:")
+            for r in regressions:
+                print(f"  - {r['key']}: {r['baseline']} → {r['current']} (Δ {r['delta']:+})")
+        else:
+            print("✓ No regression vs baseline.")
+
+    if regressions and args.exit_on_regression:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+Unified preflight entry point — single command surfaces all data the next
+work-step depends on, adapted by work_type (feature / enhancement / fix / chore).
+
+Why this exists
+---------------
+Before v7.8.5, preflight checks were scattered across:
+  - `/ux preflight {feature}`         (Phase 3 only, UX-spec specific)
+  - `/design preflight {feature}`     (Phase 3 only, DS + Figma MCP)
+  - `make integrity-check`            (system-wide, no work-type lens)
+  - `make documentation-debt`         (system-wide)
+  - `make measurement-adoption`       (system-wide)
+  - `make membrane-status`            (operator readout)
+  - `make verify-isolation`           (branch isolation status)
+  - `scripts/check-ssh-agent.sh`      (W1, SessionStart only)
+  - `make observed-patterns`          (pattern catalog)
+
+Every new feature, enhancement, fix, or chore re-runs an overlapping subset
+of these manually. This script aggregates them into one call, returns a
+structured snapshot at `.claude/shared/preflight-cache.json`, and tailors
+the output to the work_type:
+
+  - feature     → full lifecycle preflight (research baseline, gate health, similar-feature scan, anchor diff)
+  - enhancement → parent-feature integrity + gate health + anchor diff
+  - fix         → high-risk-area touch detection + gate health
+  - chore       → infra-path detection (auto-isolation reminder) + gate health
+
+Downstream skills (ux, design, dev, qa, analytics, cx, marketing, research, ops, release)
+read the cache instead of re-computing. The cache schema is documented at
+`docs/skills/preflight-cache-schema.md`.
+
+Usage
+-----
+  python3 scripts/preflight.py --work-type {feature|enhancement|fix|chore} \\
+                               [--feature <name>] \\
+                               [--json] \\
+                               [--quiet]
+
+  # Via Makefile:
+  make preflight WORK_TYPE=feature FEATURE=my-feature-name
+  make preflight WORK_TYPE=chore
+
+Exit codes
+----------
+  0  — no blocking issues (advisories OK)
+  1  — blocking issues found
+  2  — invalid inputs
+
+Cache path
+----------
+  .claude/shared/preflight-cache.json (overwritten each run)
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CACHE = REPO_ROOT / ".claude" / "shared" / "preflight-cache.json"
+
+WORK_TYPES = ("feature", "enhancement", "fix", "chore")
+
+# Paths flagged by Mode B BRANCH_ISOLATION_VIOLATION (infra-only commits).
+INFRA_GLOBS = (
+    ".githooks/", ".github/workflows/", "scripts/", ".claude/skills/",
+    ".claude/shared/", "docs/architecture/", "Makefile", "CLAUDE.md",
+)
+
+HIGH_RISK_FILES = (
+    "FitTracker/Models/DomainModels.swift",
+    "FitTracker/Services/EncryptionService.swift",
+    "FitTracker/Services/SupabaseSyncService.swift",
+    "FitTracker/Services/CloudKitSyncService.swift",
+    "FitTracker/Services/SignInService.swift",
+    "FitTracker/Services/AuthManager.swift",
+    "FitTracker/Services/AIOrchestrator.swift",
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper runners
+# ─────────────────────────────────────────────────────────────────────────────
+
+def run(cmd: list[str], timeout: int = 60) -> tuple[int, str]:
+    try:
+        r = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True,
+                           timeout=timeout, check=False)
+        return r.returncode, (r.stdout or "") + (r.stderr or "")
+    except subprocess.TimeoutExpired:
+        return 124, f"<timeout {timeout}s>"
+    except FileNotFoundError as e:
+        return 127, f"<not found: {e}>"
+
+
+def load_json(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Always-run checks (every work_type)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def check_w1_ssh_agent() -> dict:
+    """W1: ssh-agent has loaded identity (prevents silent sign hang)."""
+    rc, _ = run(["ssh-add", "-l"], timeout=5)
+    return {
+        "name": "W1_ssh_agent",
+        "status": "ok" if rc == 0 else "warning",
+        "detail": "ssh-add has loaded identities" if rc == 0
+                  else "no identities; signed commits will hang silently",
+        "blocking": False,  # advisory — many sessions skip signing
+    }
+
+
+def check_pr_cache_fresh() -> dict:
+    """v7.8.4 PR_CACHE_STALE prevention."""
+    rc, out = run(["python3", "scripts/ensure-pr-cache-fresh.py", "--quiet"], timeout=30)
+    return {
+        "name": "pr_cache_fresh",
+        "status": "ok" if rc == 0 else "warning",
+        "detail": "PR citation cache fresh" if rc == 0
+                  else "PR cache refresh failed; BROKEN_PR_CITATION may false-positive",
+        "blocking": False,
+    }
+
+
+def check_integrity() -> dict:
+    """Current cycle-time integrity findings."""
+    rc, out = run(["python3", "scripts/integrity-check.py", "--findings-only"], timeout=120)
+    findings, advisory = -1, -1
+    for line in out.splitlines():
+        if line.strip().startswith("Findings:"):
+            try:
+                rhs = line.split(":", 1)[1].strip()
+                findings = int(rhs.split("+")[0].strip())
+                adv = "".join(c for c in rhs.split("+", 1)[1] if c.isdigit())
+                advisory = int(adv or "0")
+            except (ValueError, IndexError):
+                pass
+            break
+    return {
+        "name": "integrity_check",
+        "status": "ok" if findings == 0 else "blocking",
+        "detail": f"{findings} findings + {advisory} advisory",
+        "findings_count": findings,
+        "advisory_count": advisory,
+        "blocking": findings > 0,
+    }
+
+
+def check_integrity_diff() -> dict:
+    """Drift vs 2026-05-14 anchor."""
+    rc, out = run(["python3", "scripts/integrity-diff.py", "--json"], timeout=60)
+    if rc != 0:
+        return {
+            "name": "integrity_diff",
+            "status": "warning",
+            "detail": "integrity-diff failed (baseline not found?)",
+            "blocking": False,
+        }
+    try:
+        data = json.loads(out)
+        regressions = data.get("regressions", [])
+    except json.JSONDecodeError:
+        return {
+            "name": "integrity_diff",
+            "status": "warning",
+            "detail": "could not parse integrity-diff output",
+            "blocking": False,
+        }
+    return {
+        "name": "integrity_diff",
+        "status": "ok" if not regressions else "warning",
+        "detail": (f"{len(regressions)} regression(s) vs 2026-05-14 anchor"
+                   if regressions else "no regression vs 2026-05-14 anchor"),
+        "regressions": regressions,
+        "blocking": False,  # advisory; daily checkpoint is authoritative
+    }
+
+
+def check_branch_isolation() -> dict:
+    """Current branch + isolation status from membrane-status."""
+    rc, branch = run(["git", "branch", "--show-current"], timeout=5)
+    branch = branch.strip()
+    on_main = branch == "main"
+    return {
+        "name": "branch_isolation",
+        "status": "warning" if on_main else "ok",
+        "detail": f"current branch: {branch}" + (
+            " (on main — infra commits will trigger BRANCH_ISOLATION_VIOLATION advisory)"
+            if on_main else ""
+        ),
+        "current_branch": branch,
+        "blocking": False,
+    }
+
+
+def check_documentation_debt() -> dict:
+    debt = load_json(REPO_ROOT / ".claude" / "shared" / "documentation-debt.json")
+    open_count = debt.get("summary", {}).get("open_debt_items", -1)
+    return {
+        "name": "documentation_debt",
+        "status": "ok" if open_count == 0 else "info",
+        "detail": f"{open_count} open documentation-debt item(s)",
+        "open_count": open_count,
+        "blocking": False,
+    }
+
+
+def check_measurement_adoption() -> dict:
+    adopt = load_json(REPO_ROOT / ".claude" / "shared" / "measurement-adoption.json")
+    s = adopt.get("summary", {})
+    fa_pv6 = s.get("fully_adopted_post_v6", 0)
+    fpv6 = max(s.get("features_post_v6", 1), 1)
+    pct = round(100 * fa_pv6 / fpv6, 1)
+    return {
+        "name": "measurement_adoption",
+        "status": "info",
+        "detail": f"post-v6 adoption: {pct}% ({fa_pv6}/{fpv6}) — baseline for any new shipped feature",
+        "fully_adopted_post_v6": fa_pv6,
+        "features_post_v6": fpv6,
+        "adoption_pct_post_v6": pct,
+        "blocking": False,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Work-type-specific checks
+# ─────────────────────────────────────────────────────────────────────────────
+
+def feature_brainstorm_state(feature: str | None) -> dict | None:
+    """Whether brainstorm + PRD have been started/completed for a named feature."""
+    if not feature:
+        return None
+    sf = REPO_ROOT / ".claude" / "features" / feature / "state.json"
+    if not sf.exists():
+        return {
+            "name": "feature_state_json",
+            "status": "info",
+            "detail": f"feature '{feature}' has no state.json yet (Phase 0 will create it)",
+            "blocking": False,
+        }
+    s = load_json(sf)
+    phase = s.get("current_phase", "(unknown)")
+    return {
+        "name": "feature_state_json",
+        "status": "ok",
+        "detail": f"feature '{feature}' current_phase={phase}",
+        "current_phase": phase,
+        "blocking": False,
+    }
+
+
+def enhancement_parent_state(feature: str | None) -> dict | None:
+    """Enhancement requires a parent feature with a PRD."""
+    if not feature:
+        return None
+    sf = REPO_ROOT / ".claude" / "features" / feature / "state.json"
+    if not sf.exists():
+        return {
+            "name": "enhancement_parent",
+            "status": "warning",
+            "detail": f"no state.json for '{feature}' — enhancements require a parent feature with PRD",
+            "blocking": False,
+        }
+    s = load_json(sf)
+    phase = s.get("current_phase", "")
+    has_prd = (REPO_ROOT / ".claude" / "features" / feature / "prd.md").exists()
+    ok = has_prd and phase in ("complete", "implementation", "merge", "docs", "post_launch_review")
+    return {
+        "name": "enhancement_parent",
+        "status": "ok" if ok else "warning",
+        "detail": f"parent='{feature}' phase={phase}, prd.md present={has_prd}",
+        "blocking": not ok,
+    }
+
+
+def fix_high_risk_touch_check() -> dict:
+    """Check git diff for high-risk files touched."""
+    rc, out = run(["git", "diff", "--name-only", "HEAD"], timeout=5)
+    touched = [f for f in out.splitlines() if f.strip()]
+    risky = [f for f in touched if any(f.endswith(hr.split("/")[-1]) or f == hr for hr in HIGH_RISK_FILES)]
+    return {
+        "name": "fix_high_risk_touch",
+        "status": "warning" if risky else "ok",
+        "detail": (f"touches high-risk file(s): {', '.join(risky)} — extra review required"
+                   if risky else "no high-risk files touched"),
+        "high_risk_files_touched": risky,
+        "blocking": False,
+    }
+
+
+def chore_infra_path_check() -> dict:
+    """Detect infra-path changes that require isolated worktree."""
+    rc, out = run(["git", "diff", "--name-only", "HEAD"], timeout=5)
+    touched = [f for f in out.splitlines() if f.strip()]
+    infra = [f for f in touched
+             if any(f.startswith(g) if g.endswith("/") else f == g for g in INFRA_GLOBS)]
+    return {
+        "name": "chore_infra_paths",
+        "status": "warning" if infra else "ok",
+        "detail": (f"infra paths touched: {', '.join(infra[:5])}"
+                   f"{' (+more)' if len(infra) > 5 else ''} — use isolated worktree"
+                   if infra else "no infra paths touched"),
+        "infra_paths_touched": infra,
+        "blocking": False,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Orchestrator
+# ─────────────────────────────────────────────────────────────────────────────
+
+def run_preflight(work_type: str, feature: str | None) -> dict:
+    checks = []
+
+    # Always-run (every work_type)
+    checks.append(check_w1_ssh_agent())
+    checks.append(check_pr_cache_fresh())
+    checks.append(check_branch_isolation())
+    checks.append(check_integrity())
+    checks.append(check_integrity_diff())
+    checks.append(check_documentation_debt())
+    checks.append(check_measurement_adoption())
+
+    # Work-type-specific
+    if work_type == "feature":
+        bs = feature_brainstorm_state(feature)
+        if bs:
+            checks.append(bs)
+    elif work_type == "enhancement":
+        ep = enhancement_parent_state(feature)
+        if ep:
+            checks.append(ep)
+    elif work_type == "fix":
+        checks.append(fix_high_risk_touch_check())
+    elif work_type == "chore":
+        checks.append(chore_infra_path_check())
+
+    blocking = [c for c in checks if c.get("blocking")]
+    warnings = [c for c in checks if c["status"] == "warning"]
+
+    return {
+        "work_type": work_type,
+        "feature": feature,
+        "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "checks": checks,
+        "summary": {
+            "total_checks": len(checks),
+            "blocking": len(blocking),
+            "warnings": len(warnings),
+            "ok": len([c for c in checks if c["status"] == "ok"]),
+        },
+        "blocking_issues": [c["name"] for c in blocking],
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Output
+# ─────────────────────────────────────────────────────────────────────────────
+
+GLYPH = {"ok": "✓", "warning": "⚠", "blocking": "✗", "info": "·"}
+
+
+def render_human(report: dict) -> str:
+    lines = []
+    lines.append(f"=== Preflight — work_type={report['work_type']}"
+                 f"{' feature=' + report['feature'] if report['feature'] else ''} ===")
+    lines.append(f"Generated: {report['generated_at']}")
+    lines.append("")
+    for c in report["checks"]:
+        g = GLYPH.get(c["status"], "?")
+        lines.append(f"  {g} {c['name']:<28} {c['detail']}")
+    lines.append("")
+    s = report["summary"]
+    lines.append(f"Summary: {s['ok']} ok · {s['warnings']} warning · {s['blocking']} blocking")
+    if s["blocking"]:
+        lines.append(f"\n✗ BLOCKING: {', '.join(report['blocking_issues'])}")
+    else:
+        lines.append("\n✓ No blocking issues. Cache written: .claude/shared/preflight-cache.json")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--work-type", choices=WORK_TYPES, required=True)
+    ap.add_argument("--feature", default=None,
+                    help="Feature name (required for enhancement; optional for feature)")
+    ap.add_argument("--json", action="store_true",
+                    help="Output machine-readable JSON")
+    ap.add_argument("--quiet", action="store_true",
+                    help="Suppress human output (still writes cache)")
+    args = ap.parse_args()
+
+    report = run_preflight(args.work_type, args.feature)
+
+    CACHE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE.write_text(json.dumps(report, indent=2))
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    elif not args.quiet:
+        print(render_human(report))
+
+    return 1 if report["summary"]["blocking"] > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/weekly-trend-scan.py
+++ b/scripts/weekly-trend-scan.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Weekly trend scan — extends framework-status-weekly.yml with:
+
+(A2) Mechanism A gate-coverage zero-drift detection:
+     A gate that previously emitted coverage telemetry but no longer does
+     is a silent-pass risk (observed-patterns.md #3). Compare CURRENT
+     distinct-gate set vs the union of all previously-seen gates from
+     `.claude/shared/gate-coverage-weekly.jsonl`. Missing gates → regression.
+
+(A4) Per-dimension adoption trend nudge:
+     The existing weekly cron only watches `fully_adopted` + `any_adopted`.
+     This adds the four dimension percentages (timing, per_phase, cache_hits,
+     cu_v2) — the master plan (data-integrity §2.5) explicitly flags
+     `cu_v2 ≥50%` chronic miss and `fully_adopted_post_v6` regression
+     (27.3%→8.3%) as targets to watch.
+
+Outputs:
+  - Digest fragment (markdown) → stdout (suitable for $GITHUB_ENV heredoc)
+  - GitHub Actions outputs → $GITHUB_OUTPUT (when set):
+      a2_gate_regression=true|false
+      a2_gates_current=N
+      a2_gates_ever_seen=N
+      a2_gates_missing=<csv>
+      a4_dim_regression=true|false
+      a4_dim_deltas=<json>
+
+Side-effect: appends one row to `.claude/shared/gate-coverage-weekly.jsonl`
+each run, unless --no-append is passed (test mode).
+
+Exit code 0 always — regression flagging is via outputs only. The orchestrating
+workflow OR's these flags into the existing measurement-adoption regression.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_COV = REPO_ROOT / ".claude" / "logs" / "gate-coverage.jsonl"
+WEEKLY_GATE_LEDGER = REPO_ROOT / ".claude" / "shared" / "gate-coverage-weekly.jsonl"
+ADOPT = REPO_ROOT / ".claude" / "shared" / "measurement-adoption.json"
+ADOPT_HIST = REPO_ROOT / ".claude" / "shared" / "measurement-adoption-history.json"
+
+DIMENSION_KEYS = ("timing_wall_time", "per_phase_timing", "cache_hits", "cu_v2")
+
+
+def load_json(p: Path) -> dict:
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def current_distinct_gates() -> set[str]:
+    if not GATE_COV.exists():
+        return set()
+    gates: set[str] = set()
+    for line in GATE_COV.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            d = json.loads(line)
+            g = d.get("gate")
+            if g:
+                gates.add(g)
+        except json.JSONDecodeError:
+            continue
+    return gates
+
+
+def ever_seen_gates() -> set[str]:
+    """Union of all distinct_gates fields from prior weekly rows."""
+    if not WEEKLY_GATE_LEDGER.exists():
+        return set()
+    seen: set[str] = set()
+    for line in WEEKLY_GATE_LEDGER.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+            for g in row.get("distinct_gates", []):
+                seen.add(g)
+        except json.JSONDecodeError:
+            continue
+    return seen
+
+
+def append_weekly_row(gates: set[str], append: bool) -> None:
+    if not append:
+        return
+    WEEKLY_GATE_LEDGER.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        "date": dt.date.today().isoformat(),
+        "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "distinct_gate_count": len(gates),
+        "distinct_gates": sorted(gates),
+    }
+    with WEEKLY_GATE_LEDGER.open("a") as f:
+        f.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+
+def dim_deltas() -> tuple[dict, bool]:
+    """Return per-dimension deltas vs prior snapshot + regression flag.
+
+    Regression = any dimension percentage dropped vs prior snapshot.
+    Note: cu_v2 chronic-miss is informational; only DROP triggers regression.
+    """
+    cur = load_json(ADOPT)
+    hist = load_json(ADOPT_HIST)
+    snaps = hist.get("snapshots", [])
+
+    cur_dim = cur.get("dimension_coverage", {})
+    prior_dim = (snaps[-1] if snaps else {}).get("dimension_coverage", {})
+    prior_date = (snaps[-1] if snaps else {}).get("date", "(no prior)")
+
+    deltas = {}
+    regression = False
+    for k in DIMENSION_KEYS:
+        cur_pct = cur_dim.get(k, {}).get("post_v6_percent", 0)
+        prior_pct = prior_dim.get(k, {}).get("post_v6_percent", 0)
+        delta = round(cur_pct - prior_pct, 1)
+        deltas[k] = {
+            "current": cur_pct,
+            "prior": prior_pct,
+            "delta": delta,
+        }
+        if delta < 0:
+            regression = True
+
+    # Also surface fully_adopted_post_v6 since master-plan §2.5 calls it out
+    cur_sum = cur.get("summary", {})
+    prior_sum = (snaps[-1] if snaps else {}).get("summary", {})
+    cur_fa = cur_sum.get("fully_adopted_post_v6", 0)
+    prior_fa = prior_sum.get("fully_adopted_post_v6", 0)
+    fa_delta = cur_fa - prior_fa
+    deltas["fully_adopted_post_v6"] = {
+        "current": cur_fa,
+        "prior": prior_fa,
+        "delta": fa_delta,
+    }
+    if fa_delta < 0:
+        regression = True
+
+    deltas["__meta__"] = {"prior_date": prior_date}
+    return deltas, regression
+
+
+def write_github_outputs(payload: dict) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a") as f:
+        for k, v in payload.items():
+            if isinstance(v, (dict, list)):
+                v = json.dumps(v, separators=(",", ":"))
+            f.write(f"{k}={v}\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--no-append", action="store_true",
+                    help="Don't append to the weekly gate ledger (test mode)")
+    ap.add_argument("--json", action="store_true",
+                    help="Output a single JSON blob instead of the markdown digest")
+    args = ap.parse_args()
+
+    cur_gates = current_distinct_gates()
+    prior_gates = ever_seen_gates()
+    missing = sorted(prior_gates - cur_gates)
+    a2_regression = bool(missing)
+
+    deltas, a4_regression = dim_deltas()
+
+    append_weekly_row(cur_gates, append=not args.no_append)
+
+    payload = {
+        "a2_gate_regression": "true" if a2_regression else "false",
+        "a2_gates_current": len(cur_gates),
+        "a2_gates_ever_seen": len(prior_gates),
+        "a2_gates_missing": ",".join(missing),
+        "a4_dim_regression": "true" if a4_regression else "false",
+        "a4_dim_deltas": deltas,
+    }
+    write_github_outputs(payload)
+
+    if args.json:
+        print(json.dumps({
+            "a2": {
+                "regression": a2_regression,
+                "current_count": len(cur_gates),
+                "ever_seen_count": len(prior_gates),
+                "missing": missing,
+                "current_gates": sorted(cur_gates),
+            },
+            "a4": {
+                "regression": a4_regression,
+                "deltas": deltas,
+            },
+        }, indent=2))
+        return 0
+
+    lines = []
+    lines.append("### Weekly trend scan (Mechanism A + per-dimension)")
+    lines.append("")
+    if a2_regression:
+        lines.append(f"**A2 — Gate coverage REGRESSION:** {len(missing)} gate(s) previously emitted but no longer do:")
+        for g in missing:
+            lines.append(f"  - `{g}`")
+    else:
+        lines.append(f"**A2 — Gate coverage OK:** {len(cur_gates)} distinct gates currently emitting "
+                     f"(ever-seen: {len(prior_gates)}).")
+    lines.append("")
+    lines.append(f"**A4 — Per-dimension adoption** (vs {deltas['__meta__']['prior_date']}):")
+    lines.append("")
+    lines.append("| Dimension | Current | Prior | Δ |")
+    lines.append("|---|---|---|---|")
+    for k in DIMENSION_KEYS:
+        d = deltas[k]
+        sign = "+" if d["delta"] > 0 else ""
+        flag = " ⚠" if d["delta"] < 0 else ""
+        lines.append(f"| {k} | {d['current']}% | {d['prior']}% | {sign}{d['delta']}{flag} |")
+    fa = deltas["fully_adopted_post_v6"]
+    sign = "+" if fa["delta"] > 0 else ""
+    flag = " ⚠" if fa["delta"] < 0 else ""
+    lines.append(f"| fully_adopted_post_v6 | {fa['current']} | {fa['prior']} | {sign}{fa['delta']}{flag} |")
+    lines.append("")
+    if a4_regression:
+        lines.append("⚠ At least one dimension regressed; opens digest issue per workflow regression rule.")
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements all MUST-have items from the 2026-05-15 cadence cross-reference of `infra-master-plan-2026-05-12.md` §4.1 + `data-integrity-and-rollback-2026-05-14.md` §2.1+§2.5 + `test-coverage-master-plan-2026-05-13.md` §6.2.

### What ships

| Stream | Item | Files |
|---|---|---|
| **A1** | `make integrity-diff` — compare vs 2026-05-14 baseline anchor (closes the 96h cron-gap) | `scripts/integrity-diff.py`, `Makefile` |
| **A2** | Mechanism A gate-coverage zero-drift weekly scan | `scripts/weekly-trend-scan.py`, `.github/workflows/framework-status-weekly.yml` |
| **A3** | W1 SSH-agent preflight in SessionStart hook | `scripts/check-ssh-agent.sh`, `.claude/settings.json` |
| **A4** | cu_v2 + fully_adopted_post_v6 trend nudge in weekly cron | (same files as A2) |
| **D** | Unified preflight entry point — single command surfaces all pre-work data, work_type-aware | `scripts/preflight.py`, `Makefile`, all 10 skills, `pm-workflow/SKILL.md` Phase 0.0, `docs/skills/preflight-cache-schema.md` |
| **B+C** | Single tracking artifact for calendar-anchored verifications + feature-scope MUST items + daily-checkpoint reminders (≤14d lookahead) | `.claude/shared/must-have-cadence-followups.md`, `scripts/daily-integrity-checkpoint.py` |

### Why now

- **2026-05-21 v7.9 promotion decision** is 6 days out — the data freeze + integrity-diff anchor close the only documented silent-pass class (96h window per data-integrity §2.1).
- **fully_adopted_post_v6** regressed 27.3% → 8.3% from 2026-04-30; weekly cron now flags any further drop on Monday's run.
- **cu_v2** chronic miss (19.4% baseline) is now surfaced weekly — no automation, but visibility prevents drift acceleration.
- **W1** witnessed twice in recent session-clusters; ssh-add preflight closes it via the same SessionStart-hook channel as the daily-integrity-checkpoint.
- **Unified preflight** replaces ~6 ad-hoc `make` invocations per skill with one `make preflight WORK_TYPE=<type>` call + a shared cache.

### Calendar items now visible

Daily checkpoint prints (≤14d):
- **B1** 2026-05-21 (in 6d): v7.9 promotion-decision data freeze
- **B2** 2026-05-28 (in 13d): Post-v7.9 T+7d baseline snapshot

Feature-scope MUST items (require their own PM-workflow features):
- **C1** F14/F15 dispatch-test coverage push (gates v7.9; open `/pm-workflow framework-f14-f15-dispatch-test-coverage` before 5/21)
- **C2** T6 web PR JS test gate (RICE 200.0 — highest leverage in test-coverage plan)
- **C3** T2 Sentry reachability test (iOS pre-launch crash gate)

Full list: `.claude/shared/must-have-cadence-followups.md`.

## Test plan

- [x] `make integrity-check` → 0 findings + 2 advisory
- [x] `make integrity-diff` → no regression vs 2026-05-14 anchor
- [x] `make preflight WORK_TYPE=chore` → 5 ok · 1 warning · 0 blocking
- [x] `make preflight WORK_TYPE=feature FEATURE=analytics-observability` → reports current_phase=implementation
- [x] `scripts/check-ssh-agent.sh` smoke-tested with 3 SSH-agent states (loaded / unreachable / disabled)
- [x] `scripts/weekly-trend-scan.py --no-append` smoke-tested
- [x] preflight-fixture-test: 4/4 passed
- [x] Calendar reminders surface B1 + B2 in `scripts/daily-integrity-checkpoint.py`

## Affected gates

None. This PR adds new observability surfaces — no advisory→enforced flips, no schema changes, no removed checks.

## Related

- Spec/master plan: `docs/master-plan/infra-master-plan-2026-05-12.md` §4.1
- Companion: `docs/master-plan/data-integrity-and-rollback-2026-05-14.md` §2.1, §2.5
- Companion: `docs/master-plan/test-coverage-master-plan-2026-05-13.md` §6.2
- Schema doc: `docs/skills/preflight-cache-schema.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)