### PR TITLE
fix(ci): trailing newline on dependency-audit digest — fix weekly cron failure

### DIFF
--- a/scripts/aggregate-dependency-audit.py
+++ b/scripts/aggregate-dependency-audit.py
@@ -141,8 +141,13 @@ def main() -> int:
         "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
-    Path(args.output_md).write_text(render_markdown(by_subdir, totals, swift))
-    Path(args.output_json).write_text(json.dumps(payload, indent=2))
+    # Trailing newline is REQUIRED: the consuming workflow pipes this file into
+    # $GITHUB_ENV via a heredoc (`cat audit-summary.md; echo "DIGEST_EOF"`). Without
+    # it, the closing delimiter glues onto the last markdown line and GitHub's
+    # env-file parser fails with "Matching delimiter not found" — failing the step
+    # on every run regardless of vulnerability count.
+    Path(args.output_md).write_text(render_markdown(by_subdir, totals, swift) + "\n")
+    Path(args.output_json).write_text(json.dumps(payload, indent=2) + "\n")
 
     print(render_markdown(by_subdir, totals, swift))
     return 0

--- a/scripts/tests/test_aggregate_dependency_audit.py
+++ b/scripts/tests/test_aggregate_dependency_audit.py
@@ -1,0 +1,69 @@
+"""Regression tests for scripts/aggregate-dependency-audit.py.
+
+Primary guard: the markdown + JSON outputs MUST end with a trailing newline.
+The consuming workflow (.github/workflows/dependency-audit-weekly.yml) pipes
+audit-summary.md into $GITHUB_ENV via a heredoc:
+
+    {
+      echo "DIGEST<<DIGEST_EOF"
+      cat /tmp/audit-summary.md
+      echo "DIGEST_EOF"
+    } >> "$GITHUB_ENV"
+
+If the file lacks a trailing newline, `DIGEST_EOF` glues onto the last
+markdown line and GitHub's env-file parser fails with
+"Invalid value. Matching delimiter not found 'DIGEST_EOF'" — failing the
+step on EVERY run regardless of vulnerability count (observed 2026-06-01,
+run 26750972795). See observed-patterns catalog.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "aggregate-dependency-audit.py"
+
+
+def _run(tmp_path: Path, *extra: str) -> tuple[Path, Path]:
+    md = tmp_path / "audit-summary.md"
+    js = tmp_path / "audit-summary.json"
+    missing = tmp_path / "does-not-exist.json"  # parse_npm_audit returns zeros
+    cmd = [
+        sys.executable, str(SCRIPT),
+        "--npm-audit", f"{missing}:root",
+        "--output-md", str(md),
+        "--output-json", str(js),
+        *extra,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return md, js
+
+
+def test_markdown_ends_with_newline(tmp_path):
+    md, _ = _run(tmp_path)
+    assert md.read_text().endswith("\n")
+
+
+def test_json_ends_with_newline(tmp_path):
+    _, js = _run(tmp_path)
+    assert js.read_text().endswith("\n")
+
+
+def test_heredoc_delimiter_lands_on_own_line(tmp_path):
+    """Simulate the workflow's cat-then-echo heredoc; the closing delimiter
+    must be on its own line."""
+    md, _ = _run(tmp_path)
+    composed = md.read_text() + "DIGEST_EOF\n"  # `cat md` + `echo DIGEST_EOF`
+    assert composed.splitlines()[-1] == "DIGEST_EOF"
+
+
+def test_totals_keys_present_for_github_output(tmp_path):
+    """The workflow's inline python reads totals[high|critical|total]."""
+    _, js = _run(tmp_path)
+    totals = json.loads(js.read_text())["totals"]
+    for key in ("high", "critical", "total"):
+        assert key in totals
+        assert isinstance(totals[key], int)


### PR DESCRIPTION
## What

`dependency-audit-weekly.yml` has failed on every run since it shipped (most recently run [26750972795](https://github.com/Regevba/FitTracker2/actions/runs/26750972795), 2026-06-01) — **not** because of any vulnerability (npm audit = 0 critical / 0 high / 0 moderate / 0 low across all subdirs), but because of a digest-emit bug.

## Root cause

`scripts/aggregate-dependency-audit.py` wrote `audit-summary.md` via `"\n".join(lines)` with **no trailing newline**. The workflow pipes that file into `$GITHUB_ENV` with a heredoc:

```bash
{ echo "DIGEST<<DIGEST_EOF"; cat /tmp/audit-summary.md; echo "DIGEST_EOF"; } >> "$GITHUB_ENV"
```

Without a trailing newline the closing delimiter glued onto the last markdown line (`…weekly digest.DIGEST_EOF`), so GitHub's env-file parser failed:

```
##[error]Invalid value. Matching delimiter not found 'DIGEST_EOF'
```

Under `bash -e` that killed the step → red job, every week, regardless of vuln count.

## Fix

- Append `"\n"` to both the `.md` and `.json` outputs (with an explanatory comment tying it to the heredoc contract).
- Add `scripts/tests/test_aggregate_dependency_audit.py` — 4 cases: md trailing newline, json trailing newline, heredoc delimiter lands on its own line, and the `totals[high|critical|total]` keys the workflow's `GITHUB_OUTPUT` step reads.

## Verification

```
$ pytest scripts/tests/test_aggregate_dependency_audit.py
4 passed in 0.17s
# heredoc simulation: DIGEST_EOF now on its own line ✓
```

No behavior change to the audit itself — only the digest now emits cleanly so the job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)