### PR TITLE
chore(disco): Phase 1 status update — P1.3 + P1.4 shipped + bug-fix doc

### DIFF
--- a/docs/master-plan/fitme-story-discoverability-plan-2026-05-20.md
+++ b/docs/master-plan/fitme-story-discoverability-plan-2026-05-20.md
@@ -58,15 +58,17 @@ Three causes, ordered by likelihood:
 
 ### Phase 1 — Foundation (~2h, target 2026-05-21 → 05-23)
 
-| # | Action | Effort | Effect |
-|---|---|---|---|
-| **P1.1** | Submit `fitme-story.vercel.app` to Google Search Console + verify via DNS TXT or HTML meta tag | 30 min | Google starts crawling the site; baseline traffic data available |
-| **P1.2** | Submit sitemap URL (`/sitemap.xml`) to Search Console | 5 min | All 13+ static + dynamic routes prioritized for crawl |
-| **P1.3** | Add OpenGraph + Twitter Card meta tags to root layout (`src/app/layout.tsx`) | 45 min | Social shares produce rich previews (title, description, OG image) |
-| **P1.4** | Create OG image at 1200×630 (default site card) + commit to `public/og-default.png` | 30 min | Visual asset for social previews |
-| **P1.5** | Verify GA Realtime sees a visit from incognito window | 5 min | Confirms wiring once and for all |
+| # | Action | Effort | Effect | Status |
+|---|---|---|---|---|
+| **P1.1** | Submit `fitme-story.vercel.app` to Google Search Console + verify via DNS TXT or HTML meta tag | 30 min | Google starts crawling the site; baseline traffic data available | ⏳ pending (operator action — Google account auth required) |
+| **P1.2** | Submit sitemap URL (`/sitemap.xml`) to Search Console | 5 min | All 13+ static + dynamic routes prioritized for crawl | ⏳ pending (gated on P1.1) |
+| ~~**P1.3**~~ | ~~Add OpenGraph + Twitter Card meta tags to root layout~~ | ~~45 min~~ | ~~Social shares produce rich previews~~ | ✅ **SHIPPED 2026-05-21** via fitme-story root layout + `src/lib/seo.ts::buildMetadata()` helper + per-page `generateMetadata`. Verified live via `curl https://fitme-story.vercel.app \| grep og:`. All openGraph + twitter:card meta present on every page. |
+| ~~**P1.4**~~ | ~~Create OG image at 1200×630~~ | ~~30 min~~ | ~~Visual asset for social previews~~ | ✅ **SHIPPED 2026-05-21** via [`fitme-story/src/app/opengraph-image.tsx`](https://github.com/Regevba/fitme-story/blob/main/src/app/opengraph-image.tsx) — Next.js ImageResponse generates the 1200×630 PNG at runtime at `/opengraph-image`. Auto-applied via Next.js Metadata API auto-detection. ⚠ **2026-05-27 live bug discovered + fixed:** `buildMetadata()` was hardcoding `og:image` URL as `/og.png` which 404'd → social previews silently broken for 6 days; fixed via [fitme-story PR #156](https://github.com/Regevba/fitme-story/pull/156) (`fix(seo): og:image defaults to /opengraph-image`) + 6 regression tests in `src/lib/seo.test.ts`. |
+| **P1.5** | Verify GA Realtime sees a visit from incognito window | 5 min | Confirms wiring once and for all | ⏳ pending (operator action — needs incognito browser visit + GA4 Realtime tab check). **GA4 7-day backward check 2026-05-27:** 0 fitme-story.vercel.app sessions in 2026-05-21 → 05-27 window (only iOS app traffic present); confirms P1.1 GSC verification is the gating step. |
 
-**Outcome:** site is indexable + shares look professional + GA wiring proven.
+**Outcome (so far):** P1.3 + P1.4 SHIPPED (with 1 silent-bug post-deploy fix); P1.1 + P1.2 + P1.5 pending operator actions (Google account auth + browser visit).
+
+**Phase 1 lesson captured:** the `og:image` URL must round-trip via curl HEAD after every layout/seo.ts change. The 6-day silent-404 reproduced because no test asserted the URL resolved to 200. Closed via [fitme-story `src/lib/seo.test.ts`](https://github.com/Regevba/fitme-story/blob/main/src/lib/seo.test.ts) — 6 unit tests pin the contract. A v7.9.1 candidate could extend this to a deployed-URL HEAD probe in CI; queued informally.
 
 ### Phase 2 — Crosslinking (~2h, target 2026-05-23 → 05-25)
 


### PR DESCRIPTION
Hygiene update to [`docs/master-plan/fitme-story-discoverability-plan-2026-05-20.md`](docs/master-plan/fitme-story-discoverability-plan-2026-05-20.md) reflecting today's 2026-05-27 follow-up audit findings.

## What the audit found

**P1.3 + P1.4 already SHIPPED 2026-05-21** (the master plan didn't reflect this; verified today via live curl + source inspection).

**BUT** a 6-day silent bug was discovered in P1.4's wiring: `buildMetadata()` in `src/lib/seo.ts` hardcoded `og:image` URL as `/og.png` which 404s. The actual auto-generated 1200×630 image lives at `/opengraph-image` (per Next.js Metadata API convention). Social platforms fetching the URL got 404 → all rich previews silently broken since 2026-05-21.

The bug-fix ships as a parallel **fitme-story PR #156** (`fix(seo): og:image defaults to /opengraph-image`) with 6 new regression tests.

**P1.5 verification:** GA4 7-day backward check confirms 0 fitme-story.vercel.app sessions in 2026-05-21 → 05-27 window. Only iOS app traffic visible. P1.1 (GSC verification — operator action) is the binding step.

## What's in this PR

| File | Change |
|---|---|
| [`docs/master-plan/fitme-story-discoverability-plan-2026-05-20.md`](docs/master-plan/fitme-story-discoverability-plan-2026-05-20.md) | Phase 1 table: P1.3 + P1.4 marked SHIPPED with closure refs + bug-fix note; P1.1/P1.2/P1.5 status clarified as operator-action-pending |

## Phase 1 status after this PR

- ✅ P1.3 (OG meta) — shipped 2026-05-21
- ✅ P1.4 (OG image 1200×630) — shipped 2026-05-21 (+ 1 silent-bug fix today via fitme-story #156)
- ⏳ P1.1 (GSC verification) — operator action pending
- ⏳ P1.2 (sitemap submit to GSC) — gated on P1.1
- ⏳ P1.5 (GA Realtime incognito check) — operator action pending (GA4 7-day shows 0 sessions, P1.1 is the unlock)

## Lesson captured

The `og:image` URL must round-trip via curl HEAD after every layout/seo.ts change. The 6-day silent-404 reproduced because no test asserted URL resolution. Closed via fitme-story `src/lib/seo.test.ts` contract. A v7.9.1 candidate could extend this to a deployed-URL HEAD probe in CI; queued informally.

## Test plan

- [x] `make integrity-check` → **0 findings + 0 advisory**
- [x] Branch is `chore/*` per v7.9 BRANCH_ISOLATION_VIOLATION enforcement
- [ ] User per-PR merge approval (paired with fitme-story #156)

🤖 Generated with [Claude Code](https://claude.com/claude-code)