### PR TITLE
chore(framework): patch feature-completeness-audit chore-skip + backfill cu_v2 on 3d-interactive

### DIFF
--- a/.claude/features/3d-interactive-framework-flow-diagram/state.json
+++ b/.claude/features/3d-interactive-framework-flow-diagram/state.json
@@ -136,5 +136,15 @@
   ],
   "state_owner_sync_origin": "fitme-story-reverse",
   "state_owner_sync_origin_commit": "52f221342d794f771be116457ce1a09d2f8d6bf1",
-  "state_owner_sync_origin_pr_url": "pending"
+  "state_owner_sync_origin_pr_url": "pending",
+  "cu_v2": {
+    "factors": {
+      "complexity": 0.8,
+      "blast_radius": 0.5,
+      "novelty": 0.8,
+      "verification_difficulty": 0.7
+    },
+    "total": 2.8,
+    "tier_class": "A_high"
+  }
 }

--- a/scripts/feature-completeness-audit.py
+++ b/scripts/feature-completeness-audit.py
@@ -77,7 +77,9 @@ def _audit_feature(state_path: Path, css_module) -> list[dict]:
                              "message": "framework_version not set (recommended for v7.6+ features)"})
 
     # PRD phase — cu_v2 required (forward-only since V6 ship)
-    if (phase == "prd" or _phase_index(phase) >= _phase_index("prd")) and not is_terminal:
+    # Chores are 1-phase per CLAUDE.md (Implement only) — no PRD, no cu_v2 obligation.
+    work_type = (state.get("work_type") or "").lower()
+    if (phase == "prd" or _phase_index(phase) >= _phase_index("prd")) and not is_terminal and work_type != "chore":
         if created_date >= V6_SHIP and not (state.get("cu_v2") or state.get("complexity")):
             findings.append({"feature": feature, "phase": phase, "severity": "blocking",
                              "code": "MISSING_CU_V2",


### PR DESCRIPTION
## Summary

Closes the 2 BLOCKING findings surfaced by the 2026-05-17 daily integrity check:

1. **`3d-interactive-framework-flow-diagram`** (PRD, Feature, post-V6) — missing `cu_v2`. Backfilled:
   - factors: complexity 0.8 / blast_radius 0.5 / novelty 0.8 / verification_difficulty 0.7
   - total: 2.8
   - tier_class: `A_high`
   - Calibrated against 4 prior `A_high` precedents: auth-polish-v2 (2.3), framework-v7-7 (2.65), framework-v7-8-branch-isolation (2.55), roadmap-stress-test (3.1).

2. **`scripts/feature-completeness-audit.py`** — patched cu_v2 check to honor `work_type=chore`. Per [CLAUDE.md "Work Item Types"](https://github.com/Regevba/FitTracker2/blob/main/CLAUDE.md): "Chore — 1-phase (Implement only)." Chores have no PRD, therefore no cu_v2 obligation. The check was firing indiscriminately on `phase >= PRD` without honoring the work-type sub-phase contract.

## Exemption scope

8 chore features exist; 7 are in `complete`/`closed` terminal state where the existing `not is_terminal` guard already exempts them — **no behavior change for them**. Only the 1 active chore (`ios-code-connect` at `implementation`) is newly exempted, which is the intended fix.

## Verification

- `python3 scripts/validate-cu-v2.py --state .claude/features/3d-interactive-framework-flow-diagram/state.json` → exit 0
- `make feature-completeness-audit` → 0 blocking + 2 advisory (was 2 blocking + 2 advisory)
- `make integrity-check` → 0 findings + 4 advisory (unchanged — the 2 BLOCKING items were from feature-completeness, not integrity-check)
- 2 remaining advisories (`NO_IMPL_COMMITS` on analytics-observability + ios-code-connect) are genuine and tracked separately.

## Test plan

- [x] `make feature-completeness-audit` exits 0 (blocking = 0)
- [x] `make integrity-check` shows no new findings
- [x] cu_v2 schema validates on 3d-interactive
- [x] Sanity-checked which features are now newly exempted (1 active chore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)