### PR TITLE
chore(3d-universe): sync reverse-mirror state.json + tasks.md to current reality

### DIFF
--- a/.claude/features/3d-interactive-framework-flow-diagram/state.json
+++ b/.claude/features/3d-interactive-framework-flow-diagram/state.json
@@ -113,6 +113,18 @@
     "launch_window": "Track A (ship pre-v8.0)"
   },
   "tasks": [],
+  "related_prs": [
+    {"repo": "fitme-story", "n": 198, "title": "T-ga4-events: typed framework_universe_* GA4 helpers", "phase": "4.H", "status": "merged"},
+    {"repo": "fitme-story", "n": 199, "title": "T-fallback-cascade: FR-4 capability detection + tier resolution", "phase": "4.F", "status": "merged"},
+    {"repo": "fitme-story", "n": 200, "title": "T-comprehension-panel: operator dashboard for GA4 Universe events", "phase": "4.H", "status": "merged"},
+    {"repo": "fitme-story", "n": 201, "title": "Phase 4.H wire act_enter + label_hover GA4 events in ActSequencer + HoverCard", "phase": "4.H", "status": "merged", "sha": "ace1cde"},
+    {"repo": "fitme-story", "n": 202, "title": "Phase 4.H propagate analytics props to Act 3 + Act 4 HoverCards", "phase": "4.H", "status": "merged", "sha": "fd02fce"},
+    {"repo": "fitme-story", "n": 203, "title": "Phase 4.I T-aggregator extension — HADF Phase 3a hooks block (path-agnostic)", "phase": "4.I", "status": "merged", "sha": "e7c1b51"},
+    {"repo": "fitme-story", "n": 204, "title": "lighthouse-ci: add /framework + /framework/universe", "phase": "4.J", "status": "merged", "sha": "50e1983"},
+    {"repo": "fitme-story", "n": 205, "title": "temporarily 404 /framework/universe pending animation polish", "phase": "4-disable", "status": "merged", "sha": "3d46664"}
+  ],
+  "prod_status": "temporarily_404 (2026-06-06)",
+  "prod_status_reason": "Operator decision 2026-06-06: animation polish needed before re-launching to the public. R3F scene tree, all primitives, scenes, fallback cascade, analytics wiring, and operator route stay on main so iteration continues. /framework/universe returns notFound(); /framework discovery card removed; /framework/universe dropped from lighthouse-ci URL list. Re-launch checklist captured inline at src/app/framework/universe/page.tsx (3 steps).",
   "figma_node_ids": {},
   "figma_build_status": null,
   "pre_merge_review": {
@@ -188,5 +200,5 @@
       "deferred_at": "2026-06-04T19:30:00Z"
     }
   },
-  "updated_at": "2026-06-04T19:30:00Z"
+  "updated_at": "2026-06-07T00:00:00Z"
 }

--- a/.claude/features/3d-interactive-framework-flow-diagram/tasks.md
+++ b/.claude/features/3d-interactive-framework-flow-diagram/tasks.md
@@ -7,6 +7,42 @@
 > T-act-iv-pattern-hover) from §Data Contracts + §Acceptance Criteria, plus
 > ~30 additional implementation tasks derived from the 12 FRs + 11 ACs.
 
+## Implementation status (as of 2026-06-07)
+
+**Shipped: 20 of 36 tasks**. The block descriptions below remain the authoritative scope spec; the table here is the rolling status overlay. For PR-level provenance, see `state.json::related_prs`.
+
+| Task | Status | Shipping PR(s) |
+|---|---|---|
+| T-aggregator | ✅ shipped + extended | fitme-story #182 (base) + #203 (HADF Phase 3a hooks block) |
+| T-versions-mirror, T-adoption-mirror, T-pattern-skill-mirror | ✅ shipped | fitme-story #183 |
+| T-snapshot-loader | ✅ shipped | fitme-story #184 |
+| T-primitive-chambers, T-primitive-terrain, T-primitive-signage, T-primitive-motion | ✅ shipped | fitme-story #185 (4.B pipeline) |
+| T-act1-threshold, T-act2-emergence, T-act3-architecture, T-act4-gate-firings, T-act5-measurement, T-act6-legacy | ✅ shipped | fitme-story #186–#191 (Acts I–VI) |
+| T-overlay-wiring | ✅ shipped | fitme-story #192 + #193 |
+| T-act-iv-pattern-hover | ✅ shipped | fitme-story #194 (via HoverCard) |
+| T-glossary-tooltips | ✅ shipped | fitme-story #195 |
+| T-pr-link-click | ✅ shipped | fitme-story #194 (via HoverCard `prNumber` prop) |
+| T-fallback-cascade | ✅ shipped | fitme-story #199 |
+| T-route-framework, T-route-control-room | ✅ shipped | fitme-story #196 + #197 |
+| T-bundle-size-check | ✅ shipped | fitme-story #197 |
+| T-ga4-events | ✅ shipped (helpers + scene wiring) | fitme-story #198 (typed helpers) + #201 (ActSequencer wiring) + #202 (scene-side analytics props) |
+| T-comprehension-panel | ✅ shipped | fitme-story #200 |
+| T-hadf-sensing-layer-hooks (aggregator half) | ✅ shipped (path-agnostic) | fitme-story #203 |
+| T-lighthouse-perf URL list | ✅ shipped | fitme-story #204 |
+| T-hero-gate-machinery, T-hero-telemetry-instruments, T-hero-signature-props (×4) | 🔒 gated | visual-direction lock + Blender authoring decision |
+| T-scrub-pause-timedilation | 🔒 gated | Theatre.js v9 compatibility OR alternative path |
+| T-rive-tier-2 | 🔒 gated | operator Rive asset |
+| T-poster-tier-3 | 🔒 gated | operator hero PNG/WebP capture |
+| T-hadf-sensing-layer-hooks (scene consumer half) | 🔒 gated | operator path 1 (Act III chambers) vs path 2 (new sub-Act) decision |
+| T-playwright-ac10, T-playwright-ac11, T-mobile-60fps | 🔒 gated | Playwright browser binary install approval (~200 MB) |
+| T-lighthouse-perf assertion promotion | 🔒 gated | calibration window (currently `warn` @ minScore 0.8; AC-16 target ≥0.95) |
+
+### Production status (2026-06-06)
+
+`/framework/universe` is **temporarily 404'd** in production pending animation polish (operator decision 2026-06-06, shipped via fitme-story PR #205). The R3F scene tree + every shipped task above stays on `main` for iteration; only the user-facing entry point is gated. Re-launch checklist captured inline at [`fitme-story/src/app/framework/universe/page.tsx`](../../../../fitme-story/src/app/framework/universe/page.tsx) (3 steps).
+
+`/control-room/framework/universe` (operator route) stays mounted as the iteration surface.
+
 ## Task structure
 
 Each task block carries:


### PR DESCRIPTION
## Summary

Paired with **[fitme-story PR #206](https://github.com/Regevba/fitme-story/pull/206)** — adds the same `related_prs[]` + `prod_status` to the reverse-sync mirror at \`FitTracker2/.claude/features/3d-interactive-framework-flow-diagram/state.json\` so both sides match before the next reverse-sync GH Action fires.

## state.json changes

| Field | Change |
|---|---|
| \`related_prs[]\` | Added 8 entries — #198, #199, #200, #201, #202, #203, #204, #205 (with phase + SHA) |
| \`prod_status\` | Added \`\"temporarily_404 (2026-06-06)\"\` with full reason note |
| \`updated_at\` | 2026-06-04 → 2026-06-07 |

Other fields untouched; the FT2 mirror already had the correct \`v7.9.1 / tasks_phase / oq_closures / cu_v2\` state.

## tasks.md changes

Added a top-level **\"Implementation status (as of 2026-06-07)\"** section:

- Status table mapping each of the 20 shipped tasks → its shipping PR
- Gated reasons for the 16 remaining tasks (hero assets, Theatre.js scrub, Rive/poster, HADF path 1 vs 2, Playwright, lighthouse promotion)
- Production status subsection (route 404'd + re-launch checklist pointer)

Per-task block descriptions BELOW the status table are **NOT** bulk-edited — they remain the authoritative scope spec; the table on top is the rolling status overlay.

## Validation

\`python3 -m json.tool state.json\` passes; pre-commit schema-check passes (\"✓ All 1 state.json files pass all checks\").

Unrelated session-script churn in \`.claude/shared/measurement-adoption*.json\` explicitly NOT included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)