### PR TITLE
docs(hadf): fix case_study_showcase pointer 30 → 22c (dangling pointer)

### DIFF
--- a/docs/case-studies/hadf-phase2bis-cross-sub-exp-synthesis-case-study.md
+++ b/docs/case-studies/hadf-phase2bis-cross-sub-exp-synthesis-case-study.md
@@ -33,7 +33,7 @@ preregistration_paths:
   subexp1: .claude/shared/hadf/preregistration-phase2bis-subexp1.json
   subexp2: .claude/shared/hadf/preregistration-phase2bis-subexp2.json
   subexp3: .claude/shared/hadf/preregistration-phase2bis-subexp3.json
-case_study_showcase: fitme-story/content/04-case-studies/30-hadf-phase2bis-cross-sub-exp-synthesis.mdx
+case_study_showcase: fitme-story/content/04-case-studies/22c-hadf-phase2bis-cross-sub-exp-synthesis.mdx
 external_audit_schedule:
   - audit-1-v7-9-promotion: 2026-05-22 (scope: Sub-exp 1 prereg + smoke-fire data quality)
   - audit-2-v7-9-1-ship: 2026-06-12 (scope: Sub-exps 1-3 raw data integrity + verdict scripts + THIS case study)


### PR DESCRIPTION
Surfaced by the 2026-06-02 cross-reference sweep.

The HADF Phase 2-bis synthesis case study's `case_study_showcase` frontmatter pointed at `…/30-hadf-phase2bis-cross-sub-exp-synthesis.mdx`, but:
- The real showcase MDX is **`22c-hadf-phase2bis-cross-sub-exp-synthesis.mdx`**
- Slot 30 is already taken by `fitme-story-ds-p2-deferred`
- The MDX's `timeline_position.order` is **22.7** (v7.8.3) → 22c is the correct chronological slot per the publication+chronological rule

One-line frontmatter fix so the pointer resolves to the real file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)