### PR TITLE
fix(app-store-assets): rename stale paused block to previous_pause (resolve duplicate-key collision from PR #378)

### DIFF
--- a/.claude/features/app-store-assets/state.json
+++ b/.claude/features/app-store-assets/state.json
@@ -271,21 +271,12 @@
   },
   "case_study_type": "no_case_study_required",
   "case_study_exempt_reason": "App Store assets (screenshots, ASO copy, metadata) are operational artifacts; no case-study narrative warranted. Approved 2026-04-27 during v7.7 M2 T9.",
-  "paused": {
+  "previous_pause": {
     "at": "2026-04-27T14:00:00Z",
     "reason": "v7.7 Validity Closure full-priority freeze",
     "resume_signal": "framework-v7-7-validity-closure phase=complete",
     "resolved_at": "2026-04-27T00:00:00Z",
-    "resolved_note": "Resume signal fired 2026-04-27 when framework-v7-7-validity-closure shipped (PR #144 merge 01b9e11). Feature is unblocked but has not yet been picked back up; current_phase remains 'implementation' awaiting user-initiated resume.",
-    "snapshot": {
-      "current_phase": "implementation",
-      "next_action_when_resumed": "Resume implementation; case_study link already resolved by v7.7 T9 (exempt tag applied during v7.7)",
-      "blockers": [],
-      "context_links": [
-        ".claude/features/app-store-assets/state.json",
-        "~/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/paused_app_store_assets.md"
-      ]
-    }
+    "resolved_note": "Resume signal fired 2026-04-27 when framework-v7-7-validity-closure shipped (PR #144 merge 01b9e11). Feature was unblocked but never picked back up. Historical record retained; current pause status is in the top-level `paused` field (post-2026-05-16 system-sweep audit, Apple Dev Program external blocker)."
   },
   "_meta": {
     "deprecation_warnings": []


### PR DESCRIPTION
## Summary

Follow-up to [PR #378](https://github.com/Regevba/FitTracker2/pull/378) catching a defect in my own system-sweep gap closure: PR #378 added an **active** \`paused\` block at the top of [\`state.json\`](.claude/features/app-store-assets/state.json) for the Apple Dev Program external blocker, but the file already contained a \`paused\` block at the bottom from the 2026-04-27 v7.7 Validity Closure freeze (whose \`resume_signal\` already resolved that day).

## Why this matters

JSON syntactically allows duplicate keys but parsers vary in resolution:

| Parser | Resolution |
|---|---|
| Python \`json.load\` | LAST key wins |
| Node \`JSON.parse\` | LAST key wins |
| jq | LAST key wins |

So tests / scripts reading state.json via stdlib were seeing the **stale** \`"v7.7 Validity Closure full-priority freeze"\` reason instead of the **active** \`"External blockers — 5 of 10 tasks ... Apple Developer Program"\` reason. Caught by my own post-merge schema sanity check (\`jq '.paused.paused_at'\` returned \`null\`).

## Fix

Rename the older block to \`previous_pause\` — semantically correct (it IS a historical record of a resolved pause). Trim its fields to the minimum needed for archival + document the relationship to the new top-level \`paused\` field in \`resolved_note\`.

## Verification

```
$ python3 -c "
import json
with open('.claude/features/app-store-assets/state.json') as f:
    raw = f.read()
print('paused count:', raw.count('\"paused\"'))
print('previous_pause count:', raw.count('\"previous_pause\"'))
data = json.load(open('.claude/features/app-store-assets/state.json'))
print('paused.paused_at:', data['paused'].get('paused_at'))
print('previous_pause.resolved_at:', data['previous_pause'].get('resolved_at'))
"
paused count: 1
previous_pause count: 1
paused.paused_at: 2026-04-27T00:00:00Z
previous_pause.resolved_at: 2026-04-27T00:00:00Z
```

Before: 2 \`paused\` keys in raw file (1 active + 1 stale, last wins per JSON.load).
After: 1 \`paused\` (active) + 1 \`previous_pause\` (historical archive).

## v7.9 calibration window safety

- No new gate, no current_phase mutation, JSON schema-valid → no telemetry contamination
- Pure data hygiene cleanup on top of PR #378

## Lesson (for the audit honesty log)

Closes a defect I introduced in my own gap closure ~30 minutes earlier. The system-sweep audit's "P1 — Decide app-store-assets disposition" was implemented without checking whether a \`paused\` field already existed → ended up creating a silent override. Schema collision diagnostics via \`jq '.paused.paused_at'\` are now a useful pattern: if the field returns \`null\` for a key your edit just added, suspect a duplicate-key collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)