### PR TITLE
chore(ucc-passkey-auth-audit-log-redis-fix): T6 BLOCKED — Vercel Blob host restriction blocks GHA sync

### DIFF
--- a/.claude/features/ucc-passkey-auth-audit-log-redis-fix/state.json
+++ b/.claude/features/ucc-passkey-auth-audit-log-redis-fix/state.json
@@ -5,7 +5,7 @@
   "parent_feature": "ucc-passkey-auth",
   "framework_version": "v7.8.6",
   "created_at": "2026-05-17T05:50:00Z",
-  "updated": "2026-05-17T05:50:00Z",
+  "updated": "2026-05-18T05:38:00Z",
   "branch": "feature/ucc-passkey-auth-audit-log-redis-fix",
   "state_owner": "ft2",
   "current_phase": "implementation",
@@ -48,6 +48,22 @@
       "tasks_done_in_pr_383": ["T9"],
       "tasks_done_in_pr_387": ["T7", "T8"],
       "tasks_pending": ["T6"],
+      "tasks_blocked_at_t6": "blob 403 host_not_allowed — GHA sync at 05:17 UTC made no commit (verified via GitHub API 2026-05-18T05:38Z). Two-factor blocker: (1) Vercel Blob CDN returns 403 to external hosts; (2) Vercel cron at 05:13 UTC not confirmed — no runtime log entry for that time window. Operator action required — see t6_block_2026_05_18.",
+      "t6_block_2026_05_18": {
+        "blocked_at": "2026-05-18T05:38:00Z",
+        "blocked_by": "scheduled_agent_sonnet_4_6",
+        "blob_probe_result": "HTTP 403 x-deny-reason: host_not_allowed — from remote execution environment (not a true 404; Vercel Blob CDN blocks external IPs)",
+        "gha_sync_result": "No commit to FT2 main since 2026-05-18T00:00Z (verified via GitHub API list_commits). GHA ucc-audit-log-sync.yml at 05:17 UTC: curl --fail received 403 or 404 and exited non-zero — no commit made.",
+        "vercel_cron_result": "No runtime log entry at 05:13 UTC in production logs (05:00–05:38 window). One unrelated 401 at 05:34 on /api/cron/sync-audit-log (no CRON_SECRET header — external probe, not the Vercel cron system). Billing rate limit prevented yesterday's logs from confirming whether cron fired then.",
+        "root_cause": "Vercel Deployment Protection restricts blob reads from external hosts to allowlisted origins (fitme-story.vercel.app and Vercel infrastructure only). GHA ubuntu-latest runners are not in the allowlist. The curl --fail in ucc-audit-log-sync.yml cannot fetch the blob URL regardless of whether the blob exists.",
+        "operator_actions_required": [
+          "1. Check Upstash Redis console: does list 'ucc:audit-log:events' have entries? (verifies whether sign-in on 2026-05-17 afternoon populated Redis after the PR #122 deploy)",
+          "2. If Redis has events: manually trigger cron from your local machine: curl -s -H 'Authorization: Bearer <CRON_SECRET>' https://fitme-story.vercel.app/api/cron/sync-audit-log — expect {ok:true, synced:N>=3}",
+          "3. Fix GHA workflow: add 'Authorization: Bearer ${{ vars.VERCEL_BYPASS_SECRET }}' header to the curl step in .github/workflows/ucc-audit-log-sync.yml, OR configure Vercel project blob allowed domains to include external IPs, OR switch to a different export mechanism (e.g., a Vercel API endpoint that reads from Redis directly and writes to a publicly accessible store without host restrictions)",
+          "4. After fixing: verify blob URL returns 200, re-run GHA workflow via workflow_dispatch, confirm FT2 .claude/logs/ucc-auth-events.jsonl populated, then advance T6 → done and phase → testing"
+        ],
+        "b8_deadline": "2026-05-23 — still 5 days away; operator has time to fix before kill-criteria checkpoint"
+      },
       "t6_resume_plan_2026_05_18": {
         "trigger": "Natural Vercel cron fires daily at 05:13 UTC; GHA ucc-audit-log-sync.yml fires at 05:17 UTC (now wired with UCC_AUDIT_BLOB_URL per T7 close 2026-05-17T14:05:50Z; workflow self-activates when the blob exists).",
         "operator_action_today": "Sign in once at https://fitme-story.vercel.app/control-room/sign-in to populate Redis with 3 audit events (auth_passkey_authenticate_started + auth_passkey_authenticate_succeeded + auth_session_minted).",
@@ -61,7 +77,8 @@
           "T8 parts_deferred reconcile already done in PR #387; SKIP",
           "Append §99 sub-entry to case study: 'T6 closed 2026-05-18, B7 fully validated end-to-end, B8 kill-criteria gate ready'"
         ],
-        "why_path_b": "Vercel Hobby plan lacks 'Run Now' cron trigger (Pro-only). Vercel UI /crons URL 404'd (correct path is /cron-jobs but operator confirmed no Run button visible). Curl-with-CRON_SECRET path declined to keep secret out of conversation transcript. Path B = natural cron + 17h wait, well within B8 deadline (2026-05-23) 5-day buffer."
+        "why_path_b": "Vercel Hobby plan lacks 'Run Now' cron trigger (Pro-only). Vercel UI /crons URL 404'd (correct path is /cron-jobs but operator confirmed no Run button visible). Curl-with-CRON_SECRET path declined to keep secret out of conversation transcript. Path B = natural cron + 17h wait, well within B8 deadline (2026-05-23) 5-day buffer.",
+        "status": "BLOCKED — see t6_block_2026_05_18"
       }
     },
     "testing": {
@@ -176,7 +193,9 @@
       "type": "test",
       "skill": "qa",
       "lane": "p-core",
-      "status": "pending",
+      "status": "blocked",
+      "blocked_at": "2026-05-18T05:38:00Z",
+      "block_reason": "Vercel Blob CDN returns 403 host_not_allowed to external hosts. GHA ucc-audit-log-sync.yml at 05:17 UTC made no commit (curl --fail failed). Operator must: (1) manually trigger cron with CRON_SECRET, (2) fix GHA workflow to bypass Vercel host restriction. See phases.implementation.t6_block_2026_05_18 for full diagnosis.",
       "priority": "critical",
       "effort_days": 0.05,
       "depends_on": ["T2", "T3", "T4", "T5"],
@@ -202,7 +221,9 @@
       "type": "docs",
       "skill": "release",
       "lane": "e-core",
-      "status": "pending",
+      "status": "done",
+      "completed_at": "2026-05-17T16:28:50Z",
+      "result_note": "Reconciled in PR #387 (commit 31ea322): parent ucc-passkey-auth/state.json rollout_status.parts_deferred entry for Part 9 moved to parts_shipped. Status corrected from 'pending' to 'done' by 2026-05-18 scheduled agent — tasks_done_in_pr_387 already listed T8 but per-task status was not updated in PR #387.",
       "priority": "high",
       "effort_days": 0.02,
       "depends_on": ["T7"],

--- a/.claude/logs/ucc-passkey-auth-audit-log-redis-fix.log.json
+++ b/.claude/logs/ucc-passkey-auth-audit-log-redis-fix.log.json
@@ -6,7 +6,7 @@
   "current_phase": "implementation",
   "framework_version": "v7.8.6",
   "started_at": "2026-05-17T05:57:00Z",
-  "updated_at": "2026-05-17T06:08:53Z",
+  "updated_at": "2026-05-18T05:42:28Z",
   "events": [
     {
       "timestamp": "2026-05-17T05:57:00Z",
@@ -46,6 +46,21 @@
         "auth_tests_passing": 27
       },
       "actor": "claude_opus_4_7",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-18T05:42:28Z",
+      "event_type": "phase_blocked",
+      "phase": "implementation",
+      "summary": "T6 BLOCKED: blob URL 403 host_not_allowed from external hosts. GHA ucc-audit-log-sync.yml at 05:17 UTC made no commit to FT2 main. Vercel Blob CDN host restriction prevents GHA runners from fetching the blob. Vercel cron at 05:13 UTC not confirmed in runtime logs. T8 status inconsistency fixed (was pending, should be done per tasks_done_in_pr_387). Operator action required: manual cron trigger + GHA workflow fix for Vercel host bypass.",
+      "artifacts": [],
+      "metrics": {
+        "blob_probe_status": 403,
+        "gha_sync_commits_today": 0,
+        "vercel_cron_log_entries_0513": 0
+      },
+      "actor": "scheduled_agent_sonnet_4_6",
       "status": "recorded",
       "recording_mode": "contemporaneous"
     }


### PR DESCRIPTION
## Summary

Scheduled agent resume (2026-05-18T05:30Z) found T6 blocked — the "natural cron + GHA sync" Path B did not succeed:

- **Blob URL returns 403 `host_not_allowed`** from external IPs — Vercel Deployment Protection restricts blob reads to allowlisted origins (fitme-story.vercel.app / Vercel infra only; GHA runners are not in the allowlist)
- **GHA `ucc-audit-log-sync.yml` at 05:17 UTC made zero commits** to FT2 main (verified via GitHub API — no commits since midnight UTC)
- **Vercel cron at 05:13 UTC**: no runtime log entry visible in the 05:00–05:38 window (possible Redis was empty when cron fired, or billing rate limit obscured it)

## State changes

- **T6**: `pending` → `blocked` with diagnosis + operator action list in `t6_block_2026_05_18`
- **T8**: `pending` → `done` (consistency fix: was listed in `tasks_done_in_pr_387` since PR #387 but per-task status was not updated there)
- **Phase**: remains `implementation` — testing phase NOT opened per orchestrator hard rules

## Operator actions required

1. **Check Redis**: open Upstash console → verify `ucc:audit-log:events` list has entries (sign-in events from 2026-05-17 afternoon after PR #122 deploy)
2. **Manually trigger cron** from your local machine: `curl -s -H "Authorization: Bearer $CRON_SECRET" https://fitme-story.vercel.app/api/cron/sync-audit-log` — expect `{ok: true, synced: N}`
3. **Fix GHA workflow** (one of):
   - Add `Authorization: Bearer ${{ vars.VERCEL_BYPASS_SECRET }}` header to the `curl` step in `.github/workflows/ucc-audit-log-sync.yml`
   - OR configure Vercel project blob allowed domains to include external IPs
4. **After fix**: re-run `gh workflow run ucc-audit-log-sync.yml --repo Regevba/FitTracker2`, confirm `.claude/logs/ucc-auth-events.jsonl` gets populated, then advance T6 → done and open testing phase

## Deadlines

- **B8 kill-criteria checkpoint**: 2026-05-23 (5 days remaining — enough buffer for the operator fix)

## Test plan

- [ ] Operator manually triggers Vercel cron with `CRON_SECRET` and sees `{ok: true, synced: N>=3}`
- [ ] Blob URL returns 200 with sanitized JSONL (`operator_label_hash` present, `operator_label` absent)
- [ ] GHA workflow run succeeds and commits `.claude/logs/ucc-auth-events.jsonl` to main
- [ ] T6 marked done, phase advanced to testing

https://claude.ai/code/session_01SpMQYTa1TFxq6Cc2rGQLNu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpMQYTa1TFxq6Cc2rGQLNu)_