### PR TITLE
chore(dev-env): R4 — replug-detection launchd watcher for /Volumes/DevSSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Carthage/Build/
 .claude/logs/_session-*.events.jsonl
 .claude/active-feature
 .claude/logs/gate-coverage.jsonl
+.claude/logs/devssd-uuid-watcher.log
 .claude/shared/preflight-cache.json
 .claude/shared/integrity-checkpoint-regression.flag
 .claude/worktrees/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -489,6 +489,33 @@ install-daily-cron:
 
 uninstall-daily-cron:
 	@PLIST_DEST=$$HOME/Library/LaunchAgents/com.fittracker.daily-integrity-checkpoint.plist; \
+	if [ ! -f "$$PLIST_DEST" ]; then \
+		echo "Not installed: $$PLIST_DEST"; \
+		exit 0; \
+	fi; \
+	launchctl unload "$$PLIST_DEST" 2>/dev/null || true; \
+	rm "$$PLIST_DEST"; \
+	echo "Uninstalled: $$PLIST_DEST"
+
+# R4 (FIT-170): replug-detection watcher. Fires every 5 min; loud warning when
+# /Volumes/DevSSD's volume UUID changes vs R3's baseline. Idempotent install.
+install-devssd-watcher:
+	@PLIST_DEST=$$HOME/Library/LaunchAgents/com.fittracker.devssd-uuid-watcher.plist; \
+	if [ -f "$$PLIST_DEST" ]; then \
+		echo "Already installed: $$PLIST_DEST"; \
+		echo "To reinstall: make uninstall-devssd-watcher && make install-devssd-watcher"; \
+		exit 0; \
+	fi; \
+	cp infrastructure/launchd/com.fittracker.devssd-uuid-watcher.plist.template "$$PLIST_DEST"; \
+	launchctl load "$$PLIST_DEST"; \
+	echo "Installed launchd watcher: $$PLIST_DEST"; \
+	echo "Polls /Volumes/DevSSD volume UUID every 5 min vs R3 baseline."; \
+	echo "Verify with: launchctl list | grep devssd-uuid"; \
+	echo "Audit log:   .claude/logs/devssd-uuid-watcher.log"; \
+	echo "stdout/err:  ~/Library/Logs/fittracker-devssd-uuid-watcher.{log,err}"
+
+uninstall-devssd-watcher:
+	@PLIST_DEST=$$HOME/Library/LaunchAgents/com.fittracker.devssd-uuid-watcher.plist; \
 	if [ ! -f "$$PLIST_DEST" ]; then \
 		echo "Not installed: $$PLIST_DEST"; \
 		exit 0; \

--- a/infrastructure/launchd/com.fittracker.devssd-uuid-watcher.plist.template
+++ b/infrastructure/launchd/com.fittracker.devssd-uuid-watcher.plist.template
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  TEMPLATE — DO NOT load directly. Install via `make install-devssd-watcher`.
+
+  Replug-detection watcher (R4 from dev-env audit). Fires every 5 minutes
+  and runs scripts/check-devssd-uuid.sh. Silent no-op when the SSD's volume
+  UUID matches the baseline captured in R3's daily integrity checkpoint;
+  loud warning + macOS notification + audit-log entry when it changes.
+
+  This is what catches:
+    - Operator replugs the drive (USB-C cable disconnect/reconnect)
+    - A different drive gets mounted at /Volumes/DevSSD (backup, clone)
+    - Filesystem corruption that re-mounts under a new UUID
+
+  KnownIssue: BRANCH_ISOLATION_LAUNCHD_DRIFT (v7.8.1 advisory) applies —
+  template anchors to /Volumes/DevSSD/FitTracker2. If the SSD ever unmounts,
+  the script's exit-2 path logs probe_failed and the next fire retries.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.fittracker.devssd-uuid-watcher</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Volumes/DevSSD/FitTracker2/scripts/check-devssd-uuid.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Volumes/DevSSD/FitTracker2</string>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/regevbarak/Library/Logs/fittracker-devssd-uuid-watcher.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/regevbarak/Library/Logs/fittracker-devssd-uuid-watcher.err</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/check-devssd-uuid.sh
+++ b/scripts/check-devssd-uuid.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# check-devssd-uuid.sh — replug-detection watcher for /Volumes/DevSSD.
+#
+# Reads the SSD's current Volume UUID via diskutil, compares against the
+# baseline captured by R3 in the daily integrity checkpoint ledger, and
+# emits a loud notification if they differ. Silent no-op when they match.
+#
+# Designed to be invoked by a launchd watcher (StartInterval=300s) installed
+# via `make install-devssd-watcher`. Also safe to call manually.
+#
+# Exit codes:
+#   0 — UUID matches baseline (or no baseline yet — R3 hasn't fired)
+#   1 — UUID changed; replug or drive-swap detected; warning emitted
+#   2 — probe failed (mount missing, ledger unreadable, diskutil missing)
+#
+# Output:
+#   - On match: silent unless --verbose
+#   - On change: stderr WARNING + macOS osascript notification + audit-log entry
+#                in .claude/logs/devssd-uuid-watcher.log
+#
+# Linear: FIT-170
+# Plan: docs/research/2026-05-19-dev-env-audit-stability-and-scale.md (R4)
+
+set -u
+
+MOUNT="/Volumes/DevSSD"
+REPO_ROOT="${DEVSSD_WATCHER_REPO_ROOT:-/Volumes/DevSSD/FitTracker2}"
+LEDGER="$REPO_ROOT/.claude/shared/integrity-checkpoint-ledger.jsonl"
+AUDIT_LOG="$REPO_ROOT/.claude/logs/devssd-uuid-watcher.log"
+VERBOSE="${1:-}"
+
+log_audit() {
+  mkdir -p "$(dirname "$AUDIT_LOG")"
+  printf '%s\n' "$1" >> "$AUDIT_LOG"
+}
+
+now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# 1. Probe current UUID
+if [[ "$(uname)" != "Darwin" ]] || ! command -v diskutil >/dev/null 2>&1; then
+  [[ "$VERBOSE" == "--verbose" ]] && echo "Non-darwin or no diskutil — skipping"
+  exit 0
+fi
+if [[ ! -d "$MOUNT" ]]; then
+  msg="$(now) probe_failed mount_missing=$MOUNT"
+  log_audit "$msg"
+  echo "WARNING: $msg" >&2
+  exit 2
+fi
+
+CURRENT_UUID=$(diskutil info "$MOUNT" 2>/dev/null \
+  | awk -F': *' '/Volume UUID:/ {print $2}')
+
+if [[ -z "$CURRENT_UUID" ]]; then
+  msg="$(now) probe_failed uuid_unreadable mount=$MOUNT"
+  log_audit "$msg"
+  echo "WARNING: $msg" >&2
+  exit 2
+fi
+
+# 2. Read baseline from R3's ledger (last JSON row with hardware.volume_uuid)
+if [[ ! -f "$LEDGER" ]]; then
+  [[ "$VERBOSE" == "--verbose" ]] && echo "No ledger yet — baseline-pending"
+  log_audit "$(now) baseline_pending no_ledger uuid=$CURRENT_UUID"
+  exit 0
+fi
+
+BASELINE_UUID=$(python3 -c "
+import json, sys
+last = None
+try:
+    with open('$LEDGER') as f:
+        for line in f:
+            line = line.strip()
+            if not line: continue
+            try:
+                row = json.loads(line)
+                if row.get('hardware', {}).get('volume_uuid'):
+                    last = row['hardware']['volume_uuid']
+            except json.JSONDecodeError:
+                continue
+    print(last or '')
+except Exception:
+    pass
+" 2>/dev/null)
+
+if [[ -z "$BASELINE_UUID" ]]; then
+  [[ "$VERBOSE" == "--verbose" ]] && echo "No baseline UUID in ledger — pending first R3 fire"
+  log_audit "$(now) baseline_pending no_uuid_in_ledger current=$CURRENT_UUID"
+  exit 0
+fi
+
+# 3. Compare
+if [[ "$CURRENT_UUID" == "$BASELINE_UUID" ]]; then
+  [[ "$VERBOSE" == "--verbose" ]] && echo "✓ UUID matches baseline: $CURRENT_UUID"
+  exit 0
+fi
+
+# 4. Mismatch — alert
+TS="$(now)"
+msg="$TS UUID_CHANGED baseline=$BASELINE_UUID current=$CURRENT_UUID"
+log_audit "$msg"
+
+cat >&2 <<EOF
+⚠ ⚠ ⚠  DEVSSD UUID CHANGED — REPLUG OR DRIVE SWAP DETECTED  ⚠ ⚠ ⚠
+
+  Baseline (last R3 checkpoint): $BASELINE_UUID
+  Current ($MOUNT):               $CURRENT_UUID
+
+  This indicates the drive at $MOUNT is not the same one R3 last captured.
+  Action: investigate before continuing work. Possible causes:
+    - SSD replug (most likely)
+    - Drive swap to a backup/clone
+    - Different volume mounted at the same path
+
+  Audit log: $AUDIT_LOG
+  Re-baseline: run \`make daily-checkpoint-force\` to capture the new UUID.
+
+EOF
+
+# Best-effort macOS notification (silent if osascript missing or no display session)
+if command -v osascript >/dev/null 2>&1; then
+  osascript -e "display notification \"Baseline: ${BASELINE_UUID:0:8}… Current: ${CURRENT_UUID:0:8}…\" with title \"DevSSD UUID Changed\" sound name \"Basso\"" 2>/dev/null || true
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

Replug-detection watcher that pairs with R3 (PR #424, merged). Polls `/Volumes/DevSSD`'s volume UUID every 5 minutes; loudly alerts if it ever differs from the baseline R3 captures in the daily checkpoint ledger.

## What catches what

| Event | Detection |
|---|---|
| SSD replug (USB-C cable cycle) | UUID stays same → no alert. But if FS forces re-mount under new UUID → loud alert |
| Drive swap (clone mounted at same path) | New UUID → loud alert |
| FS corruption that remounts under new UUID | Loud alert |

## Components

- **`scripts/check-devssd-uuid.sh`** — bash watcher. Exit codes: 0 (match / pending baseline), 1 (changed), 2 (probe failed). Output: silent on match; stderr WARNING + macOS notification + audit-log entry on change.
- **`infrastructure/launchd/com.fittracker.devssd-uuid-watcher.plist.template`** — `StartInterval=300s`, `RunAtLoad`.
- **Makefile** — `install-devssd-watcher` + `uninstall-devssd-watcher` targets (idempotent).
- **`.gitignore`** — `.claude/logs/devssd-uuid-watcher.log` (runtime audit trace, not source).

## Smoke tests

- ✅ Match scenario: silent, exit 0
- ✅ Baseline pending (no R3 row yet): silent, exit 0
- ✅ Synthetic mismatch: loud warning, audit-log entry, exit 1
- ✅ Non-darwin: silent skip, exit 0
- ✅ `make -n install-devssd-watcher` / `uninstall-devssd-watcher` parse

## Operator setup (one-time, after merge)

```bash
make daily-checkpoint-force    # seed R3 baseline (or wait for tomorrow's 06:00 UTC cron)
make install-devssd-watcher    # installs the launchd plist; runs immediately + every 5 min thereafter
```

## Depends on

- R3 (PR #424, merged 4ecbf16b) — provides the baseline UUID in `hardware.volume_uuid` ledger field

## Overlay safety (Phase E 2026-05-21 → 2026-06-04)

- ✅ No new gates introduced (operator-facing alert only)
- ✅ No `state.json` mutations
- ✅ No F14/F18 test discipline changes
- ✅ Isolated chore branch off main
- ✅ Cross-platform-safe (silent skip on non-darwin)

## Links

- Plan: [`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](https://github.com/Regevba/FitTracker2/blob/main/docs/research/2026-05-19-dev-env-audit-stability-and-scale.md) R4
- Linear: [FIT-170](https://linear.app/fitme-project/issue/FIT-170) (sub of epic [FIT-166](https://linear.app/fitme-project/issue/FIT-166))
- Notion: [Dev-Env Upgrade Plan](https://www.notion.so/3670e7a0eace819dba31c2427cff92fd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)