### PR TITLE
chore(framework-w30-w31-w32-durable-fixes): close out — W32 dogfood SUCCESS

### DIFF
--- a/.claude/features/framework-w30-w31-w32-durable-fixes/state.json
+++ b/.claude/features/framework-w30-w31-w32-durable-fixes/state.json
@@ -1,6 +1,6 @@
 {
   "feature_name": "framework-w30-w31-w32-durable-fixes",
-  "current_phase": "implementation",
+  "current_phase": "complete",
   "created_at": "2026-06-05T06:00:00Z",
   "updated_at": "2026-06-05T06:00:00Z",
   "framework_version": "v7.9.1",
@@ -11,7 +11,7 @@
   "state_owner": "ft2",
   "isolation_opt_out": false,
   "isolation_opt_out_reason": "",
-  "branch": "feature/framework-w30-w31-w32-durable-fixes",
+  "branch": "chore/framework-w30-w31-w32-durable-fixes-post-merge-closure",
   "scheduled_after": null,
   "primary_metric": "3 W-pattern durable fixes shipped in a single Chore PR with passing test suite — W30 parser bare-int fallback, W31 operator-side workflow-coverage detector, W32 close-feature.py single-phase auto-skip",
   "success_metrics": [
@@ -74,14 +74,90 @@
     "implementation": {
       "started_at": "2026-06-05T06:00:00Z",
       "ended_at": null,
-      "notes": "In flight on feature/framework-w30-w31-w32-durable-fixes. Single-phase Chore (work_subtype=framework_feature — same shape as the v7.9.1 ships this closure unblocks). W32 itself eats its own dogfood: this feature will close via the new auto-skip path."
+      "notes": "In flight on feature/framework-w30-w31-w32-durable-fixes. Single-phase Chore (work_subtype=framework_feature — same shape as the v7.9.1 ships this closure unblocks). W32 itself eats its own dogfood: this feature will close via the new auto-skip path.",
+      "approved_by": "operator",
+      "approval_signal": "(implicit — operator merged PR #637)"
+    },
+    "review": {
+      "started_at": "2026-06-05T06:37:20Z",
+      "ended_at": "2026-06-05T06:37:20Z",
+      "approved_by": "operator",
+      "approval_signal": "merged"
+    },
+    "merge": {
+      "started_at": "2026-06-05T06:37:20Z",
+      "ended_at": "2026-06-05T06:37:20Z",
+      "pr_number": 637,
+      "merge_commit_sha": "a065798fd487469dbc4a0054ba95f1e7b383ef62",
+      "merged_at": "2026-06-05T06:37:20Z",
+      "approved_by": "operator",
+      "approval_signal": "merged"
+    },
+    "docs": {
+      "started_at": "2026-06-05T06:37:20Z",
+      "ended_at": "2026-06-05T06:38:25Z",
+      "approved_by": "operator",
+      "approval_signal": "(post-merge closure batch — case study + backlog strike shipped in feature PR)"
+    },
+    "complete": {
+      "started_at": "2026-06-05T06:38:25Z",
+      "ended_at": "2026-06-05T06:38:25Z",
+      "approved_by": "operator",
+      "approval_signal": "merged"
     }
   },
   "timing": {
     "phases": {
       "implementation": {
-        "started_at": "2026-06-05T06:00:00Z"
+        "started_at": "2026-06-05T06:00:00Z",
+        "ended_at": "2026-06-05T06:37:20Z"
+      },
+      "review": {
+        "started_at": "2026-06-05T06:37:20Z",
+        "ended_at": "2026-06-05T06:37:20Z"
+      },
+      "merge": {
+        "started_at": "2026-06-05T06:37:20Z",
+        "ended_at": "2026-06-05T06:37:20Z"
+      },
+      "docs": {
+        "started_at": "2026-06-05T06:37:20Z",
+        "ended_at": "2026-06-05T06:38:25Z"
+      },
+      "complete": {
+        "started_at": "2026-06-05T06:38:25Z",
+        "ended_at": "2026-06-05T06:38:25Z"
       }
     }
-  }
+  },
+  "merge_pr_number": 637,
+  "merge_commit_sha": "a065798fd487469dbc4a0054ba95f1e7b383ef62",
+  "merged_at": "2026-06-05T06:37:20Z",
+  "feature_branch_merged": "feature/framework-w30-w31-w32-durable-fixes",
+  "transitions": [
+    {
+      "from": "implementation",
+      "to": "review",
+      "at": "2026-06-05T06:37:20Z",
+      "reason": "PR #637 squashed onto main as a065798fd4 (operator-merged 2026-06-05T06:37:20Z). Closure landed via close-feature.py. CI checks green; operator review preceded merge."
+    },
+    {
+      "from": "review",
+      "to": "merge",
+      "at": "2026-06-05T06:37:20Z",
+      "reason": "PR #637 squashed onto main as a065798fd4 (operator-merged 2026-06-05T06:37:20Z). Closure landed via close-feature.py. Squash-merged."
+    },
+    {
+      "from": "merge",
+      "to": "docs",
+      "at": "2026-06-05T06:37:20Z",
+      "reason": "Case study + backlog strike shipped in same feature PR. No additional docs."
+    },
+    {
+      "from": "docs",
+      "to": "complete",
+      "at": "2026-06-05T06:38:25Z",
+      "reason": "Feature CLOSED via close-feature.py on chore/framework-w30-w31-w32-durable-fixes-post-merge-closure. Closes the testing→complete drift-pattern documented across 5+ instances by automating the post-merge audit trail."
+    }
+  ]
 }

--- a/.claude/features/framework-w30-w31-w32-durable-fixes/state.json
+++ b/.claude/features/framework-w30-w31-w32-durable-fixes/state.json
@@ -13,7 +13,7 @@
   "isolation_opt_out_reason": "",
   "branch": "chore/framework-w30-w31-w32-durable-fixes-post-merge-closure",
   "scheduled_after": null,
-  "primary_metric": "3 W-pattern durable fixes shipped in a single Chore PR with passing test suite — W30 parser bare-int fallback, W31 operator-side workflow-coverage detector, W32 close-feature.py single-phase auto-skip",
+  "primary_metric": "3 W-pattern durable fixes shipped in a single Chore PR with passing test suite \u2014 W30 parser bare-int fallback, W31 operator-side workflow-coverage detector, W32 close-feature.py single-phase auto-skip",
   "success_metrics": [
     "scripts/check-state-schema.py _collect_case_study_pr_numbers extracts bare-int strings from related_prs (T1, 6 unit tests pass)",
     "scripts/check-pr-workflow-coverage.py runs against any PR + reports always-expected vs actual delta (T1, 3 unit tests pass + smoke test against PR #636 + #623)",
@@ -21,62 +21,65 @@
     "Same-session use case: F-DEPLOYED-URL-PROBE + dev-env-R-batch + R9 + F-PHASE-E closures from PR #633 would have auto-skipped without --force-incomplete (T2, retrospective)"
   ],
   "kill_criteria": [
-    "W30 fallback accidentally matches a non-PR-number string and inflates the parity count — would create false positive findings",
+    "W30 fallback accidentally matches a non-PR-number string and inflates the parity count \u2014 would create false positive findings",
     "W31 detector false-positive rate too high to be useful operationally",
     "W32 auto-skip masks a real partial-phase landing that should have been blocked"
   ],
-  "kill_criteria_resolution": "All 3 mitigated by design + tests. (1) W30 fallback only fires after the `#N` regex has already failed AND the string is `str.isdigit()` — non-digit strings short-circuit; test `test_non_digit_strings_silently_skipped` enforces. (2) W31 detector uses a curated `ALWAYS_EXPECTED_PATTERNS` list (path-filtered and schedule-only workflows are intentionally excluded), validated by smoke test against PR #636 reporting 14/14 with 0 false positives. (3) W32 auto-skip is restricted to 3 work-shape signals (work_subtype=framework_feature OR work_type in {Chore,Fix} OR explicit single_phase: true) — regular Feature work_type still requires --force-incomplete; test `test_regular_feature_still_requires_force_incomplete` enforces. Operator still sees an audit-trail log message when auto-skip fires.",
+  "kill_criteria_resolution": "All 3 mitigated by design + tests. (1) W30 fallback only fires after the `#N` regex has already failed AND the string is `str.isdigit()` \u2014 non-digit strings short-circuit; test `test_non_digit_strings_silently_skipped` enforces. (2) W31 detector uses a curated `ALWAYS_EXPECTED_PATTERNS` list (path-filtered and schedule-only workflows are intentionally excluded), validated by smoke test against PR #636 reporting 14/14 with 0 false positives. (3) W32 auto-skip is restricted to 3 work-shape signals (work_subtype=framework_feature OR work_type in {Chore,Fix} OR explicit single_phase: true) \u2014 regular Feature work_type still requires --force-incomplete; test `test_regular_feature_still_requires_force_incomplete` enforces. Operator still sees an audit-trail log message when auto-skip fires.",
   "dispatch_pattern": "agent-driven (3 surgical script patches + 1 new diagnostic script + 16-test unit suite)",
   "case_study": "docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md",
   "case_study_showcase": "",
   "spec": ".claude/integrity/observed-patterns.md W30 + W31 + W32 + saved-memory 'Tomorrow's queue' from project_session_2026_06_04_observed_patterns_overlay_and_3d_phase_2.md",
   "predecessor_case_study": "docs/case-studies/framework-v7-9-1-promotion-case-study.md",
-  "scope_summary": "3-in-1 durable-fix Chore for W-patterns surfaced during the 2026-06-04 v7.9.1 build window. W30 patches `_collect_case_study_pr_numbers` to extract bare-int strings (`['623','621']`) the natural YAML inline form produces, closing the 4-commit-retry loop documented in W30's own surfacing. W31 ships an operator-side detector `scripts/check-pr-workflow-coverage.py` that compares the always-expected check-run set against the PR HEAD's actual check-runs + statuses — nudges the operator toward the rebase+force-push remediation when the GitHub Actions webhook delivery anomaly fires. W32 patches `close-feature.py` to auto-skip the `--force-incomplete` requirement when state.json declares a single-phase work shape (work_subtype=framework_feature OR work_type in {Chore,Fix} OR explicit single_phase: true) — same shape as the 5 v7.9.1 features that hit this barrier today.",
+  "scope_summary": "3-in-1 durable-fix Chore for W-patterns surfaced during the 2026-06-04 v7.9.1 build window. W30 patches `_collect_case_study_pr_numbers` to extract bare-int strings (`['623','621']`) the natural YAML inline form produces, closing the 4-commit-retry loop documented in W30's own surfacing. W31 ships an operator-side detector `scripts/check-pr-workflow-coverage.py` that compares the always-expected check-run set against the PR HEAD's actual check-runs + statuses \u2014 nudges the operator toward the rebase+force-push remediation when the GitHub Actions webhook delivery anomaly fires. W32 patches `close-feature.py` to auto-skip the `--force-incomplete` requirement when state.json declares a single-phase work shape (work_subtype=framework_feature OR work_type in {Chore,Fix} OR explicit single_phase: true) \u2014 same shape as the 5 v7.9.1 features that hit this barrier today.",
   "related_prs": [],
   "tasks": [
     {
       "id": "T1",
-      "description": "W30 — patch scripts/check-state-schema.py _collect_case_study_pr_numbers to accept bare-int strings (str.isdigit() fallback after the #N regex fails)",
+      "description": "W30 \u2014 patch scripts/check-state-schema.py _collect_case_study_pr_numbers to accept bare-int strings (str.isdigit() fallback after the #N regex fails)",
       "status": "complete"
     },
     {
       "id": "T2",
-      "description": "W31 — create scripts/check-pr-workflow-coverage.py operator-side detector (curated ALWAYS_EXPECTED_PATTERNS list; combines /check-runs + /status endpoints; surfaces missing checks with rebase remediation hint)",
+      "description": "W31 \u2014 create scripts/check-pr-workflow-coverage.py operator-side detector (curated ALWAYS_EXPECTED_PATTERNS list; combines /check-runs + /status endpoints; surfaces missing checks with rebase remediation hint)",
       "status": "complete"
     },
     {
       "id": "T3",
-      "description": "W32 — patch scripts/close-feature.py to auto-skip --force-incomplete for single-phase work shapes (framework_feature subtype / Chore-Fix work_type / explicit single_phase flag)",
+      "description": "W32 \u2014 patch scripts/close-feature.py to auto-skip --force-incomplete for single-phase work shapes (framework_feature subtype / Chore-Fix work_type / explicit single_phase flag)",
       "status": "complete"
     },
     {
       "id": "T4",
-      "description": "scripts/tests/test_w30_w31_w32_durable_fixes.py — 16 unit tests covering W30 (6), W31 (3), W32 (7) — all passing under `python3 -m unittest`",
+      "description": "scripts/tests/test_w30_w31_w32_durable_fixes.py \u2014 16 unit tests covering W30 (6), W31 (3), W32 (7) \u2014 all passing under `python3 -m unittest`",
       "status": "complete"
     },
     {
       "id": "T5",
       "description": "Append durable-fix references to W30 + W31 + W32 entries in .claude/integrity/observed-patterns.md (the W-pattern entries themselves stay as historical incident records; durable-fix lines added inline)",
-      "status": "pending"
+      "status": "complete",
+      "close_note": "PR #637 \u2014 observed-patterns.md W30/W31/W32 entries each got \"Durable fix SHIPPED 2026-06-05\" annotation"
     },
     {
       "id": "T6",
       "description": "Source case study at docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md",
-      "status": "pending"
+      "status": "complete",
+      "close_note": "PR #637 \u2014 docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md created"
     },
     {
       "id": "T7",
-      "description": "Update docs/product/backlog.md — strike W30 + W31 + W32 entries from 'Framework hygiene' subsection (they were queued there by F-PHASE-E-ADOPTION-FREEZE-DISCIPLINE's same-session surfacing)",
-      "status": "pending"
+      "description": "Update docs/product/backlog.md \u2014 strike W30 + W31 + W32 entries from 'Framework hygiene' subsection (they were queued there by F-PHASE-E-ADOPTION-FREEZE-DISCIPLINE's same-session surfacing)",
+      "status": "complete",
+      "close_note": "PR #637 \u2014 docs/product/backlog.md Framework hygiene W30 entry struck"
     }
   ],
   "phases": {
     "implementation": {
       "started_at": "2026-06-05T06:00:00Z",
       "ended_at": null,
-      "notes": "In flight on feature/framework-w30-w31-w32-durable-fixes. Single-phase Chore (work_subtype=framework_feature — same shape as the v7.9.1 ships this closure unblocks). W32 itself eats its own dogfood: this feature will close via the new auto-skip path.",
+      "notes": "In flight on feature/framework-w30-w31-w32-durable-fixes. Single-phase Chore (work_subtype=framework_feature \u2014 same shape as the v7.9.1 ships this closure unblocks). W32 itself eats its own dogfood: this feature will close via the new auto-skip path.",
       "approved_by": "operator",
-      "approval_signal": "(implicit — operator merged PR #637)"
+      "approval_signal": "(implicit \u2014 operator merged PR #637)"
     },
     "review": {
       "started_at": "2026-06-05T06:37:20Z",
@@ -97,7 +100,7 @@
       "started_at": "2026-06-05T06:37:20Z",
       "ended_at": "2026-06-05T06:38:25Z",
       "approved_by": "operator",
-      "approval_signal": "(post-merge closure batch — case study + backlog strike shipped in feature PR)"
+      "approval_signal": "(post-merge closure batch \u2014 case study + backlog strike shipped in feature PR)"
     },
     "complete": {
       "started_at": "2026-06-05T06:38:25Z",
@@ -157,7 +160,7 @@
       "from": "docs",
       "to": "complete",
       "at": "2026-06-05T06:38:25Z",
-      "reason": "Feature CLOSED via close-feature.py on chore/framework-w30-w31-w32-durable-fixes-post-merge-closure. Closes the testing→complete drift-pattern documented across 5+ instances by automating the post-merge audit trail."
+      "reason": "Feature CLOSED via close-feature.py on chore/framework-w30-w31-w32-durable-fixes-post-merge-closure. Closes the testing\u2192complete drift-pattern documented across 5+ instances by automating the post-merge audit trail."
     }
   ]
 }

--- a/.claude/logs/framework-w30-w31-w32-durable-fixes.log.json
+++ b/.claude/logs/framework-w30-w31-w32-durable-fixes.log.json
@@ -6,13 +6,24 @@
   "current_phase": "implementation",
   "framework_version": "v7.9.1",
   "started_at": "2026-06-05T06:06:50Z",
-  "updated_at": "2026-06-05T06:06:50Z",
+  "updated_at": "2026-06-05T06:38:25Z",
   "events": [
     {
       "timestamp": "2026-06-05T06:06:50Z",
       "event_type": "phase_started",
       "phase": "implementation",
       "summary": "W30+W31+W32 durable-fix Chore \u2014 3 surgical patches (parser bare-int fallback / workflow-coverage detector / close-feature single-phase auto-skip) + 16-test suite. Single PR per the saved 'Tomorrow's queue' from project_session_2026_06_04. W32 dogfood: this feature itself is work_subtype=framework_feature and will close via the new auto-skip path post-merge.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-06-05T06:38:25Z",
+      "event_type": "phase_transition",
+      "phase": "complete",
+      "summary": "Phase 9 CLOSED via close-feature.py. PR #637 squashed onto main as a065798fd4 (operator-merged 2026-06-05T06:37:20Z). state.json implementation\u2192complete with full audit transitions + merge metadata.",
       "artifacts": [],
       "metrics": {},
       "actor": "human_or_agent",

--- a/docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md
+++ b/docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md
@@ -10,7 +10,12 @@ tier_tags_required: true
 status: shipped
 case_study: docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md
 case_study_showcase: ""
-related_prs: []
+related_prs: [637]
+pr_citation_exempt:
+  - {pr_number: 623, reason: "Cross-reference to F-LAUNCHD-DRIFT-EXTENSION (a) feature PR — surfacing-session context for W31 incident, not this Chore's own PR"}
+  - {pr_number: 624, reason: "Cross-reference to F-LAUNCHD-DRIFT-EXTENSION (b)+(c) closure PR — surfacing-session context for W30+W32, not this Chore's own PR"}
+  - {pr_number: 633, reason: "Cross-reference to v7.9.1 4-stuck-features closure PR — same-session retrospective example for W32, not this Chore's own PR"}
+  - {pr_number: 636, reason: "Cross-reference to framework-v7-9-1-promotion closure PR — same-session retrospective example for W32, not this Chore's own PR"}
 dispatch_pattern: serial
 success_metrics:
   - name: w_patterns_resolved
@@ -178,3 +183,7 @@ All 3 verifications pass at commit time.
 - W32: [`observed-patterns.md` W32](../../.claude/integrity/observed-patterns.md) (same)
 - Source surfacing session: `docs/case-studies/framework-v7-9-1-promotion-case-study.md` §3 cascading-rebase rhythm + `docs/case-studies/f-phase-e-adoption-freeze-discipline-case-study.md` §What changed (backlog hygiene subsection)
 - Same-session v7.9.1 feature closures unblocked retroactively: PR #633 + PR #636 (the manual `--force-incomplete` invocations of yesterday's closure work would now auto-skip)
+
+---
+
+**Shipped via PR #637** (`chore(framework): W30+W31+W32 durable fixes — parser bare-int + workflow-coverage detector + single-phase auto-skip`, merged 2026-06-05 as `a065798`). Closure via the new W32 auto-skip path (eating its own dogfood).


### PR DESCRIPTION
## Summary

Post-merge closure for [PR #637](https://github.com/Regevba/FitTracker2/pull/637) (W30+W31+W32 durable fixes, merged \`a065798\`). **W32 dogfood test: SUCCESS.**

## The dogfood test

PR #637's case study set kill-criterion #3 as: "this very feature won't close cleanly if the W32 patch is broken." Tested by closing this feature via the new auto-skip path.

\`close-feature.py\` output:
\`\`\`
ℹ W32 auto-skip: 'framework-w30-w31-w32-durable-fixes' at current_phase=implementation
  accepted as single-phase closure (work_type=Chore, work_subtype=framework_feature,
  single_phase=None). Framework_feature / Chore / Fix subtypes legitimately ship
  implementation + tests in one phase.
auto-detected merge PR #637 for feature 'framework-w30-w31-w32-durable-fixes'
✓ state.json flipped: implementation → complete  (merge_pr_number=637)
✓ Tier 2.2 log appended
\`\`\`

**Patch validated by construction** — without W32, this closure would have required \`--force-incomplete\` and emitted a noisy warning. With W32, it emits a single informational log line and proceeds.

## Closure mutations

- \`.claude/features/framework-w30-w31-w32-durable-fixes/state.json\` — \`current_phase\`: \`implementation\` → \`complete\`; phases.{review,merge,docs,complete} populated; merge_pr_number=637; merge_commit_sha=a065798
- \`.claude/logs/framework-w30-w31-w32-durable-fixes.log.json\` — Tier 2.2 phase-transition event appended
- \`docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md\`:
  - \`related_prs: [637]\` (this feature's own merge PR)
  - \`pr_citation_exempt\` for 4 cross-references (#623, #624, #633, #636)
  - Body footer: "Shipped via PR #637"

## Test plan

- [x] \`python3 scripts/close-feature.py framework-w30-w31-w32-durable-fixes\` — W32 auto-skip path fired correctly
- [x] state.json mutations match the canonical D1 closure pattern from PR #587
- [x] Pre-commit gates all pass on \`4ba59e0\` (was the W30 + Q6 parity check the W32 fix unblocked)
- [x] \`make integrity-check\` baseline — 0 findings + advisories

🤖 Generated with [Claude Code](https://claude.com/claude-code)