### PR TITLE
fix(ci): Dependabot-safe plist-decode (unblocks dep-bump PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,34 @@ jobs:
           PLIST_BASE64: ${{ secrets.GOOGLESERVICE_INFO_PLIST_BASE64 }}
         run: |
           if [ -z "$PLIST_BASE64" ]; then
-            echo "::error::GOOGLESERVICE_INFO_PLIST_BASE64 secret is not set"
-            exit 1
+            # GitHub does not expose repo secrets to Dependabot PRs (or forks);
+            # in those contexts write a minimal stub so xcodebuild's resource
+            # phase succeeds. Analytics tests will silently fall back to
+            # MockAnalyticsAdapter — acceptable for dep-bump PRs that don't
+            # touch iOS code paths. Operator-owned PRs and main-branch builds
+            # still get the real secret and exercise the real adapter.
+            echo "::warning::GOOGLESERVICE_INFO_PLIST_BASE64 secret not exposed (Dependabot PR or fork). Writing stub plist; iOS analytics tests will use MockAnalyticsAdapter."
+            cat > FitTracker/GoogleService-Info.plist <<'PLIST_EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>BUNDLE_ID</key><string>com.fittracker.regev</string>
+            <key>PROJECT_ID</key><string>stub-no-secret</string>
+            <key>GCM_SENDER_ID</key><string>0</string>
+            <key>GOOGLE_APP_ID</key><string>1:0:ios:stub</string>
+            <key>API_KEY</key><string>stub</string>
+            <key>STORAGE_BUCKET</key><string>stub.appspot.com</string>
+            <key>IS_ADS_ENABLED</key><false/>
+            <key>IS_ANALYTICS_ENABLED</key><false/>
+            <key>IS_APPINVITE_ENABLED</key><false/>
+            <key>IS_GCM_ENABLED</key><false/>
+            <key>IS_SIGNIN_ENABLED</key><false/>
+          </dict>
+          </plist>
+          PLIST_EOF
+            echo "Wrote stub plist ($(wc -c < FitTracker/GoogleService-Info.plist) bytes)"
+            exit 0
           fi
           echo "$PLIST_BASE64" | base64 -d > FitTracker/GoogleService-Info.plist
           echo "Decoded plist ($(wc -c < FitTracker/GoogleService-Info.plist) bytes)"


### PR DESCRIPTION
## Summary

The fail-fast plist-decode step from #388 currently blocks **every** Dependabot PR because GitHub denies repo secrets to Dependabot (and forks) by default. Witnessed on #395 (devalue 5.6.4 → 5.8.1 in /dashboard — npm lockfile-only diff that doesn't touch any iOS code path).

## Change

When `GOOGLESERVICE_INFO_PLIST_BASE64` is empty:
- Log a `::warning::` (visible in CI summary)
- Write a minimal stub plist with `IS_ANALYTICS_ENABLED=false` so xcodebuild's resource phase succeeds
- Exit 0

Analytics tests fall back to `MockAnalyticsAdapter` — acceptable for dep-bump PRs that don't exercise the iOS analytics code path. Operator-owned PRs and main-branch builds still get the real secret and exercise the real Firebase adapter (unchanged path).

## Test plan

- [x] YAML still parses (`python -c 'yaml.safe_load'`)
- [x] No untrusted-input interpolation (PLIST_BASE64 from trusted repo secret; stub plist is hardcoded HEREDOC)
- [ ] CI green on this PR (operator-owned: uses real secret path)
- [ ] After merge, re-run #395 — should now pass Build & Test

## Follow-up

After merge, rebase #395 (Dependabot devalue bump) so it picks up this workflow change, then it'll merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>