### PR TITLE
chore(dev-env): R20 — integrity-snapshot retention policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher doctor
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher doctor integrity-snapshot-rotate
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -530,6 +530,18 @@ uninstall-devssd-watcher:
 # a single colored table. Use when something feels off.
 doctor:
 	@bash scripts/doctor.sh
+
+# R20 (FIT-186): rotate / prune integrity-check snapshots under
+# .claude/integrity/snapshots/<TIMESTAMP>.json. Companion to R2 (checkpoint
+# rotation) — same retention policy, different target dir.
+# Dry-run by default — re-run with EXECUTE=1 to apply.
+#   make integrity-snapshot-rotate                      # dry-run, default keep-30
+#   make integrity-snapshot-rotate EXECUTE=1            # apply
+#   make integrity-snapshot-rotate KEEP_COUNT=60 EXECUTE=1
+integrity-snapshot-rotate:
+	@python3 scripts/rotate-integrity-snapshots.py \
+		$(if $(KEEP_COUNT),--keep-count=$(KEEP_COUNT),) \
+		$(if $(EXECUTE),--execute,)
 
 # Auto-install on first run
 node_modules:

--- a/scripts/rotate-integrity-snapshots.py
+++ b/scripts/rotate-integrity-snapshots.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+rotate-integrity-snapshots.py — R20 from 2026-05-19 dev-env audit.
+
+Rotates / prunes integrity-check snapshots under
+.claude/integrity/snapshots/<TIMESTAMP>.json to prevent the snapshot
+directory from growing unbounded after months of `make integrity-snapshot`
+invocations.
+
+Companion to R2 (rotate-checkpoint-snapshots.py) — same retention policy,
+different target dir. R2 handles `~/Documents/FitTracker2-backups/daily/`;
+R20 handles `.claude/integrity/snapshots/`.
+
+Retention policy (default):
+- Last 30 snapshots: kept uncompressed
+- First-of-month anchors (any snapshot dated YYYY-MM-01): kept permanently
+- All other older snapshots: removed
+
+Calendar safety:
+- Pure file-system housekeeping; no state.json mutation, no gate impact
+- Snapshot files are JSON metadata only; no other code reads them after
+  the next `make integrity-snapshot` comparison consumes the prior file
+
+Usage:
+  python3 scripts/rotate-integrity-snapshots.py            # dry-run
+  python3 scripts/rotate-integrity-snapshots.py --execute  # actually rotate
+  python3 scripts/rotate-integrity-snapshots.py --keep-count=60 --execute
+
+Exit codes:
+  0 — success (or dry-run completed without errors)
+  1 — error during rotation
+  2 — snapshot dir not found
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SNAPSHOT_DIR = REPO_ROOT / ".claude" / "integrity" / "snapshots"
+DEFAULT_KEEP_COUNT = 30
+
+# Filenames look like: 2026-05-12T07-22-35Z.json
+SNAPSHOT_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})T\d{2}-\d{2}-\d{2}Z\.json$")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--snapshot-dir", type=Path, default=DEFAULT_SNAPSHOT_DIR,
+                   help="Directory containing snapshot JSON files")
+    p.add_argument("--keep-count", type=int, default=DEFAULT_KEEP_COUNT,
+                   help=f"Most-recent N snapshots to keep (default {DEFAULT_KEEP_COUNT})")
+    p.add_argument("--execute", action="store_true",
+                   help="Actually delete; without this flag, dry-run only")
+    p.add_argument("--quiet", action="store_true",
+                   help="Suppress progress; errors still print")
+    return p.parse_args()
+
+
+def is_first_of_month(name: str) -> bool:
+    m = SNAPSHOT_RE.match(name)
+    return bool(m and m.group(3) == "01")
+
+
+def parse_date(name: str) -> dt.date | None:
+    m = SNAPSHOT_RE.match(name)
+    if not m:
+        return None
+    try:
+        return dt.date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    args = parse_args()
+    log = (lambda *a, **kw: None) if args.quiet else print
+
+    if not args.snapshot_dir.exists():
+        log(f"Snapshot dir not found: {args.snapshot_dir}", file=sys.stderr)
+        return 2
+
+    # Gather snapshots with valid name pattern
+    candidates = []
+    for p in sorted(args.snapshot_dir.glob("*.json")):
+        d = parse_date(p.name)
+        if d is None:
+            log(f"  skip (unparseable name): {p.name}")
+            continue
+        candidates.append((d, p))
+
+    if not candidates:
+        log(f"No snapshots found in {args.snapshot_dir}")
+        return 0
+
+    # Sort by date descending — most recent first
+    candidates.sort(key=lambda t: t[0], reverse=True)
+
+    # Decide who to keep
+    keep_recent = set(p for _, p in candidates[:args.keep_count])
+    keep_anchors = set(p for _, p in candidates if is_first_of_month(p.name))
+    keep = keep_recent | keep_anchors
+
+    to_remove = [p for _, p in candidates if p not in keep]
+
+    log(f"=== Integrity-snapshot retention ===")
+    log(f"  Dir:          {args.snapshot_dir}")
+    log(f"  Total:        {len(candidates)} snapshots")
+    log(f"  Keep (recent):  {len(keep_recent)} (last {args.keep_count})")
+    log(f"  Keep (anchors): {len(keep_anchors)} (first-of-month)")
+    log(f"  Keep (union):   {len(keep)}")
+    log(f"  Remove:         {len(to_remove)}")
+
+    if not to_remove:
+        log(f"\n✓ Nothing to remove")
+        return 0
+
+    log(f"\nRemoval list:")
+    for p in to_remove:
+        log(f"  - {p.name}")
+
+    if not args.execute:
+        log(f"\n[dry-run] Re-run with --execute to apply")
+        return 0
+
+    log(f"\n[execute] removing {len(to_remove)} snapshot(s)...")
+    errors = 0
+    for p in to_remove:
+        try:
+            p.unlink()
+        except Exception as e:
+            log(f"  ERROR removing {p.name}: {e}", file=sys.stderr)
+            errors += 1
+    if errors:
+        log(f"\n⚠ {errors} error(s) during removal")
+        return 1
+    log(f"\n✓ Removed {len(to_remove)} snapshot(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Companion to R2 (#423 merged) — same rotation pattern, applied to `.claude/integrity/snapshots/` instead of `~/Documents/FitTracker2-backups/daily/`.

- **`scripts/rotate-integrity-snapshots.py`** — dry-run by default, `--execute` to apply
- **Retention:** last 30 snapshots + first-of-month anchors (`YYYY-MM-01`) kept permanently; all other older snapshots removed
- **Makefile:** `integrity-snapshot-rotate` target with `EXECUTE` + `KEEP_COUNT` overrides

## Today's state

```
=== Integrity-snapshot retention ===
  Dir:          .claude/integrity/snapshots
  Total:        7 snapshots
  Keep (recent):  7 (last 30)
  Keep (anchors): 0 (first-of-month)
  Keep (union):   7
  Remove:         0
✓ Nothing to remove
```

R20 only takes effect once the dir crosses 30 snapshots (~2-3 months out at current cadence). Shipping early to lock the policy.

## Overlay safety (Phase E 2026-05-21 → 2026-06-04)

- ✅ No new gates introduced
- ✅ No `state.json` mutations
- ✅ No F14/F18 test discipline changes
- ✅ No state-engine touches
- ✅ Pure file-system housekeeping under `--execute` (dry-run otherwise)
- ✅ Isolated chore branch off main

## Links

- Plan: [`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](https://github.com/Regevba/FitTracker2/blob/main/docs/research/2026-05-19-dev-env-audit-stability-and-scale.md) R20
- Linear: [FIT-186](https://linear.app/fitme-project/issue/FIT-186) (sub of epic [FIT-166](https://linear.app/fitme-project/issue/FIT-166))
- Notion: [Dev-Env Upgrade Plan](https://www.notion.so/3670e7a0eace819dba31c2427cff92fd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)