### PR TITLE
chore(security): GitHub Security Tier S — 4 hardening surfaces

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -123,3 +123,80 @@ for prereg in $(git diff --cached --name-only | grep -E "^\.claude/shared/hadf/p
         fi
     fi
 done
+
+# ── GitHub Security Tier S (added 2026-05-21) ──────────────────────────────
+# Pre-commit checks for: (1) file-size limit (>5MB rejected), (2) high-confidence
+# secret patterns (AWS access keys, GitHub PATs, private-key markers). Local
+# secret-scan as belt-and-braces to GitGuardian server-side scan: catches
+# secrets BEFORE they leave the machine (vs. AFTER in PR audit).
+# Bypass: git commit --no-verify (use only with full understanding of the risk).
+
+# File-size guard: anything >5MB committed is almost always a mistake.
+SECURITY_MAX_BYTES="${SECURITY_MAX_BYTES:-5242880}"  # 5 MB default
+oversize_failed=0
+for f in $(git diff --cached --name-only --diff-filter=ACM); do
+    [ -f "$f" ] || continue
+    size=$(wc -c <"$f" | tr -d ' ')
+    if [ "$size" -gt "$SECURITY_MAX_BYTES" ]; then
+        echo "ERROR: $f is $(printf '%.1f' "$(echo "$size / 1048576" | bc -l)") MB (limit ${SECURITY_MAX_BYTES} B)"
+        echo "       Either reduce, move to a release artifact, or set SECURITY_MAX_BYTES=$((size+1024)) for this commit."
+        oversize_failed=1
+    fi
+done
+if [ "$oversize_failed" -ne 0 ]; then
+    exit 1
+fi
+
+# Secret-pattern guard: high-confidence patterns only (no generic API-key
+# regex; too noisy). Skip the pre-commit hook file itself + setup runbook +
+# test/fixture dirs that intentionally document the patterns.
+secret_failed=0
+secret_patterns=(
+    'AKIA[0-9A-Z]{16}'                            # AWS access key
+    'ghp_[A-Za-z0-9]{36}'                         # GitHub classic PAT
+    'gho_[A-Za-z0-9]{36}'                         # GitHub OAuth token
+    'github_pat_[A-Za-z0-9_]{82}'                 # GitHub fine-grained PAT
+    'glpat-[A-Za-z0-9_-]{20}'                     # GitLab PAT
+    '-----BEGIN (RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----'  # private key
+    'xoxb-[0-9]+-[0-9]+-[A-Za-z0-9]+'             # Slack bot token
+    'sk-[A-Za-z0-9]{48,}'                         # OpenAI API key
+)
+secret_skip_patterns=(
+    '^\.githooks/pre-commit$'
+    '^docs/setup/'
+    '^scripts/audit-'
+    '^\.claude/skills/'
+    'fixtures/'
+    'observed-patterns\.md'
+)
+for f in $(git diff --cached --name-only --diff-filter=ACM); do
+    [ -f "$f" ] || continue
+    # Skip well-known false-positive paths (this hook + setup docs + fixtures)
+    skip=0
+    for skip_re in "${secret_skip_patterns[@]}"; do
+        if echo "$f" | grep -qE "$skip_re"; then
+            skip=1
+            break
+        fi
+    done
+    [ "$skip" -eq 1 ] && continue
+    # Skip files >2MB (likely binary; grep noisy)
+    fsize=$(wc -c <"$f" | tr -d ' ')
+    [ "$fsize" -gt 2097152 ] && continue
+    for pat in "${secret_patterns[@]}"; do
+        if grep -nE "$pat" "$f" >/dev/null 2>&1; then
+            match=$(grep -nE "$pat" "$f" | head -1)
+            echo "ERROR: possible secret matching /$pat/ in $f"
+            echo "       $match"
+            secret_failed=1
+        fi
+    done
+done
+if [ "$secret_failed" -ne 0 ]; then
+    echo ""
+    echo "Pre-commit rejected: high-confidence secret pattern detected."
+    echo "If this is a false positive, you can either:"
+    echo "  1. Add the path to secret_skip_patterns in .githooks/pre-commit"
+    echo "  2. git commit --no-verify (use ONLY if certain it's not a real secret)"
+    exit 1
+fi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,76 @@
+# CODEOWNERS — ownership lock for security-relevant + framework-critical paths.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Today this enables review-mention on PRs touching these paths. Becomes
+# review-required (and self-approval becomes mandatory) only when branch
+# protection sets `require_code_owner_reviews: true` — currently OFF for
+# solo-dev workflow; flip when team grows or for higher-assurance phases.
+
+# Catch-all — solo dev today
+* @Regevba
+
+# ─────────────────────────────────────────────────────────────
+# Security-critical infrastructure
+# ─────────────────────────────────────────────────────────────
+
+# Pre-commit hooks (every commit is gated by these)
+/.githooks/         @Regevba
+
+# CI/CD workflows (control plane for every PR; deploy tokens accessible)
+/.github/workflows/ @Regevba
+/.github/CODEOWNERS @Regevba
+/.github/dependabot.yml @Regevba
+
+# Launchd plists (live on operator's machine post-`make install-*`)
+/infrastructure/launchd/ @Regevba
+
+# ─────────────────────────────────────────────────────────────
+# Framework gate engine (every PR is validated by these)
+# ─────────────────────────────────────────────────────────────
+
+/scripts/check-state-schema.py         @Regevba
+/scripts/integrity-check.py            @Regevba
+/scripts/ensure-pr-cache-fresh.py      @Regevba
+/scripts/preflight.py                  @Regevba
+/scripts/check-case-study-preflight.py @Regevba
+
+# ─────────────────────────────────────────────────────────────
+# Operator-facing surfaces (dev-env upgrade R-series)
+# ─────────────────────────────────────────────────────────────
+
+/scripts/daily-integrity-checkpoint.py     @Regevba
+/scripts/rotate-checkpoint-snapshots.py    @Regevba
+/scripts/rotate-integrity-snapshots.py     @Regevba
+/scripts/rotate-feature-logs.py            @Regevba
+/scripts/compact-session-ledgers.py        @Regevba
+/scripts/check-ssd-health.sh               @Regevba
+/scripts/check-devssd-uuid.sh              @Regevba
+/scripts/doctor.sh                         @Regevba
+/scripts/audit-cache-hit-rate.py           @Regevba
+/scripts/audit-script-imports.py           @Regevba
+
+# ─────────────────────────────────────────────────────────────
+# Top-level config that changes app-wide behavior
+# ─────────────────────────────────────────────────────────────
+
+/Makefile              @Regevba
+/CLAUDE.md             @Regevba
+/.gitignore            @Regevba
+/.editorconfig         @Regevba
+/.tool-versions        @Regevba
+/.vscode/              @Regevba
+
+# Design system primitives (drift here breaks every UI surface)
+/FitTracker/Services/AppTheme.swift       @Regevba
+/FitTracker/DesignSystem/                 @Regevba
+/design-tokens/                           @Regevba
+
+# High-risk domain layer (per CLAUDE.md "High-risk areas")
+/FitTracker/Models/DomainModels.swift          @Regevba
+/FitTracker/Services/EncryptionService.swift   @Regevba
+/FitTracker/Services/SupabaseSyncService.swift @Regevba
+/FitTracker/Services/CloudKitSyncService.swift @Regevba
+/FitTracker/Services/SignInService.swift       @Regevba
+/FitTracker/Services/AuthManager.swift         @Regevba
+/FitTracker/Services/AIOrchestrator.swift      @Regevba

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+# Dependabot config — keeps deps + GH Actions current.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # ─────────────────────────────────────────────────────────────
+  # GitHub Actions — pin to SHA, auto-PR on upgrade
+  # ─────────────────────────────────────────────────────────────
+  # Tier S security hardening (2026-05-21): tag-retag attack
+  # vector — a compromised maintainer can retag e.g. `@v4` at a
+  # malicious SHA. Dependabot opens PRs that pin to specific SHAs;
+  # auto-merge them after CI passes.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    # When upgrading from @v4 to @v5, Dependabot writes the SHA in
+    # the version field automatically (modern behavior). Operator
+    # confirms via PR review then squash-merges.
+
+  # ─────────────────────────────────────────────────────────────
+  # npm (root + website/dashboard if those exist as separate trees)
+  # ─────────────────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      # Group minor + patch upgrades so the PR cadence stays manageable.
+      # Majors stay as individual PRs for explicit review.
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─────────────────────────────────────────────────────────────
+  # Python (HADF analysis venv via ai-engine)
+  # ─────────────────────────────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/ai-engine"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -233,6 +233,37 @@ except Exception:
   fi
 fi
 
+# 11. GitHub branch protection: required_signatures (Tier S item 1, 2026-05-21)
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  req_sig=$(gh api repos/Regevba/FitTracker2/branches/main/protection 2>/dev/null \
+    | python3 -c "import json, sys; print(json.load(sys.stdin).get('required_signatures', {}).get('enabled'))" 2>/dev/null)
+  if [[ "$req_sig" == "True" ]]; then
+    ok "branch protection" "required_signatures=ON on main"
+  elif [[ "$req_sig" == "False" ]]; then
+    warn "branch protection" "required_signatures=OFF on main — flip via gh API"
+  else
+    info "branch protection" "could not read; check gh permissions"
+  fi
+fi
+
+# 12. GHA workflow SHA-pin compliance (Tier S item 3, 2026-05-21)
+# Counts workflow `uses:` lines pinned to @sha vs @vN/@tag-name.
+if [[ -d .github/workflows ]]; then
+  total=$(grep -hE '^\s*uses:' .github/workflows/*.yml 2>/dev/null | grep -v '^\s*#' | wc -l | tr -d ' ')
+  # SHA-pinned: 40-hex character ref after @
+  pinned=$(grep -hE '^\s*uses:.*@[a-f0-9]{40}' .github/workflows/*.yml 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$total" -gt 0 ]]; then
+    pct=$(( 100 * pinned / total ))
+    if [[ "$pinned" -eq "$total" ]]; then
+      ok "gha sha-pin" "$pinned/$total workflows pinned to @sha (100%)"
+    elif [[ "$pct" -ge 50 ]]; then
+      info "gha sha-pin" "$pinned/$total pinned ($pct%); Dependabot opens upgrade PRs weekly"
+    else
+      warn "gha sha-pin" "$pinned/$total pinned ($pct%); tag-retag attack surface — accept Dependabot PRs"
+    fi
+  fi
+fi
+
 printf "\n${B}Tip:${N} \`make doctor\` is read-only. To act on warnings:\n"
 printf "  ssh-agent:      \`ssh-add\`\n"
 printf "  hooks:          \`make install-hooks\`\n"


### PR DESCRIPTION
## Summary

Closes the highest-leverage GitHub security gaps from today's post-YubiKey audit. **4 files-only changes** (this PR) + **1 live API operation** (post-merge: flip `required_signatures: true` on main).

## Items in this PR

### 1. `.github/CODEOWNERS`
Locks ownership of security-critical paths to `@Regevba`:
- `.githooks/`, `.github/workflows/`, `infrastructure/launchd/`
- Framework gate-engine scripts (`check-state-schema.py`, `integrity-check.py`, etc.)
- High-risk domain layer (DomainModels, EncryptionService, SyncService, AuthManager, SignInService, AIOrchestrator)

Today: review-mention only. Becomes review-required when `require_code_owner_reviews=true` in branch protection (TBD when team grows).

### 2. `.github/dependabot.yml`
Weekly Mondays 06:00 UTC:
- **GitHub Actions** — closes tag-retag attack surface (Dependabot writes SHAs into version field automatically)
- **npm** (root) — minor+patch grouped; majors individual
- **pip** (ai-engine)

### 3. `.githooks/pre-commit` extensions
Two new gates after the existing HADF prereg-lock check:
- **File-size**: reject any file >5MB (`SECURITY_MAX_BYTES` env override)
- **Secret patterns**: high-confidence regex for AWS, GitHub PATs (classic + OAuth + fine-grained), GitLab PAT, private-key markers, Slack bot token, OpenAI API key. Skip-list excludes hook itself + setup docs + fixtures + observed-patterns catalog.

Belt-and-braces to GitGuardian: catches BEFORE push.

### 4. `scripts/doctor.sh` extensions
Two new checks:
- **`branch protection`** — reports `required_signatures` status on main
- **`gha sha-pin`** — counts workflow `uses:` lines pinned to `@sha` vs `@vN`/tag

First run (today):
```
⚠ branch protection          required_signatures=OFF on main — flip via gh API
⚠ gha sha-pin                0/24 pinned (0%); tag-retag attack surface — accept Dependabot PRs
```

Both warnings will clear after item 5 (toggle) + Dependabot SHA-pin upgrades over coming weeks.

## Item 5 — live API operation post-merge (not in PR diff)

```bash
gh api -X POST \
  repos/Regevba/FitTracker2/branches/main/protection/required_signatures \
  -f enabled=true
```

Forces every commit to main to be cryptographically signed. Today's YubiKey FIDO2 cut-over makes this no-op for current workflow; the toggle closes the "forgot --no-verify slipped through" class.

## Overlay safety (Phase E 2026-05-21 → 2026-06-04)

- ✅ No new **framework** gates (pre-commit additions are operator secret/file hygiene, not state-engine data gates)
- ✅ No `state.json` mutations
- ✅ No F14/F18 test discipline changes
- ✅ No state-engine touches
- ✅ Isolated chore branch off main

## Verification

- [x] `make doctor` rendered both new checks with actionable warnings
- [x] Pre-commit regex patterns tested against synthetic AWS key + 6MB file
- [x] First commit on this branch signed cleanly by YubiKey
- [ ] Post-merge: branch-protection toggle exercised → `make doctor` flips to ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)