### PR TITLE
chore(cycle): daily diagnostic outputs — 2026-05-28 measurement-adoption + doc-debt snapshots

### DIFF
--- a/.claude/shared/documentation-debt.json
+++ b/.claude/shared/documentation-debt.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0",
-  "updated": "2026-05-25T17:33:43Z",
+  "updated": "2026-05-28T06:08:05Z",
   "description": "Baseline documentation-debt report for case-study structure, state linkage, and integrity-cycle readiness.",
   "summary": {
-    "case_studies_scanned": 80,
+    "case_studies_scanned": 81,
     "features_scanned": 79,
     "integrity_snapshot_files": 9,
     "integrity_cycle_snapshots": 7,
@@ -12,39 +12,39 @@
   },
   "coverage": {
     "date_written": {
-      "present": 80,
+      "present": 81,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "work_type": {
-      "present": 80,
+      "present": 81,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "dispatch_pattern": {
-      "present": 80,
+      "present": 81,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "success_metrics": {
-      "present": 80,
+      "present": 81,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "kill_criteria": {
-      "present": 80,
+      "present": 81,
       "missing": 0,
       "percent": 100.0,
       "examples": []
     },
     "kill_criteria_resolution": {
-      "present": 21,
+      "present": 22,
       "missing": 59,
-      "percent": 26.2,
+      "percent": 27.2,
       "examples": [
         "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
         "docs/case-studies/android-design-system-case-study.md",
@@ -54,9 +54,9 @@
       ]
     },
     "pr_citation_exempt": {
-      "present": 11,
+      "present": 12,
       "missing": 69,
-      "percent": 13.8,
+      "percent": 14.8,
       "examples": [
         "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
         "docs/case-studies/android-design-system-case-study.md",

--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -821,7 +821,48 @@
           "post_v6_percent": 31.1
         }
       }
+    },
+    {
+      "date": "2026-05-28",
+      "generated_at": "2026-05-28T06:08:06Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 79,
+        "features_post_v6": 45,
+        "features_pre_v6": 34,
+        "fully_adopted": 3,
+        "partial_adopted": 40,
+        "zero_adopted": 36,
+        "fully_adopted_post_v6": 3,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 17,
+          "overall_percent": 21.5,
+          "post_v6_present": 17,
+          "post_v6_percent": 37.8
+        },
+        "per_phase_timing": {
+          "overall_present": 42,
+          "overall_percent": 53.2,
+          "post_v6_present": 39,
+          "post_v6_percent": 86.7
+        },
+        "cache_hits": {
+          "overall_present": 24,
+          "overall_percent": 30.4,
+          "post_v6_present": 23,
+          "post_v6_percent": 51.1
+        },
+        "cu_v2": {
+          "overall_present": 14,
+          "overall_percent": 17.7,
+          "post_v6_present": 14,
+          "post_v6_percent": 31.1
+        }
+      }
     }
   ],
-  "updated": "2026-05-25T17:33:43Z"
+  "updated": "2026-05-28T06:08:06Z"
 }

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-05-25T17:33:43Z",
+  "updated": "2026-05-28T06:08:06Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {
@@ -677,7 +677,7 @@
       "feature": "analytics-observability",
       "created": "2026-05-13",
       "post_v6": true,
-      "current_phase": "implementation",
+      "current_phase": "testing",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
@@ -1601,7 +1601,7 @@
       "feature": "ucc-passkey-auth-audit-log-redis-fix",
       "created": "2026-05-17",
       "post_v6": true,
-      "current_phase": "implementation",
+      "current_phase": "complete",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
@@ -1615,7 +1615,7 @@
       "feature": "ucc-passkey-auth-security-hardening",
       "created": "2026-05-19",
       "post_v6": true,
-      "current_phase": "documentation",
+      "current_phase": "complete",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
@@ -1629,7 +1629,7 @@
       "feature": "ucc-sign-in-figma-mapping",
       "created": "2026-05-17",
       "post_v6": true,
-      "current_phase": "implementation",
+      "current_phase": "complete",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,


### PR DESCRIPTION
Cycle outputs from the 2026-05-28 09:00 IDT scheduled daily digest run.

## Changes

- **measurement-adoption-history.json** — 2026-05-28 snapshot appended (fully_adopted=3, zero=36, partial=40 — no regression vs 2026-05-25)
- **measurement-adoption.json** — current snapshot refreshed to 2026-05-28T06:08:06Z
- **documentation-debt.json** — report refreshed; 1 open debt item (low severity), kill_criteria_resolution 27.2% (59 grandfathered case studies, advisory only), all 7 mandatory fields at 100% across 81 case studies

## Context

Generated as side-effects of `make measurement-adoption` and `make documentation-debt` during the scheduled daily ecosystem digest. These are routine cycle outputs — safe to merge directly into main.

## Merge guidance

Operator: review diff is mechanical (JSON timestamp + snapshot append). Safe to merge when convenient. If the daily digest also opens a PR for PR #510 (UCC audit log sync), merge that one first.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NPekjsCJER2Ahb9sRgYgY)_