### PR TITLE
fix(ci): distinct concurrency groups for ci.yml + ci-docs-skip.yml (W26)

### DIFF
--- a/.claude/integrity/observed-patterns.md
+++ b/.claude/integrity/observed-patterns.md
@@ -1280,3 +1280,31 @@ This matches the pattern already used in [`ReminderPreferencesStoreTests`](../..
 
 **Sibling patterns:** None directly; closest is the design-system test discipline that XCTest's main-actor handling enables — not yet codified as a W-code.
 
+### W26 — Two workflows sharing `name:` clash in `${{ github.workflow }}` concurrency groups → cross-workflow cancellation blocks merges (2026-06-01)
+
+**Surfaced by:** PR #560 (C2 readiness-aware-training-alert, mixed iOS code + docs/.claude). The PR's required `Build and Test` status check appeared TWICE in the rollup — one CANCELLED, one SUCCESS — blocking the green-status criterion even though no real failure occurred.
+
+**Root cause:** both `.github/workflows/ci.yml` (heavy macos-15 iOS pipeline) and `.github/workflows/ci-docs-skip.yml` (cheap ubuntu-latest fast-path) declare `name: CI`. The `${{ github.workflow }}` expression resolves to the workflow NAME (not file), so both files computed identical concurrency groups (`ci-CI-refs/pull/N/merge`). With `cancel-in-progress: true`, whichever workflow entered the group second cancelled the first — typically the fast docs-skip job cancelled the heavy iOS job. The CANCELLED status persisted in the PR rollup and blocked merge even with `--admin` until rerun-superseded.
+
+Compounding cause: the `paths:` vs `paths-ignore:` filters in the two files are not mutually exclusive on mixed PRs. A PR touching BOTH `FitTracker/**` files AND `docs/**` files trips ci.yml's `paths:` (at least one match) AND ci-docs-skip.yml's `paths-ignore:` (at least one non-match) — so both fire and immediately race for the shared concurrency group.
+
+**Fix (PR pending):** give each workflow its own hardcoded concurrency-group prefix instead of `${{ github.workflow }}`:
+
+```yaml
+# ci.yml
+concurrency:
+  group: ci-yml-${{ github.ref }}
+  cancel-in-progress: true
+
+# ci-docs-skip.yml
+concurrency:
+  group: ci-docs-skip-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Both workflows then run independently. On a mixed PR you get TWO passing `Build and Test` status checks (one from each file) — branch protection accepts the rollup because both are SUCCESS.
+
+**Generalizable rule:** when two workflow files share the same `name:` (intentional, to satisfy branch protection by status-check-name matching), DO NOT use `${{ github.workflow }}` in their `concurrency.group` expressions. Use file-specific hardcoded prefixes. Anywhere two workflows share a status-check name, audit their concurrency groups for collision.
+
+**Sibling patterns:** the original W26 placeholder note in [`project_session_2026_05_31_tier_carryover_plan.md`](../../.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_session_2026_05_31_tier_carryover_plan.md) captured the Catch-22 symptom (cancelled status blocking merge) but mis-attributed the cause to `cancel-in-progress: true` alone. The actual root cause is the cross-workflow group sharing — `cancel-in-progress: true` per workflow is correct and desirable; only the cross-workflow collision is wrong.
+

--- a/.github/workflows/ci-docs-skip.yml
+++ b/.github/workflows/ci-docs-skip.yml
@@ -33,8 +33,13 @@ on:
       - '.github/workflows/ci.yml'
       - 'Package.swift'
 
+# ci-docs-skip.yml-specific concurrency group. Hardcoded prefix (NOT the
+# workflow-name expression) because ci.yml also has `name: CI` — sharing
+# the workflow-name across both files clashes the groups, racing into
+# mutual cancellation on every mixed-content PR. See
+# .claude/integrity/observed-patterns.md W26 for the historical incident.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-docs-skip-${{ github.ref }}
   cancel-in-progress: true
 
 # Least-privilege GITHUB_TOKEN — this workflow only writes a status check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,14 @@ on:
       - main
   workflow_dispatch:
 
+# ci.yml-specific concurrency group. We use a hardcoded prefix here (NOT
+# the workflow name expression) because ci-docs-skip.yml ALSO has `name:
+# CI` — the workflow-name expression would resolve identically in both
+# files and the two workflows would clash on the same group, racing each
+# other into mutual cancellation on every mixed-content PR. See
+# .claude/integrity/observed-patterns.md W26 for the historical incident.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-yml-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Surfaced empirically by PR #560 on 2026-06-01: every mixed-content PR (touching both `FitTracker/**` AND `docs/**` / `.claude/**`) shows TWO `Build and Test` status checks in the rollup — one CANCELLED, one SUCCESS — blocking the green-status criterion required by branch protection. Diagnosed as W26 in [`observed-patterns.md`](.claude/integrity/observed-patterns.md).

**Root cause:** both `ci.yml` (heavy macos-15 iOS pipeline) and `ci-docs-skip.yml` (cheap ubuntu fast-path) declare `name: CI`. The `${{ github.workflow }}` expression resolves to the workflow NAME (not file), so both files computed identical concurrency groups (`ci-CI-refs/pull/N/merge`). With `cancel-in-progress: true`, whichever workflow entered the group second cancelled the first.

**Fix:** replace `${{ github.workflow }}` with file-specific hardcoded prefixes:

```yaml
# ci.yml
concurrency:
  group: ci-yml-${{ github.ref }}
  cancel-in-progress: true

# ci-docs-skip.yml
concurrency:
  group: ci-docs-skip-${{ github.ref }}
  cancel-in-progress: true
```

Each workflow now keeps its own intra-workflow cancellation behaviour (a new push cancels the prior run of THAT workflow on the same branch) without colliding with the sibling workflow.

**Trade-off (acknowledged):** the underlying mixed-PR-fires-both-workflows behaviour is a separate issue — `paths:` vs `paths-ignore:` is not mutually exclusive on PRs touching both globs. With this fix, mixed PRs continue to fire BOTH workflows, but both run to completion and both publish a `Build and Test` SUCCESS status. Branch protection accepts that. The extra cost is ~5 seconds of ubuntu runner per mixed PR. (The further-tightening of mutual exclusivity via `dorny/paths-filter` job-level skip is a separate, larger PR.)

## What does NOT change

- Pure-docs PRs still hit only `ci-docs-skip.yml` → ~5 second total CI time
- Pure-iOS PRs still hit only `ci.yml` → ~10-15 minute total CI time
- Main-branch pushes still hit `ci.yml` unconditionally (trunk-of-record validation)
- Branch protection's required-status-check name match continues to work — both workflows publish a check named `Build and Test`

## Test plan

- [ ] CI on this PR passes — it's a pure-`.github/workflows/*` + observability-catalog change, the `ci-docs-skip.yml` fast-path should fire and produce one `Build and Test` SUCCESS
- [ ] Verify by checking the run rollup: there should be exactly ONE `Build and Test` in the status list (not two)
- [ ] After merge: validate on a mixed-content PR (e.g. C2 PR #560 if not yet merged) that BOTH `Build and Test` checks pass without cancellation
- [ ] Catalog entry W26 verified in [`make observed-patterns`](.claude/integrity/observed-patterns.md)

## Files

- `.github/workflows/ci.yml` — 7 lines added (concurrency group rename + explanatory comment)
- `.github/workflows/ci-docs-skip.yml` — 6 lines added (same shape, symmetric)
- `.claude/integrity/observed-patterns.md` — 28 lines added (W26 entry with root cause + fix + sibling pattern note)

## Cross-references

- W26 placeholder in [`project_session_2026_05_31_tier_carryover_plan`](~/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_session_2026_05_31_tier_carryover_plan.md) — Catch-22 lesson, which mis-attributed the cause to `cancel-in-progress: true` alone
- PR #558 — introduced the dispatcher pattern (`ci-docs-skip.yml` sibling) that revealed this bug
- PR #560 — empirical surfacing PR (C2 readiness-aware-training-alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)