### PR TITLE
ci(framework-status-weekly): add shell-fallback path with retry/backoff (closes B14)

### DIFF
--- a/.github/workflows/framework-status-weekly.yml
+++ b/.github/workflows/framework-status-weekly.yml
@@ -154,8 +154,19 @@ jobs:
             echo "Snapshot staged for ${today}."
           fi
 
-      - name: Open PR with weekly snapshot
+      # B14 (2026-05-30): peter-evans/create-pull-request@v8 fails when GitHub
+      # returns 500 on the internal push (2 transient failures observed in last
+      # 5 weeks: 2026-05-04 + 2026-05-25). continue-on-error keeps the workflow
+      # from terminating; the shell fallback below retries push + PR creation
+      # via gh CLI with linear backoff (2s, 5s, 15s).
+      #
+      # Injection-safe: all dynamic values are passed via env: (TODAY,
+      # REGRESSION, GH_TOKEN) and consumed as $-prefixed shell vars. No
+      # ${{ ... }} substitution inside run: blocks.
+      - name: Open PR with weekly snapshot (primary path)
+        id: open-pr
         if: steps.stage.outputs.has_changes == 'true'
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v8
         env:
           REGRESSION: ${{ steps.compare.outputs.regression }}
@@ -180,6 +191,76 @@ jobs:
           committer: Framework Status Bot <framework-status@actions>
           author: Framework Status Bot <framework-status@actions>
           labels: framework-status,automated
+
+      - name: Open PR with weekly snapshot (shell fallback on primary-path failure)
+        if: |
+          steps.stage.outputs.has_changes == 'true' &&
+          steps.open-pr.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TODAY: ${{ steps.stage.outputs.today }}
+          REGRESSION: ${{ steps.compare.outputs.regression }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          echo "Primary path (peter-evans/create-pull-request@v8) failed — falling back to shell with retry/backoff."
+          BRANCH="framework-status/${TODAY}"
+
+          git config user.name "Framework Status Bot"
+          git config user.email "framework-status@actions"
+          if ! git rev-parse --verify "${BRANCH}" >/dev/null 2>&1; then
+            git checkout -b "${BRANCH}"
+          else
+            git checkout "${BRANCH}"
+          fi
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore(framework-status): weekly snapshot ${TODAY} (shell-fallback after primary action failed) - Regression=${REGRESSION}"
+          fi
+
+          push_ok=""
+          for delay in 2 5 15; do
+            if git push --force-with-lease origin "HEAD:${BRANCH}"; then
+              echo "::notice::push succeeded after primary-action failure"
+              push_ok=1
+              break
+            fi
+            echo "push failed, sleeping ${delay}s before retry…"
+            sleep "${delay}"
+          done
+          if [ -z "${push_ok}" ]; then
+            echo "::error::push failed all 3 retry attempts; abandoning fallback"
+            exit 1
+          fi
+
+          pr_ok=""
+          PR_BODY="Automated weekly framework-status snapshot (shell-fallback path).
+
+          - Snapshot date: ${TODAY}
+          - Regression detected: ${REGRESSION}
+          - Run: ${RUN_URL}
+          - Primary path (peter-evans/create-pull-request@v8) returned a non-zero outcome; this PR was opened via the B14 shell-fallback after push --force-with-lease succeeded.
+
+          Merging this PR persists the cron-tagged snapshot — required for Tier 1.1 trend mode unlock."
+          for delay in 2 5 15; do
+            if gh pr create \
+                --base main \
+                --head "${BRANCH}" \
+                --title "chore(framework-status): weekly snapshot ${TODAY}" \
+                --body "${PR_BODY}" \
+                --label framework-status \
+                --label automated; then
+              echo "::notice::PR created via shell fallback"
+              pr_ok=1
+              break
+            fi
+            echo "gh pr create failed, sleeping ${delay}s before retry…"
+            sleep "${delay}"
+          done
+          if [ -z "${pr_ok}" ]; then
+            echo "::error::gh pr create failed all 3 retry attempts after successful push"
+            exit 1
+          fi
 
       - name: Package digest body
         if: always()


### PR DESCRIPTION
## Summary

Closes **B14** in [`must-have-cadence-followups.md`](.claude/shared/must-have-cadence-followups.md).

**2 transient failures** in the last 5 weeks (2026-05-04 + 2026-05-25) on the "Open PR with weekly snapshot" step where `peter-evans/create-pull-request@v8` hit GitHub 500 on its internal `git push`. Workflow terminated → missed Monday snapshot in `measurement-adoption-history.json` → gap in Tier 1.1 trend data.

## Fix

Primary path (`peter-evans/create-pull-request@v8`) gets `continue-on-error: true` + a **fallback shell step** that runs only when the primary returned `failure`.

Fallback flow:
1. Re-stage + commit on snapshot branch (idempotent if peter-evans already committed)
2. `git push --force-with-lease` with linear backoff: **2s / 5s / 15s, 3 attempts**
3. `gh pr create` with same backoff (3 attempts)

| Path | Wall-clock cost |
|---|---|
| Happy path (peter-evans succeeds) | +0s — fallback's `if:` evaluates false → skipped |
| Failure path (one transient blip on push) | +22s worst case for push retry, +0s for PR create |
| Worst case (both push + PR create flap) | +44s total |

## Injection safety

All dynamic values pass through `env:` (TODAY, REGRESSION, GH_TOKEN, RUN_URL) and are consumed as `$`-prefixed shell vars. **No `${{ }}` substitution inside `run:` blocks.** Values come from internal step outputs + secrets — not untrusted `github.event.*` inputs.

## What does NOT change

- Schedule (Mondays 05:00 UTC) unchanged
- Snapshot generation logic unchanged
- All other workflow steps unchanged
- `peter-evans/create-pull-request@v8` remains the primary path (preserves prior happy-path behavior including automatic branch-update + label management)

## Backfill

The missed 2026-05-25 snapshot can be regenerated via manual rerun of the workflow once this PR lands. (Optional follow-up — not blocking on this PR's merge.)

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [x] Branch isolation: chore branch on isolated worktree
- [x] Touch ID signed commit (`3eb1902`)
- [ ] Operator manual: re-run the failed run [26392565971](https://github.com/Regevba/FitTracker2/actions/runs/26392565971) after merge to verify backfill works
- [ ] Operator manual: observe next Monday 2026-06-01 05:00 UTC run — should succeed on primary path (no transient expected) but if it fails, fallback should kick in transparently

🤖 Generated with [Claude Code](https://claude.com/claude-code)