### PR TITLE
chore(dev-env): R7 + R10 audit — gh-pr-cache surface + verify-local idempotency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher doctor integrity-snapshot-rotate logs-rotate sessions-compact
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher verify-local-idempotent-check doctor integrity-snapshot-rotate logs-rotate sessions-compact
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -273,6 +273,29 @@ install:
 # Any new P0 (raw Color literal, raw animation, raw font, missing colorset)
 # or any SCHEMA_DRIFT introduced by a PR fails the local + CI verify pass.
 verify-local: tokens-check schema-check ui-audit ui-audit-drift verify-web verify-ai verify-evals verify-ios verify-timing verify-framework
+
+# R10 (FIT-176): defensive check that `make verify-local` does NOT mutate
+# tracked repo state. Captures git porcelain before + after; asserts
+# byte-identical. Use as pre-merge sanity or as a standing guard against
+# future regressions where a new verify-local subtarget might quietly
+# write to a tracked file. See docs/setup/verify-local-idempotency-audit.md.
+verify-local-idempotent-check:
+	@echo "=== verify-local idempotency check ==="
+	@_before=$$(mktemp); _after=$$(mktemp); \
+	 git status --porcelain | sort > $$_before; \
+	 echo "→ pre-state: $$(wc -l < $$_before | tr -d ' ') file(s) in porcelain"; \
+	 $(MAKE) --no-print-directory verify-local || { rm -f $$_before $$_after; exit 1; }; \
+	 git status --porcelain | sort > $$_after; \
+	 echo "→ post-state: $$(wc -l < $$_after | tr -d ' ') file(s) in porcelain"; \
+	 if diff -q $$_before $$_after >/dev/null 2>&1; then \
+	   echo "✓ verify-local is idempotent — no tracked-file mutations detected"; \
+	   rm -f $$_before $$_after; \
+	 else \
+	   echo "✗ verify-local mutated tracked state — review diff:"; \
+	   diff $$_before $$_after || true; \
+	   rm -f $$_before $$_after; \
+	   exit 1; \
+	 fi
 
 verify-web:
 	cd dashboard && npm test

--- a/docs/setup/verify-local-idempotency-audit.md
+++ b/docs/setup/verify-local-idempotency-audit.md
@@ -1,0 +1,77 @@
+# `make verify-local` Idempotency Audit (R10, 2026-05-21)
+
+> **R10 from dev-env audit.** Verifies that running `make verify-local` does
+> not mutate tracked repo state — a property assumed by every CI workflow
+> + local pre-merge check.
+
+## Result
+
+✅ **`make verify-local` is already idempotent.** No code changes needed.
+
+## Audit method
+
+Inspected every subtarget invoked by `make verify-local`:
+
+```makefile
+verify-local: tokens-check schema-check ui-audit ui-audit-drift \
+              verify-web verify-ai verify-evals verify-ios \
+              verify-timing verify-framework
+```
+
+For each subtarget, categorized write surfaces as:
+- **🟢 read-only** — emits to stdout/stderr; no filesystem writes
+- **🟡 gitignored writes** — writes to `.build/`, `dashboard/dist/`,
+  `website/dist/`, or other gitignored directories (does NOT affect
+  tracked repo state)
+- **🔴 tracked writes** — would mutate the repo (none found in this audit)
+
+| Subtarget | Surface | Notes |
+|---|---|---|
+| `tokens-check` | 🟢 read-only | Compares generated `DesignTokens.swift` vs `tokens.json`; exits 1 on drift. No writes. |
+| `schema-check` | 🟢 read-only | Runs `python3 scripts/check-state-schema.py --all` (read-only inspection). |
+| `ui-audit` | 🟢 read-only | Scans `FitTracker/Views/` for raw colors etc; emits findings to stdout. |
+| `ui-audit-drift` | 🟢 read-only ✱ | Compares committed baseline vs regenerated; uses **backup-then-restore** pattern (`_tmp=$$(mktemp); cp $$_baseline $$_tmp; … cp $$_tmp $$_baseline`) so working tree is never left polluted. |
+| `verify-web` | 🟡 gitignored writes | `npm test` + `npm run build` for `dashboard/` + `website/`. Outputs → `dist/` (gitignored). |
+| `verify-ai` | 🟡 gitignored writes | `pytest` in `ai-engine/`. May create `__pycache__/` (gitignored). |
+| `verify-evals` | 🟡 gitignored writes | Same as `verify-ai`; eval suite under `ai-engine/evals/`. |
+| `verify-ios` | 🟡 gitignored writes | `xcodebuild build` → `.build/DerivedData/` (gitignored). No edits to `FitTracker/`. |
+| `verify-timing` | 🟢 read-only | Inspects `.claude/features/*/state.json` phases + timing; emits report. |
+| `verify-framework` | 🟢 read-only | Validates `.claude/shared/cache-metrics.json` exists + parses; per-feature cache audit. Emits report. |
+
+✱ `ui-audit-drift` is the closest thing to a mutator in the chain. The
+backup/restore is the right defense; we verified it works by inspecting
+the recipe (lines 60-70 of `Makefile`).
+
+## Defensive check added
+
+`make verify-local-idempotent-check` — captures `git status --porcelain`
+before + after `make verify-local`, asserts they are byte-identical.
+Fails loud if any tracked file was added, modified, or deleted by
+the verify run.
+
+Use cases:
+- Pre-merge sanity: `make verify-local-idempotent-check` once, ensure
+  CI assumptions still hold
+- Defense against future regressions: if a new subtarget gets added
+  that quietly mutates tracked state, this check will catch it
+
+## Why this audit matters
+
+CI workflows assume `make verify-local` leaves the tree clean. If a
+subtarget ever started writing into tracked files (e.g.
+`measurement-adoption.json` got pulled into verify-local without a
+backup/restore), pre-commit hooks + integrity-check would start flagging
+"unrelated" mutations on every PR. That class of bug is hard to debug
+because it's invisible until it appears in CI logs.
+
+Today's audit confirms no such regression is present. The defensive
+check is the standing guard.
+
+## Related
+
+- [R7 — `gh-pr-cache.json` freshness audit](#) — verified the cache is
+  refreshed at 3 invocation surfaces (Makefile, CI workflow,
+  preflight.py); no extension needed.
+- Dev-env audit source:
+  [`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](../research/2026-05-19-dev-env-audit-stability-and-scale.md) R10
+- Linear: [FIT-176](https://linear.app/fitme-project/issue/FIT-176)


### PR DESCRIPTION
## Summary

Two audit recs concluded "no core change needed" — but ship defensive surfaces so future regressions are caught early.

### R7 — `gh-pr-cache.json` freshness ([FIT-173](https://linear.app/fitme-project/issue/FIT-173))

Audit confirmed `scripts/ensure-pr-cache-fresh.py` is invoked at all 3 expected surfaces:
- `Makefile:integrity-check` target
- `.github/workflows/integrity-cycle.yml` CI cron
- `scripts/preflight.py` (every `make preflight WORK_TYPE=…`)

`scripts/doctor.sh` surfaces cache age but does not refresh (read-only — correct for doctor).

**Conclusion:** no code change needed. Surface is complete.

### R10 — `make verify-local` idempotency ([FIT-176](https://linear.app/fitme-project/issue/FIT-176))

Audit confirmed every subtarget is either purely read-only OR writes only to gitignored directories:

| Subtarget | Surface |
|---|---|
| `tokens-check`, `schema-check`, `ui-audit`, `verify-timing`, `verify-framework` | 🟢 read-only |
| `ui-audit-drift` | 🟢 read-only (backup-restore pattern) |
| `verify-web`, `verify-ai`, `verify-evals`, `verify-ios` | 🟡 gitignored writes (`dist/`, `__pycache__/`, `.build/`) |

**Conclusion:** `verify-local` is already idempotent w.r.t. tracked state.

### Defensive surfaces shipped

1. **`docs/setup/verify-local-idempotency-audit.md`** — full audit report + per-subtarget table; anchor for future re-audits when new subtargets get added
2. **`make verify-local-idempotent-check`** — captures `git status --porcelain` before + after `make verify-local`, fails loud if any tracked file mutated. Use as pre-merge sanity or standing guard.

## Overlay safety (Phase E)

- ✅ No new gates introduced (the make target is a defensive check, not a gate)
- ✅ No `state.json` mutations
- ✅ No F14/F18 test discipline changes
- ✅ No state-engine touches
- ✅ Isolated chore branch off main

🤖 Generated with [Claude Code](https://claude.com/claude-code)