### PR TITLE
chore(dev-env): R8 + R9 — log rotation + session-ledger compaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher doctor integrity-snapshot-rotate
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher doctor integrity-snapshot-rotate logs-rotate sessions-compact
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -541,6 +541,29 @@ doctor:
 integrity-snapshot-rotate:
 	@python3 scripts/rotate-integrity-snapshots.py \
 		$(if $(KEEP_COUNT),--keep-count=$(KEEP_COUNT),) \
+		$(if $(EXECUTE),--execute,)
+
+# R8 (FIT-174): rotate .claude/logs/<feature>.log.json files when they
+# exceed 5MB. Tier 2.2 lineage preserved — rotation MOVES into
+# .claude/logs/_archive/, never deletes.
+# Dry-run by default; EXECUTE=1 applies. Override THRESHOLD_MB.
+#   make logs-rotate                          # dry-run, default 5MB threshold
+#   make logs-rotate EXECUTE=1                # apply
+#   make logs-rotate THRESHOLD_MB=10 EXECUTE=1
+logs-rotate:
+	@python3 scripts/rotate-feature-logs.py \
+		$(if $(THRESHOLD_MB),--threshold-mb=$(THRESHOLD_MB),) \
+		$(if $(EXECUTE),--execute,)
+
+# R9 (FIT-175): archive Mechanism C session ledgers older than 30 days.
+# Sessions MOVED to .claude/logs/_archive/sessions/, never deleted.
+# Default min-age 30d is conservative — Mechanism C lookup is days, not weeks.
+#   make sessions-compact                          # dry-run
+#   make sessions-compact EXECUTE=1                # apply
+#   make sessions-compact MIN_AGE_DAYS=60 EXECUTE=1
+sessions-compact:
+	@python3 scripts/compact-session-ledgers.py \
+		$(if $(MIN_AGE_DAYS),--min-age-days=$(MIN_AGE_DAYS),) \
 		$(if $(EXECUTE),--execute,)
 
 # Auto-install on first run

--- a/scripts/compact-session-ledgers.py
+++ b/scripts/compact-session-ledgers.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+compact-session-ledgers.py — R9 from 2026-05-19 dev-env audit.
+
+Archives Mechanism C session-event ledgers (`_session-*.events.jsonl`)
+that are older than N days (default 30). Sessions are MOVED — never
+deleted — to `.claude/logs/_archive/sessions/` so Mechanism C session
+attribution remains queryable post-archive.
+
+Critical safety: Mechanism C reads recent session ledgers for the
+PostToolUse:Read attribution loop. This script must NEVER touch a
+session younger than --min-age-days (default 30). The default is
+intentionally conservative — Mechanism C lookup windows are typically
+days, not weeks.
+
+Usage:
+  python3 scripts/compact-session-ledgers.py            # dry-run
+  python3 scripts/compact-session-ledgers.py --execute  # actually archive
+  python3 scripts/compact-session-ledgers.py --min-age-days=60 --execute
+
+Exit codes:
+  0 — success (or dry-run completed cleanly)
+  1 — error during archive
+  2 — logs dir not found
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_LOGS_DIR = REPO_ROOT / ".claude" / "logs"
+DEFAULT_MIN_AGE_DAYS = 30
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--logs-dir", type=Path, default=DEFAULT_LOGS_DIR)
+    p.add_argument("--min-age-days", type=int, default=DEFAULT_MIN_AGE_DAYS,
+                   help=f"Only archive sessions older than this many days (default {DEFAULT_MIN_AGE_DAYS})")
+    p.add_argument("--execute", action="store_true",
+                   help="Actually move; without this flag, dry-run only")
+    p.add_argument("--quiet", action="store_true")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    log = (lambda *a, **kw: None) if args.quiet else print
+
+    if not args.logs_dir.exists():
+        print(f"Logs dir not found: {args.logs_dir}", file=sys.stderr)
+        return 2
+
+    archive_dir = args.logs_dir / "_archive" / "sessions"
+    cutoff = dt.datetime.now() - dt.timedelta(days=args.min_age_days)
+
+    log(f"=== Mechanism C session-ledger compaction ===")
+    log(f"  Logs dir:     {args.logs_dir}")
+    log(f"  Archive dir:  {archive_dir}")
+    log(f"  Cutoff:       sessions older than {args.min_age_days}d")
+    log(f"                (mtime before {cutoff.strftime('%Y-%m-%d')})")
+    log("")
+
+    all_sessions = sorted(args.logs_dir.glob("_session-*.events.jsonl"))
+    candidates = []
+    for p in all_sessions:
+        mtime = dt.datetime.fromtimestamp(p.stat().st_mtime)
+        if mtime < cutoff:
+            candidates.append((p, mtime))
+
+    log(f"  Total session ledgers: {len(all_sessions)}")
+    log(f"  Older than cutoff:     {len(candidates)}")
+
+    if not candidates:
+        log(f"\n✓ Nothing to archive")
+        return 0
+
+    log(f"\nArchive list:")
+    for p, mtime in candidates:
+        size_kb = p.stat().st_size / 1024
+        log(f"  - {p.name} ({size_kb:.1f} KB, last touched {mtime.strftime('%Y-%m-%d')})")
+
+    if not args.execute:
+        log(f"\n[dry-run] Re-run with --execute to apply")
+        return 0
+
+    log(f"\n[execute] archiving {len(candidates)} session(s)...")
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    errors = 0
+    for p, _ in candidates:
+        target = archive_dir / p.name
+        try:
+            shutil.move(str(p), str(target))
+            log(f"  ✓ {p.name} → _archive/sessions/")
+        except Exception as e:
+            log(f"  ERROR {p.name}: {e}", file=sys.stderr)
+            errors += 1
+    if errors:
+        log(f"\n⚠ {errors} error(s) during archive")
+        return 1
+    log(f"\n✓ Archived {len(candidates)} session(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rotate-feature-logs.py
+++ b/scripts/rotate-feature-logs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+rotate-feature-logs.py — R8 from 2026-05-19 dev-env audit.
+
+Rotates `.claude/logs/<feature>.log.json` files when they exceed a size
+threshold (default 5MB). The rotated file is moved into
+`.claude/logs/_archive/<feature>.log.json.<timestamp>` so Tier 2.2
+contemporaneous-log lineage is preserved — never deleted, only moved.
+
+After rotation, the original file path is recreated as an empty JSON array
+`[]` so subsequent log-append operations continue cleanly.
+
+Critical safety: this rotation does NOT touch:
+  - `_session-*.events.jsonl` files (Mechanism C — see R9 for that)
+  - `devssd-uuid-watcher.log` (R4 audit; small + caller-managed)
+  - `README.md`
+  - any file outside `.claude/logs/`
+
+Usage:
+  python3 scripts/rotate-feature-logs.py             # dry-run
+  python3 scripts/rotate-feature-logs.py --execute   # actually rotate
+  python3 scripts/rotate-feature-logs.py --threshold-mb=10 --execute
+
+Exit codes:
+  0 — success (or dry-run completed cleanly)
+  1 — error during rotation
+  2 — logs dir not found
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_LOGS_DIR = REPO_ROOT / ".claude" / "logs"
+DEFAULT_THRESHOLD_MB = 5
+
+EXCLUDE_NAMES = {"README.md", "devssd-uuid-watcher.log"}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--logs-dir", type=Path, default=DEFAULT_LOGS_DIR)
+    p.add_argument("--threshold-mb", type=int, default=DEFAULT_THRESHOLD_MB,
+                   help=f"Files larger than this many MB get rotated (default {DEFAULT_THRESHOLD_MB})")
+    p.add_argument("--execute", action="store_true",
+                   help="Actually rotate; without this flag, dry-run only")
+    p.add_argument("--quiet", action="store_true")
+    return p.parse_args()
+
+
+def is_feature_log(p: Path) -> bool:
+    """Skip Mechanism C session ledgers + excluded names + archive subdir."""
+    if not p.is_file():
+        return False
+    if p.name in EXCLUDE_NAMES:
+        return False
+    if p.name.startswith("_session-"):
+        return False
+    # Only .log.json
+    if not p.name.endswith(".log.json"):
+        return False
+    return True
+
+
+def main() -> int:
+    args = parse_args()
+    log = (lambda *a, **kw: None) if args.quiet else print
+
+    if not args.logs_dir.exists():
+        print(f"Logs dir not found: {args.logs_dir}", file=sys.stderr)
+        return 2
+
+    threshold_bytes = args.threshold_mb * 1024 * 1024
+    archive_dir = args.logs_dir / "_archive"
+
+    log(f"=== Feature-log rotation ===")
+    log(f"  Logs dir:    {args.logs_dir}")
+    log(f"  Archive dir: {archive_dir}")
+    log(f"  Threshold:   {args.threshold_mb} MB")
+    log("")
+
+    candidates = []
+    total_count = 0
+    for p in sorted(args.logs_dir.iterdir()):
+        if not is_feature_log(p):
+            continue
+        total_count += 1
+        size = p.stat().st_size
+        if size > threshold_bytes:
+            candidates.append((p, size))
+
+    log(f"  Total feature logs: {total_count}")
+    log(f"  Over threshold:     {len(candidates)}")
+
+    if not candidates:
+        log(f"\n✓ Nothing to rotate")
+        return 0
+
+    log(f"\nRotation list:")
+    for p, size in candidates:
+        size_mb = size / (1024 * 1024)
+        log(f"  - {p.name} ({size_mb:.1f} MB)")
+
+    if not args.execute:
+        log(f"\n[dry-run] Re-run with --execute to apply")
+        return 0
+
+    log(f"\n[execute] rotating {len(candidates)} file(s)...")
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    errors = 0
+    ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    for p, _ in candidates:
+        target = archive_dir / f"{p.name}.{ts}"
+        try:
+            shutil.move(str(p), str(target))
+            p.write_text("[]\n")  # reset to empty JSON array
+            log(f"  ✓ {p.name} → _archive/{target.name}")
+        except Exception as e:
+            log(f"  ERROR {p.name}: {e}", file=sys.stderr)
+            errors += 1
+    if errors:
+        log(f"\n⚠ {errors} error(s) during rotation")
+        return 1
+    log(f"\n✓ Rotated {len(candidates)} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Batched dev-env recs — both touch `.claude/logs/`, different rotation criteria, ship together.

### R8 — feature-log size cap

- `scripts/rotate-feature-logs.py` — scans `.claude/logs/<feature>.log.json`; files > 5MB move to `.claude/logs/_archive/<feature>.log.json.<timestamp>` + replaced with `[]`
- **Tier 2.2 lineage preserved** — MOVE only, never delete
- Excludes Mechanism C ledgers (`_session-*.events.jsonl`), R4 audit log, README, archive subdir
- Makefile: `make logs-rotate` (`THRESHOLD_MB`, `EXECUTE` overrides)

### R9 — Mechanism C session compaction

- `scripts/compact-session-ledgers.py` — archives `_session-*.events.jsonl` older than 30 days to `.claude/logs/_archive/sessions/`
- 30d default is **conservative** — Mechanism C lookups are days, not weeks
- Makefile: `make sessions-compact` (`MIN_AGE_DAYS`, `EXECUTE` overrides)

## Today's state (both PRs)

```
=== Feature-log rotation ===           === Session-ledger compaction ===
  Total feature logs:     41             Total session ledgers:    4
  Over threshold:          0             Older than cutoff:        0
  ✓ Nothing to rotate                    ✓ Nothing to archive
```

Pre-shipping the policy; no actual data moves today.

## Overlay safety (Phase E 2026-05-21 → 2026-06-04)

- ✅ No new gates introduced
- ✅ No `state.json` mutations
- ✅ No F14/F18 test discipline changes
- ✅ No state-engine touches
- ✅ Both scripts dry-run by default; `--execute` required for mutation
- ✅ Mechanism C reader path not affected (R9 only touches >30d files)
- ✅ Tier 2.2 lineage preserved (R8 moves, never deletes)
- ✅ Isolated chore branch off main

## Links

- Plan: [`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](https://github.com/Regevba/FitTracker2/blob/main/docs/research/2026-05-19-dev-env-audit-stability-and-scale.md) R8 + R9
- Linear: [FIT-174](https://linear.app/fitme-project/issue/FIT-174) (R8) + [FIT-175](https://linear.app/fitme-project/issue/FIT-175) (R9)
- Epic: [FIT-166](https://linear.app/fitme-project/issue/FIT-166)
- Notion: [Dev-Env Upgrade Plan](https://www.notion.so/3670e7a0eace819dba31c2427cff92fd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)