### PR TITLE
chore(dev-env): Tier 1 R1 + R6 + R2 — .tool-versions + .editorconfig + checkpoint-rotate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# EditorConfig — R6 from 2026-05-19 dev-env audit.
+#
+# Cross-editor formatting rules. Cuts whitespace-drift PR noise across
+# operator + Claude-agent sessions + future contributors.
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[*.{swift,py}]
+indent_size = 4
+
+[*.{md,mdx}]
+# Markdown lines can legitimately exceed line length (long URLs, prose);
+# don't auto-trim trailing whitespace because Markdown uses "  " (2 spaces)
+# as a hard line break.
+max_line_length = off
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml,json,jsonl}]
+indent_size = 2
+
+[*.{tsx,ts,jsx,js,mjs,cjs}]
+indent_size = 2
+quote_type = single

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,22 @@
+# Tool-versions pin file for mise / asdf — R1 from 2026-05-19 dev-env audit.
+#
+# Eliminates "works on my Mac" drift between operator sessions, Claude
+# agents in subagent dispatch, and any future contributor's checkout.
+# Daily-checkpoint cron + integrity-cycle workflow rely on stable Node
+# + Python versions; without a pin, a Homebrew bump silently changes
+# downstream behavior.
+#
+# Versions captured 2026-05-21 from the operator's working toolchain:
+#   node --version    -> v24.14.0
+#   python3 --version -> Python 3.14.4
+#   swift --version   -> Apple Swift 6.3.1 (Xcode-controlled; pinned declaratively for parity)
+#
+# Pin source of truth: this file. To bump a version, update this line +
+# verify on a feature/chore branch BEFORE merging to main.
+#
+# If `mise` is installed and operator runs `mise install` from repo root,
+# the listed versions auto-install + activate per-shell.
+
+node 24.14.0
+python 3.14.4
+swift 6.3.1

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+  "recommendations": [
+    "swiftlang.swift",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "redhat.vscode-yaml",
+    "editorconfig.editorconfig",
+    "github.vscode-pull-request-github",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "yzhang.markdown-all-in-one",
+    "davidanson.vscode-markdownlint",
+    "figma.figma-vscode-extension",
+    "anthropic.claude-code"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,42 @@
+{
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "editor.rulers": [100],
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.exclude": {
+    "**/.DS_Store": true,
+    "**/.build": true,
+    "**/node_modules": true,
+    "**/__pycache__": true,
+    "**/.pytest_cache": true
+  },
+  "search.exclude": {
+    "**/.build": true,
+    "**/node_modules": true,
+    "**/__pycache__": true,
+    "**/dist": true,
+    "**/coverage": true
+  },
+  "[swift]": {
+    "editor.tabSize": 4
+  },
+  "[python]": {
+    "editor.tabSize": 4,
+    "editor.formatOnSave": false
+  },
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+  "[makefile]": {
+    "editor.insertSpaces": false
+  },
+  "python.analysis.typeCheckingMode": "basic",
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": "active"
+}

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,21 @@ integrity-check:
 integrity-diff:
 	@python3 scripts/integrity-diff.py $(if $(EXIT_ON_REGRESSION),--exit-on-regression,)
 
+# Rotate / prune daily-checkpoint snapshots under
+# ~/Documents/FitTracker2-backups/daily/ (R2 from 2026-05-19 dev-env audit).
+# Dry-run by default — re-run with EXECUTE=1 to apply changes.
+# Retention: last 30 days uncompressed + first-of-month anchors permanent
+# (optionally compressed via COMPRESS_ANCHORS=1).
+#   make checkpoint-rotate                              # dry-run, default 30d retention
+#   make checkpoint-rotate EXECUTE=1                    # actually rotate
+#   make checkpoint-rotate KEEP_DAYS=60 EXECUTE=1       # custom retention
+#   make checkpoint-rotate EXECUTE=1 COMPRESS_ANCHORS=1 # also compress older anchors to .tar.zst
+checkpoint-rotate:
+	@python3 scripts/rotate-checkpoint-snapshots.py \
+		$(if $(KEEP_DAYS),--keep-days=$(KEEP_DAYS),) \
+		$(if $(EXECUTE),--execute,) \
+		$(if $(COMPRESS_ANCHORS),--compress-anchors,)
+
 # Unified preflight entry point — aggregates all pre-work data checks adapted
 # by work_type (feature / enhancement / fix / chore). Writes
 # .claude/shared/preflight-cache.json that downstream skills (ux, design, dev,

--- a/scripts/rotate-checkpoint-snapshots.py
+++ b/scripts/rotate-checkpoint-snapshots.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+rotate-checkpoint-snapshots.py — R2 from 2026-05-19 dev-env audit.
+
+Rotates / prunes daily-integrity-checkpoint snapshots under
+~/Documents/FitTracker2-backups/daily/ to prevent silent backup-pipeline
+failure when the internal disk fills up.
+
+Retention policy (default):
+- Last 30 daily snapshots: kept uncompressed
+- First-of-month anchors (e.g. 2026-04-01, 2026-05-01, ...): kept permanently,
+  optionally compressed to .tar.zst if older than 30 days
+- All other older daily snapshots: removed
+
+Companion to scripts/daily-integrity-checkpoint.py. Invoked manually
+or via `make checkpoint-rotate`. The daily-checkpoint cron does NOT
+call this automatically — operator runs weekly OR when disk usage
+crosses a threshold.
+
+Calendar safety:
+- Pure file-system housekeeping; no state.json mutation, no infra-glob
+  outside scripts/ itself, no gate impact.
+- Backup root is on the macOS internal disk (NOT the SSD); no impact
+  on canonical repo state.
+
+Usage:
+  python3 scripts/rotate-checkpoint-snapshots.py             # dry-run by default
+  python3 scripts/rotate-checkpoint-snapshots.py --execute   # actually rotate
+  python3 scripts/rotate-checkpoint-snapshots.py --keep-days=60 --execute  # custom retention
+
+Exit codes:
+  0 - success (or dry-run completed without errors)
+  1 - error during rotation (partial state may exist; investigate)
+  2 - backup root not found
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_BACKUP_ROOT = Path.home() / "Documents" / "FitTracker2-backups" / "daily"
+DEFAULT_KEEP_DAYS = 30
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--backup-root", type=Path, default=DEFAULT_BACKUP_ROOT,
+                   help=f"Backup directory (default: {DEFAULT_BACKUP_ROOT})")
+    p.add_argument("--keep-days", type=int, default=DEFAULT_KEEP_DAYS,
+                   help=f"Keep uncompressed snapshots from the last N days (default: {DEFAULT_KEEP_DAYS})")
+    p.add_argument("--execute", action="store_true",
+                   help="Actually perform the rotation (default is dry-run)")
+    p.add_argument("--compress-anchors", action="store_true",
+                   help="Compress first-of-month anchors older than --keep-days to .tar.zst")
+    return p.parse_args()
+
+
+def list_snapshot_dirs(root: Path) -> list[Path]:
+    """Return all YYYY-MM-DD dirs under backup root, sorted ascending."""
+    if not root.is_dir():
+        return []
+    out = []
+    for child in root.iterdir():
+        if child.is_dir():
+            try:
+                dt.date.fromisoformat(child.name)
+                out.append(child)
+            except ValueError:
+                continue
+    return sorted(out, key=lambda p: p.name)
+
+
+def is_first_of_month_anchor(snap_dir: Path) -> bool:
+    try:
+        d = dt.date.fromisoformat(snap_dir.name)
+        return d.day == 1
+    except ValueError:
+        return False
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.backup_root
+
+    if not root.is_dir():
+        print(f"[rotate] Backup root not found: {root}", file=sys.stderr)
+        return 2
+
+    snapshots = list_snapshot_dirs(root)
+    if not snapshots:
+        print(f"[rotate] No snapshots found under {root}")
+        return 0
+
+    today = dt.date.today()
+    cutoff = today - dt.timedelta(days=args.keep_days)
+
+    to_remove: list[Path] = []
+    to_compress: list[Path] = []
+    kept: list[Path] = []
+
+    for snap in snapshots:
+        try:
+            d = dt.date.fromisoformat(snap.name)
+        except ValueError:
+            continue
+
+        if d >= cutoff:
+            kept.append(snap)
+            continue
+
+        if is_first_of_month_anchor(snap):
+            already_compressed = snap.with_suffix(".tar.zst").exists()
+            if args.compress_anchors and not already_compressed:
+                to_compress.append(snap)
+            else:
+                kept.append(snap)
+            continue
+
+        to_remove.append(snap)
+
+    mode_label = "DRY-RUN" if not args.execute else "EXECUTE"
+    print(f"[rotate] {mode_label} — backup root: {root}")
+    print(f"[rotate]   cutoff date (keep newer than): {cutoff.isoformat()}")
+    print(f"[rotate]   snapshots inspected: {len(snapshots)}")
+    print(f"[rotate]   to keep:     {len(kept)}")
+    print(f"[rotate]   to remove:   {len(to_remove)}")
+    print(f"[rotate]   to compress: {len(to_compress)}")
+    print()
+
+    if to_remove:
+        print("  Snapshots to remove:")
+        for p in to_remove:
+            size_kb = sum(f.stat().st_size for f in p.rglob("*") if f.is_file()) // 1024
+            print(f"    - {p.name}  ({size_kb:,} KB)")
+    if to_compress:
+        print("  Snapshots to compress (first-of-month anchors > keep-days):")
+        for p in to_compress:
+            print(f"    + {p.name} → {p.name}.tar.zst")
+
+    if not args.execute:
+        print()
+        print("[rotate] dry-run complete; re-run with --execute to apply changes.")
+        return 0
+
+    errors = 0
+
+    for p in to_compress:
+        archive = p.with_suffix(".tar.zst")
+        try:
+            print(f"[rotate] compressing {p.name} → {archive.name}")
+            subprocess.run(
+                ["tar", "--zstd", "-cf", str(archive), "-C", str(p.parent), p.name],
+                check=True, capture_output=True,
+            )
+            shutil.rmtree(p)
+        except (subprocess.CalledProcessError, OSError) as e:
+            print(f"[rotate] ERROR compressing {p}: {e}", file=sys.stderr)
+            errors += 1
+
+    for p in to_remove:
+        try:
+            print(f"[rotate] removing {p.name}")
+            shutil.rmtree(p)
+        except OSError as e:
+            print(f"[rotate] ERROR removing {p}: {e}", file=sys.stderr)
+            errors += 1
+
+    if errors:
+        print(f"[rotate] completed with {errors} error(s).", file=sys.stderr)
+        return 1
+
+    print(f"[rotate] done. {len(kept)} snapshot(s) retained.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First batch from the 2026-05-19 dev-env audit ([`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](docs/research/2026-05-19-dev-env-audit-stability-and-scale.md)). Three Tier 1 / Tier 2 items in one chore branch, three commits, zero gate firings.

| Commit | R-ID | Tier | Files |
|---|---|---|---|
| `3b2fa04` | **R1** — pin language versions via `.tool-versions` | 1 | `.tool-versions` (node 24.14.0 + python 3.14.4 + swift 6.3.1) |
| `1c4d33b` | **R6** — `.editorconfig` + `.vscode/{settings,extensions}.json` | 2 | `.editorconfig`, `.vscode/settings.json`, `.vscode/extensions.json` |
| `f9ea77c` | **R2** — daily-checkpoint snapshot rotation script + Makefile target | 1 | `scripts/rotate-checkpoint-snapshots.py` (new), `Makefile` (new `checkpoint-rotate` target) |

## Overlay check (per operator's W-series rule)

Cross-referenced against master plan / infra master plan / sub-plans / cadence followups before each commit:

| Document | R1 | R6 | R2 |
|---|---|---|---|
| `master-plan-2026-04-15.md` | not addressed; no conflict | not addressed; no conflict | not addressed; no conflict |
| `infra-master-plan-2026-05-12.md` Phase E rule (no new gates, no F14/F18, F17 read-only OK) | adds no gates ✓ | adds no gates ✓ | adds no gates ✓ |
| `post-v7-9-candidate-plan-2026-05-20.md` | no overlap | no overlap | no overlap |
| `must-have-cadence-followups.md` (B/C items) | C1 (F14/F15) also targets 2026-05-22 + `scripts/*` — parallel track, no path overlap | no overlap | no overlap |
| HADF Phase 2-bis spec | no conflict (Sub-exp 1 launches 2026-05-23) | no conflict | no conflict |
| UCC hardening spec | no conflict | no conflict | no conflict |
| v7.9 candidates spec | F14/F15 v8.0 docket touches `scripts/*` too — no file overlap with this PR | no overlap | no overlap |
| Mechanism E driver | doesn't touch ledgers | doesn't touch ledgers | rotation may affect daily-checkpoint ledger; Mechanism E auto-resolves any concurrent ledger appends ✓ |

**Verdict:** zero violations.

## Data-integrity safety (same as W-series)

| # | Condition | Result |
|---|---|---|
| 1 | No infra-glob (`.githooks/*`, `.github/workflows/*`, `scripts/*`, `.claude/skills/*`, `.claude/shared/*`, `CLAUDE.md`, `docs/architecture/*`, `Makefile`) ON MAIN | ✅ R2 + Makefile changes are on `chore/*` branch (auto-allowed by Mode B) |
| 2 | No `state.json::current_phase` mutation | ✅ Zero state.json edits |
| 3 | No `current_phase=complete` transition | ✅ None |
| 4 | MDX in `content/framework/` or `content/04-case-studies/` no unescaped `<digit` | ✅ N/A — no MDX touched |

**Pre-commit gates fired:** none (all 3 commits passed the hook chain cleanly).
**`make integrity-check` baseline post-commit:** 0 findings + 2 advisory (pre-existing).

## Why now (vs the audit doc's "defer to 2026-05-22")

The audit doc said "defer to 2026-05-22" because R1 + R2 touch `scripts/*` + `Makefile` (both infra-glob). That deferral was to protect the v7.9 calibration window — which **closed at today's freeze decision** (2026-05-21T05:44Z). Mode B + Mechanism A coverage have all data they need; new `scripts/*` commits no longer contaminate. So today is fine, especially on an isolated chore branch.

## What's NOT in this PR

- **R3** (YubiKey) — hardware pending; ships when device arrives
- **R4** (MEMORY.md cleanup) — already shipped 2026-05-19 per memory `project_session_2026_05_19_ssd_prep_devenv_audit.md`
- **R5** (branch protection) — already shipped 2026-05-19 per same memory
- **R7-R12 Tier 2** — scheduled 30 days post-v7.9 per audit calendar
- **R13-R19 Tier 3** — scheduled 60-90 days post-v7.9
- **R20-R24 Tier 4** — post App Store launch
- **fitme-story parallel** — R1 + R6 will land in fitme-story via separate PR (R2 is FT2-only since the daily-checkpoint script is FT2's)

## Linear + Notion

A new Linear epic + 24 sub-issues + a Notion plan page under FitMe Product Hub are queued (separate steps in the same session).

## Test plan

- [x] All 3 commits pre-commit hooks GREEN (no gates fired)
- [x] `make integrity-check` clean (0 findings + 2 baseline advisory)
- [x] R2 script verified: `python3 scripts/rotate-checkpoint-snapshots.py` dry-run = OK
- [x] R2 Makefile target verified: `make checkpoint-rotate` = OK
- [ ] CI green on this PR (`integrity` + `pr-integrity` + `Build and Test`)
- [ ] Operator merge confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)