### PR TITLE
chore(ios-code-connect): T4 root-cause diagnosis — FIGMA token missing Code Connect Write scope

### DIFF
--- a/.claude/features/ios-code-connect/state.json
+++ b/.claude/features/ios-code-connect/state.json
@@ -2,7 +2,7 @@
   "feature_name": "ios-code-connect",
   "current_phase": "implementation",
   "created_at": "2026-05-09T19:27:43Z",
-  "updated_at": "2026-05-10T05:26:37Z",
+  "updated_at": "2026-05-16T06:30:00Z",
   "framework_version": "v7.8.1",
   "work_type": "chore",
   "work_subtype": "design_system_extension",
@@ -69,9 +69,28 @@
     {
       "id": "T4",
       "title": "Run figma connect publish \u2014 push iOS mappings to FitMe Design System Library; verify Code Connect snippets appear in Figma Dev Mode",
-      "status": "pending",
+      "status": "blocked",
       "effort_days": 0.25,
-      "blocker": "T3"
+      "blocker": "FIGMA_ACCESS_TOKEN repo secret is missing the Code Connect Write scope. CI workflow .github/workflows/figma-code-connect-publish.yml has run 3 times (run IDs 25621980058 / 25623253076 / 25629689372 on 2026-05-10): first run succeeded (token write-attempted on empty file), runs 2-3 failed with `Failed to upload to Figma (403): 403 Invalid scope(s): Please ensure that you have selected both the File Read scope and the Code Connect Write scope when generating the token.`",
+      "diagnostic": {
+        "diagnosed_at": "2026-05-16T06:30:00Z",
+        "diagnosed_via": "gh run view 25629689372 --log-failed",
+        "infrastructure_status": {
+          "ci_workflow": ".github/workflows/figma-code-connect-publish.yml present in main (1.7KB, dated 2026-05-10)",
+          "mapping_files": "5 .figma.swift files present (ImportPreviewView, NotificationPermissionRow, OnboardingWelcomeView.v2, ImportedPlansListScreen.v2, TrainingPlanView.v2)",
+          "secret_present": "FIGMA_ACCESS_TOKEN secret exists in repo (added 2026-05-10T08:20:15Z)",
+          "swift_parser": "Successfully built; all 6 Code Connect files validated locally per run-25629689372 logs"
+        },
+        "root_cause": "The FIGMA_ACCESS_TOKEN was generated with read scopes only. Code Connect publish requires the `file_dev_resources:write` scope (Figma calls this \"Code Connect Write\" in the token-generation UI).",
+        "operator_fix": [
+          "1. Visit https://www.figma.com/settings \u2192 Security \u2192 Personal access tokens.",
+          "2. Generate a new token with these scopes per CLAUDE.md: file_content:read + file_dev_resources:read + file_dev_resources:write (the \"Code Connect Write\" checkbox is the third one). library_content:read is recommended.",
+          "3. Update the FIGMA_ACCESS_TOKEN secret in Regevba/FitTracker2 repo settings: `gh secret set FIGMA_ACCESS_TOKEN --body \"<new-token>\"`.",
+          "4. Re-run the failed workflow: `gh run rerun 25629689372` OR push any change touching `*.figma.swift` to trigger a fresh publish.",
+          "5. Verify in Figma Dev Mode: open the FitMe Design System Library (file 0Ai7s3fCFqR5JXDW8JvgmD), inspect one of the 5 mapped screens (e.g., OnboardingWelcomeView.v2), confirm the iOS code panel shows the SwiftUI snippet."
+        ],
+        "related_gate": "/design preflight Step 3.5 (Code Connect write-access gate, FT2 PR #280) is the gate designed to catch this BEFORE the publish workflow fires \u2014 by probing the publish path during preflight. Running `/design preflight ios-code-connect` would have surfaced the scope gap at spec-time rather than at CI-time."
+      }
     },
     {
       "id": "T5",


### PR DESCRIPTION
## Summary

Closes the open question on T4 of the `ios-code-connect` chore feature ("Run `figma connect publish`") which has been sitting at `status: pending` since 2026-05-10 with the misleading `blocker: "T3"` (T3 was already done).

## Investigation

Re-investigated the 3 CI workflow runs of `.github/workflows/figma-code-connect-publish.yml` since 2026-05-10:

| Run | Time | Result |
|---|---|---|
| `25621980058` | 2026-05-10T06:36Z | ✅ SUCCESS (initial publish from PR #281 — empty mapping set, nothing to upload) |
| `25623253076` | 2026-05-10T07:46Z | ❌ FAILURE |
| `25629689372` | 2026-05-10T13:14Z | ❌ FAILURE with: `Failed to upload to Figma (403): 403 Invalid scope(s): Please ensure that you have selected both the File Read scope and the Code Connect Write scope when generating the token.` |

## Root cause

The `FIGMA_ACCESS_TOKEN` repo secret was generated with read-only scopes. Code Connect publish requires `file_dev_resources:write` (Figma calls this "Code Connect Write" in the token-generation UI per CLAUDE.md design-system §"Operator setup").

Everything else is wired correctly:
- ✅ CI workflow present in main (1.7 KB, dated 2026-05-10)
- ✅ 5 `.figma.swift` mappings present
- ✅ Swift Code Connect parser builds clean (per run-25629689372 logs)
- ✅ Local validation passes ("All Code Connect files are valid (1865ms)")

## State.json update

Updates `tasks[3]` (T4):

```diff
-      "status": "pending",
+      "status": "blocked",
-      "blocker": "T3"
+      "blocker": "FIGMA_ACCESS_TOKEN repo secret is missing the Code Connect Write scope. CI workflow ...",
+      "diagnostic": { ... full operator-fix playbook ... }
```

No phase transition. No metric changes. JSON schema valid.

## Operator fix (5 steps, documented in `state.json::tasks[3].diagnostic.operator_fix`)

1. Visit https://www.figma.com/settings → Security → Personal access tokens.
2. Generate a new token with: `file_content:read` + `file_dev_resources:read` + `file_dev_resources:write` (the "Code Connect Write" checkbox). `library_content:read` recommended.
3. `gh secret set FIGMA_ACCESS_TOKEN --body "<new-token>"` for `Regevba/FitTracker2`.
4. Re-run failed workflow: `gh run rerun 25629689372` (or push any commit touching `*.figma.swift`).
5. Verify in Figma Dev Mode (file `0Ai7s3fCFqR5JXDW8JvgmD`) that one of the 5 mapped screens (e.g., `OnboardingWelcomeView.v2`) shows the SwiftUI snippet.

## Related gate that should have caught this

`/design preflight` Step 3.5 — **Code Connect write-access gate** (FT2 PR #280) is specifically designed to probe the publish path during preflight rather than waiting for CI failure. Running `/design preflight ios-code-connect` would have surfaced the scope gap at spec-time.

## v7.9 calibration safety

- No state.json `current_phase` mutation → no `BRANCH_ISOLATION_VIOLATION` (Mode C)
- Edit touches `.claude/features/<feature>/state.json` only — not an infra-path glob → no Mode B fire
- No phase=complete transition → `FEATURE_CLOSURE_COMPLETENESS` not triggered
- No gate-coverage telemetry contamination during the 2026-05-15→05-21 calibration window

🤖 Generated with [Claude Code](https://claude.com/claude-code)