### PR TITLE
feat(smart-reminders): C1 item #1 — route scheduleIfAllowed through NotificationGateway (L207)

### DIFF
--- a/FitTracker/Services/Reminders/ReminderScheduler.swift
+++ b/FitTracker/Services/Reminders/ReminderScheduler.swift
@@ -34,39 +34,39 @@ final class ReminderScheduler: ObservableObject {
 
     // ── Public API ───────────────────────────────────────
 
-    /// Schedules a reminder notification if all frequency and quiet-hour guards
-    /// pass.  Silently no-ops when any guard rejects the request.
+    /// Schedules a reminder notification if all smart-reminder guards pass AND
+    /// the v2 NotificationGateway accepts the dispatch.
+    ///
+    /// **Guard ownership split (C1 item #1, 2026-05-31):**
+    ///
+    /// - Smart-reminders owns: per-type daily cap, per-type lifetime cap, minimum
+    ///   interval between any two reminders. These are smart-reminders' policy and
+    ///   the gateway has no concept of `ReminderType`.
+    /// - `NotificationGateway` owns: authorization, quiet hours, global standard-tag
+    ///   cap (3/day). Routing through the gateway means smart-reminders + future
+    ///   consumers (ReadinessAlertObserver, etc.) share one accurate cap counter.
+    ///
+    /// Silently no-ops when any guard rejects the request. Analytics events are
+    /// emitted at every gate so downstream funnel analysis can attribute drop-off.
     ///
     /// - Parameters:
     ///   - type:         The `ReminderType` that categorises this notification.
     ///   - body:         The notification body string (personalised by the caller).
     ///   - delayMinutes: How many minutes from now the notification should fire.
-    ///                   Pass `0` to fire after a 1-second delay (effectively
-    ///                   immediate, required by UNTimeIntervalNotificationTrigger).
+    ///                   Pass `0` to fire after a 1-second delay (required by
+    ///                   `UNTimeIntervalNotificationTrigger`).
     func scheduleIfAllowed(
         type: ReminderType,
         body: String,
         delayMinutes: Int = 0
     ) async {
-        // 1. Quiet-hours guard
-        guard !isQuietHour() else {
-            analytics?.logReminderSuppressed(type: type.rawValue, reason: "quiet_hours")
-            return
-        }
-
-        // 2. Global daily cap — use actual send count (more reliable than pending queue)
-        guard todaySendCount() < maxDailyGlobal else {
-            analytics?.logReminderSuppressed(type: type.rawValue, reason: "global_daily_cap")
-            return
-        }
-
-        // 3. Per-type daily cap (resets at midnight via key naming)
+        // 1. Per-type daily cap (resets at midnight via key naming)
         guard !dailyCapReached(for: type) else {
             analytics?.logReminderSuppressed(type: type.rawValue, reason: "per_type_daily_cap")
             return
         }
 
-        // 4. Per-type lifetime cap
+        // 2. Per-type lifetime cap
         if let maxLifetime = type.maxLifetime {
             let sent = lifetimeSentCount(for: type)
             guard sent < maxLifetime else {
@@ -76,7 +76,7 @@ final class ReminderScheduler: ObservableObject {
             }
         }
 
-        // 5. Minimum interval since last reminder of any type
+        // 3. Minimum interval since last reminder of any type
         guard minimumIntervalElapsed() else {
             analytics?.logReminderSuppressed(type: type.rawValue, reason: "min_interval")
             return
@@ -101,21 +101,34 @@ final class ReminderScheduler: ObservableObject {
             repeats: false
         )
 
-        let request = UNNotificationRequest(
-            identifier: "\(type.rawValue)_\(Date().timeIntervalSince1970)",
+        // Route through the v2 NotificationGateway (auth + quiet hours +
+        // standard-tag global cap all enforced there).
+        let result = await NotificationGateway.shared.dispatch(
             content: content,
-            trigger: trigger
+            trigger: trigger,
+            consumerID: SmartRemindersConsumerRegistration.consumerID,
+            tag: .standard
         )
 
-        do {
-            try await center.add(request)
+        switch result {
+        case .dispatched:
             recordScheduled(for: type)
             incrementDailyCount()
             scheduledCount += 1
             analytics?.logReminderScheduled(type: type.rawValue)
-        } catch {
-            // Notifications are best-effort; silent failure is intentional.
-            analytics?.logReminderSuppressed(type: type.rawValue, reason: "system_add_failed")
+        case .denied_unauthorized:
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: "system_unauthorized")
+        case .suppressed(let reason):
+            // Map gateway suppression reasons to existing smart-reminder analytics
+            // taxonomy where possible; otherwise emit the gateway's raw reason.
+            let mapped: String
+            switch reason {
+            case .quiet_hours:       mapped = "quiet_hours"
+            case .standard_cap:      mapped = "global_daily_cap"
+            case .critical_cap:      mapped = "critical_cap"  // shouldn't fire for smart-reminders (tag=.standard)
+            case .scheduling_failed: mapped = "system_add_failed"
+            }
+            analytics?.logReminderSuppressed(type: type.rawValue, reason: mapped)
         }
     }
 


### PR DESCRIPTION
## Summary

L207 backlog "Smart Reminders ↔ Push Notifications v2 deep-link integration" item **#1 of 4**. Builds on the consumer-registration foundation shipped via PR #551.

`ReminderScheduler.scheduleIfAllowed(...)` previously called `UNUserNotificationCenter.current().add(_:)` directly with its own auth + quiet-hours + global-cap checks duplicating what the v2 `NotificationGateway` already enforces. After this PR, the scheduler calls `NotificationGateway.shared.dispatch(...)` and maps the result back into the existing smart-reminders analytics taxonomy.

## Guard ownership split (post-refactor)

| Guard | Owner | Why |
|---|---|---|
| Authorization | Gateway | Single source of truth across consumers |
| Quiet hours (22:00–07:00) | Gateway | Same |
| Standard-tag daily cap (3/day) | Gateway | Shared across all standard-tagged consumers — no double-counting |
| Per-type daily cap | ReminderScheduler | Gateway has no `ReminderType` concept |
| Per-type lifetime cap | ReminderScheduler | Same |
| Minimum interval (4h) | ReminderScheduler | Smart-reminders policy, not platform policy |

## Behavior change (intentional)

Global standard-tag cap is now shared. Before: smart-reminders had its own `ft.reminder.dailyCount.<date>` counter, readinessAlert had `ft.notification.gateway.standardCount.<date>`. A smart-reminders dispatch did NOT decrement readinessAlert's budget and vice versa. After: both budget against `ft.notification.gateway.standardCount.<date>`. This is the documented v2 platform behavior — single shared cap across consumers.

Smart-reminders still maintains its own `ft.reminder.dailyCount.<date>` for backward-compatible analytics (`incrementDailyCount()` still runs on successful dispatch). Future cleanup may drop the redundant counter.

## Suppression-reason analytics mapping

| Gateway reason | Mapped smart-reminders reason |
|---|---|
| `quiet_hours` | `quiet_hours` (preserved) |
| `standard_cap` | `global_daily_cap` (preserved — same GA4 dashboard) |
| `critical_cap` | `critical_cap` (defensive, shouldn't fire on `.standard` tag) |
| `scheduling_failed` | `system_add_failed` (preserved) |
| `denied_unauthorized` | `system_unauthorized` (new — gateway gates auth) |

## What's deferred (C1 items #3 + #4)

- **Item #3**: `ReminderType.deepLink` inline strings migrate to `DeepLinkRouter` registration entries. Separate ~30min PR.
- **Item #4**: `ReminderNotificationDelegate.didReceive` either keeps the `.fitMeReminderTapped` broadcast OR calls `DeepLinkRouter.handle(url:source:)` directly. Separate ~30min PR.

## Phase E compliance

- No new framework gates
- No state.json mutations
- No infra-glob touches
- 0+0 integrity baseline preserved

## Test plan

- [x] Existing `ReminderSchedulerTests` (contract assertions on `ReminderType.maxPerDay > 0`) unaffected — refactor preserves the contract
- [x] Existing `NotificationGatewayTests` unaffected — gateway behavior unchanged
- [x] Existing `SmartRemindersConsumerRegistrationTests` (PR #551) unaffected — registration still works
- [ ] CI: `xcodebuild build` — verifies refactor compiles + types resolve (NotificationGateway shared + SmartRemindersConsumerRegistration.consumerID)
- [ ] CI: `xcodebuild test` — verifies no test regressions
- [ ] Manual smoke (operator): trigger a smart reminder → confirm it fires through the gateway path + analytics shows expected suppression-reason taxonomy

🤖 Generated with [Claude Code](https://claude.com/claude-code)