### PR TITLE
feat(hadf-phase2bis): Sub-exp 1B prep — extended 4-endpoint cloud matrix

### DIFF
--- a/.claude/features/hadf-phase2bis-replication/launchd-templates/com.fitme.hadf-phase2bis-subexp1b.plist.template
+++ b/.claude/features/hadf-phase2bis-replication/launchd-templates/com.fitme.hadf-phase2bis-subexp1b.plist.template
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  HADF Phase 2-bis Sub-exp 1B — extended cloud matrix fingerprinting
+
+  Endpoint matrix (4 endpoints, 4 providers):
+    1. anthropic/claude-haiku-4-5-20251001  (anchor — cross-window drift vs Sub-exp 1A)
+    2. google/gemini-2.5-flash-lite          (non-reasoning Gemini)
+    3. mistral/mistral-large-latest          (first Mistral inclusion)
+    4. vercel-ai-gateway/gpt-4o-mini         (routing-layer signature probe)
+
+  Fire schedule: 5 fires/day at UTC 02/08/14/18/22 (spec §4 standard schedule).
+  Sub-exp 2 runs on a rotated schedule (UTC 05/11/15/19/23 = IDT 08/14/18/22/02);
+  the 3-hour offset means Sub-exp 1B and Sub-exp 2 NEVER co-fire — safe parallel
+  operation. Cloud (1B) + local Ollama (2) hit different resource pools anyway.
+
+  3 macOS gotchas applied (per Sub-exp 1 working plist + HADF launchd checklist):
+    (1) FDA for /bin/bash granted to terminal
+    (2) Explicit /bin/bash in ProgramArguments (no shebang reliance)
+    (3) stdout/stderr on /tmp/ (NOT /Volumes/ — SSD unmount kills logging)
+
+  WorkingDirectory uses the shared impl worktree (matches Sub-exp 1A's working
+  setup and Sub-exp 2's launched setup). Operator may switch to a dedicated
+  /Volumes/DevSSD/FitTracker2-hadf-phase2bis-subexp1b/ worktree per spec §8 if
+  desired — just update both path strings below.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.fitme.hadf-phase2bis-subexp1b</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Volumes/DevSSD/FitTracker2-feature-hadf-phase2bis-impl/scripts/hadf-phase2bis-collect.sh</string>
+        <string>--subexp</string>
+        <string>subexp1b</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Volumes/DevSSD/FitTracker2-feature-hadf-phase2bis-impl</string>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Hour</key><integer>2</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>8</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>18</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+    </array>
+    <key>StandardOutPath</key>
+    <string>/tmp/hadf-phase2bis-subexp1b-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/hadf-phase2bis-subexp1b-stderr.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/.claude/shared/hadf/preregistration-phase2bis-subexp1b.json
+++ b/.claude/shared/hadf/preregistration-phase2bis-subexp1b.json
@@ -1,0 +1,130 @@
+{
+  "subexp_id": "phase2bis-subexp1b",
+  "rq": "Does the silhouette signature generalize across a wider 4-endpoint cloud matrix (Anthropic anchor + Google non-reasoning Gemini + Mistral + Vercel AI Gateway-routed OpenAI) and span 4 providers (vs Sub-exp 1A's 2-provider matrix)? Two secondary questions: (a) does the Anthropic claude-haiku-4-5 anchor distribution drift across the Sub-exp 1A → Sub-exp 1B window (cross-window drift detection); (b) does the Vercel AI Gateway-routed gpt-4o-mini fingerprint match OpenAI-direct's gpt-4o-mini from Sub-exp 1A, or does the gateway routing inject a distinguishable signature?",
+  "endpoints": [
+    {
+      "provider": "anthropic",
+      "endpoint": "claude-haiku-4-5-20251001",
+      "api_kind": "direct",
+      "role": "anchor — cross-window drift detection vs Sub-exp 1A. Uses dated form (not the bare alias) so a downstream Anthropic alias-update mid-collection wouldn't trip kill-criterion model_id-change. Sub-exp 1A locked the bare alias; the dated form here is a tighter lock + remains comparable since both point at the same model snapshot."
+    },
+    {
+      "provider": "google",
+      "endpoint": "gemini-2.5-flash-lite",
+      "api_kind": "direct",
+      "role": "Non-reasoning Gemini class — replaces the Sub-exp 1A-dropped gemini-2.5-flash and gemini-2.5-pro (both reasoning class with thoughtsTokenCount that broke the TTFT signature comparison). 2026-05-30 verification at HADF-scale prompts: 0 thoughtsTokenCount, visible_ratio=1.0 at max_tokens=200 across the prompt-set categories."
+    },
+    {
+      "provider": "mistral",
+      "endpoint": "mistral-large-latest",
+      "api_kind": "direct",
+      "role": "First Mistral inclusion in the HADF matrix. Was deferred from Sub-exp 1A on placeholder key; key minted 2026-05-30 with chat+models scope (NO connectors — connectors scope would inject web-search/tool-call latency that distorts pure-generation TTFT). 2026-05-30 verification: real call returned in normal latency profile."
+    },
+    {
+      "provider": "vercel-ai-gateway",
+      "endpoint": "gpt-4o-mini",
+      "api_kind": "gateway",
+      "role": "Routing-layer signature probe — same model id as OpenAI-direct in Sub-exp 1A, served via Vercel AI Gateway. Tests whether the gateway routing layer injects a distinguishable signature (latency added by the gateway middleware) or transparently passes through. If gateway-routed signature matches OpenAI-direct, gateway is signal-transparent. If distinguishable, the gateway introduces a measurable routing fingerprint — useful for HADF's central dispatch claim (Sub-exp 3 echoes this with Bedrock vs Anthropic-direct same-model routing)."
+    }
+  ],
+  "per_call_controls": {
+    "calls_per_fire": 50,
+    "max_output_tokens": 200,
+    "temperature": 0.7,
+    "timeout_s": 60,
+    "streaming_required": true,
+    "system_prompt": null,
+    "tools": null,
+    "prompt_set_path": ".claude/shared/hadf/phase2bis-prompt-set.json",
+    "prompt_set_sha256": "7b4d9dc9000893fcbec1fde7c75c9e25b41bc2e7c8b05046d6f8a9dfd71c69a4"
+  },
+  "campaign_schedule": {
+    "fires_per_day": 5,
+    "fire_times_utc": [
+      "02:00",
+      "08:00",
+      "14:00",
+      "18:00",
+      "22:00"
+    ],
+    "duration_days": 3,
+    "expected_endpoints_per_fire": 4,
+    "_schedule_note": "Original spec §4 schedule (02/08/14/18/22 UTC). Sub-exp 2 is on a rotated schedule (UTC 05/11/15/19/23 = IDT 08/14/18/22/02) so Sub-exp 1B + Sub-exp 2 never co-fire — 3h offset between any pair of fires across the two sub-exps. No file-write conflicts; no cron lock contention; merge-driver-dedup handles concurrent ledger appends."
+  },
+  "primary_metric": "silhouette score at k=5",
+  "secondary_metrics": [
+    "anchor drift: Mahalanobis distance between Sub-exp 1A's anthropic/claude-haiku-4-5 distribution and Sub-exp 1B's anthropic/claude-haiku-4-5-20251001 distribution; expected < 2σ if no cross-window infrastructure drift",
+    "gateway transparency: Mahalanobis distance between Sub-exp 1A's openai/gpt-4o-mini direct distribution and Sub-exp 1B's vercel-ai-gateway/gpt-4o-mini distribution; if < 2σ gateway is transparent, if > 4σ gateway injects measurable routing signature"
+  ],
+  "expected_yield_threshold": 300,
+  "kill_criteria": [
+    "n_valid < 300",
+    "all endpoints simultaneously rate-limited > 2 fires consecutively",
+    "ANY endpoint changes streaming protocol or model id mid-collection",
+    "wrapper preflight fails 3+ times consecutively"
+  ],
+  "trip_wires": [
+    {
+      "name": "anchor_drift",
+      "applies_to": "subexp1b — vs Sub-exp 1A's anchor",
+      "action": "methodology note, do not abort",
+      "details": "Compute Mahalanobis distance between Sub-exp 1B's anthropic anchor (claude-haiku-4-5-20251001) and Sub-exp 1A's anthropic anchor (claude-haiku-4-5, same model snapshot via alias). If > 2σ flag a methodology note in the verdict; do not invalidate the cross-window drift secondary metric unless drift > 4σ."
+    },
+    {
+      "name": "cost_overrun_3x",
+      "action": "pause for operator review",
+      "note": "Expected ~$1.10 over 3 days (Anthropic $0.12 + Google free + Mistral free-tier-or-$0.90 + Vercel-AI-Gateway $0.10). Pause at ~$3.30."
+    },
+    {
+      "name": "gemini_reasoning_regression",
+      "applies_to": "subexp1b google endpoint",
+      "action": "halt + investigate",
+      "details": "If gemini-2.5-flash-lite responses begin emitting non-zero thoughtsTokenCount mid-collection (Google model-update during the 3-day window), the gemini distribution becomes contaminated with reasoning-latency signal. Heartbeat ledger should monitor; halt sub-exp + decide rerun with fresh anchor if observed."
+    }
+  ],
+  "verdict_thresholds": {
+    "pass_silhouette_min": 0.5,
+    "pass_yield_min": 600,
+    "fail_clusters_lt": 3
+  },
+  "harness_hardening_proof": {
+    "env_local_sha256_at_deploy": "TBD — computed at lock time via shasum -a 256 /Volumes/DevSSD/FitTracker2-feature-hadf-phase2bis-impl/.env.local",
+    "fix1_commit_hash": "442427d feat(hadf-phase2bis-replication): Block A — soak window scaffolding — establishes worktree-local venv pattern (Fix #1) via scripts/hadf-phase2bis-collect.sh preflight Check A (venv binary executable). Carries forward for Sub-exp 1B unchanged.",
+    "preflight_test_log_path": ".claude/shared/hadf/phase2bis-deploy-verification/subexp1b-deliberate-break.log",
+    "state_owner_at_creation": "ft2"
+  },
+  "endpoints_full_design": [
+    {
+      "provider": "anthropic",
+      "endpoint": "claude-haiku-4-5-20251001",
+      "api_kind": "direct"
+    },
+    {
+      "provider": "google",
+      "endpoint": "gemini-2.5-flash-lite",
+      "api_kind": "direct"
+    },
+    {
+      "provider": "mistral",
+      "endpoint": "mistral-large-latest",
+      "api_kind": "direct"
+    },
+    {
+      "provider": "vercel-ai-gateway",
+      "endpoint": "gpt-4o-mini",
+      "api_kind": "gateway"
+    }
+  ],
+  "deferred_endpoints": [
+    {
+      "provider": "xai",
+      "endpoint": "(TBD — grok-4 or grok-2-latest)",
+      "deferred_reason": "Operator decision 2026-05-30: skip xAI for Sub-exp 1B to minimize API surface area + $2-3 cost. Mint key + add as Sub-exp 1C if signature-breadth analysis benefits from a 5th provider. xAI's deferred status is intentional, not a key-acquisition blocker."
+    },
+    {
+      "provider": "openai",
+      "endpoint": "gpt-4o-mini + gpt-4o",
+      "deferred_reason": "Sub-exp 1A already collected 1,100+ records on each. Sub-exp 1B adds vercel-ai-gateway routing of gpt-4o-mini as the gateway probe; direct OpenAI re-sampling would be redundant + the gateway comparison is more informative."
+    }
+  ]
+}

--- a/scripts/hadf-phase2bis-collect.py
+++ b/scripts/hadf-phase2bis-collect.py
@@ -47,6 +47,21 @@ ENDPOINTS = {
         ("anthropic", "claude-haiku-4-5", "direct"),
         ("anthropic", "claude-sonnet-4-6", "direct"),
     ],
+    "subexp1b": [
+        # 2026-05-30 follow-up to Sub-exp 1A. Verifies that the silhouette
+        # signature generalizes to a wider 4-endpoint cloud matrix spanning 4
+        # providers (vs 1A's 2-provider 4-endpoint matrix). Key acquisitions
+        # closed the deferral from 1A: Mistral + Vercel-AI-Gateway minted
+        # 2026-05-30; Google rotated to a non-reasoning model (gemini-2.5-flash-lite
+        # — verified 0 thoughtsTokens at HADF-scale prompts); Anthropic anchor
+        # carries forward from 1A for cross-window drift detection.
+        # xAI deferred per operator decision 2026-05-30 (skip cost + API gateway
+        # surface area until a future Sub-exp 1C if signature breadth demands it).
+        ("anthropic", "claude-haiku-4-5-20251001", "direct"),  # anchor — dated form for lock stability
+        ("google", "gemini-2.5-flash-lite", "direct"),
+        ("mistral", "mistral-large-latest", "direct"),
+        ("vercel-ai-gateway", "gpt-4o-mini", "gateway"),
+    ],
     "subexp2": [
         ("ollama", "llama3.2:3b", "local"),
     ],

--- a/scripts/hadf-phase2bis-collect.sh
+++ b/scripts/hadf-phase2bis-collect.sh
@@ -84,7 +84,14 @@ source "$ENV_FILE"
 set +a
 
 case "$SUBEXP" in
-    subexp1)  REQUIRED_KEYS="OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY VERCEL_AI_GATEWAY_KEY MISTRAL_API_KEY XAI_API_KEY" ;;
+    # subexp1 = original 9-endpoint matrix (narrowed at 2026-05-25 launch to openai+anthropic).
+    #   Typo fix 2026-05-30: VERCEL_AI_GATEWAY_KEY → VERCEL_AI_GATEWAY_API_KEY (matches
+    #   the .env.local naming convention; pre-fix subexp1 would always fail preflight here
+    #   even with a valid key).
+    # subexp1b = 2026-05-30 follow-up: anthropic anchor + google (non-reasoning) +
+    #   mistral + vercel-ai-gateway. xAI deferred per operator decision.
+    subexp1)  REQUIRED_KEYS="OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY VERCEL_AI_GATEWAY_API_KEY MISTRAL_API_KEY XAI_API_KEY" ;;
+    subexp1b) REQUIRED_KEYS="ANTHROPIC_API_KEY GOOGLE_API_KEY MISTRAL_API_KEY VERCEL_AI_GATEWAY_API_KEY" ;;
     subexp2)  REQUIRED_KEYS="" ;;  # Ollama is local, no API key
     subexp3)  REQUIRED_KEYS="OPENAI_API_KEY ANTHROPIC_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY" ;;
     test)     REQUIRED_KEYS="OPENAI_API_KEY" ;;  # for preflight test fixture


### PR DESCRIPTION
## Summary

Scaffolds **HADF Sub-exp 1B** (follow-up to Sub-exp 1A). Adds a 4-endpoint cloud matrix spanning 4 providers — Anthropic (anchor for cross-window drift) + Google (non-reasoning Gemini) + Mistral (new) + Vercel AI Gateway (routing-layer probe).

Sub-exp 1B can run **in parallel with Sub-exp 2** (which is collecting Ollama-local data on UTC 05/11/15/19/23). Sub-exp 1B uses UTC 02/08/14/18/22 — 3-hour offset, zero cron collisions, no resource contention (cloud APIs vs M2 GPU).

## Endpoint matrix

| # | Provider | Endpoint | Role |
|---|---|---|---|
| 1 | anthropic | `claude-haiku-4-5-20251001` | Anchor — cross-window drift vs Sub-exp 1A's bare alias |
| 2 | google | `gemini-2.5-flash-lite` | Non-reasoning Gemini (verified 0 thoughtsTokens at HADF prompt sizes) |
| 3 | mistral | `mistral-large-latest` | First Mistral inclusion |
| 4 | vercel-ai-gateway | `gpt-4o-mini` | Routing-layer signature probe vs Sub-exp 1A's OpenAI-direct |

**xAI deferred** per operator decision (skip $2-3 cost + an extra API surface area until a future Sub-exp 1C if breadth analysis warrants it).

## What ships

| File | Change |
|---|---|
| `scripts/hadf-phase2bis-collect.py` | `ENDPOINTS["subexp1b"]` entry with 4-tuple list + rationale comments |
| `scripts/hadf-phase2bis-collect.sh` | `subexp1b` REQUIRED_KEYS case **+ typo fix**: `VERCEL_AI_GATEWAY_KEY` → `VERCEL_AI_GATEWAY_API_KEY` on subexp1's case (pre-fix subexp1 always failed preflight) |
| `.claude/shared/hadf/preregistration-phase2bis-subexp1b.json` | Full pre-ceremony prereg with concrete values; TBD only for `env_local_sha256_at_deploy` (computed at lock time) |
| `.claude/features/hadf-phase2bis-replication/launchd-templates/com.fitme.hadf-phase2bis-subexp1b.plist.template` | UTC 02/08/14/18/22 schedule, /tmp logs, /bin/bash invocation (3 macOS gotchas applied) |

## Verification

- [x] Python syntax (`ast.parse`)
- [x] Bash syntax (`bash -n`)
- [x] JSON validity (`json.load` — 14 top-level keys)
- [x] Plist XML validity (`plutil -lint`)
- [x] ENDPOINTS["subexp1b"] correctly populated
- [x] **Live end-to-end test on HADF worktree's venv + .env.local — all 4 endpoints respond:**
  - anthropic claude-haiku-4-5-20251001: ttft=0.78s, tps=59
  - google gemini-2.5-flash-lite: ttft=0.92s, tokens=5 (TPS artifact from tiny sample)
  - mistral mistral-large-latest: ttft=0.005s, tps=52
  - vercel-ai-gateway gpt-4o-mini: ttft=0.33s, tps=50.5
- [x] Touch ID signed commit
- [x] Branch isolation: feat branch on isolated worktree

## ⚠ Prerequisite

**Depends on PR #532 landing first** (the `prompt_obj['text']` extract fix). Without #532, Sub-exp 1B will fire 100% errors on main — the same bug that broke Sub-exp 2's first launch this morning.

Recommended merge order: #532 → this PR.

If #532 is delayed, the operator can still launch Sub-exp 1B from the HADF worktree (which has the local fix `f174ef9`); this PR just gets the ENDPOINTS + REQUIRED_KEYS + prereg + plist into main for posterity.

## Operator post-merge steps to launch Sub-exp 1B

1. Refresh HADF worktree from main (operator's call: cherry-pick / rebase / pull)
2. `bash scripts/hadf-phase2bis-smoke-fire.sh subexp1b` (validates preflight passes with new REQUIRED_KEYS)
3. `bash scripts/hadf-phase2bis-lock-prereg.sh subexp1b` (cryptographic lock — may need `--no-verify` per [v7.9.1 F-LOCK-INTRODUCING-COMMIT-PERMIT](.) hook bypass)
4. Install + bootstrap plist:
   ```bash
   cp .claude/features/hadf-phase2bis-replication/launchd-templates/com.fitme.hadf-phase2bis-subexp1b.plist.template \
      ~/Library/LaunchAgents/com.fitme.hadf-phase2bis-subexp1b.plist
   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fitme.hadf-phase2bis-subexp1b.plist
   ```
5. (Optional) Manual Fire 0 to start collection now: `bash scripts/hadf-phase2bis-collect.sh --subexp subexp1b`

## Estimated cost (3-day window)

| Endpoint | Calls | Cost |
|---|---|---|
| anthropic claude-haiku-4-5-20251001 | 750 | ~$0.12 |
| google gemini-2.5-flash-lite | 750 | $0 (free tier covers) |
| mistral mistral-large-latest | 750 | $0-0.90 (free tier or paid) |
| vercel-ai-gateway gpt-4o-mini | 750 | ~$0.10 |
| **Total** | **3,000** | **~$1.10 worst case** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)