### PR TITLE
feat(hadf-phase2bis): verdict-script --metric signature_delta_ratio for Sub-exp 3

### DIFF
--- a/scripts/hadf-phase2bis-verdict.py
+++ b/scripts/hadf-phase2bis-verdict.py
@@ -3,7 +3,7 @@
 Loads all phase2bis-raw-<subexp>-*.jsonl files in --raw-dir, filters
 status=='ok', computes either:
 
-  --metric silhouette  (default, Sub-exp 1 + 1B + 3)
+  --metric silhouette  (default, Sub-exp 1 + 1B)
     Silhouette score at k=5 over (ttft_s, tps); PASS if silhouette ≥
     threshold AND yield ≥ yield_min AND clusters ≥ clusters_min.
 
@@ -15,9 +15,24 @@ status=='ok', computes either:
     dimensions) AND yield ≥ yield_min. Per Sub-exp 2 prereg primary
     metric `pass_ks_p_max=0.01` + `pass_yield_min=250`.
 
+  --metric signature_delta_ratio  (Sub-exp 3 Bedrock-vs-Anthropic-direct
+    routing test; added 2026-05-31)
+    Mahalanobis-distance effect-size between the routing-test target
+    provider's records (default: aws-bedrock) and the routing-anchor
+    provider's records (default: anthropic), expressed in units of the
+    intra-anchor noise floor (Mahalanobis radius within the anchor
+    relative to itself). Per Sub-exp 3 prereg verdict_thresholds:
+      ratio > 2.0  → PASS  (Bedrock distinguishable from Anthropic-direct
+                            — central HADF dispatch claim survives)
+      ratio < 1.0  → FAIL  (signatures indistinguishable — HADF claim
+                            REFUTED on this metric)
+      1.0 ≤ r ≤ 2.0 → INCONCLUSIVE
+
 The --subexp argument selects target records from filenames matching
 `phase2bis-raw-<subexp>-*.jsonl`. For --metric ks, --anchor-subexp
-selects the anchor (default: subexp1) from the same --raw-dir.
+selects the anchor (default: subexp1) from the same --raw-dir. For
+--metric signature_delta_ratio, --routing-target-provider and
+--routing-anchor-provider slice within the --subexp's records.
 """
 import argparse
 import json
@@ -207,16 +222,156 @@ def _ks_verdict(args, target_records):
     print(json.dumps(report))
 
 
+def _signature_delta_ratio_verdict(args, target_records):
+    """Sub-exp 3 Bedrock-vs-Anthropic-direct routing-test verdict.
+
+    Computes the inter-provider Mahalanobis distance between the routing-
+    test target provider (default aws-bedrock) and the routing anchor
+    provider (default anthropic) on (ttft_s, tps), then expresses it in
+    units of the intra-anchor noise floor (median per-fire centroid
+    spread within the anchor). Per Sub-exp 3 prereg verdict thresholds:
+
+      ratio > pass_threshold  → PASS  (HADF dispatch claim survives)
+      ratio < fail_threshold  → FAIL  (HADF claim REFUTED on this metric)
+      between thresholds      → INCONCLUSIVE
+
+    Requires scipy + numpy.
+    """
+    try:
+        import numpy as np
+    except ImportError:
+        print(json.dumps({
+            "subexp": args.subexp,
+            "metric": "signature_delta_ratio",
+            "verdict": "ERROR",
+            "fail_reason": "numpy_unavailable",
+        }))
+        sys.exit(2)
+
+    def _filter(records, provider, endpoint):
+        out = []
+        for r in records:
+            if r.get("provider") != provider:
+                continue
+            if endpoint is not None and r.get("endpoint") != endpoint:
+                continue
+            out.append(r)
+        return out
+
+    anchor_records = _filter(
+        target_records,
+        args.routing_anchor_provider,
+        args.routing_anchor_endpoint,
+    )
+    routing_records = _filter(
+        target_records,
+        args.routing_target_provider,
+        args.routing_target_endpoint,
+    )
+
+    n_anchor = len(anchor_records)
+    n_routing = len(routing_records)
+
+    if n_routing < args.yield_min:
+        print(json.dumps({
+            "subexp": args.subexp,
+            "metric": "signature_delta_ratio",
+            "yield_target": int(n_routing),
+            "yield_anchor": int(n_anchor),
+            "routing_target_provider": args.routing_target_provider,
+            "routing_anchor_provider": args.routing_anchor_provider,
+            "verdict": "FAIL",
+            "fail_reason": "low_yield_target",
+            "yield_min_required": int(args.yield_min),
+        }))
+        return
+
+    if n_anchor < args.yield_min:
+        print(json.dumps({
+            "subexp": args.subexp,
+            "metric": "signature_delta_ratio",
+            "yield_target": int(n_routing),
+            "yield_anchor": int(n_anchor),
+            "routing_target_provider": args.routing_target_provider,
+            "routing_anchor_provider": args.routing_anchor_provider,
+            "verdict": "INCONCLUSIVE",
+            "fail_reason": "low_yield_anchor",
+            "yield_min_required": int(args.yield_min),
+        }))
+        return
+
+    X_anchor = np.array([[r["ttft_s"], r["tps"]] for r in anchor_records])
+    X_routing = np.array([[r["ttft_s"], r["tps"]] for r in routing_records])
+
+    mean_anchor = X_anchor.mean(axis=0)
+    mean_routing = X_routing.mean(axis=0)
+    diff = mean_routing - mean_anchor
+
+    # Intra-anchor covariance — the noise floor scale
+    cov_anchor = np.cov(X_anchor.T)
+    # Add tiny ridge for numerical stability when ttft + tps are tightly correlated
+    ridge = 1e-9 * np.trace(cov_anchor) * np.eye(2)
+    cov_inv = np.linalg.pinv(cov_anchor + ridge)
+
+    inter_mahalanobis = float(np.sqrt(diff @ cov_inv @ diff))
+
+    # Intra-anchor noise floor: expected Mahalanobis radius of anchor points
+    # from anchor mean using the same covariance. This is 1.0 in expectation
+    # if the cov is well-fit, so the ratio = inter / 1 in units of "anchor std-dev".
+    intra_distances = np.array([
+        np.sqrt((p - mean_anchor) @ cov_inv @ (p - mean_anchor))
+        for p in X_anchor
+    ])
+    intra_noise = float(np.median(intra_distances))
+    intra_noise = max(intra_noise, 1e-9)  # avoid division by zero
+
+    ratio = inter_mahalanobis / intra_noise
+
+    if ratio > args.pass_threshold:
+        verdict = "PASS"
+        fail_reason = None
+    elif ratio < args.fail_threshold:
+        verdict = "FAIL"
+        fail_reason = "signatures_indistinguishable"
+    else:
+        verdict = "INCONCLUSIVE"
+        fail_reason = "in_inconclusive_band"
+
+    report = {
+        "subexp": args.subexp,
+        "metric": "signature_delta_ratio",
+        "yield_target": int(n_routing),
+        "yield_anchor": int(n_anchor),
+        "routing_target_provider": args.routing_target_provider,
+        "routing_target_endpoint": args.routing_target_endpoint,
+        "routing_anchor_provider": args.routing_anchor_provider,
+        "routing_anchor_endpoint": args.routing_anchor_endpoint,
+        "inter_mahalanobis": inter_mahalanobis,
+        "intra_anchor_noise_floor": intra_noise,
+        "signature_delta_ratio": ratio,
+        "thresholds": {
+            "pass_threshold": float(args.pass_threshold),
+            "fail_threshold": float(args.fail_threshold),
+            "yield_min": int(args.yield_min),
+        },
+        "verdict": str(verdict),
+        "fail_reason": fail_reason,
+    }
+    print(json.dumps(report))
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--raw-dir", required=True)
     p.add_argument("--subexp", required=True)
     p.add_argument(
         "--metric",
-        choices=["silhouette", "ks"],
+        choices=["silhouette", "ks", "signature_delta_ratio"],
         default="silhouette",
-        help="silhouette = Sub-exp 1/1B/3 fingerprint clustering; "
-             "ks = Sub-exp 2 cloud-vs-local Kolmogorov-Smirnov test",
+        help="silhouette = Sub-exp 1/1B fingerprint clustering; "
+             "ks = Sub-exp 2 cloud-vs-local Kolmogorov-Smirnov test; "
+             "signature_delta_ratio = Sub-exp 3 Bedrock-vs-Anthropic-direct "
+             "routing-test Mahalanobis effect size",
     )
     # Silhouette-mode args
     p.add_argument("--silhouette-min", type=float, default=0.5)
@@ -235,6 +390,41 @@ def main():
         help="For --metric ks: KS p-value below which distributions "
              "are considered distinguishable. Sub-exp 2 prereg = 0.01.",
     )
+    # signature_delta_ratio mode args (Sub-exp 3 routing test)
+    p.add_argument(
+        "--routing-target-provider",
+        default="aws-bedrock",
+        help="For --metric signature_delta_ratio: routing-test target provider",
+    )
+    p.add_argument(
+        "--routing-target-endpoint",
+        default=None,
+        help="For --metric signature_delta_ratio: optional endpoint filter on target",
+    )
+    p.add_argument(
+        "--routing-anchor-provider",
+        default="anthropic",
+        help="For --metric signature_delta_ratio: routing-anchor provider",
+    )
+    p.add_argument(
+        "--routing-anchor-endpoint",
+        default=None,
+        help="For --metric signature_delta_ratio: optional endpoint filter on anchor",
+    )
+    p.add_argument(
+        "--pass-threshold",
+        type=float,
+        default=2.0,
+        help="For --metric signature_delta_ratio: ratio above which routing test PASSes. "
+             "Sub-exp 3 prereg = 2.0.",
+    )
+    p.add_argument(
+        "--fail-threshold",
+        type=float,
+        default=1.0,
+        help="For --metric signature_delta_ratio: ratio below which routing test FAILs. "
+             "Sub-exp 3 prereg = 1.0.",
+    )
     # Shared
     p.add_argument(
         "--yield-min",
@@ -251,6 +441,8 @@ def main():
         _silhouette_verdict(args, target_records)
     elif args.metric == "ks":
         _ks_verdict(args, target_records)
+    elif args.metric == "signature_delta_ratio":
+        _signature_delta_ratio_verdict(args, target_records)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the **\`--metric signature_delta_ratio\`** path to \`scripts/hadf-phase2bis-verdict.py\` so Sub-exp 3 (Bedrock vs Anthropic-direct routing test — the central HADF falsification experiment per spec §1 RQ3) has its verdict mode ready before launch.

Closes the **second half** of HADF runbook §232. The \`--metric ks\` half for Sub-exp 2 shipped 2026-05-30 via [PR #536](https://github.com/Regevba/FitTracker2/pull/536). This PR completes the verdict-script extension; both halves now ready before their respective closure windows.

## Math

For each provider's records, compute joint (ttft_s, tps) distribution:
- Inter-provider effect: Mahalanobis distance between provider means using intra-anchor covariance (with tiny ridge for numerical stability)
- Intra-anchor noise floor: median Mahalanobis radius of anchor points from anchor mean using the same covariance
- **\`signature_delta_ratio = inter / intra\`** — expresses the cross-provider mean shift in units of intra-anchor standard deviations

Per Sub-exp 3 prereg verdict_thresholds:
- **ratio > 2.0** → PASS (HADF dispatch claim survives — Bedrock and Anthropic-direct have distinguishable streaming signatures)
- **ratio < 1.0** → FAIL (signatures indistinguishable — HADF claim REFUTED on this metric)
- **1.0 ≤ r ≤ 2.0** → INCONCLUSIVE

## Verification — live smoke against Sub-exp 1A data

Sub-exp 3 hasn't launched yet (awaits operator AWS Bedrock setup). Used Sub-exp 1A's 2-provider matrix (openai + anthropic) as proof-of-concept:

| Test | Result |
|---|---|
| \`--metric silhouette --subexp subexp1\` (backwards compat) | ✅ PASS · silhouette=**0.700** · clusters=5 |
| \`--metric ks --subexp subexp2\` (backwards compat) | ✅ PASS · KS TTFT p=9.3e-62 · KS TPS p=1.3e-204 |
| **\`--metric signature_delta_ratio\` openai vs anthropic** | ✅ PASS · ratio=**6.62** · inter=1.29 · intra=0.19 |
| \`--metric signature_delta_ratio\` same provider both sides (degenerate) | ✅ FAIL · fail_reason=\`signatures_indistinguishable\` · ratio=0.0 |
| \`--metric signature_delta_ratio --yield-min 5000\` (low yield) | ✅ FAIL · fail_reason=\`low_yield_target\` |

The openai-vs-anthropic ratio of **6.62** confirms real cross-provider distinguishability (well above 2.0 PASS threshold) — sanity check that the metric is sensitive to real signature differences.

## New CLI args (signature_delta_ratio mode only)

| Arg | Default | Purpose |
|---|---|---|
| \`--routing-target-provider\` | \`aws-bedrock\` | Routing-test target (Sub-exp 3 Bedrock side) |
| \`--routing-target-endpoint\` | None | Optional endpoint filter on target |
| \`--routing-anchor-provider\` | \`anthropic\` | Routing-anchor (Sub-exp 3 Anthropic-direct side) |
| \`--routing-anchor-endpoint\` | None | Optional endpoint filter on anchor |
| \`--pass-threshold\` | 2.0 | Per prereg verdict_thresholds.pass_signature_delta_ratio_gt |
| \`--fail-threshold\` | 1.0 | Per prereg verdict_thresholds.fail_signature_delta_ratio_lt |

## Phase E safety

- ✅ Non-gate code extension (analysis script, not enforcement)
- ✅ Backward-compatible defaults preserve existing behavior
- ✅ Isolated worktree off origin/main
- ✅ Sub-exp 2 (LIVE, mid-campaign) unaffected — different metric path
- ✅ No new dependencies — numpy already required for silhouette mode

## Test plan

- [x] \`python3 -m py_compile\` passes
- [x] Live smoke against Sub-exp 1A for all 3 verdict paths
- [x] Backward compat verified for silhouette + ks modes
- [x] Degenerate case (same provider) correctly returns ratio=0.0
- [x] Low-yield FAIL branch verified
- [ ] CI green
- [ ] Re-run with real Sub-exp 3 Bedrock data when collection closes (~2026-06-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)