### PR TITLE
fix(framework): pr-cache freshness gate validates per-repo completeness (W11)

### DIFF
--- a/.claude/integrity/observed-patterns.md
+++ b/.claude/integrity/observed-patterns.md
@@ -656,6 +656,42 @@ git branch -d <branch>                             # safe (refuses if unmerged)
 
 ---
 
+### W11 — Incomplete PR cache (one of two expected repos absent)
+
+**Pattern:** [`scripts/ensure-pr-cache-fresh.py`](../../scripts/ensure-pr-cache-fresh.py) (v7.8.4 `PR_CACHE_STALE` gate) refreshes `.cache/gh-pr-cache.json` when the cache is **missing**, **empty** (zero PRs across all repos), or **stale** (>24h). It does NOT validate that all expected repos are present. If a refresh ever produces a cache with only one of the two expected repos populated (e.g., `Regevba/FitTracker2` present but `Regevba/fitme-story` absent), the freshness check sees a non-empty, recently-rebuilt cache and skips refresh — but every cross-repo `BROKEN_PR_CITATION` lookup fires a false-positive finding.
+
+**Why expected:** Variant of W3-class issues — silent-pass-then-fixed. The v7.8.4 emptiness check uses "any repo has any PRs" semantics. v7.8.3's D-3 unified cross-repo PR cache assumed the canonical repo list (`REPOS = ["Regevba/FitTracker2", "Regevba/fitme-story"]`) would always be fully populated by `scripts/refresh-pr-cache.py`. A partial-write (gh CLI rate-limited mid-refresh, network blip after first repo, manual edit, parallel write race) violates this assumption silently.
+
+**Distinguishing real signal:**
+
+- **Real signal:** every BROKEN_PR_CITATION finding's URL or `pull/N` cite resolves manually with `gh pr view N --repo <owner>/<repo>` AND the case study or state.json was NOT recently introduced with a placeholder PR number. **AND** the cache file is recent (<24h) so the v7.8.4 refresh logic considers it "fresh."
+- **W11 artifact (skip):** ALL BROKEN_PR_CITATION findings cite the SAME absent repo (e.g., all cite `Regevba/fitme-story` while `Regevba/FitTracker2` cites resolve fine). Cache inspection (`python3 -c "import json; print(list(json.load(open('.cache/gh-pr-cache.json'))['repos'].keys()))"`) confirms the expected repo is missing from the `repos` dict.
+
+**Silence path:**
+
+```bash
+make refresh-pr-cache               # forces a full re-fetch across all REPOS
+make integrity-check                # findings should drop to baseline
+```
+
+The fix shipped in this PR (`fix/pr-cache-completeness-w3b`) extends `ensure-pr-cache-fresh.py` to validate per-repo completeness: cache is considered stale if ANY expected repo is absent OR has zero PRs in all buckets. After this fix lands, the `PR_CACHE_STALE` gate auto-recovers from this scenario on next invocation (typically next `make integrity-check` or pre-commit hook fire).
+
+**First observed:** 2026-05-16. The autonomous launchd cron rebuilt the cache at 03:04 UTC (06:04 IDT) but produced a single-repo cache. The 06:21 UTC daily-checkpoint then captured 32 BROKEN_PR_CITATION findings as a phantom regression vs baseline. Diagnosed within ~10 minutes via direct cache inspection + `make refresh-pr-cache` recovery. The script-side fix codifies the recovery so future occurrences self-heal.
+
+**Notes:**
+
+- Sibling to W3 / W3.b in spirit but tracked as its own W-number (W11) per the sequential-numbering convention used in this catalog.
+- Related: `BROKEN_PR_CITATION` (Section 1, #13) — this pattern's surface; `PR_CACHE_STALE` (Section 1, #12) — the cache-freshness gate; v7.8.3 D-3 cross-repo cache spec.
+- Lesson: emptiness checks must enforce per-element completeness, not aggregate presence. "Some data present somewhere" ≠ "all expected data present."
+
+**Files involved:**
+
+- Cache freshness gate: [`scripts/ensure-pr-cache-fresh.py`](../../scripts/ensure-pr-cache-fresh.py)
+- Cache writer: [`scripts/refresh-pr-cache.py`](../../scripts/refresh-pr-cache.py)
+- Cache file: `.cache/gh-pr-cache.json`
+
+---
+
 ## Pattern submission template
 
 When you discover a NEW pattern (gate fires + no matching entry above), add it here.
@@ -717,6 +753,7 @@ Commit the new entry on a `chore/document-pattern-<slug>` branch + open PR + mer
 | W8 Audit status is UI marker | W8 | — |
 | W9 Branch-drift from concurrent-session collision (DETECTED via PostToolUse:Bash hook) | W9 | 2026-05-13 |
 | W10 Stale `[gone]` branches + orphan worktrees | W10 | 2026-05-15 |
+| W11 Incomplete PR cache (one of two expected repos absent) | W11 | 2026-05-16 |
 
 ---
 

--- a/scripts/ensure-pr-cache-fresh.py
+++ b/scripts/ensure-pr-cache-fresh.py
@@ -33,6 +33,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CACHE_PATH = REPO_ROOT / ".cache" / "gh-pr-cache.json"
 REFRESH_SCRIPT = REPO_ROOT / "scripts" / "refresh-pr-cache.py"
 
+# Keep in sync with REPOS in scripts/refresh-pr-cache.py (v7.8.3 D-3 unified cache).
+# If refresh-pr-cache.py ever adds a third repo, append it here too — otherwise
+# the per-repo completeness check below will perpetually request a refresh.
+EXPECTED_REPOS = ("Regevba/FitTracker2", "Regevba/fitme-story")
+
 
 def cache_age_seconds() -> float | None:
     """Return cache age in seconds, or None if cache is missing/unreadable."""
@@ -76,6 +81,34 @@ def cache_is_empty() -> bool:
     return True
 
 
+def cache_missing_expected_repos() -> tuple[bool, list[str]]:
+    """Detect the W11 pattern: cache exists + non-empty but one of the expected
+    cross-repo entries is absent or has zero PRs in all buckets. A partial-write
+    or refresh interruption can leave the cache in this state, causing every
+    cross-repo BROKEN_PR_CITATION lookup to false-positive.
+
+    Returns (is_incomplete, missing_repos). Sibling check to cache_is_empty —
+    we run both so a fully-empty cache surfaces its own clearer reason string.
+    """
+    if not CACHE_PATH.exists():
+        return False, []  # cache_age_seconds() already covers this case
+    try:
+        data = json.loads(CACHE_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False, []
+    repos = data.get("repos", {})
+    missing: list[str] = []
+    for expected in EXPECTED_REPOS:
+        info = repos.get(expected)
+        if not isinstance(info, dict):
+            missing.append(expected)
+            continue
+        has_any = any(info.get(b) for b in ("open", "merged", "closed"))
+        if not has_any:
+            missing.append(expected)
+    return (len(missing) > 0), missing
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -100,9 +133,16 @@ def main() -> int:
     elif cache_is_empty():
         needs_refresh = True
         reason = "cache reports 0 PRs in all repos (likely never populated)"
-    elif age > max_age_seconds:
-        needs_refresh = True
-        reason = f"cache age {age/3600:.1f}h > threshold {args.max_age_hours}h"
+    else:
+        # W11 — incomplete cache (one of two expected repos absent or empty).
+        # See .claude/integrity/observed-patterns.md §W11 for the full story.
+        incomplete, missing = cache_missing_expected_repos()
+        if incomplete:
+            needs_refresh = True
+            reason = f"cache missing expected repo(s): {', '.join(missing)} (W11 incomplete-cache pattern)"
+        elif age > max_age_seconds:
+            needs_refresh = True
+            reason = f"cache age {age/3600:.1f}h > threshold {args.max_age_hours}h"
 
     if not needs_refresh:
         if not args.quiet:


### PR DESCRIPTION
## Summary

Closes a v7.8.4 silent-pass in [`scripts/ensure-pr-cache-fresh.py`](scripts/ensure-pr-cache-fresh.py) where the emptiness check used aggregate semantics ("any repo has any PRs") instead of per-element completeness. If `refresh-pr-cache.py` ever produces a partial cache (e.g., only `Regevba/FitTracker2` populated, `fitme-story` absent), the freshness gate saw a non-empty, recently-rebuilt cache and skipped refresh — while every cross-repo `BROKEN_PR_CITATION` lookup false-positived.

## Trigger incident

**2026-05-16 06:04 IDT** — the autonomous launchd cron rebuilt the cache with only `Regevba/FitTracker2` populated. The 06:21 UTC daily-checkpoint then captured **32 phantom `BROKEN_PR_CITATION` findings** as a regression vs the 2026-05-14 baseline.

- Diagnosed in ~10min via direct cache inspection + `make refresh-pr-cache` recovery
- Verified main was clean once cache was complete
- This commit codifies the recovery so future occurrences self-heal

## Changes

**`scripts/ensure-pr-cache-fresh.py`** (+43 / -3)
- New `EXPECTED_REPOS` constant (kept in sync with `refresh-pr-cache.py::REPOS`)
- New `cache_missing_expected_repos()` check
- `main()` now triggers refresh when ANY expected repo is missing or has zero PRs in all buckets — even if the cache file itself is recent (<24h)
- Refresh reason includes which repos were missing, for diagnostic logs

**`.claude/integrity/observed-patterns.md`** (+37 / -0)
- New **W11** entry documenting the incomplete-cache pattern (sibling to W3 in spirit, sequential W-number per catalog convention)
- Index table updated

## Test plan

- [x] Test 1 (healthy cache): "PR cache fresh" rc=0
- [x] Test 2 (simulated W11 by stripping fitme-story from cache): `PR_CACHE_STALE: cache missing expected repo(s): Regevba/fitme-story (W11 incomplete-cache pattern). Refreshing…` → rc=0, cache restored
- [x] `integrity-check` post-change: 0 findings + 2 advisory (unchanged baseline)
- [ ] CI green on this branch
- [ ] PR-integrity check passes

## v7.9 promotion impact

None — this is a freshness-gate enhancement, not a new check code. Pure operability fix that strengthens an existing v7.8.4 gate. v7.9 promotion-decision data freeze (2026-05-21, B1 follow-up) is unaffected; this fix actually **improves** the data-freeze readiness by closing a phantom-regression failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)