### PR TITLE
fix(hadf-phase2bis): extract prompt_obj['text'] in collect.py main loop

### DIFF
--- a/scripts/hadf-phase2bis-collect.py
+++ b/scripts/hadf-phase2bis-collect.py
@@ -412,7 +412,12 @@ def main():
     written = 0
     with tmp_path.open("w") as f:
         for provider, endpoint, api_kind in ENDPOINTS[args.subexp]:
-            for i, prompt in enumerate(prompts):
+            for i, prompt_obj in enumerate(prompts):
+                # Prompt set entries are {id, category, text} dicts; APIs expect a string.
+                # First caught 2026-05-25 (commit 3b1938a, lost in 2026-05-29 worktree reset).
+                # Re-applied 2026-05-30 04:55 UTC after Sub-exp 2 launch fire failed
+                # 50/50 with HTTP 400 (dict-as-prompt → Ollama "Bad Request").
+                prompt = prompt_obj["text"] if isinstance(prompt_obj, dict) else prompt_obj
                 t_start = time.time()
                 try:
                     result = call_endpoint(provider, endpoint, prompt)


### PR DESCRIPTION
## Summary

Re-applies a critical correctness fix from 2026-05-25 (commit `3b1938a`) that was lost during the 2026-05-29 HADF worktree reset to origin/main. PR #520 squashed Sub-exp 1A closure work but **omitted this single-line fix**; main has been carrying the bug since.

## Bug

`main()` iterated the prompt set with:
```python
for i, prompt in enumerate(prompts):
```

But the prompt set's entries are `{id, category, text}` dicts (per `phase2bis-prompt-set.json` schema). The whole dict was passed to `call_endpoint` → providers received a JSON body with `"prompt": {...}` (object) instead of `"prompt": "..."` (string). Ollama responds `HTTP 400 Bad Request`; OpenAI/Anthropic would reject similarly.

## How it was caught

2026-05-30 04:50 UTC, Sub-exp 2 launch fire 0:
```
50 records written  ·  status: {'error': 50}
first error: Ollama unreachable at http://localhost:11434: HTTP Error 400: Bad Request
```

Standalone 1-call test of `call_endpoint('ollama', 'llama3.2:3b', 'hi')` worked, narrowing the bug to `main()`'s loop iteration.

## Fix

```python
for i, prompt_obj in enumerate(prompts):
    # Prompt set entries are {id, category, text} dicts; APIs expect a string.
    prompt = prompt_obj["text"] if isinstance(prompt_obj, dict) else prompt_obj
```

`isinstance` guard preserves backward compat with the (hypothetical) string-only prompt set.

## Verification

Applied the same patch on the HADF worktree at 04:55 UTC. Re-fired Sub-exp 2 at 04:57 UTC:

```
50 records written  ·  status: {'ok': 50}
TTFT p50: 0.153s  ·  TPS p50: 44.58  ·  output_tokens p50: 141
```

Sub-exp 2's first fire is now in the bag. Cron is bootstrapped on the new IDT-anchored schedule (UTC 05/11/15/19/23 = IDT 08/14/18/22/02). Next fire: 11:00 UTC.

## Impact if not landed

- **Sub-exp 2 (Ollama)** — empirically broken on main; fix already applied locally on `feat/hadf-phase2bis-impl` worktree to unblock tonight's collection
- **Sub-exp 3 (Bedrock + Anthropic)** — would fail 100% on launch (~2026-06-02 if Sub-exp 2 passes); this PR is the prerequisite
- **Sub-exp 1B follow-up** — same

## Test plan

- [x] Python syntax check (`ast.parse`)
- [x] Empirical verification on HADF worktree (50/50 OK)
- [x] Branch isolation: fix branch on isolated worktree
- [x] Touch ID signed
- [ ] Operator: confirm the fire 0 raw `.jsonl` looks reasonable before merging (latest at `/Volumes/DevSSD/FitTracker2-feature-hadf-phase2bis-impl/.claude/shared/hadf/phase2bis-raw-subexp2-subexp2-2026-05-30T04-57-52Z.jsonl`)

## Companion work

- HADF worktree's local `feat/hadf-phase2bis-impl` branch already has this fix applied; no PR/merge needed there since the cron uses local files
- After this PR merges, the HADF worktree's local change matches main; future worktree refreshes won't reintroduce the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)