### PR TITLE
chore(ucc-passkey-auth-security-hardening): Phase 2 → 3 advance — Implementation start

### DIFF
--- a/.claude/features/ucc-passkey-auth-security-hardening/state.json
+++ b/.claude/features/ucc-passkey-auth-security-hardening/state.json
@@ -5,10 +5,10 @@
   "parent_feature": "ucc-passkey-auth",
   "framework_version": "v7.8.6",
   "created_at": "2026-05-19T14:30:00Z",
-  "updated": "2026-05-19T20:01:44Z",
+  "updated": "2026-05-20T03:25:26Z",
   "branch": "feat/ucc-passkey-security-hardening",
   "state_owner": "ft2",
-  "current_phase": "tasks",
+  "current_phase": "implementation",
   "has_ui": false,
   "requires_analytics": false,
   "isolation_opt_out": false,
@@ -26,7 +26,7 @@
       "note": "PRD inherited from parent ucc-passkey-auth \u00a77 Q1 + Q2. Delta scope + success_metrics + kill_criteria captured directly in this state.json. Technical authority: docs/superpowers/specs/2026-05-19-ucc-passkey-security-hardening-design.md. Operational authority: docs/master-plan/ucc-passkey-security-hardening-risk-assessment-2026-05-19.md."
     },
     "tasks": {
-      "status": "in_progress",
+      "status": "approved",
       "started_at": "2026-05-19T14:30:00Z",
       "paused_at": "2026-05-19T15:00:00Z",
       "pause_reason": "Operator requested save + end session after design + sub-plan + state.json scaffolded. Implementation plan not yet generated.",
@@ -57,14 +57,16 @@
           "Anything else to edit before writing-plans runs?"
         ]
       },
-      "count": 26
+      "count": 26,
+      "approved_at": "2026-05-20T03:25:26Z"
     },
     "ux_or_integration": {
       "status": "skipped",
       "skip_reason": "work_type:enhancement (backend + CLI only, no UI changes)"
     },
     "implementation": {
-      "status": "pending"
+      "status": "in_progress",
+      "commits": []
     },
     "testing": {
       "status": "pending",
@@ -587,9 +589,21 @@
     "phases": {
       "tasks": {
         "started_at": "2026-05-19T14:30:00Z",
+        "ended_at": "2026-05-20T03:25:26Z"
+      },
+      "implementation": {
+        "started_at": "2026-05-20T03:25:26Z",
         "ended_at": null
       }
     }
   },
-  "transitions": []
+  "transitions": [
+    {
+      "from": "tasks",
+      "to": "implementation",
+      "timestamp": "2026-05-20T03:25:26Z",
+      "approved_by": "user",
+      "note": "Phase 2 (Tasks) complete; advancing to Phase 3 (Implementation). User approval recorded 2026-05-20."
+    }
+  ]
 }

--- a/.claude/logs/ucc-passkey-auth-security-hardening.log.json
+++ b/.claude/logs/ucc-passkey-auth-security-hardening.log.json
@@ -6,7 +6,7 @@
   "current_phase": "tasks",
   "framework_version": "v7.8.6",
   "started_at": "2026-05-19T16:23:07Z",
-  "updated_at": "2026-05-19T20:05:17Z",
+  "updated_at": "2026-05-20T03:25:27Z",
   "events": [
     {
       "timestamp": "2026-05-19T16:23:07Z",
@@ -35,6 +35,28 @@
       "event_type": "phase_paused",
       "phase": "tasks",
       "summary": "Phase 2 (Tasks) complete: 26-task list generated; infra master plan overlay written; risk register has 9 entries (3 timing-sensitive, none blocking). Resume = operator approval to advance Phase 2 \u2192 Phase 3 (Implementation).",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-20T03:25:26Z",
+      "event_type": "phase_approved",
+      "phase": "tasks",
+      "summary": "Phase 2 (Tasks) approved by user 2026-05-20. 26-task list captured in tasks.md + state.json::tasks[]; 9-risk infra overlay merged via PR #410.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-20T03:25:27Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "Phase 3 (Implementation) started. Critical path: T1 \u2192 T8 \u2192 T9 \u2192 T12 \u2192 T20 \u2192 T22. Code work happens in fitme-story; this FT2 branch carries phase-transition tracking commits only.",
       "artifacts": [],
       "metrics": {},
       "actor": "human_or_agent",


### PR DESCRIPTION
## Summary
- User-approved transition 2026-05-20: Phase 2 (Tasks) → Phase 3 (Implementation)
- 2 files changed (state.json + log)
- Code work proceeds in fitme-story (separate PR T22, opening next)

## Phase 3 plan (per tasks.md critical path)
1. T1 — Extract `ipClassFromRaw` + `uaFamilyFromRaw` to `audit-log-redactors.ts` (refactor)
2. T2 + T3 — Extend `AuthEventType` + `AuthEventReason` enums
3. T4 — Create `src/lib/auth/allowlist.ts`
4. T5 — Wire allowlist gate in `/api/auth/register/options/route.ts`
5. T8 — Create `src/lib/auth/redis-lockout.ts`
6. T9 + T10 — Wire lockout in auth + register verify routes
7. T13 + T14 — Bootstrap-token issuance audit + cli/ UA family
8. T16 — Create `scripts/clear-lockout.ts`
9. T18 — Document `UCC_ALLOWED_EMAILS` in fitme-story `.env.example`
10. T6 + T7 + T11 + T12 + T15 + T17 — 34-case test suite (Vitest)
11. T20 (operator) — Manual verification matrix per spec §8.2
12. T22 — Open fitme-story PR for merge

## Deadlines
- 2026-05-20 EOD: target ship (gate: 2026-05-21 v7.9 freeze)
- 2026-05-22: B11 calibration check
- 2026-05-23: parent UCC T+7d kill-criteria checkpoint

## Test plan
- [ ] FT2 integrity gates pass (verified at commit time)
- [ ] CI green on this small chore PR
- [ ] fitme-story PR (T22) opens cleanly afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)