### PR TITLE
fix(checkpoint): key daily-checkpoint idempotency on ledger row, not snapshot dir

### DIFF
--- a/scripts/daily-integrity-checkpoint.py
+++ b/scripts/daily-integrity-checkpoint.py
@@ -561,11 +561,16 @@ def main():
 
     log = (lambda *a, **kw: None) if args.quiet else print
 
-    # Idempotency check
-    if local_dir.exists() and not args.force:
+    # Idempotency check — keyed on the ledger row, not the snapshot dir.
+    # Why: if a prior fire crashed after creating the snapshot dir but before
+    # appending the ledger row, gating on `local_dir.exists()` would leave the
+    # ledger permanently missing today's row. Gating on the ledger row makes
+    # subsequent fires self-heal by re-running the full pipeline.
+    last_row = load_last_ledger_row()
+    if last_row and last_row.get("date") == today and not args.force:
         if args.idempotent:
             sys.exit(0)
-        log(f"Today's local snapshot already exists at {local_dir}. Use --force to overwrite.")
+        log(f"Today's ledger row already exists ({today}). Use --force to overwrite.")
         sys.exit(0)
 
     log(f"=== Daily integrity checkpoint — {today} ===")


### PR DESCRIPTION
## Summary

- Bug: `scripts/daily-integrity-checkpoint.py` gated idempotency on `local_dir.exists()`. If a prior fire crashed after creating the snapshot dir but before appending the ledger row, every subsequent fire that day exited silently — no row was ever written.
- Discovered 2026-05-16 during a session-end health sweep: launchd cron fired 4 times today (06:04 / 08:00 / 13:00 / 18:00 IDT) but `.claude/shared/integrity-checkpoint-ledger.jsonl` had zero rows for the day.
- Fix: gate on `load_last_ledger_row().date == today` instead. Snapshot creation is idempotent at the file-write level; re-running the pipeline when the ledger row is missing is safe and self-heals the partial-failure case.

## Test plan

- [x] Local `python3 scripts/daily-integrity-checkpoint.py` — reports `Today's ledger row already exists (2026-05-16)` (was previously `Today's local snapshot already exists at /…`).
- [x] `python3 -c "import ast; ast.parse(open('scripts/daily-integrity-checkpoint.py').read())"` — syntax OK.
- [ ] Next launchd cron fire (post-merge) — must append a fresh ledger row even when today's snapshot dir already exists.

## Related

- Session-sweep finding 2: pre-commit hooks were silently de-installed in the main worktree (`core.hooksPath` unset). Resolved separately via `make install-hooks`. Captured in memory file `feedback_pre_commit_hook_deinstall.md` for future-session preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)