### PR TITLE
fix(ci): skip Build and Test for Dependabot PRs (follow-up to #398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test
+    # Skip iOS build/test for Dependabot PRs — they update npm/JS deps in
+    # /dashboard or /website and never touch Swift code. GitHub denies repo
+    # secrets to Dependabot anyway, so even with the stub-plist fallback
+    # from PR #398, Firebase tries to configure with invalid IDs and the
+    # app crashes on launch → UI tests time out. Skipping the job entirely
+    # is cheaper and avoids the false-failure. If Dependabot ever proposes
+    # an SPM/iOS-relevant change, manually convert the PR (close + reopen
+    # from a non-Dependabot branch) to run the full pipeline.
+    if: github.actor != 'dependabot[bot]'
     runs-on: macos-15
     env:
       PROJECT_PATH: FitTracker.xcodeproj


### PR DESCRIPTION
## Summary

Follow-up to #398. The stub-plist fallback let the Decode step succeed, but Firebase parses the stub during app launch and crashes (invalid `GOOGLE_APP_ID` format → `1:0:ios:stub`). UI tests then time out waiting for the app to enter foreground — see [#395's failed run 26028723668](https://github.com/Regevba/FitTracker2/actions/runs/26028723668/job/76508783012).

## Change

Add a job-level `if: github.actor != 'dependabot[bot]'` to `build-and-test`. Dependabot only bumps npm deps in `/dashboard` or `/website` (never iOS), so iOS validation has nothing to assert. Saves ~15min of CI per Dependabot PR.

The stub-plist code from #398 stays as defense-in-depth for fork PRs or any context where the secret is unavailable.

## Operator note

If Dependabot ever proposes an SPM/iOS-relevant change, close + reopen the PR from a non-Dependabot branch to run the full pipeline.

## Test plan

- [x] YAML parses
- [ ] CI on this PR (operator branch → job runs normally with real secret, proves we didn't break the operator path)
- [ ] After merge, re-run #395 — Build and Test should be marked `skipped` and PR becomes mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>