### PR TITLE
fix(ci): UCC audit log sync — open PR instead of direct push to main

### DIFF
--- a/.github/workflows/ucc-audit-log-sync.yml
+++ b/.github/workflows/ucc-audit-log-sync.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: ucc-audit-log-sync
@@ -72,13 +73,34 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      - name: Commit + open PR (branch-protection-safe)
         if: steps.diff.outputs.changed == 'true'
         env:
-          DATE: ${{ steps.diff.outputs.date }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          DATE_STAMP=$(date -u +%Y%m%d)
+          BRANCH="chore/ucc-audit-log-sync-${DATE_STAMP}"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add "$TARGET_PATH"
-          git commit -m "chore(ucc-auth): daily sync of audit log"
-          git push origin main
+
+          # If a sync PR for today already exists, push onto its branch (idempotent within the day)
+          if git ls-remote --exit-code origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "${BRANCH}"
+            git checkout -B "${BRANCH}" "origin/${BRANCH}"
+            # bring in the freshly-fetched file
+            git checkout main -- "$TARGET_PATH" 2>/dev/null || true
+            git add "$TARGET_PATH"
+            git commit -m "chore(ucc-auth): daily sync of audit log (append)" || echo "no changes vs branch HEAD"
+            git push origin "${BRANCH}"
+          else
+            git checkout -b "${BRANCH}"
+            git add "$TARGET_PATH"
+            git commit -m "chore(ucc-auth): daily sync of audit log"
+            git push -u origin "${BRANCH}"
+            gh pr create \
+              --base main \
+              --head "${BRANCH}" \
+              --title "chore(ucc-auth): daily sync of audit log (${DATE_STAMP})" \
+              --body "Daily UCC audit log sync from fitme-story Vercel Blob → \`.claude/logs/ucc-auth-events.jsonl\`.\n\nAutomated by \`.github/workflows/ucc-audit-log-sync.yml\` (T22 companion to fitme-story T21 sync-audit-log-to-blob).\n\nOperator: review the diff and merge when convenient. If multiple daily PRs accumulate, they're cumulative — merge the latest one and close the older ones." || echo "PR likely already exists; skipping creation"
+          fi


### PR DESCRIPTION
## Summary
- Workflow has been failing daily since 2026-05-18 (every cron run since branch protection was tightened): `remote: error: GH006: Protected branch update failed for refs/heads/main. Changes must be made through a pull request.`
- Replaces `git push origin main` with the branch-protection-safe "create branch → open PR" pattern
- Adds `pull-requests: write` permission (already had `contents: write`)
- Workflow is idempotent within a day: if today's `chore/ucc-audit-log-sync-YYYYMMDD` branch already exists, the next run appends rather than creates a duplicate

## Why this pattern over alternatives
- **PAT with branch-protection bypass:** introduces a long-lived secret with elevated scope; declined
- **Bypass list in branch protection:** adds the bot to bypass list; less auditable than PR pattern
- **Move log file off main:** defeats the purpose (operator dashboard reads from main)

## Operator workflow after this lands
- One PR/day from `github-actions[bot]` titled `chore(ucc-auth): daily sync of audit log (YYYYMMDD)`
- Review the diff (1 file: `.claude/logs/ucc-auth-events.jsonl`) and merge when convenient
- If multiple daily PRs accumulate, merge the most recent and close the older ones (the latest is cumulative)

## Test plan
- [ ] Workflow syntax passes YAML lint (verified locally)
- [ ] Manual dispatch run opens a PR successfully (operator can trigger via `gh workflow run "UCC audit log sync"` after merge)
- [ ] Next 05:17 UTC cron run is the empirical confirmation

## Related
- Earlier UCC passkey cutover Parts 1-6 shipped 2026-05-16/17 via FT2 #380 + fitme-story #120
- T22 (this workflow) was added during the cutover; T21 (fitme-story side) writes to Vercel Blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)