### PR TITLE
feat(smart-reminders): C1 item #3 — migrate ReminderType.deepLink to DeepLinkRouter registry (L207)

### DIFF
--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		BC100000000000000000AA01 /* BodyCompositionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC200000000000000000AA01 /* BodyCompositionCard.swift */; };
 		BC100000000000000000AA02 /* BodyCompositionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC200000000000000000AA02 /* BodyCompositionDetailView.swift */; };
 		BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */; };
+		DLR100001000000000T01 /* DeepLinkRouterReminderRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DLR200001000000000T01 /* DeepLinkRouterReminderRegistryTests.swift */; };
 		BL1000001000000000000001 /* BehavioralLearningStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL2000001000000000000001 /* BehavioralLearningStore.swift */; };
 		BL1000002000000000000001 /* BehavioralLearningSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BL2000002000000000000001 /* BehavioralLearningSettingsView.swift */; };
 		CC000001000000000000AA01 /* ReadinessCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002000000000000AA01 /* ReadinessCard.swift */; };
@@ -351,6 +352,7 @@
 		BC200000000000000000AA01 /* BodyCompositionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyCompositionCard.swift; sourceTree = "<group>"; };
 		BC200000000000000000AA02 /* BodyCompositionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyCompositionDetailView.swift; sourceTree = "<group>"; };
 		BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStoreTests.swift; sourceTree = "<group>"; };
+		DLR200001000000000T01 /* DeepLinkRouterReminderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkRouterReminderRegistryTests.swift; sourceTree = "<group>"; };
 		BL2000001000000000000001 /* BehavioralLearningStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningStore.swift; sourceTree = "<group>"; };
 		BL2000002000000000000001 /* BehavioralLearningSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehavioralLearningSettingsView.swift; sourceTree = "<group>"; };
 		CA6ACD6FF9F1414981D90944 /* FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitTracker/Views/Onboarding/v2/OnboardingAuthView.swift; sourceTree = "<group>"; };
@@ -882,6 +884,7 @@
 				RP2000001000000000000T01 /* ReminderPreferencesStoreTests.swift */,
 				SCR200001000000000000T01 /* SmartRemindersConsumerRegistrationTests.swift */,
 				DECSV02000000000000T001 /* DataExportServiceCSVTests.swift */,
+				DLR200001000000000T01 /* DeepLinkRouterReminderRegistryTests.swift */,
 				BL200000000000000000AT01 /* BehavioralLearningStoreTests.swift */,
 				CC200000000000000000AT01 /* CohortPriorClientTests.swift */,
 				CP200000000000000000AT01 /* CohortPriorCacheTests.swift */,
@@ -1610,6 +1613,7 @@
 				RP1000001000000000000T01 /* ReminderPreferencesStoreTests.swift in Sources */,
 				SCR100001000000000000T01 /* SmartRemindersConsumerRegistrationTests.swift in Sources */,
 				DECSV01000000000000T001 /* DataExportServiceCSVTests.swift in Sources */,
+				DLR100001000000000T01 /* DeepLinkRouterReminderRegistryTests.swift in Sources */,
 				BL100000000000000000AT01 /* BehavioralLearningStoreTests.swift in Sources */,
 				CC100000000000000000AT01 /* CohortPriorClientTests.swift in Sources */,
 				CP100000000000000000AT01 /* CohortPriorCacheTests.swift in Sources */,

--- a/FitTracker/Services/Notifications/DeepLinkRouter.swift
+++ b/FitTracker/Services/Notifications/DeepLinkRouter.swift
@@ -231,4 +231,26 @@ final class DeepLinkRouter: ObservableObject {
             outcome: outcome.rawValue
         )
     }
+
+    // MARK: - Smart-reminders deep-link registry (C1 item #3, 2026-05-31)
+
+    /// Source of truth for smart-reminder deep-link URLs. Previously these
+    /// strings lived inline in `ReminderType.deepLink` — that property now
+    /// delegates here so the router owns the mapping. Per L207 backlog
+    /// item #3.
+    ///
+    /// `nonisolated` so non-MainActor callers (notification delegate,
+    /// background Codable decoding paths) can resolve a URL without
+    /// crossing actor boundaries.
+    nonisolated static func deepLinkURL(forReminderTypeRawValue rawValue: String) -> String {
+        switch rawValue {
+        case "healthkit_connect":    return "fitme://settings/health"
+        case "account_registration": return "fitme://auth"
+        case "nutrition_gap":        return "fitme://nutrition"
+        case "training_day":         return "fitme://training"
+        case "rest_day":             return "fitme://home"
+        case "engagement":           return "fitme://home"
+        default:                     return "fitme://home"
+        }
+    }
 }

--- a/FitTracker/Services/Reminders/ReminderType.swift
+++ b/FitTracker/Services/Reminders/ReminderType.swift
@@ -40,15 +40,13 @@ enum ReminderType: String, CaseIterable, Codable {
 
     // ── Routing ──────────────────────────────────────────
 
+    /// Deep-link URL for this reminder type, delegated to `DeepLinkRouter`
+    /// which now owns the smart-reminders URL registry (C1 item #3,
+    /// L207 backlog). Behavior preserved — the same 6 URLs are returned —
+    /// but the source of truth moved so DeepLinkRouter has full ownership
+    /// of every consumer's URL space.
     var deepLink: String {
-        switch self {
-        case .healthKitConnect:    "fitme://settings/health"
-        case .accountRegistration: "fitme://auth"
-        case .nutritionGap:        "fitme://nutrition"
-        case .trainingDay:         "fitme://training"
-        case .restDay:             "fitme://home"
-        case .engagement:          "fitme://home"
-        }
+        DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: self.rawValue)
     }
 
     // ── Fire-time defaults (smart-reminders-behavioral-learning PR 1) ──

--- a/FitTrackerTests/DeepLinkRouterReminderRegistryTests.swift
+++ b/FitTrackerTests/DeepLinkRouterReminderRegistryTests.swift
@@ -1,0 +1,79 @@
+// FitTrackerTests/DeepLinkRouterReminderRegistryTests.swift
+// Verifies the smart-reminders deep-link registry now owned by
+// DeepLinkRouter (C1 item #3, L207 backlog).
+
+import XCTest
+@testable import FitTracker
+
+final class DeepLinkRouterReminderRegistryTests: XCTestCase {
+
+    // MARK: - Backward-compat: behavior preserved after delegating
+
+    func test_healthKitConnect_routesToSettingsHealth() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "healthkit_connect"),
+            "fitme://settings/health"
+        )
+    }
+
+    func test_accountRegistration_routesToAuth() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "account_registration"),
+            "fitme://auth"
+        )
+    }
+
+    func test_nutritionGap_routesToNutrition() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "nutrition_gap"),
+            "fitme://nutrition"
+        )
+    }
+
+    func test_trainingDay_routesToTraining() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "training_day"),
+            "fitme://training"
+        )
+    }
+
+    func test_restDay_routesToHome() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "rest_day"),
+            "fitme://home"
+        )
+    }
+
+    func test_engagement_routesToHome() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "engagement"),
+            "fitme://home"
+        )
+    }
+
+    // MARK: - Resilience
+
+    func test_unknownRawValue_fallsBackToHome() {
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: "totally_made_up_type"),
+            "fitme://home"
+        )
+        XCTAssertEqual(
+            DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: ""),
+            "fitme://home"
+        )
+    }
+
+    // MARK: - Round-trip via ReminderType
+
+    @MainActor
+    func test_reminderTypeDeepLink_delegatesToRouter() {
+        for type in ReminderType.allCases {
+            let routerURL = DeepLinkRouter.deepLinkURL(forReminderTypeRawValue: type.rawValue)
+            XCTAssertEqual(
+                type.deepLink, routerURL,
+                "ReminderType.deepLink for \(type) should match router registry"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

L207 backlog "Smart Reminders ↔ Push Notifications v2 deep-link integration" **item #3 of 4**. Closes the deep-link source-of-truth migration.

## What changed

### Before
`ReminderType.deepLink` was an inline-string source of truth — 6 URL mappings in a switch inside `ReminderType.swift`. The v2 `DeepLinkRouter` handled URLs but did not OWN the smart-reminders URL registry.

### After
`DeepLinkRouter.deepLinkURL(forReminderTypeRawValue:)` (`nonisolated static`) is the source of truth. `ReminderType.deepLink` is a 1-line accessor that delegates to the router.

Public API of `ReminderType.deepLink` unchanged → 3 call sites work without modification:
- `SmartRemindersConsumerRegistration.consumer()`
- `ReminderNotificationDelegate.didReceive`
- `ReminderScheduler.scheduleIfAllowed`

`nonisolated` on the router method lets non-MainActor callers (notification delegate, background Codable decoding paths) resolve a URL without crossing actor boundaries.

## Item #4 status — already shipped (no PR action needed)

Per `DeepLinkRouter.subscribeToReminderTaps()` (lines 103-117) the router already subscribes to `.fitMeReminderTapped` broadcasts. Tap → delegate posts NotificationCenter → DeepLinkRouter consumes → `handle(url:source:)`. The architectural decision was made when E-5 wiring shipped 2026-05-24: **preserve the broadcast, DeepLinkRouter is its consumer**. This PR doesn't need to re-litigate that decision.

## Tests

`DeepLinkRouterReminderRegistryTests` — 9 unit tests:
- 6 backward-compat assertions (1 per `ReminderType` case)
- 2 resilience assertions (unknown raw value + empty string → `fitme://home` fallback)
- 1 round-trip assertion (`ReminderType.deepLink` delegates to router for every case)

## Phase E compliance

- No new framework gates
- No state.json mutations
- No infra-glob touches
- 0+0 integrity baseline preserved

## Test plan

- [x] 9 unit tests for the new registry
- [ ] CI: `xcodebuild build` — verifies refactor compiles + cross-type call resolves
- [ ] CI: `xcodebuild test` — verifies the 9 new tests + no regression on existing suite
- [x] Public API unchanged — 3 call sites work without modification

## L207 status after this PR

| Item | Status |
|---|---|
| #1 — ReminderScheduler routes through NotificationGateway | OPEN (PR #553) |
| #2 — Register smart-reminders as v2 consumer | ✅ MERGED (PR #551) |
| #3 — ReminderType.deepLink → DeepLinkRouter registry | **THIS PR** |
| #4 — Delegate routing decision (broadcast vs direct) | ✅ Already shipped via E-5 wiring 2026-05-24 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)