### PR TITLE
feat(dynamic-type): L353 Phase 1 — @ScaledMetric on 4 v2 icon containers

### DIFF
--- a/FitTracker/Views/Auth/AuthHubView.swift
+++ b/FitTracker/Views/Auth/AuthHubView.swift
@@ -428,12 +428,16 @@ private struct AuthProviderRow: View {
     let subtitle: String
     let tint: Color
 
+    // L353 Phase 1 (2026-05-31): scale icon-leading width with Dynamic Type so
+    // the sectionTitle-sized icon's leading column grows together.
+    @ScaledMetric private var iconLeadingWidth: CGFloat = 26
+
     var body: some View {
         HStack(spacing: AppSpacing.xSmall) {
             Image(systemName: icon)
                 .font(AppText.sectionTitle)
                 .foregroundStyle(tint)
-                .frame(width: 26)
+                .frame(width: iconLeadingWidth)
 
             VStack(alignment: .leading, spacing: AppSpacing.micro) {
                 Text(title)

--- a/FitTracker/Views/Settings/v2/Components/ImportedPlanRow.swift
+++ b/FitTracker/Views/Settings/v2/Components/ImportedPlanRow.swift
@@ -13,12 +13,17 @@ import SwiftUI
 struct ImportedPlanRow: View {
     let plan: ImportedTrainingPlan
 
+    // L353 Phase 1 (2026-05-31): scale the icon-container frame with Dynamic Type
+    // so a user at AX5 settings gets a proportionally larger icon, not the
+    // captionStrong-sized symbol clipped to a 26pt box.
+    @ScaledMetric private var iconBox: CGFloat = 26
+
     var body: some View {
         HStack(spacing: AppSpacing.xSmall) {
             Image(systemName: plan.source.iconName)
                 .font(AppText.captionStrong)
                 .foregroundStyle(AppColor.Accent.primary)
-                .frame(width: 26, height: 26)
+                .frame(width: iconBox, height: iconBox)
                 .background(AppColor.Accent.primary.opacity(0.14),
                             in: RoundedRectangle(cornerRadius: AppRadius.xSmall))
 

--- a/FitTracker/Views/Settings/v2/Components/SettingsFormComponents.swift
+++ b/FitTracker/Views/Settings/v2/Components/SettingsFormComponents.swift
@@ -16,12 +16,16 @@ struct SettingsActionLabel: View {
     let tint: Color
     var trailing: SettingsActionTrailing = .chevron
 
+    // L353 Phase 1 (2026-05-31): scale the icon-container frame with Dynamic
+    // Type so the captionStrong-sized symbol grows together with its 26pt box.
+    @ScaledMetric private var iconBox: CGFloat = 26
+
     var body: some View {
         HStack(spacing: AppSpacing.xSmall) {
             Image(systemName: icon)
                 .font(AppText.captionStrong)
                 .foregroundStyle(tint)
-                .frame(width: 26, height: 26)
+                .frame(width: iconBox, height: iconBox)
                 .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: AppRadius.xSmall))
 
             VStack(alignment: .leading, spacing: AppSpacing.micro) {

--- a/FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
+++ b/FitTracker/Views/Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift
@@ -8,6 +8,10 @@ struct GoalsPreferencesSettingsScreen: View {
     @EnvironmentObject private var dataStore: EncryptedDataStore
     @EnvironmentObject private var settings: AppSettings
 
+    // L353 Phase 1 (2026-05-31): scale stats-metric icon leading width with
+    // Dynamic Type so the captionStrong icon grows together with its 20pt column.
+    @ScaledMetric private var metricIconWidth: CGFloat = 20
+
     var body: some View {
         SettingsDetailScaffold(
             title: SettingsCategory.goalsPreferences.title,
@@ -64,7 +68,7 @@ struct GoalsPreferencesSettingsScreen: View {
                             Image(systemName: metric.icon)
                                 .font(AppText.captionStrong)
                                 .foregroundStyle(metric.tint)
-                                .frame(width: 20)
+                                .frame(width: metricIconWidth)
 
                             Text(metric.title)
                                 .font(AppText.body)


### PR DESCRIPTION
## Summary

L353 backlog "Dynamic Type @ScaledMetric sweep" — **Phase 1 narrow correction set**. Adds `@ScaledMetric` to 4 v2 Settings + Auth components where `Image(systemName:).font(...).frame(width: N)` patterns let the icon glyph scale via `.font(...)` but clip it to a fixed-size container.

After this PR, container + glyph grow proportionally — at AX5 Dynamic Type setting both scale, no overflow, no clip.

## Files (4)

| File | Property | Base size |
|---|---|---|
| `Settings/v2/Components/ImportedPlanRow.swift` | `iconBox` | 26pt |
| `Settings/v2/Components/SettingsFormComponents.swift` (SettingsActionLabel) | `iconBox` | 26pt |
| `Auth/AuthHubView.swift` (AuthProviderRow) | `iconLeadingWidth` | 26pt |
| `Settings/v2/Screens/GoalsPreferencesSettingsScreen.swift` | `metricIconWidth` | 20pt |

## Audit-doc correction

My PR #555 estimated "~40-50 SF Symbol point-dimension call sites" from a loose grep. Deeper inspection showed most use `.font(AppText.X)` WITHOUT a `.frame(width:)` constraint — those already scale correctly via SwiftUI's `.font` auto-scaling.

The TRUE non-token, fixed-frame `Image` sites in v2 code turn out to be the 4 in this PR plus a handful in v1 HISTORICAL files (out of build target). A follow-up audit-doc revision PR will tighten PR #555's estimate.

## Phase 2-4 status

| Phase | Status |
|---|---|
| Phase 1 (SF Symbol sweep) | **THIS PR** |
| Phase 2 (asset-catalog icons) | Verified narrow — no immediate Phase 2 PR queued |
| Phase 3 (touch target audit) | Document fixed-at-44pt rationale — deferred to a follow-up doc PR |
| Phase 4 (layout dimensions) | Case-by-case — no blanket sweep needed |

## Phase E compliance

- No new framework gates
- No state.json mutations
- No infra-glob touches
- 0+0 integrity baseline preserved

## Test plan

- [x] 4 file edits compile cleanly with `@ScaledMetric` propertyWrapper
- [ ] CI: `xcodebuild build` — verifies refactor compiles
- [ ] CI: `xcodebuild test` — no test regressions
- [ ] Manual smoke (operator): Settings → Goals & Preferences screen, toggle Dynamic Type to AX5 in simulator, verify metric icon column grows; same for ImportedPlanRow and Auth provider rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)