### PR TITLE
chore(gap-close): D-AUDIT-1 backlog row + D-RECON-7 framework-story-site phase canonicalize

### DIFF
--- a/.claude/features/framework-story-site/state.json
+++ b/.claude/features/framework-story-site/state.json
@@ -3,7 +3,7 @@
   "created_at": "2026-04-19T00:00:00Z",
   "updated": "2026-04-20T00:00:00Z",
   "branch": "main",
-  "current_phase": "closed",
+  "current_phase": "complete",
   "work_type": "feature",
   "framework_version": "v6.0",
   "agent_manifest": {
@@ -129,6 +129,11 @@
         "PM-workflow-led variant of /pm-flow that leads with phases instead of skills",
         "Revisit desktop perf on /case-studies/full-system-audit (94, 1 below target)"
       ]
+    },
+    "complete": {
+      "status": "complete",
+      "started_at": "2026-05-23T19:40:55Z",
+      "note": "Canonicalized from 'closed' (non-canonical pre-v7.8.1 terminal state) during 2026-05-23 post-audit hygiene. Feature continues PROD LIVE at fitme-story.vercel.app \u2014 no behavior change."
     }
   },
   "case_study": "docs/case-studies/framework-story-site-case-study.md",
@@ -149,5 +154,28 @@
       "topic": "SSR regression bisect lesson"
     }
   ],
-  "phase_schema_note": "current_phase='closed' is a non-canonical pre-v7.8.1 terminal state used before the lifecycle enum was standardized to {complete}. Feature shipped 2026-04-21 (PROD LIVE at fitme-story.vercel.app); leaving 'closed' preserves git history continuity. Forward-only: any future similar terminal-state feature must use canonical 'complete'."
+  "phase_schema_note": "current_phase canonicalized 'closed' \u2192 'complete' on 2026-05-23 (D-RECON-7 closure). 'closed' was a pre-v7.8.1 terminal-state convention; kept the additional_case_studies field documenting the 2 sibling case studies (dispatchreplay + ssr-regression) which had been unpointed.",
+  "isolation_opt_out": true,
+  "isolation_opt_out_reason": "Post-audit canonicalization 2026-05-23. Feature shipped 2026-04-21 (PROD LIVE at fitme-story.vercel.app/) \u2014 code work all on the original feature/framework-story-site branch (merged + deleted). This commit only canonicalizes the non-standard 'closed' phase \u2192 'complete' per docs/audits/internal/2026-05-23-comprehensive-pr-sync-audit.md D-RECON-7. No code risk.",
+  "cache_hits": [
+    {
+      "level": "L3",
+      "key": "closure_canonicalization_sentinel",
+      "count": 0,
+      "note": "Closure sentinel for the 2026-05-23 canonicalization commit. Original feature shipped pre-Mechanism-C; reads not attributed.",
+      "timestamp": "2026-05-23T19:40:55Z"
+    }
+  ],
+  "timing": {
+    "phases": {
+      "complete": {
+        "started_at": "2026-05-23T19:40:55Z"
+      },
+      "closed": {
+        "started_at": "2026-04-21T00:00:00Z",
+        "ended_at": "2026-05-23T19:42:18Z",
+        "note": "Non-canonical 'closed' state held from 2026-04-21 (PROD LIVE) to 2026-05-23 (canonicalization). Estimated start = ship date."
+      }
+    }
+  }
 }

--- a/.claude/logs/framework-story-site.log.json
+++ b/.claude/logs/framework-story-site.log.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0",
+  "feature": "framework-story-site",
+  "title": "framework story site",
+  "work_type": "feature",
+  "current_phase": "complete",
+  "framework_version": "v6.0",
+  "started_at": "2026-05-23T19:40:55Z",
+  "updated_at": "2026-05-23T19:42:53Z",
+  "events": [
+    {
+      "timestamp": "2026-05-23T19:40:55Z",
+      "event_type": "tier_closure",
+      "phase": "complete",
+      "summary": "Tier closure \u2014 'closed' \u2192 'complete' canonicalization per D-RECON-7",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-23T19:42:18Z",
+      "event_type": "tier_closure",
+      "phase": "complete",
+      "summary": "Tier closure (retry) \u2014 case-study frontmatter added + closed.ended_at set",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-05-23T19:42:53Z",
+      "event_type": "tier_closure",
+      "phase": "complete",
+      "summary": "Tier closure (retry 2) \u2014 kill_criteria_resolution added to case study frontmatter",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/docs/case-studies/framework-story-site-case-study.md
+++ b/docs/case-studies/framework-story-site-case-study.md
@@ -1,7 +1,21 @@
+---
+date_written: 2026-04-20
+work_type: enhancement
+dispatch_pattern: serial
+framework_version: v7.0
+tier_tags_present: true
+case_study_type: pre_pm_workflow_backfill
+primary_metric: "n/a — meta-build (no instrumented metric for the site itself); commit count + wall-clock time captured narratively [T3]"
+success_metrics: "N/A — pre-PRD document type (audit/chore/roundup; field not applicable to this case study type). Frontmatter added 2026-05-23 per D-RECON-7 closure to satisfy FEATURE_CLOSURE_COMPLETENESS gate's required-fields list."
+kill_criteria: "N/A — pre-PRD document type (audit/chore/roundup; field not applicable to this case study type)."
+kill_criteria_resolution: "not tripped — pre-PRD document type with no defined kill thresholds. Frontmatter field present to satisfy FEATURE_CLOSURE_COMPLETENESS gate Q7 (kill_criteria set → resolution required). Feature shipped 2026-04-21 PROD LIVE; no kill scenarios encountered in 30+ days of operation."
+---
+
 # Building the Site That Tells the Story — A Two-Hour Meta-Build
 
 **Date written:** 2026-04-20
 <!-- doc-debt-backfill: fields added by scripts/backfill-case-study-fields.py -->
+<!-- 2026-05-23 D-RECON-7 closure: YAML frontmatter added above to satisfy FEATURE_CLOSURE_COMPLETENESS gate's required-fields list. Original markdown-table format below preserved as historical record. -->
 
 | Field | Value |
 |---|---|

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -10,6 +10,7 @@
 | # | Feature | PR/Commit | Date | Notes |
 |---|---------|-----------|------|-------|
 | 1 | Core app foundation (SwiftUI shell, encrypted data, HealthKit) | Initial commits | 2026-02-28 | Base product |
+| 1a | Pre-PM-workflow seed PRs (#1, #2, #3, #4, #5, #6, #7, #20, Mar 13 → Apr 2) | PRs #1-#7 + #20 | 2026-03-13 → 04-02 | Housekeeping ships pre-dating /pm-workflow skill (PR #21): home-screen spacing, second-pass review fixes, simulator biometric skip, v3.0 UX/UI pass, Phase 0 PRD+metrics+backlog seed (PR #20 = this document's origin). Added 2026-05-23 per audit `docs/audits/internal/2026-05-23-comprehensive-pr-sync-audit.md` D-AUDIT-1. |
 | 2 | Today-first product redesign (Home, Training, Nutrition, Stats) | Redesign phase | 2026-03-14 | 5-pass redesign |
 | 3 | Auth & settings overhaul (Apple Sign In, passkeys, grouped settings) | PR #10, #13 | 2026-03-25 | Auth hub + 5 settings groups |
 | 4 | Federated cohort intelligence (AI engine, backend, iOS AI layer) | PR #12 | 2026-03-26 | FastAPI + AIOrchestrator |


### PR DESCRIPTION
## Summary

2 more drift closures from the 2026-05-23 comprehensive audit. Each commit is independent + atomic.

## Commits

| SHA | Drift | Subject |
|---|---|---|
| `56232c9` | D-AUDIT-1 | docs(backlog): add row 1a covering pre-PM-workflow seed PRs (#1-#7 + #20) |
| `b0b25be` | D-RECON-7 | feat(framework-story-site): canonicalize 'closed' → 'complete' |

## D-AUDIT-1 closure

8 pre-PM-workflow seed PRs (Mar 13 → Apr 2 2026) had no backlog/feature/case-study anchor. Added row 1a to `docs/product/backlog.md` between rows 1 + 2 as a single archive entry. PR #20 is the meta-PR that created the backlog file itself.

## D-RECON-7 closure

`framework-story-site/state.json` used non-canonical `current_phase: closed` (pre-v7.8.1 terminal state convention). Canonicalized to `complete`.

Required gate prep:
- **PHASE_TRANSITION_NO_TIMING:** added `timing.phases.closed.{started_at,ended_at}` + `timing.phases.complete.started_at`
- **PHASE_TRANSITION_NO_LOG:** appended tier_closure event
- **BRANCH_ISOLATION_VIOLATION Mode C:** `isolation_opt_out=true` with reason (post-audit canonicalization from non-feature branch; all code on merged-and-deleted upstream)
- **FEATURE_CLOSURE_COMPLETENESS:** added YAML frontmatter to case study with the 9 required fields including `kill_criteria_resolution: "not tripped"` for the N/A kill_criteria

Case study YAML frontmatter added at top; original markdown-table format preserved below as historical record. `case_study_type: pre_pm_workflow_backfill` flag added.

No behavior change. fitme-story.vercel.app continues PROD LIVE.

## Test plan

- [x] Both commits pass pre-commit hooks (state.json schema + case study frontmatter + Q6+Q7 gates)
- [x] No infra-glob writes
- [ ] CI green: `pm-framework/pr-integrity` + `integrity` + `Build and Test`
- [ ] Post-merge: framework-story-site now appears in `current_phase=complete` count + has canonical case_study frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)