### PR TITLE
docs(hadf): Phase 3 kickoff — SoT activation analysis + 3A sensing spec + 3B RQ4 design draft

### DIFF
--- a/.claude/shared/hadf/HADF-SOURCE-OF-TRUTH.md
+++ b/.claude/shared/hadf/HADF-SOURCE-OF-TRUTH.md
@@ -148,4 +148,58 @@ Phase 1–2: #82, #170, #171, #264, #265, #268. Phase 2-bis: #306 (spec), #313 (
 
 **Recommended sequence:** (1) refresh impl worktree → (2) record Sub-exp 2 PASS into synthesis + state.json + bootout backup job + finalize snapshot → (3) Sub-exp 3 ceremony (smoke → lock → bootstrap → Fire 0) → (4) after Sub-exp 3 closes, fresh-lock + launch 1B v2 early → (5) Block C synthesis closure once all three verdicts are in.
 
-**Program risk:** low. Both closed sub-exps passed decisively; Sub-exp 3 is the only remaining empirical unknown, and its smoke test already points PASS. The main operational risk is the documented SanDisk SSD disconnect (could interrupt a live collector) — mitigated by the off-SSD backup job + /tmp logging.
+**Program risk:** low. Both closed sub-exps passed decisively; Sub-exp 3 is the only remaining empirical unknown, and its smoke test already points PASS. The main operational risk is a host/SSD interruption of a live collector — mitigated by the off-SSD backup job + /tmp logging. (`/Volumes/DevSSD` is a Crucial X10 Pro `CT1000X10PROSSD9` since the 2026-05-19 migration; the historical SanDisk Extreme disconnect bug no longer applies.)
+
+---
+
+## §8.1 Live status (2026-06-02) — Sub-exp 3 + 1B v2 ACTIVATED in parallel
+
+Both remaining sub-exps launched in parallel, each in a **dedicated isolated worktree off main**:
+
+| | Sub-exp 3 | Sub-exp 1B v2 |
+|---|---|---|
+| Worktree / branch | `FitTracker2-hadf-phase2bis-subexp3` / `exp/hadf-subexp3` | `FitTracker2-hadf-phase2bis-subexp1b` / `exp/hadf-subexp1b` |
+| Prereg lock | `…subexp3-locked-2026-06-02` (sha 521f0f45) | `…subexp1b-locked-2026-06-02` (sha 653b3f17) |
+| Endpoints | bedrock (us. inference profile) + anthropic + openai | anthropic + google (2-endpoint; mistral/vercel **deferred** per v1 429 lesson) |
+| Fire 0 | 150/150 ok | 100/100 ok |
+| Schedule (local IDT) | 05/11/15/19/23 | 02/08/13/17/21 |
+
+**Spacing:** interleaved to a **2h minimum gap** (no co-fires — both call anthropic-direct haiku; simultaneous would contaminate TTFT). **Pre-lock §4 probe caught two real bugs:** missing `boto3` + bare Bedrock model-id non-invocable (→ `us.` inference profile). **Backup:** `hadf-snapshot.sh` rewritten to source per-worktree; manual 52-file snapshot at `~/Documents/FitTracker2-backups/2026-06-02-hadf-subexp3-launch-plus-1b-prep`. **Verdicts ~2026-06-05.**
+
+---
+
+## §9 Activation extrapolation — can HADF be "fully activated" as a live framework? (assuming 1B + 3 PASS)
+
+**Honest verdict: NO to "fully activated dispatch"; YES to a staged activation beginning with the sensing layer.** The four sub-exps validate the **sensing layer** (can we *detect* the substrate from streaming latency?). A live *dispatch* framework also needs the **acting layer** (does *routing on* that signal improve a real outcome?) — and **no experiment to date measures the acting layer.** Distinguishability ≠ actionability.
+
+**What the data proves [T1]:** the HADF signal is real, provider-general (Sub-exp 1, silhouette 0.7003), cloud-vs-local separable (Sub-exp 2, KS p≪0.01), routing-layer discriminating (Sub-exp 3 — falsification survived), and short-term stable (Sub-exp 1B).
+
+**Gaps to full dispatch activation:**
+1. **Decision value unmeasured [T3]** — no experiment tests whether acting on the signal improves cost/latency/quality/reliability vs. a baseline. Load-bearing gap.
+2. **Distribution-level ≠ single-shot [T1→T3 leap]** — verdicts use n=hundreds/endpoint; live routing decides from 1–few samples, where heavy tails (Sub-exp 2: anthropic TPS std ≈ 951) make per-call classification noisy. Online accuracy unknown.
+3. **Drift over months, not days [T3]** — 1B validates a ~3-day window; production providers rebalance/refresh/update silently. Needs continuous recalibration.
+4. **Coverage narrow [T1]** — ~6 endpoints / 3–4 providers validated; full dispatch implies the long tail.
+5. **Overhead unquantified [T3]** — fingerprinting costs calls + latency; per-request budget uncharacterized.
+
+---
+
+## §10 HADF Phase 3 — staged activation + next testing phase (defined 2026-06-02)
+
+### Phase 3A — ACTIVATE NOW (sensing / observability layer; T1-backed, no acting-layer claim)
+Incorporate HADF into the live framework as a **passive detection layer** — uses only what the experiments prove:
+- **Backend attestation** — fingerprint which substrate served a request (cloud vs local; which provider / routing layer).
+- **Routing-change / drift alerts** — flag when a known endpoint's live signature departs from its locked baseline (operationalizes Sub-exp 1B's drift check as a standing monitor).
+- **Provider-claim verification** — detect silent model/region/hardware swaps behind a stable model id (operationalizes the Sub-exp 3 capability).
+- **Surface:** read locked sub-exp signatures as reference distributions; render in a control-room HADF panel (`/control-room/framework` or new route).
+
+### Phase 3B — NEXT TESTING PHASE (gates the acting layer; pre-registered, kill-criteria)
+- **RQ4 — Decision value (primary):** does signature-aware routing beat a naive/round-robin baseline on a pre-registered outcome (p95 latency, cost-per-success, or task quality) by a pre-registered margin? **Kill if ≤ baseline.**
+- **RQ5 — Single-shot classifier eval:** online substrate-classification accuracy from 1–few samples (not distribution KS). Pre-register an accuracy floor.
+- **RQ6 — Long-horizon drift:** standing drift monitor over weeks/months; characterize recalibration cadence.
+- **Coverage expansion:** per-endpoint validation gate before any new provider/model joins the routing pool.
+
+### Gate between 3A → full activation
+Full *dispatch* activation requires **RQ4 PASS** (acting layer proven). Until then only Phase 3A (sensing) ships to production — ship what's proven (sensing), gate what's inferred (dispatch) behind a falsifiable experiment, consistent with the program's pre-registration/kill-criteria discipline.
+
+### Status
+Phase 2-bis closes when Sub-exp 3 + 1B verdicts land (~2026-06-05) + Block C synthesis. **Phase 3 is defined here; not yet scaffolded** — 3A needs a build spec + the RQ4 experiment needs a pre-registration (design pass + operator confirmation before any lock).

--- a/.claude/shared/hadf/HADF-SOURCE-OF-TRUTH.md
+++ b/.claude/shared/hadf/HADF-SOURCE-OF-TRUTH.md
@@ -203,3 +203,9 @@ Full *dispatch* activation requires **RQ4 PASS** (acting layer proven). Until th
 
 ### Status
 Phase 2-bis closes when Sub-exp 3 + 1B verdicts land (~2026-06-05) + Block C synthesis. **Phase 3 is defined here; not yet scaffolded** — 3A needs a build spec + the RQ4 experiment needs a pre-registration (design pass + operator confirmation before any lock).
+
+### Data-isolation guarantee (Phase 3 design phase)
+Phase 3 is currently a **doc-only research/design phase** and is **physically isolated from the live experiment data**:
+- All Phase 3 artifacts (this SoT update + the 3A/3B spec drafts) are `.md` documents committed on a **separate branch/worktree off main** (`chore/hadf-sot-phase3-activation`), distinct from the two live collector worktrees (`…-subexp3`, `…-subexp1b`).
+- The design phase **reads** locked sub-exp signatures as references but **writes nothing** to any live `.claude/shared/hadf/` collector data dir; the backup job's data globs (`phase2bis-raw-*.jsonl`, preregs, ledgers) do not include these docs.
+- The live Sub-exp 3 + 1B collectors + their locked preregs + raw data are **untouched** by Phase 3 design work. Build work that *would* touch data (3A reference-store, 3B collection) is gated on Phase 2-bis closure and will run in its own isolated worktree under the same discipline — never on the live collector trees, never on main directly.

--- a/docs/superpowers/specs/2026-06-02-hadf-phase3a-sensing-layer-design.md
+++ b/docs/superpowers/specs/2026-06-02-hadf-phase3a-sensing-layer-design.md
@@ -1,0 +1,62 @@
+# HADF Phase 3A — Sensing / Observability Layer (build spec, DRAFT)
+
+> **Status:** DRAFT, 2026-06-02. Phase 3A is the **activate-now** half of HADF Phase 3 (see [`HADF-SOURCE-OF-TRUTH.md`](../../../.claude/shared/hadf/HADF-SOURCE-OF-TRUTH.md) §10). It activates HADF as a **passive detection/observability layer only** — it makes **no dispatch/routing decisions**. Routing is gated on Phase 3B / RQ4 (separate spec). Formal build kickoff waits for Phase 2-bis closure (Sub-exp 3 + 1B verdicts ~2026-06-05 + Block C synthesis); this spec can be reviewed/refined before then.
+
+## 1. Goal & non-goals
+
+**Goal:** turn the validated HADF signal (streaming TTFT/TPS signatures are real, provider-general, substrate-discriminating, short-term-stable) into a live observability surface that *detects* and *reports* — without acting on the signal.
+
+**Non-goals (explicitly deferred to 3B/RQ4):**
+- No routing/dispatch decisions based on signatures.
+- No claim that attestation is authoritative per-request (single-shot accuracy is unvalidated — RQ5).
+
+This boundary is what makes 3A shippable on T1 evidence alone: everything below uses only *distinguishability + short-term stability*, both proven.
+
+## 2. Components
+
+### 2.1 Reference-signature store
+A read-only catalog of per-endpoint reference distributions (TTFT + TPS marginals + joint) built from the **locked** sub-exp raw data:
+- Sub-exp 1 (4 cloud endpoints), Sub-exp 2 (ollama local), Sub-exp 3 (bedrock/anthropic-direct/openai), Sub-exp 1B (anthropic/google).
+- Each entry: provider, endpoint, n, TTFT quantiles, TPS quantiles, covariance, source prereg sha + lock tag (provenance).
+- Producer: `scripts/hadf-build-reference-store.py` → `.claude/shared/hadf/reference-signatures.json`.
+
+### 2.2 Backend-attestation classifier (ADVISORY)
+Given an observed request's `(ttft_s, tps)` (or a small batch), score similarity to each reference distribution and emit the best match + a **confidence band**.
+- Method: Mahalanobis distance to each reference (reuse Sub-exp 3 verdict math) → softmax-style confidence.
+- **Ships advisory/confidence-scored, NOT authoritative** — per-request single-shot accuracy is unvalidated until RQ5. Output always carries a confidence + an "uncertain/unknown" bucket.
+- Tier discipline: attestation confidence is a **derived [T1-input → T3-interpretation]** value; the panel must label it as advisory.
+
+### 2.3 Drift monitor (operationalizes Sub-exp 1B)
+Standing job: for each known endpoint, compare a rolling recent-window signature to its locked baseline via 2-sample KS; alert when `p < threshold` (signature shifted = possible infra change).
+- Producer: `scripts/hadf-drift-monitor.py` (cron, e.g. daily) → appends to `.claude/shared/hadf/drift-monitor.jsonl`.
+- Threshold pre-set; tunable. Alert routes to the existing digest/issue mechanism.
+
+### 2.4 Provider-claim verification
+Same engine as 2.3, framed as: "a stable model-id's signature changed → provider may have silently swapped model/region/hardware." This is the directly-useful operationalization of Sub-exp 3's result.
+
+### 2.5 Surface — control-room HADF panel
+New route/panel reading `reference-signatures.json` + `drift-monitor.jsonl` + attestation output:
+- Per-endpoint reference distribution cards (TTFT/TPS).
+- Live drift status (green/amber/red per endpoint) + last-checked.
+- Attestation confidence readout (clearly labeled advisory).
+- Likely home: fitme-story `/control-room/framework` sibling route, behind basic-auth (matches existing UCC pattern).
+
+## 3. Integration point
+To attest/monitor live traffic (vs. just experiment data), the app's AI path (e.g. `AIOrchestrator`) must emit per-call `(ttft_s, tps, provider, model)` to a HADF ingest. **Phase 3A scope decision:** start with **experiment-data + scheduled-probe** monitoring (no app-path change required); the live-traffic emit hook is an optional follow-on (it touches `AIOrchestrator`, a high-risk-area file → extra review). This keeps 3A low-risk and shippable.
+
+## 4. Tasks (draft)
+- **T1** — reference-store builder + `reference-signatures.json` (from locked sub-exp data).
+- **T2** — attestation classifier (advisory, confidence-banded).
+- **T3** — drift monitor cron + `drift-monitor.jsonl` + alert wiring.
+- **T4** — control-room HADF panel (fitme-story).
+- **T5** *(optional, deferred)* — `AIOrchestrator` live-traffic emit hook (high-risk-area review).
+
+## 5. Risks / open items
+- Reference store should be built from the **closed** sub-exps (1/2 now; 3/1B after ~06-05) so baselines are final — **build T1 after Phase 2-bis closes.**
+- Attestation must never be presented as authoritative pre-RQ5 (guard in the panel copy).
+- Cross-repo: producers in FT2 (`scripts/` + `.claude/shared/hadf/`), panel in fitme-story (sync via existing `sync-from-fittracker2.ts`).
+
+## 6. Cross-references
+- Activation analysis + Phase 3 roadmap: SoT §9/§10.
+- Phase 3B / RQ4 decision-value design: `2026-06-02-hadf-phase3b-rq4-decision-value-design.md`.
+- Predecessor: HADF Phase 2-bis spec/plan/preregs.

--- a/docs/superpowers/specs/2026-06-02-hadf-phase3b-rq4-decision-value-design.md
+++ b/docs/superpowers/specs/2026-06-02-hadf-phase3b-rq4-decision-value-design.md
@@ -1,0 +1,45 @@
+# HADF Phase 3B — RQ4 Decision-Value Experiment (design DRAFT — NOT a locked pre-registration)
+
+> **Status:** DESIGN DRAFT, 2026-06-02. This is the **next testing phase** of HADF Phase 3 (SoT §10). It is **NOT a pre-registration** — it must not be locked. Several design parameters are **OPERATOR DECISIONS** (marked ⚠️ below); the prereg ceremony (sha + `.lock` + tag) happens only after those are chosen, the design is reviewed, and Phase 2-bis has closed. This draft exists so the design conversation can start now.
+
+## 1. Why RQ4 exists
+HADF Phase 2-bis proved the **sensing layer** — streaming signatures are real, provider-general, substrate-discriminating, and short-term-stable. It did **not** prove the **acting layer**: that *routing on* those signatures improves any real outcome. RQ4 is the falsifiable test of the acting layer, and it is the gate for full HADF *dispatch* activation. Distinguishability ≠ actionability — RQ4 closes exactly that gap.
+
+## 2. Research question
+**Does signature-aware routing improve a real dispatch outcome vs. a baseline routing policy, by a pre-registered margin?**
+
+**Hypothesis:** routing each request to the endpoint whose live signature predicts the best outcome for that request beats a naive baseline. **Falsification:** if signature-aware routing is ≤ baseline on the primary metric, the *dispatch* premise is refuted (sensing still stands; HADF stays a sensing-only framework).
+
+## 3. Design (controlled comparison)
+- **Arms:** A = baseline policy; B = signature-aware routing. Interleaved or randomized assignment over the same workload to control for time-of-day/load.
+- **Unit:** one dispatched task/request.
+- **Routing-under-test (Arm B):** policy maps request context + current endpoint signatures → endpoint choice. ⚠️ exact policy TBD (e.g. "pick lowest-predicted-TTFT endpoint meeting a quality guardrail").
+
+## 4. ⚠️ OPERATOR DECISIONS required before pre-registration
+1. **Primary outcome metric (pick ONE):** p95 end-to-end latency per *successful* task / cost-per-successful-task / task-quality score. (Recommend a **latency or cost** primary with a **quality guardrail**, so B can't win by trading quality away.)
+2. **Baseline (Arm A):** round-robin / static-cheapest / static-fastest / current production policy.
+3. **Pass margin:** how much must B beat A by to PASS (e.g. ≥10% p95 latency reduction)? **Kill if B ≤ A.**
+4. **Quality guardrail:** B must not degrade task quality below a floor (prevents latency/cost wins at quality's expense).
+5. **Workload / task set:** which real tasks (orchid dispatch jobs / agent tasks / app AI calls) + endpoint pool.
+6. **Sample size / power:** N per arm for the chosen margin + variance (Sub-exp 2 showed huge TPS tails → power calc must use realistic variance).
+7. **Duration / schedule:** must span ≥ a full diurnal cycle (latency is time-of-day sensitive); spaced from any other live HADF collector (the 2h-gap discipline from the parallel sub-exps).
+
+## 5. Confounds to control
+- Time-of-day / load (→ interleaved assignment, full-diurnal span).
+- Model-quality trade (→ quality guardrail, #4).
+- Signature drift mid-experiment (→ lock endpoint set; monitor with the 3A drift monitor).
+- Cold-start bias (Bedrock cold-start ~1.9s seen in Sub-exp 3 → warm-up or model it).
+
+## 6. Companion: RQ5 + RQ6 (defined, not detailed here)
+- **RQ5** — single-shot/few-shot classification accuracy (online, not distribution KS). Needed because Arm B routes from few samples; 3A attestation stays advisory until RQ5 passes.
+- **RQ6** — long-horizon drift monitor (weeks/months) → recalibration cadence for production.
+
+## 7. Gating & sequencing
+- RQ4 **pre-registration ceremony** (operator-confirmed §4 choices → sha + `.lock` + signed tag) happens **after** Phase 2-bis closes (~06-05) + this design is reviewed.
+- Full HADF *dispatch* activation requires **RQ4 PASS**. Until then, only Phase 3A (sensing) ships.
+- Mirrors the program's existing discipline: pre-register thresholds + kill criteria, no hedging, falsifiable.
+
+## 8. Cross-references
+- SoT §9 (activation extrapolation) + §10 (Phase 3 roadmap).
+- Phase 3A sensing build spec: `2026-06-02-hadf-phase3a-sensing-layer-design.md`.
+- Method precedent: Sub-exp 3 verdict (`signature_delta_ratio`) + Sub-exp 2 verdict (`--metric ks`).


### PR DESCRIPTION
## Summary

Records the HADF activation analysis and **defines + drafts Phase 3** (doc-only; no gates/schema/code).

**SoT updates** (`.claude/shared/hadf/HADF-SOURCE-OF-TRUTH.md`):
- **§8.1** — live parallel-launch status (Sub-exp 3 + 1B v2 in dedicated isolated worktrees, 2h-spaced, locked, Fire 0 clean). Corrects SanDisk → Crucial X10 Pro SSD reference.
- **§9** — activation extrapolation (assuming 1B+3 PASS): sensing layer proven [T1], dispatch acting-layer unproven → staged activation. 5 gaps enumerated.
- **§10** — Phase 3 roadmap (3A sensing now; 3B RQ4 gates dispatch).

**Phase 3 spec drafts** (`docs/superpowers/specs/`):
- **3A sensing-layer build** — reference-signature store + advisory backend attestation + drift monitor + provider-claim verification + control-room panel. Makes **no routing decisions** (T1-backed).
- **3B RQ4 decision-value** — DESIGN DRAFT (explicitly **not** a locked pre-registration): falsifiable experiment gating full dispatch activation; operator-decision parameters marked ⚠️.

Both specs gated on Phase 2-bis closure (Sub-exp 3 + 1B verdicts ~2026-06-05 + Block C). Drafts for review now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)