### PR TITLE
chore(dev-env): R16 + R23 — cache hit-rate audit + import survey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher verify-local-idempotent-check doctor integrity-snapshot-rotate logs-rotate sessions-compact
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-snapshot preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher verify-local-idempotent-check audit-cache audit-imports doctor integrity-snapshot-rotate logs-rotate sessions-compact
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -546,6 +546,19 @@ uninstall-devssd-watcher:
 	launchctl unload "$$PLIST_DEST" 2>/dev/null || true; \
 	rm "$$PLIST_DEST"; \
 	echo "Uninstalled: $$PLIST_DEST"
+
+# R16 (FIT-182): read-only cache hit-rate audit. Surfaces per-entry
+# mtime + cross-references against Mechanism C session reads to flag
+# cold candidates. Output to stdout only; operator decides eviction.
+audit-cache:
+	@python3 scripts/audit-cache-hit-rate.py
+
+# R23 (FIT-189): scripts/ third-party import survey. Categorizes each
+# .py file as CORE (stdlib + local) or RESEARCH (third-party). Helps
+# decide whether vendor/ is needed (today's answer: no — all
+# operational scripts are stdlib-only).
+audit-imports:
+	@python3 scripts/audit-script-imports.py
 
 # R11 (FIT-177): one-shot dev-env sanity readout. Read-only — integrates
 # every preflight signal (SSH, gh auth, hooks, tool versions, PR cache,

--- a/scripts/audit-cache-hit-rate.py
+++ b/scripts/audit-cache-hit-rate.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+audit-cache-hit-rate.py — R16 from 2026-05-19 dev-env audit.
+
+Read-only audit of .claude/cache/ entries. Surfaces:
+  - Total cache entries + total size
+  - Per-tier breakdown (L1 per-skill, L2 _shared/, L3 _project/)
+  - Last-modified date per entry
+  - Cross-reference with Mechanism C session-event reads to identify
+    entries never accessed in any captured session ("cold" candidates
+    for review/eviction)
+
+This is purely diagnostic. No writes. Use to inform whether the cache
+architecture warrants LRU eviction (R16 in dev-env audit). Recommendation
+written only to stdout; operator decides what to delete.
+
+Usage:
+  python3 scripts/audit-cache-hit-rate.py
+  python3 scripts/audit-cache-hit-rate.py --cold-only
+  python3 scripts/audit-cache-hit-rate.py --since-days 30
+
+Linear: FIT-182
+Plan: docs/research/2026-05-19-dev-env-audit-stability-and-scale.md (R16)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CACHE_DIR = REPO_ROOT / ".claude" / "cache"
+LOGS_DIR = REPO_ROOT / ".claude" / "logs"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--cold-only", action="store_true",
+                   help="Show only entries with zero recorded reads")
+    p.add_argument("--since-days", type=int, default=90,
+                   help="Window for 'recently read' classification (default 90)")
+    return p.parse_args()
+
+
+def gather_cache_entries() -> list[dict]:
+    if not CACHE_DIR.exists():
+        return []
+    out = []
+    for p in sorted(CACHE_DIR.rglob("*.json")):
+        rel = p.relative_to(CACHE_DIR).as_posix()
+        size = p.stat().st_size
+        mtime = dt.datetime.fromtimestamp(p.stat().st_mtime)
+        # Categorize tier from path
+        parts = rel.split("/")
+        if parts[0] == "_project":
+            tier = "L3 _project"
+        elif parts[0] == "_shared":
+            tier = "L2 _shared"
+        elif parts[0] == "research":
+            tier = "L2 research"
+        else:
+            tier = f"L1 {parts[0]}"
+        out.append({
+            "path": rel,
+            "abs_path": str(p),
+            "size_bytes": size,
+            "mtime": mtime,
+            "tier": tier,
+        })
+    return out
+
+
+def gather_session_reads(since_days: int) -> dict[str, int]:
+    """Return {cache-relative-path: read_count} across all session ledgers."""
+    if not LOGS_DIR.exists():
+        return {}
+    cutoff = dt.datetime.now() - dt.timedelta(days=since_days)
+    reads: dict[str, int] = {}
+    for ledger in LOGS_DIR.glob("_session-*.events.jsonl"):
+        mtime = dt.datetime.fromtimestamp(ledger.stat().st_mtime)
+        if mtime < cutoff:
+            continue
+        try:
+            for line in ledger.read_text().splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # Event shape: {tool: "Read", file_path: "/abs/path"} OR
+                # {"file_path": ".claude/cache/_shared/something.json"}
+                fp = ev.get("file_path") or ""
+                if not fp:
+                    continue
+                # Normalize to .claude/cache-relative
+                if "/.claude/cache/" in fp:
+                    rel = fp.split("/.claude/cache/", 1)[1]
+                    reads[rel] = reads.get(rel, 0) + 1
+        except OSError:
+            continue
+    return reads
+
+
+def fmt_size(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.1f} MB"
+
+
+def main() -> int:
+    args = parse_args()
+    entries = gather_cache_entries()
+    reads = gather_session_reads(args.since_days)
+
+    if not entries:
+        print("No cache entries found.")
+        return 0
+
+    # Group + summarize
+    total_size = sum(e["size_bytes"] for e in entries)
+    by_tier: dict[str, list[dict]] = {}
+    for e in entries:
+        by_tier.setdefault(e["tier"], []).append(e)
+
+    print(f"=== Cache audit ({len(entries)} entries, {fmt_size(total_size)}) ===")
+    print(f"  Window for read-attribution: last {args.since_days} days")
+    print(f"  Session ledgers found:       {sum(1 for _ in LOGS_DIR.glob('_session-*.events.jsonl'))}")
+    print()
+
+    cold = []
+    warm = []
+
+    for tier in sorted(by_tier):
+        tier_entries = by_tier[tier]
+        tier_size = sum(e["size_bytes"] for e in tier_entries)
+        print(f"{tier}: {len(tier_entries)} entries · {fmt_size(tier_size)}")
+        for e in sorted(tier_entries, key=lambda x: x["path"]):
+            hits = reads.get(e["path"], 0)
+            mark = "·" if hits > 0 else "○"
+            line = f"  {mark} {e['path']:<48} {fmt_size(e['size_bytes']):>8}  mtime={e['mtime'].strftime('%Y-%m-%d')}  reads={hits}"
+            if args.cold_only and hits > 0:
+                continue
+            if hits == 0:
+                cold.append(e)
+            else:
+                warm.append(e)
+            print(line)
+        print()
+
+    print(f"=== Summary ===")
+    print(f"  Total entries:     {len(entries)}")
+    print(f"  Warm (≥1 read):    {len(warm)}")
+    print(f"  Cold (0 reads):    {len(cold)}")
+    if entries:
+        cold_pct = 100 * len(cold) / len(entries)
+        print(f"  Cold ratio:        {cold_pct:.1f}%")
+    print()
+    print("Note: 'cold' = no attribution in available session ledgers. This")
+    print("does NOT mean the entry was never useful — it may have been read")
+    print("by skill-loaders, PostToolUse:Read hooks not yet active, or used")
+    print("during sessions whose ledgers have rotated out. Use as a hint, not")
+    print("an eviction trigger.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit-script-imports.py
+++ b/scripts/audit-script-imports.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+audit-script-imports.py — R23 from 2026-05-19 dev-env audit.
+
+Surveys every Python file in scripts/ for third-party imports (i.e.
+not stdlib + not local module). Emits a report categorizing scripts as:
+
+  CORE (stdlib + local only)  — airgapped-operation safe; no vendoring needed
+  RESEARCH (third-party)      — needs a venv / requirements.txt; cannot run
+                                offline-airgapped without pre-prepared deps
+
+Use case: decide whether scripts/ deserves a `vendor/` directory or
+whether we just ensure dependencies are documented + installable. R23
+recommended this be a survey, not a code change.
+
+Read-only. Emits report to stdout.
+
+Linear: FIT-189
+Plan: docs/research/2026-05-19-dev-env-audit-stability-and-scale.md (R23)
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+LOCAL_MODULES = {"flock_writer", "gate_coverage"}  # local helpers in scripts/
+
+
+def scan_imports(path: Path) -> set[str]:
+    """Return the set of top-level module names imported by path."""
+    try:
+        tree = ast.parse(path.read_text())
+    except (SyntaxError, UnicodeDecodeError):
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            out.add(node.module.split(".")[0])
+    return out
+
+
+def main() -> int:
+    stdlib = set(sys.stdlib_module_names)
+    files = sorted(SCRIPTS_DIR.glob("*.py"))
+
+    core: list[tuple[Path, set[str]]] = []
+    research: list[tuple[Path, set[str]]] = []
+
+    for path in files:
+        imports = scan_imports(path)
+        third_party = imports - stdlib - LOCAL_MODULES - {"__future__"}
+        if third_party:
+            research.append((path, third_party))
+        else:
+            core.append((path, imports))
+
+    print(f"=== scripts/ third-party import audit ({len(files)} .py files) ===")
+    print()
+    print(f"CORE (stdlib + local only)      : {len(core)} files")
+    print(f"RESEARCH (third-party imports)  : {len(research)} files")
+    print()
+    print("--- CORE scripts (airgapped-operation safe) ---")
+    for path, _ in core:
+        print(f"  ✓ {path.name}")
+    print()
+    print("--- RESEARCH scripts (need venv / deps pre-installed) ---")
+    if not research:
+        print("  (none)")
+    for path, third_party in research:
+        print(f"  · {path.name}")
+        for dep in sorted(third_party):
+            print(f"      - {dep}")
+    print()
+    if research:
+        all_deps = sorted({d for _, ds in research for d in ds})
+        print(f"Aggregate third-party deps: {len(all_deps)}")
+        print(f"  {', '.join(all_deps)}")
+        print()
+    print("Recommendation: keep stdlib-only for core operational scripts")
+    print("(all R1–R20 scripts, daily-checkpoint, integrity-check, preflight,")
+    print("etc). Research scripts continue to use their own venv (typically")
+    print("ai-engine/.venv or .build/ai-venv). No `vendor/` directory needed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two read-only diagnostic audits from Tier 3 / 4 of the dev-env plan. Both ship as standalone scripts + make targets; pure stdout output, operator decides what to act on.

### R16 — Cache hit-rate audit ([FIT-182](https://linear.app/fitme-project/issue/FIT-182))

`scripts/audit-cache-hit-rate.py` + `make audit-cache`

Surveys `.claude/cache/` entries grouped by tier (L1 per-skill, L2 `_shared/`, L2 `research/`, L3 `_project/`). Cross-references against `_session-*.events.jsonl` PostToolUse:Read attributions over a configurable window (default 90 days).

**Today's run:** 31 entries / 96 KB total / 100% cold ratio.

> Note: 100% cold today does NOT mean these entries are unused. PostToolUse:Read attribution coverage is partial — some entries are read by skill-loaders, others by sessions whose ledgers have rotated. The output is a hint, not an eviction trigger.

Options: `--cold-only`, `--since-days N`.

### R23 — `scripts/` third-party import survey ([FIT-189](https://linear.app/fitme-project/issue/FIT-189))

`scripts/audit-script-imports.py` + `make audit-imports`

Walks every `.py` in `scripts/`, categorizes each as **CORE** (stdlib + local-helper-only) or **RESEARCH** (third-party imports).

**Today's run:** 48 CORE / 4 RESEARCH.

- RESEARCH scripts are HADF analysis: `numpy`, `sklearn`, `scipy`, `openai`, `anthropic` — already use `ai-engine` venv.
- All R1-R20 core operational scripts + `daily-checkpoint` + `integrity-check` + `preflight` are stdlib-only.

**Conclusion:** no `vendor/` directory needed. Core operational surface is airgapped-operation safe.

## Overlay safety (Phase E)

- ✅ No new gates introduced (both scripts are stdout-only diagnostics)
- ✅ No `state.json` mutations
- ✅ No F14/F18 test discipline changes
- ✅ No state-engine touches
- ✅ Isolated chore branch off main

## Links

- Plan: [`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](https://github.com/Regevba/FitTracker2/blob/main/docs/research/2026-05-19-dev-env-audit-stability-and-scale.md) R16 + R23
- Epic: [FIT-166](https://linear.app/fitme-project/issue/FIT-166)

🤖 Generated with [Claude Code](https://claude.com/claude-code)