### PR TITLE
feat(analytics): D-3 — wire AnalyticsScreenModifier to SettingsView (2026-05-25)

### DIFF
--- a/.claude/features/analytics-observability/state.json
+++ b/.claude/features/analytics-observability/state.json
@@ -364,23 +364,17 @@
     {
       "id": "D-3",
       "title": "Wire AnalyticsScreenModifier to main tabs (Home/Training/Stats/Nutrition/Settings) \u2014 screen-view tracking gap",
-      "status": "deferred",
+      "status": "complete",
       "phase": "implementation",
-      "earliest_start": "2026-06-04",
-      "blocked_until": "v7.9 ships",
       "effort": "1-2h",
       "calibration_class": "yellow",
-      "outcome": "(pending) Discovered 2026-05-17 during FIT-142 iOS investigation: analytics.logScreenView only called from 15 onboarding views. Main app tabs have ZERO explicit screen-view tracking. AnalyticsScreenModifier exists at FitTracker/Services/Analytics/AnalyticsScreenModifier.swift:9 but isn't applied. Symptom in GA4: Firebase auto-screen_view fires with screen_class='SwiftUIView' for ALL non-onboarding views \u2192 no screen-prefix funnel possible per analytics-taxonomy convention. Fix: apply .trackedScreen(AnalyticsScreen.<name>) modifier to each tab's root view.",
+      "outcome": "Closed 2026-05-25. SettingsView v2 was the only missing tab root view \u2014 Home / Training / Nutrition / Stats were already wired (Home via Main/v2/MainScreenView.swift:103; Training + Nutrition + Stats via RootTabView.swift:204-207 call-site modifier). Added `.analyticsScreen(AnalyticsScreen.settings)` after `.onAppear` block at FitTracker/Views/Settings/v2/SettingsView.swift:190 \u2014 fires `screen_view` event when the Settings sheet appears (presented from RootTabView profile button \u2192 ProfileView \u2192 SettingsView). Closes the GA4 screen-prefix drift: future settings_* events now have an instrumented screen-view ancestor for funnel analysis.",
       "files_touched": [
-        "FitTracker/Views/Main/MainScreenView.swift (or v2)",
-        "FitTracker/Views/Training/v2/TrainingPlanView.swift",
-        "FitTracker/Views/Stats/...",
-        "FitTracker/Views/Nutrition/...",
         "FitTracker/Views/Settings/v2/SettingsView.swift"
       ],
       "source_event": "FIT-142 closure 2026-05-17",
-      "v8_docket_candidate_id": "F21",
-      "v7_9_1_candidate": true
+      "started_at": "2026-05-25T11:45:00Z",
+      "completed_at": "2026-05-25T11:45:00Z"
     },
     {
       "id": "D-4",

--- a/FitTracker/Views/Settings/v2/SettingsView.swift
+++ b/FitTracker/Views/Settings/v2/SettingsView.swift
@@ -187,6 +187,7 @@ struct SettingsView: View {
             .onAppear {
                 applyReviewRouteIfNeeded()
             }
+            .analyticsScreen(AnalyticsScreen.settings)
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the only remaining screen-view tracking gap among the 5 main app surfaces. Adds `.analyticsScreen(AnalyticsScreen.settings)` to SettingsView v2 root, mirroring the pattern already shipping on Home / Training / Nutrition / Stats.

## Change

One line, one file:

```diff
 .onAppear {
     applyReviewRouteIfNeeded()
 }
+.analyticsScreen(AnalyticsScreen.settings)
```

[FitTracker/Views/Settings/v2/SettingsView.swift:190](https://github.com/Regevba/FitTracker2/blob/feature/analytics-d3-settings-screenview/FitTracker/Views/Settings/v2/SettingsView.swift#L190)

## Why now

D-3 was the only remaining open task on `analytics-observability` (besides D-2 which was re-deferred to app launch via chore PR #483). Blocked since 2026-05-17 (FIT-142 closure) by "v7.9 ships" — v7.9 shipped 2026-05-21, so unblocked.

## Prior state — 4 of 5 already wired

| Surface | Wiring location |
|---|---|
| Home | `FitTracker/Views/Main/v2/MainScreenView.swift:103` |
| Training | RootTabView call-site (`.swift:204`) + `Training/v2/TrainingPlanView.swift:102` |
| Nutrition | RootTabView call-site (`.swift:205`) + `Nutrition/NutritionView.swift:78` |
| Stats | RootTabView call-site (`.swift:207`) |
| **Settings** | **NOT wired anywhere** — this PR closes it |

Pattern matches 6 existing usages (`ConsentView.swift:127`, `DeleteAccountView.swift:38`, `ExportDataView.swift:62`, `Main/v2/MainScreenView.swift:103`, `BodyCompositionDetailView.swift:111`, etc.).

## GA4 impact

Settings sheet (presented from RootTabView profile button → ProfileView → SettingsView) will now fire `screen_view` with `screen_name: "settings"` on appear. Future `settings_*` events (e.g. `settings_consent_updated`, `settings_account_deleted`, `settings_export_requested` per CLAUDE.md analytics naming convention) now have an instrumented screen-view ancestor for proper funnel analysis.

Closes the symptom in GA4 where Firebase auto-`screen_view` fired with `screen_class='SwiftUIView'` for all non-onboarding views (D-3 outcome from FIT-142 investigation).

## State.json delta

`analytics-observability` tasks: **13/15 → 14/15** done.

```diff
- "status": "deferred",
- "earliest_start": "2026-06-04",
- "blocked_until": "v7.9 ships",
- "v7_9_1_candidate": true,
- "v8_docket_candidate_id": "F21",
+ "status": "complete",
+ "started_at": "2026-05-25T11:45:00Z",
+ "completed_at": "2026-05-25T11:45:00Z",
+ "files_touched": ["FitTracker/Views/Settings/v2/SettingsView.swift"],
```

Remaining open task: **D-2** (GA4 conversions config) — deferred to `app_store_launch` via chore PR #483 (`9d76b65`).

## Verification

- [x] Pre-commit hooks pass (state.json schema validator)
- [x] Pattern matches 6 existing `.analyticsScreen(...)` call sites
- [x] AnalyticsScreen.settings constant exists at `AnalyticsProvider.swift:489` (`"settings"`)
- [x] SettingsView already has `@EnvironmentObject var analytics: AnalyticsService` at line 79 — modifier's env-object dependency is satisfied
- [ ] CI build + test (incoming)

## Test plan

- [ ] xcodebuild test passes (existing `AnalyticsTests.swift` covers `logScreenView` via Mock adapter; no new test needed for a 1-line modifier addition)
- [ ] Manual smoke (post-merge, optional): launch sim → tap profile icon → tap Settings → check Firebase DebugView shows `screen_view` with `screen_name: settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)