### PR TITLE
docs(cross-repo-state-sync): restore v7.8.3 spec + plan to main (broken-ref fix)

### DIFF
--- a/docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md
+++ b/docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md
@@ -1,0 +1,2776 @@
+# Cross-Repo State Sync (v7.8.3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the v7.8.3 release umbrella — 5 sequential phases (framework gate promotions → telemetry foundations → schema + backfill + morphed validator → reverse-sync GitHub Action → cutover ceremony) that close all deferred Phase C/D state-sync work plus V2/V9 v7.9 candidates, gating HADF Phase 2-bis on framework calibration.
+
+**Architecture:** FT2 stays canonical writer for all state.json + ledgers; fitme-story is canonical reader with rare reverse-sync writes for fitme-story-native features (mediated by GitHub Action + manual merge). Each phase ships in its own per-phase branch with explicit calibration targets sourced from natural feature work.
+
+**Tech Stack:** Python 3 (pre-commit gate scripts, backfill, refresh, snapshot), Bash (snapshot script + GH Action wrapper), TypeScript / Node (fitme-story sync extension + aggregator), GitHub Actions YAML (reverse-sync workflow), git custom merge driver (V9 extension).
+
+**Source spec:** [`docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md`](../specs/2026-05-11-cross-repo-state-sync-impl-design.md) (commit `d77f23d` on branch `chore/cross-repo-state-sync-impl-spec`).
+
+---
+
+## File Structure
+
+### Created (FT2)
+
+| Path | Phase | Responsibility |
+|---|---|---|
+| `scripts/refresh-pr-cache.py` | 1 | Populates `.cache/gh-pr-cache.json` for both repos via `gh pr list` |
+| `scripts/snapshot-phase-completion.sh` | 0 | Operator script to snapshot per-phase work to `~/Documents/FitTracker2-backups/` |
+| `scripts/backfill-state-owner.py` | 2 | One-shot script: insert `state_owner: "ft2"` into all 47 existing state.json files |
+| `tests/framework/__init__.py` | 0 | Marker for new pytest test package |
+| `tests/framework/conftest.py` | 0 | Shared pytest fixtures (test repo dir, fixture state.json, etc.) |
+| `tests/framework/test_v2_writer_path.py` | 0 | V2 enforcement gate tests (CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT) |
+| `tests/framework/test_v9_merge_driver.py` | 0 | V9 union-dedup driver on synthetic feature log conflicts |
+| `tests/framework/test_snapshot_script.py` | 0 | Snapshot script idempotency + manifest correctness |
+| `tests/framework/test_pr_cite_cache.py` | 1 | D-3 regex parametrization + REPO_MAP routing + resolve_pr_cite |
+| `tests/framework/test_state_owner_gates.py` | 2 | STATE_OWNER_MISSING / INVALID / LOCATION_MISMATCH + sync_origin exemption |
+| `tests/framework/test_backfill_script.py` | 2 | backfill-state-owner.py idempotency + correctness |
+| `docs/case-studies/cross-repo-state-sync-impl-case-study.md` | 4 | Source case study documenting all 5 phases |
+
+### Modified (FT2)
+
+| Path | Phase | Change |
+|---|---|---|
+| `scripts/check-state-schema.py` | 0 + 2 | V2 enforcement (Phase 0); 3 new state_owner gates + sync_origin exemption (Phase 2) |
+| `scripts/merge-driver-dedup.py` | 0 | Extend union-dedup logic to handle `.claude/logs/*.log.json` schema |
+| `.gitattributes` | 0 | Add `.claude/logs/*.log.json merge=union-dedup-by-key` line |
+| `scripts/check-case-study-preflight.py` | 1 | Replace `_PR_CITATION_PAT` regex (lines 74-76) + add `REPO_MAP` + `resolve_pr_cite` function |
+| `Makefile` | 0 + 1 | Add `snapshot-phase` (Phase 0); `refresh-pr-cache`, `validate-existing-cites` (Phase 1) |
+| `CLAUDE.md` | 0 + 2 | Bump framework version to v7.8.3 (Phase 0); add `state_owner` paragraph (Phase 2) |
+| `.claude/integrity/schemas/state.schema.json` | 2 | Add `state_owner` to required fields (if file exists; else skip) |
+| All 47 × `.claude/features/*/state.json` | 2 | Insert `state_owner: "ft2"` field (mechanical via backfill script) |
+
+### Created (fitme-story)
+
+| Path | Phase | Responsibility |
+|---|---|---|
+| `src/lib/control-room/gate-coverage-aggregator.ts` | 1 | Reads both repos' gate-coverage.jsonl + tags by source_repo + combines time-sorted |
+| `tests/control-room/gate-coverage-aggregator.test.ts` | 1 | Aggregator on synthetic two-source data |
+| `tests/control-room/sync-extension.test.ts` | 1 | Phase 1 forward-sync extension test |
+| `.github/workflows/reverse-sync-fitme-story-to-ft2.yml` | 3 | Triggered by push to main; opens auto-PR against FT2 |
+| `scripts/test-reverse-sync-action.sh` | 3 | Local `act` wrapper for workflow testing |
+| `content/04-case-studies/<NN>-cross-repo-state-sync-impl.mdx` | 4 | Showcase MDX (slot N determined at Phase 4 by chronological-order rule — pick next slot after latest v7.8.2 case study) |
+
+### Modified (fitme-story)
+
+| Path | Phase | Change |
+|---|---|---|
+| `scripts/sync-from-fittracker2.ts` | 1 | Add forward-sync of `gate-coverage.jsonl` → `gate-coverage-ft2.jsonl` |
+| `src/app/control-room/framework/page.tsx` (or equivalent) | 1 | Add aggregated gate-coverage section using new aggregator |
+| `.claude/README.md` | 3 | Document reverse-sync flow + FT2_REPO_TOKEN setup |
+
+### Created during Phase 4
+
+| Path | Responsibility |
+|---|---|
+| `fitme-story/.claude/features/<fs-native>/state.json` | First fitme-story-native state.json (`state_owner: "fitme-story"`) |
+| `fitme-story/.claude/logs/<fs-native>.log.json` | First fitme-story-native Tier 2.2 log |
+| `FT2/.claude/features/<fs-native>/state.json` | Reverse-sync mirror (carries `state_owner_sync_origin: "fitme-story-reverse"` marker) |
+
+---
+
+## Phase 0 — v7.8.3 framework gate promotions + snapshot protocol
+
+**Branch:** `feat/cross-repo-state-sync-phase-0` (off latest `main`)
+**Single PR.** Estimated 1-2 days impl + 7 days calibration.
+
+### Task 0.1: Set up tests/ directory + pytest config
+
+**Files:**
+- Create: `tests/__init__.py` (empty)
+- Create: `tests/framework/__init__.py` (empty)
+- Create: `tests/framework/conftest.py`
+- Create: `pytest.ini` (if not already present at repo root)
+
+- [ ] **Step 1: Verify tests/ does not exist**
+
+```bash
+test ! -d /Volumes/DevSSD/FitTracker2/tests && echo "OK: tests/ absent" || echo "FAIL: tests/ exists"
+```
+
+Expected: `OK: tests/ absent`
+
+- [ ] **Step 2: Create test package structure**
+
+```bash
+mkdir -p /Volumes/DevSSD/FitTracker2/tests/framework
+touch /Volumes/DevSSD/FitTracker2/tests/__init__.py
+touch /Volumes/DevSSD/FitTracker2/tests/framework/__init__.py
+```
+
+- [ ] **Step 3: Create pytest config**
+
+`pytest.ini`:
+```ini
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*
+filterwarnings =
+    error::pytest.PytestUnraisableExceptionWarning
+```
+
+- [ ] **Step 4: Create conftest.py with shared fixtures**
+
+`tests/framework/conftest.py`:
+```python
+"""Shared fixtures for framework gate tests."""
+from __future__ import annotations
+import json
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def test_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo with .claude/features/ structure."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / ".claude" / "features").mkdir(parents=True)
+    (tmp_path / ".claude" / "logs").mkdir(parents=True)
+    (tmp_path / ".claude" / "shared").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def write_state(test_repo: Path):
+    """Helper: write a state.json under .claude/features/<name>/."""
+    def _write(name: str, content: dict) -> Path:
+        feat_dir = test_repo / ".claude" / "features" / name
+        feat_dir.mkdir(parents=True, exist_ok=True)
+        path = feat_dir / "state.json"
+        path.write_text(json.dumps(content, indent=2) + "\n")
+        return path
+    return _write
+```
+
+- [ ] **Step 5: Verify pytest discovers (zero tests is OK)**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/ -v 2>&1 | head -10
+```
+
+Expected: `collected 0 items` (no errors)
+
+- [ ] **Step 6: Commit infrastructure**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add tests/ pytest.ini
+git commit -m "$(cat <<'EOF'
+chore(tests): add tests/framework/ pytest package + conftest fixtures
+
+Foundation for v7.8.3 framework gate test suite. Creates tests/__init__.py,
+tests/framework/__init__.py, tests/framework/conftest.py with test_repo +
+write_state shared fixtures, and pytest.ini with strict warnings.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.2: V2 enforcement — write failing test
+
+**Files:**
+- Create: `tests/framework/test_v2_writer_path.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""V2 — Mechanism C writer-path enforced (CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT).
+
+Promotes the cache_hits[] writer-path gate from advisory (v7.8) to
+enforced (v7.8.3) per spec §3.5.2 Phase 0 calibration target."""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check-state-schema.py"
+
+
+def run_check(state_path: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(state_path)],
+        capture_output=True, text=True,
+    )
+    return result.returncode, result.stderr + result.stdout
+
+
+def test_v2_post_v6_with_empty_cache_hits_and_session_reads_fails(write_state, test_repo):
+    """When state.json is post-v6 (framework_version >= v6.0) AND post-Mechanism-C
+    (created_at >= 2026-05-02) AND has corresponding session Read events
+    BUT cache_hits[] is empty, V2 enforcement MUST reject."""
+    state_path = write_state("test-feature", {
+        "name": "test-feature",
+        "framework_version": "v7.8.3",
+        "created_at": "2026-05-12T00:00:00Z",
+        "current_phase": "complete",
+        "cache_hits": [],
+    })
+    # Simulate session events showing Read activity
+    session_log = test_repo / ".claude" / "logs" / "_session-test.events.jsonl"
+    session_log.write_text(json.dumps({"feature": "test-feature", "tool": "Read", "ts": "2026-05-12T01:00:00Z"}) + "\n")
+    code, output = run_check(state_path)
+    assert code != 0, f"expected V2 to fail; got code=0\n{output}"
+    assert "CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT" in output
+
+
+def test_v2_pre_v6_with_empty_cache_hits_passes(write_state):
+    """Pre-v6 features are exempt from V2 (per CLAUDE.md gate doc)."""
+    state_path = write_state("legacy-feature", {
+        "name": "legacy-feature",
+        "framework_version": "v5.1",
+        "created_at": "2026-04-01T00:00:00Z",
+        "current_phase": "complete",
+        "cache_hits": [],
+    })
+    code, output = run_check(state_path)
+    assert code == 0, f"expected pre-v6 exempt; got code != 0\n{output}"
+
+
+def test_v2_with_populated_cache_hits_passes(write_state):
+    """When cache_hits[] is non-empty, V2 passes regardless of Read events."""
+    state_path = write_state("ok-feature", {
+        "name": "ok-feature",
+        "framework_version": "v7.8.3",
+        "created_at": "2026-05-12T00:00:00Z",
+        "current_phase": "complete",
+        "cache_hits": [{"file": "x.py", "ts": "2026-05-12T01:00:00Z"}],
+    })
+    code, output = run_check(state_path)
+    assert code == 0, f"populated cache_hits; expected pass\n{output}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_v2_writer_path.py -v 2>&1 | tail -20
+```
+
+Expected: at least the first test FAILS (current code does NOT enforce V2; only emits advisory). Other tests may pass or fail depending on existing logic.
+
+- [ ] **Step 3: Note the existing advisory behavior**
+
+Read current advisory implementation in `scripts/check-state-schema.py` (search for `CACHE_HITS_AUTO_INSTRUMENTATION` or similar). Capture the function name + line range for Step 4 below.
+
+```bash
+grep -n "CACHE_HITS\|cache_hits" /Volumes/DevSSD/FitTracker2/scripts/check-state-schema.py | head -20
+```
+
+Expected: prints line numbers of existing advisory logic.
+
+### Task 0.3: V2 enforcement — implement (promote advisory → enforced)
+
+**Files:**
+- Modify: `scripts/check-state-schema.py` (advisory function found in Task 0.2 Step 3)
+
+- [ ] **Step 1: Promote the gate from advisory to enforced**
+
+In `scripts/check-state-schema.py`, locate the function that currently emits `CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE` (advisory). Change it to:
+
+1. Rename the gate code from `_INACTIVE` (advisory) to `_DRIFT` (enforced)
+2. Change return severity from `WARN` / advisory to `FAIL`
+3. Update the gate's docstring header to cite v7.8.3 promotion
+
+The exact diff depends on the existing function shape. Pattern (illustrative):
+
+```python
+def check_cache_hits_auto_instrumentation_drift(state, file_path, *, coverage=None):
+    """V2 (v7.8.3) — promoted from advisory to enforced.
+
+    Fires when post-Mechanism-C state.json (created_at >= 2026-05-02) has
+    framework_version >= v6.0 AND empty cache_hits[] AND corresponding session
+    Read events exist in `.claude/logs/_session-*.events.jsonl`.
+
+    Pre-Mechanism-C features (created_at < 2026-05-02) are exempt — the
+    auto-instrumentation didn't exist for them.
+    """
+    # ... existing logic, but return FAIL not WARN ...
+    if _is_post_v6(state) and _is_post_mechanism_c(state) and not state.get("cache_hits") and _has_session_reads(state, file_path):
+        return Finding(
+            severity="FAIL",
+            code="CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT",
+            message=f"{file_path}: post-v6 + post-Mechanism-C state.json has empty cache_hits[] but session events show Reads; auto-instrumentation appears broken",
+        )
+    return None
+```
+
+- [ ] **Step 2: Update Mechanism D header version stamp**
+
+At the top of `scripts/check-state-schema.py`, find the header version block (Mechanism D self-audit pattern). Update the version stamp:
+
+```python
+__SCHEMA_CHECKER_VERSION__ = "v7.8.3"  # bumped from v7.8.2
+__SCHEMA_CHECKER_LAST_MODIFIED__ = "2026-05-11"
+```
+
+- [ ] **Step 3: Run failing test — should pass now**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_v2_writer_path.py -v
+```
+
+Expected: ALL 3 tests PASS.
+
+- [ ] **Step 4: Run on real state.json files — verify zero false positives on shipped features**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 scripts/check-state-schema.py 2>&1 | tail -30
+```
+
+Expected: 0 NEW failures on already-shipped features. If any fail, capture the names + investigate before commit.
+
+- [ ] **Step 5: Run pre-commit self-test**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && make pre-commit-self-test
+```
+
+Expected: PASS — Mechanism D header self-audit confirms version stamp matches script version.
+
+- [ ] **Step 6: Commit V2**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add tests/framework/test_v2_writer_path.py scripts/check-state-schema.py
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): V2 promote CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT advisory → enforced
+
+Per spec §3.5.2 Phase 0 calibration target. Mechanism C writer-path is now
+mechanically enforced — post-v6 + post-Mechanism-C state.json with empty
+cache_hits[] but session Read events present causes pre-commit FAIL.
+
+Adds tests/framework/test_v2_writer_path.py with 3 cases:
+- post-v6 + Read events + empty cache_hits → FAIL
+- pre-v6 → exempt
+- populated cache_hits → PASS
+
+Bumps __SCHEMA_CHECKER_VERSION__ to v7.8.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.4: V9 driver extension — write failing test
+
+**Files:**
+- Create: `tests/framework/test_v9_merge_driver.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""V9 — Mechanism E custom git merge driver covers .claude/logs/<feature>.log.json.
+
+Per spec §10 / Phase 0. Extends existing union-dedup-by-key driver
+(measurement-adoption-history.json + documentation-debt.json) to handle
+Tier 2.2 contemporaneous feature logs."""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+DRIVER = Path(__file__).resolve().parents[2] / "scripts" / "merge-driver-dedup.py"
+
+
+def run_driver(ours_path: Path, theirs_path: Path, ancestor_path: Path, real_path: str) -> int:
+    """Invoke the driver with git's merge-driver argument convention (%O %A %B %P)."""
+    result = subprocess.run(
+        [sys.executable, str(DRIVER), str(ancestor_path), str(ours_path), str(theirs_path), real_path],
+        capture_output=True, text=True,
+    )
+    return result.returncode
+
+
+def test_v9_feature_log_union_dedup(tmp_path: Path):
+    """Two diverging feature log files merge via union-dedup-by-key on event timestamps."""
+    ours = tmp_path / "ours.json"
+    theirs = tmp_path / "theirs.json"
+    ancestor = tmp_path / "ancestor.json"
+
+    ancestor.write_text(json.dumps({
+        "feature": "test-feature",
+        "events": [{"ts": "2026-05-12T00:00:00Z", "event_type": "phase_started", "phase": "research"}],
+    }))
+    ours.write_text(json.dumps({
+        "feature": "test-feature",
+        "events": [
+            {"ts": "2026-05-12T00:00:00Z", "event_type": "phase_started", "phase": "research"},
+            {"ts": "2026-05-12T01:00:00Z", "event_type": "phase_approved", "phase": "research"},
+        ],
+    }))
+    theirs.write_text(json.dumps({
+        "feature": "test-feature",
+        "events": [
+            {"ts": "2026-05-12T00:00:00Z", "event_type": "phase_started", "phase": "research"},
+            {"ts": "2026-05-12T02:00:00Z", "event_type": "phase_started", "phase": "prd"},
+        ],
+    }))
+
+    code = run_driver(ours, theirs, ancestor, ".claude/logs/test-feature.log.json")
+    assert code == 0, "driver should return 0 on successful merge"
+
+    merged = json.loads(ours.read_text())
+    timestamps = sorted(e["ts"] for e in merged["events"])
+    assert timestamps == [
+        "2026-05-12T00:00:00Z",
+        "2026-05-12T01:00:00Z",
+        "2026-05-12T02:00:00Z",
+    ], f"expected union-dedup; got {timestamps}"
+
+
+def test_v9_feature_log_idempotent_when_no_conflict(tmp_path: Path):
+    """If ours == theirs, merge result is identical."""
+    ours = tmp_path / "ours.json"
+    theirs = tmp_path / "theirs.json"
+    ancestor = tmp_path / "ancestor.json"
+
+    content = {"feature": "x", "events": [{"ts": "2026-05-12T00:00:00Z", "event_type": "x", "phase": "x"}]}
+    ancestor.write_text(json.dumps(content))
+    ours.write_text(json.dumps(content))
+    theirs.write_text(json.dumps(content))
+
+    code = run_driver(ours, theirs, ancestor, ".claude/logs/x.log.json")
+    assert code == 0
+    merged = json.loads(ours.read_text())
+    assert merged == content
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_v9_merge_driver.py -v 2>&1 | tail -20
+```
+
+Expected: tests FAIL — driver doesn't recognize `.claude/logs/*.log.json` as a registered path.
+
+### Task 0.5: V9 driver extension — implement
+
+**Files:**
+- Modify: `scripts/merge-driver-dedup.py` (extend ledger config)
+
+- [ ] **Step 1: Add feature log config**
+
+In `scripts/merge-driver-dedup.py`, find the ledger configuration dict (likely a constant like `LEDGER_CONFIGS = {...}`). Add an entry for `.claude/logs/*.log.json`:
+
+```python
+# Existing config (illustrative — actual shape may differ slightly):
+LEDGER_CONFIGS = {
+    ".claude/shared/measurement-adoption-history.json": {
+        "array_field": "snapshots",
+        "dedup_key": "date",
+        "sort_key": "date",
+    },
+    ".claude/shared/documentation-debt.json": {
+        "array_field": "items",
+        "dedup_key": "id",
+        "sort_key": "id",
+    },
+    # NEW (V9 Phase 0 v7.8.3):
+    ".claude/logs/*.log.json": {
+        "array_field": "events",
+        "dedup_key": "ts",  # event timestamp; union-dedup by ts
+        "sort_key": "ts",
+    },
+}
+```
+
+- [ ] **Step 2: Update path-matching logic to support glob patterns**
+
+If the driver's path matching is exact-string only, extend it to handle glob patterns (`fnmatch.fnmatch` against `%P`):
+
+```python
+import fnmatch
+
+def get_config_for_path(real_path: str) -> dict | None:
+    for pattern, config in LEDGER_CONFIGS.items():
+        if "*" in pattern:
+            if fnmatch.fnmatch(real_path, pattern):
+                return config
+        else:
+            if real_path == pattern:
+                return config
+    return None
+```
+
+- [ ] **Step 3: Update driver header version stamp (Mechanism D)**
+
+```python
+__MERGE_DRIVER_VERSION__ = "v7.8.3"  # bumped from v7.8 — adds .claude/logs/*.log.json
+```
+
+- [ ] **Step 4: Run failing test — should pass now**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_v9_merge_driver.py -v
+```
+
+Expected: BOTH tests PASS.
+
+- [ ] **Step 5: Verify no regression on existing covered files**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/ -v 2>&1 | tail -20
+```
+
+Expected: no test regressions.
+
+### Task 0.6: V9 driver extension — register in .gitattributes
+
+**Files:**
+- Modify: `.gitattributes`
+
+- [ ] **Step 1: Add registration line**
+
+Append to `.gitattributes` after the existing union-dedup-by-key entries:
+
+```
+# v7.8.3: feature log files (Tier 2.2 contemporaneous logging)
+.claude/logs/*.log.json merge=union-dedup-by-key
+```
+
+- [ ] **Step 2: Reinstall hooks (registers driver in local git config)**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && make install-hooks
+```
+
+Expected: driver registered without error.
+
+- [ ] **Step 3: Manually verify with synthetic conflict**
+
+Create a synthetic feature log conflict, attempt merge, verify auto-resolution:
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git checkout -b test-v9-merge-driver-temp
+mkdir -p .claude/logs
+echo '{"feature":"test-v9","events":[{"ts":"2026-05-12T00:00:00Z","event_type":"x","phase":"x"}]}' > .claude/logs/test-v9.log.json
+git add .claude/logs/test-v9.log.json
+git commit -m "test: V9 base"
+echo '{"feature":"test-v9","events":[{"ts":"2026-05-12T00:00:00Z","event_type":"x","phase":"x"},{"ts":"2026-05-12T01:00:00Z","event_type":"y","phase":"x"}]}' > .claude/logs/test-v9.log.json
+git add .claude/logs/test-v9.log.json
+git commit -m "test: V9 ours append"
+
+git checkout -b test-v9-other HEAD~1
+echo '{"feature":"test-v9","events":[{"ts":"2026-05-12T00:00:00Z","event_type":"x","phase":"x"},{"ts":"2026-05-12T02:00:00Z","event_type":"z","phase":"x"}]}' > .claude/logs/test-v9.log.json
+git add .claude/logs/test-v9.log.json
+git commit -m "test: V9 theirs append"
+
+git checkout test-v9-merge-driver-temp
+git merge test-v9-other --no-ff -m "test: V9 merge"
+```
+
+Expected: auto-merges via the driver; resulting file has all 3 events sorted by ts.
+
+- [ ] **Step 4: Cleanup test branches**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git checkout feat/cross-repo-state-sync-phase-0
+git branch -D test-v9-merge-driver-temp test-v9-other
+rm -f .claude/logs/test-v9.log.json
+```
+
+- [ ] **Step 5: Commit V9**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add tests/framework/test_v9_merge_driver.py scripts/merge-driver-dedup.py .gitattributes
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): V9 extend Mechanism E driver to .claude/logs/<feature>.log.json
+
+Per spec §6.1 + V9 from v7.9 candidate inventory. Extends existing union-
+dedup-by-key driver (currently covers measurement-adoption-history.json +
+documentation-debt.json) to also auto-resolve merge conflicts on Tier 2.2
+contemporaneous feature log files.
+
+Adds path-glob matching (fnmatch) so the new entry .claude/logs/*.log.json
+matches any feature log. Dedup key: event ts. Sort key: event ts.
+
+Adds tests/framework/test_v9_merge_driver.py with union-dedup + idempotency
+test cases.
+
+Bumps __MERGE_DRIVER_VERSION__ to v7.8.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.7: Snapshot protocol — write failing test
+
+**Files:**
+- Create: `tests/framework/test_snapshot_script.py`
+
+- [ ] **Step 1: Write test**
+
+```python
+"""Per-phase snapshot script — spec §10.
+
+Verifies snapshot-phase-completion.sh creates correct directory structure +
+copies expected files + generates manifest + sha256 checksums."""
+from __future__ import annotations
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "snapshot-phase-completion.sh"
+
+
+def test_snapshot_creates_dir_with_manifest_and_checksums(tmp_path: Path, monkeypatch):
+    """Snapshot script creates ~/Documents/FitTracker2-backups/<date>-<feature>-<phase>/
+    with MANIFEST.md + CHECKSUMS.sha256 + state.json copies."""
+    # Set up mock home dir to avoid polluting real backups
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Set up fake repo with .claude/features/test-feature/state.json
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "features" / "test-feature").mkdir(parents=True)
+    (repo / ".claude" / "features" / "test-feature" / "state.json").write_text('{"name":"test-feature"}\n')
+    (repo / ".claude" / "logs").mkdir()
+    (repo / ".claude" / "logs" / "test-feature.log.json").write_text('{"events":[]}\n')
+
+    # Init as git repo (script reads commit SHA + branch)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=repo, check=True)
+
+    # Run snapshot script
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "phase-0-complete", "test-feature"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"script failed: {result.stderr}"
+
+    # Find the snapshot dir under fake_home
+    backup_root = fake_home / "Documents" / "FitTracker2-backups"
+    assert backup_root.exists()
+    snapshots = list(backup_root.iterdir())
+    assert len(snapshots) == 1
+    snapshot_dir = snapshots[0]
+    assert "test-feature-phase-0-complete" in snapshot_dir.name
+
+    # Verify expected files
+    assert (snapshot_dir / "state.json").exists()
+    assert (snapshot_dir / "test-feature.log.json").exists()
+    assert (snapshot_dir / "MANIFEST.md").exists()
+    assert (snapshot_dir / "CHECKSUMS.sha256").exists()
+
+    # Verify checksums valid
+    verify = subprocess.run(["shasum", "-a", "256", "-c", "CHECKSUMS.sha256"],
+                            cwd=snapshot_dir, capture_output=True, text=True)
+    assert verify.returncode == 0, f"checksum mismatch: {verify.stdout}"
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_snapshot_script.py -v 2>&1 | tail -10
+```
+
+Expected: FAIL — script doesn't exist yet.
+
+### Task 0.8: Snapshot protocol — implement
+
+**Files:**
+- Create: `scripts/snapshot-phase-completion.sh`
+- Modify: `Makefile` (add `snapshot-phase` target)
+
+- [ ] **Step 1: Write the script**
+
+Per spec §10.5. Save to `scripts/snapshot-phase-completion.sh`:
+
+```bash
+#!/usr/bin/env bash
+# scripts/snapshot-phase-completion.sh
+#
+# Per-phase snapshot to off-SSD backup. Spec §10.
+#
+# Usage: ./scripts/snapshot-phase-completion.sh <phase-or-pause-id> <feature-name>
+# Example: ./scripts/snapshot-phase-completion.sh phase-0-complete cross-repo-state-sync-impl
+
+set -euo pipefail
+
+PHASE_ID="${1:?phase-or-pause-id required (e.g., phase-0-complete, pause-end-of-session)}"
+FEATURE_NAME="${2:?feature-name required}"
+DATE=$(date +%Y-%m-%d)
+BACKUP_DIR="$HOME/Documents/FitTracker2-backups/${DATE}-${FEATURE_NAME}-${PHASE_ID}"
+
+mkdir -p "$BACKUP_DIR"
+
+# Copy feature artifacts (preserve mtimes)
+if [ -d ".claude/features/${FEATURE_NAME}" ]; then
+    cp -p ".claude/features/${FEATURE_NAME}"/* "$BACKUP_DIR/" 2>/dev/null || true
+fi
+if [ -f ".claude/logs/${FEATURE_NAME}.log.json" ]; then
+    cp -p ".claude/logs/${FEATURE_NAME}.log.json" "$BACKUP_DIR/"
+fi
+
+# Allow caller to extend via EXTRA_FILES env var (space-separated)
+for f in ${EXTRA_FILES:-}; do
+    if [ -e "$f" ]; then
+        cp -p "$f" "$BACKUP_DIR/" 2>/dev/null || true
+    fi
+done
+
+# Capture git context
+COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "(no git)")
+BRANCH=$(git branch --show-current 2>/dev/null || echo "(no git)")
+
+# Generate sha256 manifest (only of files actually copied)
+cd "$BACKUP_DIR"
+if compgen -G "*" > /dev/null; then
+    shasum -a 256 * 2>/dev/null | grep -v "CHECKSUMS.sha256" > CHECKSUMS.sha256 || true
+fi
+
+# Write MANIFEST.md
+cat > MANIFEST.md <<EOF
+# Snapshot — ${FEATURE_NAME} ${PHASE_ID}
+
+**Created:** $(date -u +%FT%TZ)
+**Branch:** ${BRANCH}
+**Commit SHA:** ${COMMIT_SHA}
+**Feature:** ${FEATURE_NAME}
+**Phase/Pause ID:** ${PHASE_ID}
+
+## Files preserved
+
+$(ls -1 | grep -v MANIFEST.md | grep -v CHECKSUMS.sha256 | sed 's/^/- /')
+
+## Verification
+
+\`\`\`bash
+cd ${BACKUP_DIR}
+shasum -a 256 -c CHECKSUMS.sha256
+\`\`\`
+
+## Source spec / plan
+
+- Spec: docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md
+- Plan: docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md
+
+## Drive risk context
+
+This backup lives on internal Mac storage, NOT the SanDisk Extreme
+\`/Volumes/DevSSD/\`, per the established convention from
+\`reference_devssd_hardware_issue.md\`.
+EOF
+
+echo "Snapshot created: $BACKUP_DIR"
+echo "Files: $(ls | wc -l | tr -d ' ')"
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x /Volumes/DevSSD/FitTracker2/scripts/snapshot-phase-completion.sh
+```
+
+- [ ] **Step 3: Add Makefile target**
+
+Append to `Makefile`:
+
+```make
+snapshot-phase:
+	@if [ -z "$(PHASE)" ]; then echo "Usage: make snapshot-phase PHASE=<id> [FEATURE=<name>]"; exit 1; fi
+	./scripts/snapshot-phase-completion.sh $(PHASE) $${FEATURE:-cross-repo-state-sync-impl}
+```
+
+- [ ] **Step 4: Run test — should pass now**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_snapshot_script.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && make snapshot-phase PHASE=test-smoke FEATURE=cross-repo-state-sync-impl 2>&1 | tail -3
+ls -la ~/Documents/FitTracker2-backups/$(date +%Y-%m-%d)-cross-repo-state-sync-impl-test-smoke/ 2>&1 | head -10
+```
+
+Expected: snapshot created with MANIFEST.md + CHECKSUMS.sha256 + any feature files (likely just the feature dir if it exists yet, otherwise empty + manifest).
+
+- [ ] **Step 6: Cleanup smoke test snapshot**
+
+```bash
+rm -rf ~/Documents/FitTracker2-backups/$(date +%Y-%m-%d)-cross-repo-state-sync-impl-test-smoke/
+```
+
+- [ ] **Step 7: Commit snapshot tooling**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add tests/framework/test_snapshot_script.py scripts/snapshot-phase-completion.sh Makefile
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): per-phase snapshot protocol script + Makefile target
+
+Per spec §10. Operator-driven off-SSD snapshot of feature work product
+to ~/Documents/FitTracker2-backups/<date>-<feature>-<phase>/ with
+MANIFEST.md + sha256-verified CHECKSUMS.sha256.
+
+Addresses SanDisk Extreme disconnect risk (per reference_devssd_hardware_issue.md)
+and the empirical loss-of-work events observed in 2026-05-11 sessions.
+
+Triggers (operator-invoked): per-phase transitions + session pauses.
+Usage: make snapshot-phase PHASE=phase-0-complete
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.9: CLAUDE.md framework version bump to v7.8.3
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add v7.8.3 paragraph**
+
+Find the existing v7.8.2 section in `CLAUDE.md` ("v7.8.2 Cross-Repo Telemetry Asymmetry…"). After it, add:
+
+```markdown
+## v7.8.3 Cross-Repo State Sync Implementation (in flight, per spec 2026-05-11)
+
+v7.8.3 is the umbrella release for the `cross-repo-state-sync-impl` Feature.
+Bundles all deferred Phase C/D state-sync work with two v7.9 candidates
+(V2 + V9) into a single 5-phase rollout. Gates HADF Phase 2-bis: that
+campaign cannot start until all 5 phases ship and per-phase calibration
+targets are met.
+
+**Phase 0 promotes (already shipped):**
+- V2 — `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` advisory → enforced
+- V9 — Mechanism E custom git merge driver extends to `.claude/logs/<feature>.log.json`
+- New `make snapshot-phase` Makefile target + `scripts/snapshot-phase-completion.sh` for per-phase off-SSD backups
+
+**Phases 1-4 (in flight):** D-3 unified PR cite cache + C-4 control-room
+aggregator (Phase 1); state_owner schema + 47-feature backfill + morphed
+C-5 (Phase 2); D-1 reverse-sync GitHub Action (Phase 3); cutover ceremony
+(Phase 4).
+
+**Spec:** [`docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md`](docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md).
+**Plan:** [`docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md`](docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md).
+```
+
+- [ ] **Step 2: Update the framework version line in the header (if exists)**
+
+Search CLAUDE.md for "v7.5 → v7.6 → v7.7 → v7.8 → v7.8.1 → v7.8.2" and append `→ v7.8.3` to that progression line.
+
+- [ ] **Step 3: Commit CLAUDE.md update**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(v7.8.3): bump framework version reference + Phase 0 deliverables
+
+Per spec §6.1 Phase 0 deliverables. Documents the v7.8.3 umbrella release
+in CLAUDE.md alongside existing v7.8 / v7.8.1 / v7.8.2 sections.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 0.10: Open Phase 0 PR + verify CI + merge
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && git push -u origin feat/cross-repo-state-sync-phase-0
+```
+
+- [ ] **Step 2: Open PR via gh**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && gh pr create --title "v7.8.3 Phase 0 — V2 + V9 + snapshot protocol" --body "$(cat <<'EOF'
+## Summary
+
+First of 5 phases shipping the v7.8.3 release umbrella per spec
+[`docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md`](docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md) §6.1.
+
+- V2 — Mechanism C writer-path enforced (`CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` advisory → enforced)
+- V9 — Mechanism E custom git merge driver extends to `.claude/logs/<feature>.log.json` (+ `.gitattributes` registration)
+- Per-phase snapshot protocol: `scripts/snapshot-phase-completion.sh` + `make snapshot-phase` target
+
+Adds `tests/framework/` pytest package with 3 new test files (V2, V9, snapshot).
+Bumps `CLAUDE.md` framework version to v7.8.3.
+
+## Calibration target (post-merge)
+
+Per spec §3.5.2: V2 ≥1 production fire without false positive in 7 days
+(soft target ≥10 fires across ≥5 features); V9 auto-resolves ≥1 real
+merge-conflict on `<feature>.log.json` (synthetic test if no natural
+conflict in 7 days). HADF Phase 2-bis Sub-exp 1 unblocks once all 5
+phases' calibration targets are met.
+
+## Test plan
+
+- [ ] `make verify-local` passes (build + tests + lint + integrity-check)
+- [ ] `make pre-commit-self-test` passes (Mechanism D header self-audit)
+- [ ] `make integrity-check` reports 0 hard findings post-merge
+- [ ] `python3 -m pytest tests/framework/ -v` all green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI green; address any failures; merge**
+
+Watch CI status: `gh pr checks --watch`. Once green, ask user for merge approval; do NOT auto-merge per `feedback_no_auto_merge_without_approval.md`. After user approval: `gh pr merge --squash`.
+
+- [ ] **Step 4: After merge: snapshot Phase 0 → 1 transition**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git checkout main && git pull origin main
+make snapshot-phase PHASE=phase-0-complete-pre-phase-1
+```
+
+Expected: snapshot created at `~/Documents/FitTracker2-backups/<date>-cross-repo-state-sync-impl-phase-0-complete-pre-phase-1/`.
+
+---
+
+## Phase 1 — Telemetry foundations (D-3 + C-4)
+
+**Branch:** `feat/cross-repo-state-sync-phase-1` (off latest `main` after Phase 0 merge)
+**Two PRs (one FT2 D-3, one fitme-story C-4).** Estimated 1-2 days impl + 5 days calibration.
+
+### Task 1.1: D-3 — refresh-pr-cache.py — write failing test + implement
+
+**Files:**
+- Create: `tests/framework/test_pr_cite_cache.py`
+- Create: `scripts/refresh-pr-cache.py`
+
+- [ ] **Step 1: Write failing test for refresh script (mocks gh)**
+
+```python
+"""D-3 — unified cross-repo PR cite cache.
+
+Tests refresh-pr-cache.py builds correct multi-repo cache shape, and
+resolve_pr_cite() routes regex matches to the right repo's cache."""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+REFRESH_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "refresh-pr-cache.py"
+
+
+def test_refresh_pr_cache_writes_correct_shape(tmp_path: Path, monkeypatch):
+    """refresh-pr-cache.py writes cache file with schema_version, last_refreshed_at, repos."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".cache").mkdir()
+    
+    # Mock gh subprocess to return synthetic PR data
+    def fake_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args", [])
+        if "gh" in cmd[0] and "pr" in cmd:
+            class R:
+                returncode = 0
+                stdout = json.dumps([{"number": 42, "title": "test", "state": "OPEN"}])
+                stderr = ""
+            return R()
+        # Fall through to real subprocess
+        return subprocess.run(*args, **kwargs)
+    
+    monkeypatch.setattr("subprocess.check_output", lambda *a, **kw: json.dumps([{"number": 42, "title": "x", "state": "OPEN"}]).encode())
+    
+    result = subprocess.run([sys.executable, str(REFRESH_SCRIPT)], capture_output=True, text=True)
+    # Note: actual test may need to mock gh CLI — script should handle gh-unavailable gracefully
+    # If gh available, verify cache file exists + has expected shape
+    cache_file = tmp_path / ".cache" / "gh-pr-cache.json"
+    if cache_file.exists():
+        cache = json.loads(cache_file.read_text())
+        assert cache["schema_version"] == 1
+        assert "last_refreshed_at" in cache
+        assert "repos" in cache
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_pr_cite_cache.py::test_refresh_pr_cache_writes_correct_shape -v 2>&1 | tail -10
+```
+
+Expected: FAIL — script doesn't exist.
+
+- [ ] **Step 3: Implement refresh-pr-cache.py**
+
+Per spec §5.2. Save to `scripts/refresh-pr-cache.py`:
+
+```python
+#!/usr/bin/env python3
+"""Refresh the unified cross-repo PR cite cache.
+
+v7.8.3 D-3. Writes .cache/gh-pr-cache.json with PRs from both
+Regevba/FitTracker2 and Regevba/fitme-story.
+
+Schema:
+  {
+    "schema_version": 1,
+    "last_refreshed_at": "<ISO timestamp>",
+    "repos": {
+      "Regevba/FitTracker2": {"open": [...], "merged": [...], "closed": [...]},
+      "Regevba/fitme-story": {"open": [...], "merged": [...], "closed": [...]},
+    }
+  }
+
+Skips gracefully when `gh` is unavailable or auth missing (matches existing
+BROKEN_PR_CITATION skip-on-missing-gh pattern).
+"""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPOS = ["Regevba/FitTracker2", "Regevba/fitme-story"]
+CACHE_FILE = Path(".cache") / "gh-pr-cache.json"
+
+
+def fetch_repo_prs(repo: str) -> dict | None:
+    """Fetch PRs for one repo across all states. Return None on gh failure."""
+    repo_data = {}
+    for state in ["open", "merged", "closed"]:
+        try:
+            result = subprocess.check_output(
+                ["gh", "pr", "list", "--repo", repo, "--state", state,
+                 "--json", "number,title,state", "--limit", "500"],
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+            repo_data[state] = json.loads(result)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            print(f"WARN: failed to fetch {repo} {state} PRs: {e}", file=sys.stderr)
+            return None
+    return repo_data
+
+
+def main() -> int:
+    cache = {
+        "schema_version": 1,
+        "last_refreshed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "repos": {},
+    }
+    for repo in REPOS:
+        repo_data = fetch_repo_prs(repo)
+        if repo_data is None:
+            print(f"WARN: skipping {repo} (gh unavailable or auth failed)", file=sys.stderr)
+            continue
+        cache["repos"][repo] = repo_data
+    
+    if not cache["repos"]:
+        print("ERROR: no repos cached; gh likely unavailable", file=sys.stderr)
+        return 1
+    
+    CACHE_FILE.parent.mkdir(exist_ok=True)
+    CACHE_FILE.write_text(json.dumps(cache, indent=2) + "\n")
+    print(f"Wrote {CACHE_FILE} ({sum(len(r.get(s, [])) for r in cache['repos'].values() for s in ['open','merged','closed'])} PRs across {len(cache['repos'])} repos)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Make executable + add to .gitignore**
+
+```bash
+chmod +x /Volumes/DevSSD/FitTracker2/scripts/refresh-pr-cache.py
+echo ".cache/" >> /Volumes/DevSSD/FitTracker2/.gitignore
+```
+
+- [ ] **Step 5: Run test — should pass now**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_pr_cite_cache.py::test_refresh_pr_cache_writes_correct_shape -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Manual smoke — actually run refresh against real gh**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 scripts/refresh-pr-cache.py
+cat .cache/gh-pr-cache.json | python3 -c "import json,sys; c=json.load(sys.stdin); print('repos:', list(c['repos'].keys())); print('FT2 open:', len(c['repos'].get('Regevba/FitTracker2',{}).get('open',[])))"
+```
+
+Expected: prints both repos + reasonable PR counts.
+
+### Task 1.2: D-3 — regex update + REPO_MAP + resolve_pr_cite
+
+**Files:**
+- Modify: `scripts/check-case-study-preflight.py` (lines 74-76 + new function)
+
+- [ ] **Step 1: Write failing test for regex**
+
+Append to `tests/framework/test_pr_cite_cache.py`:
+
+```python
+import importlib.util
+PREFLIGHT = Path(__file__).resolve().parents[2] / "scripts" / "check-case-study-preflight.py"
+
+def load_preflight():
+    spec = importlib.util.spec_from_file_location("preflight", PREFLIGHT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pr_citation_pat_matches_three_forms():
+    """Regex captures: PR #N (FT2 default), repo#N (cross-repo short), URL form."""
+    pf = load_preflight()
+    pat = pf._PR_CITATION_PAT
+    
+    # FT2 default
+    m = pat.search("see PR #290")
+    assert m and m.group(1) == "290"
+    
+    # Cross-repo short form
+    m = pat.search("backed by [fitme-story#42]")
+    assert m and m.group(2) == "fitme-story" and m.group(3) == "42"
+    
+    # URL form
+    m = pat.search("github.com/Regevba/fitme-story/pull/42")
+    assert m and m.group(4) == "Regevba" and m.group(5) == "fitme-story" and m.group(6) == "42"
+
+
+def test_repo_map_includes_both_repos():
+    pf = load_preflight()
+    assert "fitme-story" in pf.REPO_MAP
+    assert "FitTracker2" in pf.REPO_MAP
+
+
+def test_resolve_pr_cite_finds_existing_pr():
+    """When cache contains the PR number, resolve_pr_cite returns None (no Finding)."""
+    pf = load_preflight()
+    cache = {
+        "schema_version": 1,
+        "last_refreshed_at": "2026-05-12T00:00:00Z",
+        "repos": {
+            "Regevba/FitTracker2": {
+                "open": [{"number": 290, "title": "x", "state": "OPEN"}],
+                "merged": [], "closed": [],
+            },
+            "Regevba/fitme-story": {
+                "open": [{"number": 42, "title": "y", "state": "OPEN"}],
+                "merged": [], "closed": [],
+            },
+        },
+    }
+    
+    m = pf._PR_CITATION_PAT.search("PR #290")
+    assert pf.resolve_pr_cite(m, cache) is None
+    
+    m = pf._PR_CITATION_PAT.search("[fitme-story#42]")
+    assert pf.resolve_pr_cite(m, cache) is None
+
+
+def test_resolve_pr_cite_unknown_repo_short_name_fails():
+    pf = load_preflight()
+    cache = {"schema_version": 1, "repos": {}}
+    m = pf._PR_CITATION_PAT.search("[unknown-repo#1]")
+    finding = pf.resolve_pr_cite(m, cache)
+    assert finding is not None
+    assert "BROKEN_PR_CITATION" in finding.code or finding.code == "BROKEN_PR_CITATION"
+
+
+def test_resolve_pr_cite_missing_pr_fails():
+    pf = load_preflight()
+    cache = {
+        "schema_version": 1,
+        "last_refreshed_at": "2026-05-12T00:00:00Z",
+        "repos": {
+            "Regevba/FitTracker2": {"open": [], "merged": [], "closed": []},
+        },
+    }
+    m = pf._PR_CITATION_PAT.search("PR #999999")
+    finding = pf.resolve_pr_cite(m, cache)
+    assert finding is not None and finding.code == "BROKEN_PR_CITATION"
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_pr_cite_cache.py -v 2>&1 | tail -20
+```
+
+Expected: 5 NEW tests FAIL (regex shape mismatch + REPO_MAP missing + resolve_pr_cite missing).
+
+- [ ] **Step 3: Update regex + add REPO_MAP + add resolve_pr_cite**
+
+In `scripts/check-case-study-preflight.py`, replace line 74-76:
+
+```python
+# OLD:
+# _PR_CITATION_PAT = re.compile(
+#     r'(?:[Pp][Rr]\s*#?|github\.com/[^/\s]+/[^/\s]+/pull/)(\d+)'
+# )
+
+# NEW (v7.8.3 D-3):
+_PR_CITATION_PAT = re.compile(
+    r"(?:[Pp][Rr]\s*#?(\d+))"                       # group 1: FT2 default — "PR #290" or "PR#290"
+    r"|(?:\[?([\w-]+)\s*#(\d+)\]?)"                 # groups 2+3: cross-repo short form — "fitme-story#42" or "[fitme-story#42]"
+    r"|(?:github\.com/([\w-]+)/([\w-]+)/pull/(\d+))"  # groups 4+5+6: URL form
+)
+
+REPO_MAP = {
+    "fitme-story": "Regevba/fitme-story",
+    "FitTracker2": "Regevba/FitTracker2",
+    "ft2": "Regevba/FitTracker2",
+}
+
+CACHE_FILE = Path(".cache") / "gh-pr-cache.json"
+CACHE_TTL_SECONDS = 300  # 5 min
+
+
+def _load_pr_cache() -> dict | None:
+    """Load cached PR data; refresh if stale or missing."""
+    if not CACHE_FILE.exists():
+        _refresh_cache_or_skip()
+    if not CACHE_FILE.exists():
+        return None  # gh unavailable; caller skips gracefully
+    try:
+        cache = json.loads(CACHE_FILE.read_text())
+        last = datetime.fromisoformat(cache["last_refreshed_at"].replace("Z", "+00:00"))
+        age = (datetime.now(timezone.utc) - last).total_seconds()
+        if age > CACHE_TTL_SECONDS:
+            _refresh_cache_or_skip()
+            cache = json.loads(CACHE_FILE.read_text())
+        return cache
+    except Exception as e:
+        print(f"WARN: PR cache load failed: {e}", file=sys.stderr)
+        return None
+
+
+def _refresh_cache_or_skip() -> None:
+    refresh_script = Path(__file__).parent / "refresh-pr-cache.py"
+    try:
+        subprocess.run([sys.executable, str(refresh_script)], check=False, timeout=60)
+    except Exception:
+        pass  # graceful skip
+
+
+def resolve_pr_cite(match, cache: dict | None) -> Finding | None:
+    """Resolve a regex match against the multi-repo PR cache."""
+    if cache is None:
+        return None  # gh unavailable; caller has already noted this
+    
+    if match.group(1):
+        repo = "Regevba/FitTracker2"
+        pr_num = int(match.group(1))
+    elif match.group(2):
+        repo_short = match.group(2)
+        repo = REPO_MAP.get(repo_short)
+        if repo is None:
+            return Finding(
+                severity="FAIL",
+                code="BROKEN_PR_CITATION",
+                message=f"unknown repo short name '{repo_short}'; valid: {sorted(REPO_MAP.keys())}",
+            )
+        pr_num = int(match.group(3))
+    elif match.group(4):
+        repo = f"{match.group(4)}/{match.group(5)}"
+        pr_num = int(match.group(6))
+    else:
+        return None  # no match; shouldn't happen
+    
+    if repo not in cache.get("repos", {}):
+        return Finding(
+            severity="FAIL",
+            code="BROKEN_PR_CITATION",
+            message=f"no cache for repo '{repo}'; refresh cache or add to REPO_MAP",
+        )
+    
+    repo_cache = cache["repos"][repo]
+    all_prs = repo_cache.get("open", []) + repo_cache.get("merged", []) + repo_cache.get("closed", [])
+    if not any(pr["number"] == pr_num for pr in all_prs):
+        return Finding(
+            severity="FAIL",
+            code="BROKEN_PR_CITATION",
+            message=f"PR #{pr_num} not found in {repo} (cache last refreshed {cache.get('last_refreshed_at', 'unknown')})",
+        )
+    
+    return None  # valid cite
+```
+
+(Note: the `Finding` class shape may differ; mirror whatever `check-case-study-preflight.py` already uses for findings — adjust the pseudo-code to match.)
+
+- [ ] **Step 4: Wire `resolve_pr_cite` into the existing case-study scan loop**
+
+Find the existing place in `check-case-study-preflight.py` where `_PR_CITATION_PAT` is matched + a Finding is emitted on missing PR. Replace the inline single-cache lookup with:
+
+```python
+cache = _load_pr_cache()
+for match in _PR_CITATION_PAT.finditer(case_study_body):
+    finding = resolve_pr_cite(match, cache)
+    if finding:
+        findings.append(finding)
+```
+
+- [ ] **Step 5: Run all tests — should pass now**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_pr_cite_cache.py -v
+```
+
+Expected: ALL tests PASS.
+
+### Task 1.3: D-3 — add Makefile targets
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add refresh-pr-cache + validate-existing-cites targets**
+
+Append to `Makefile`:
+
+```make
+refresh-pr-cache:
+	python3 scripts/refresh-pr-cache.py
+
+validate-existing-cites: refresh-pr-cache
+	@echo "Validating PR cites in all docs/case-studies/*.md against unified cache…"
+	@python3 scripts/check-case-study-preflight.py docs/case-studies/*.md
+```
+
+- [ ] **Step 2: Run retroactive validation pass**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && make validate-existing-cites 2>&1 | tail -30
+```
+
+Expected: ZERO new failures (35/35 cross-repo cites validate). If any fail, capture per spec §6.2 calibration target and triage.
+
+- [ ] **Step 3: Commit D-3**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add tests/framework/test_pr_cite_cache.py scripts/refresh-pr-cache.py scripts/check-case-study-preflight.py Makefile .gitignore
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): D-3 unified cross-repo PR cite cache
+
+Per spec §5. Closes the BROKEN_PR_CITATION gate's two known bugs (silent
+skip on cross-repo cites, URL-form mis-routing). Now resolves all 3 cite
+forms (FT2 default, cross-repo short, URL) against a multi-repo cache
+covering both Regevba/FitTracker2 and Regevba/fitme-story.
+
+Adds:
+- scripts/refresh-pr-cache.py — populates .cache/gh-pr-cache.json
+- _PR_CITATION_PAT regex update (3 alternations) + REPO_MAP whitelist + resolve_pr_cite()
+- Makefile targets: refresh-pr-cache + validate-existing-cites
+- tests/framework/test_pr_cite_cache.py with 5 test cases
+
+Calibration target: 35/35 retroactive cross-repo cites validate clean.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 1.4: D-3 — open FT2 PR + merge
+
+- [ ] **Step 1: Push + open PR**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && git push -u origin feat/cross-repo-state-sync-phase-1
+gh pr create --title "v7.8.3 Phase 1 (D-3) — unified cross-repo PR cite cache" --body "$(cat <<'EOF'
+## Summary
+
+D-3 deliverable from spec §5. Closes BROKEN_PR_CITATION gate's silent-skip
+on cross-repo cites + URL-form mis-routing.
+
+## Calibration target
+
+`make validate-existing-cites` passes 35/35 retroactive cross-repo cites.
+
+## Test plan
+
+- [ ] `python3 -m pytest tests/framework/test_pr_cite_cache.py -v` all green
+- [ ] `make validate-existing-cites` passes
+- [ ] `make verify-local` passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI; user approves; merge squash**
+
+### Task 1.5: C-4 — fitme-story forward-sync extension
+
+**Files (in fitme-story repo):**
+- Modify: `scripts/sync-from-fittracker2.ts` (add gate-coverage-ft2.jsonl sync)
+- Create: `tests/control-room/sync-extension.test.ts`
+
+- [ ] **Step 1: Switch to fitme-story repo + create branch**
+
+```bash
+cd /Volumes/DevSSD/fitme-story
+git checkout main && git pull origin main
+git checkout -b feat/cross-repo-state-sync-phase-1
+```
+
+- [ ] **Step 2: Write failing test for sync extension**
+
+`tests/control-room/sync-extension.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+
+describe('sync-from-fittracker2 — gate-coverage-ft2.jsonl extension', () => {
+  it('mirrors FT2 .claude/logs/gate-coverage.jsonl to src/data/integrity/gate-coverage-ft2.jsonl', () => {
+    const tmp = join(tmpdir(), `sync-test-${Date.now()}`);
+    const fakeFt2 = join(tmp, 'FitTracker2');
+    const fakeFs = join(tmp, 'fitme-story');
+    mkdirSync(join(fakeFt2, '.claude', 'logs'), { recursive: true });
+    mkdirSync(join(fakeFs, 'src', 'data', 'integrity'), { recursive: true });
+
+    writeFileSync(
+      join(fakeFt2, '.claude', 'logs', 'gate-coverage.jsonl'),
+      '{"gate":"V2","outcome":"FAIL","ts":"2026-05-12T00:00:00Z"}\n'
+    );
+
+    // Run the sync script (assumes it accepts FT2_PATH + FS_PATH env vars or argv)
+    // ... actual invocation depends on how sync-from-fittracker2.ts is structured
+    // Possible approach: import the sync function directly + invoke with paths
+
+    expect(existsSync(join(fakeFs, 'src', 'data', 'integrity', 'gate-coverage-ft2.jsonl'))).toBe(true);
+    const content = readFileSync(join(fakeFs, 'src', 'data', 'integrity', 'gate-coverage-ft2.jsonl'), 'utf-8');
+    expect(content).toContain('V2');
+
+    rmSync(tmp, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 3: Run failing test**
+
+```bash
+cd /Volumes/DevSSD/fitme-story && npx vitest run tests/control-room/sync-extension.test.ts 2>&1 | tail -10
+```
+
+Expected: FAIL — no extension exists yet.
+
+- [ ] **Step 4: Implement extension**
+
+In `fitme-story/scripts/sync-from-fittracker2.ts`, locate the section that copies `.claude/logs/<feature>.log.json` (added in C-1, 2026-05-10). Add a new copy step:
+
+```typescript
+// v7.8.3 Phase 1 C-4: mirror FT2's gate-coverage.jsonl for control-room aggregator
+const ft2GateCoveragePath = path.join(FT2_PATH, '.claude', 'logs', 'gate-coverage.jsonl');
+const fsGateCoverageDest = path.join(FS_PATH, 'src', 'data', 'integrity', 'gate-coverage-ft2.jsonl');
+if (existsSync(ft2GateCoveragePath)) {
+  mkdirSync(path.dirname(fsGateCoverageDest), { recursive: true });
+  copyFileSync(ft2GateCoveragePath, fsGateCoverageDest);
+}
+```
+
+- [ ] **Step 5: Run test — should pass**
+
+```bash
+cd /Volumes/DevSSD/fitme-story && npx vitest run tests/control-room/sync-extension.test.ts -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Manual smoke**
+
+```bash
+cd /Volumes/DevSSD/fitme-story && npm run prebuild 2>&1 | tail -5
+ls -la src/data/integrity/gate-coverage-ft2.jsonl
+```
+
+Expected: file exists; size > 0 (mirror of FT2's 1734-line gate-coverage).
+
+### Task 1.6: C-4 — control-room aggregator
+
+**Files (fitme-story):**
+- Create: `src/lib/control-room/gate-coverage-aggregator.ts`
+- Create: `tests/control-room/gate-coverage-aggregator.test.ts`
+- Modify: appropriate page in `src/app/control-room/framework/` (locate via `find src/app/control-room -name '*.tsx' | head -5`)
+
+- [ ] **Step 1: Write failing test**
+
+`tests/control-room/gate-coverage-aggregator.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { aggregateGateCoverage } from '@/lib/control-room/gate-coverage-aggregator';
+
+describe('gate-coverage-aggregator', () => {
+  it('combines two sources tagged by source_repo, sorted by ts', () => {
+    const ft2Lines = [
+      '{"gate":"V2","outcome":"FAIL","ts":"2026-05-12T01:00:00Z"}',
+      '{"gate":"V9","outcome":"PASS","ts":"2026-05-12T03:00:00Z"}',
+    ].join('\n');
+    const fsLines = [
+      '{"gate":"V2","outcome":"PASS","ts":"2026-05-12T02:00:00Z"}',
+    ].join('\n');
+
+    const result = aggregateGateCoverage(ft2Lines, fsLines);
+    expect(result).toHaveLength(3);
+    expect(result[0].source_repo).toBe('ft2');
+    expect(result[0].ts).toBe('2026-05-12T01:00:00Z');
+    expect(result[1].source_repo).toBe('fitme-story');
+    expect(result[1].ts).toBe('2026-05-12T02:00:00Z');
+    expect(result[2].source_repo).toBe('ft2');
+  });
+
+  it('counts events per source', () => {
+    const ft2Lines = '{"gate":"V2","outcome":"FAIL","ts":"2026-05-12T00:00:00Z"}';
+    const fsLines = '{"gate":"V2","outcome":"PASS","ts":"2026-05-12T01:00:00Z"}';
+    const counts = countEventsBySource(ft2Lines, fsLines);
+    expect(counts.ft2).toBe(1);
+    expect(counts['fitme-story']).toBe(1);
+  });
+});
+```
+
+(Imports above assume `countEventsBySource` is also exported; adjust if needed.)
+
+- [ ] **Step 2: Run failing test**
+
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement aggregator**
+
+`src/lib/control-room/gate-coverage-aggregator.ts`:
+```typescript
+// v7.8.3 Phase 1 C-4: cross-repo gate-coverage aggregator
+// Reads FT2's gate-coverage (synced to src/data/integrity/gate-coverage-ft2.jsonl)
+// + fitme-story's local .claude/logs/gate-coverage.jsonl
+// Combines + tags + sorts by timestamp.
+
+export type GateEvent = {
+  gate: string;
+  outcome: 'PASS' | 'FAIL' | 'WARN';
+  ts: string;
+  source_repo?: 'ft2' | 'fitme-story';
+  [key: string]: unknown;
+};
+
+export function aggregateGateCoverage(ft2Content: string, fsContent: string): GateEvent[] {
+  const parseLines = (content: string, source: 'ft2' | 'fitme-story'): GateEvent[] =>
+    content
+      .split('\n')
+      .filter(line => line.trim().length > 0)
+      .map(line => {
+        const parsed = JSON.parse(line) as GateEvent;
+        parsed.source_repo = source;
+        return parsed;
+      });
+
+  const all = [...parseLines(ft2Content, 'ft2'), ...parseLines(fsContent, 'fitme-story')];
+  all.sort((a, b) => a.ts.localeCompare(b.ts));
+  return all;
+}
+
+export function countEventsBySource(ft2Content: string, fsContent: string): Record<string, number> {
+  const ft2Count = ft2Content.split('\n').filter(l => l.trim().length > 0).length;
+  const fsCount = fsContent.split('\n').filter(l => l.trim().length > 0).length;
+  return { ft2: ft2Count, 'fitme-story': fsCount };
+}
+```
+
+- [ ] **Step 4: Run test — should pass**
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire into /control-room/framework page**
+
+Locate the existing framework page (e.g., `src/app/control-room/framework/page.tsx`). Add a section that reads both files at build time + invokes `aggregateGateCoverage` + renders counts + filter chips.
+
+```tsx
+// In the existing framework page component, add at the top of the component body:
+import { aggregateGateCoverage, countEventsBySource } from '@/lib/control-room/gate-coverage-aggregator';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ft2Path = join(process.cwd(), 'src', 'data', 'integrity', 'gate-coverage-ft2.jsonl');
+const fsPath = join(process.cwd(), '.claude', 'logs', 'gate-coverage.jsonl');
+const ft2Content = existsSync(ft2Path) ? readFileSync(ft2Path, 'utf-8') : '';
+const fsContent = existsSync(fsPath) ? readFileSync(fsPath, 'utf-8') : '';
+const events = aggregateGateCoverage(ft2Content, fsContent);
+const counts = countEventsBySource(ft2Content, fsContent);
+
+// Then in JSX, add a section like:
+// <section>
+//   <h2>Gate Coverage (cross-repo)</h2>
+//   <p>FT2: {counts.ft2} fires · fitme-story: {counts['fitme-story']} fires · Total: {events.length}</p>
+//   {/* per-source filter chips + per-gate breakdown */}
+// </section>
+```
+
+- [ ] **Step 6: Local preview verify**
+
+```bash
+cd /Volumes/DevSSD/fitme-story && npm run dev
+# Visit http://localhost:3000/control-room/framework in browser
+# Verify aggregated count = ~1734 + 0 = ~1734 (matches raw line counts)
+```
+
+- [ ] **Step 7: Commit + open fitme-story PR**
+
+```bash
+cd /Volumes/DevSSD/fitme-story
+git add tests/control-room/ src/lib/control-room/gate-coverage-aggregator.ts src/app/control-room/framework/ scripts/sync-from-fittracker2.ts
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): C-4 cross-repo gate-coverage aggregator + sync extension
+
+Per FT2 spec §6.2 Phase 1. Adds:
+- forward-sync extension: FT2's gate-coverage.jsonl → src/data/integrity/gate-coverage-ft2.jsonl
+- src/lib/control-room/gate-coverage-aggregator.ts: combines both repos' streams
+- /control-room/framework page extension: aggregated counts + per-source filter chips
+
+Tests in tests/control-room/.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/cross-repo-state-sync-phase-1
+gh pr create --title "v7.8.3 Phase 1 (C-4) — control-room cross-repo gate-coverage aggregator" --body "Per FT2 spec §6.2 Phase 1. Aggregates both repos' gate-coverage at build time.
+
+Test plan:
+- [ ] vitest tests pass
+- [ ] /control-room/framework renders aggregated count correctly on Vercel preview"
+```
+
+- [ ] **Step 8: Wait for CI + Vercel preview; user approves; merge squash**
+
+### Task 1.7: After both Phase 1 PRs merge — snapshot Phase 1 → 2 transition
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && git checkout main && git pull origin main
+make snapshot-phase PHASE=phase-1-complete-pre-phase-2
+```
+
+---
+
+## Phase 1 — Adjustments from prep validation (added 2026-05-11)
+
+The original Phase 1 task instructions above were drafted from the spec. During Phase 0 ship + Phase 1 prep validation, 6 plan-vs-codebase deltas were discovered. These adjustments **supersede** the original task instructions where they conflict. Subagent prompts dispatching Tasks 1.1-1.7 must reference both the original task AND this adjustment section.
+
+### A1. Cross-repo cite count: 35 → 63
+
+**Original calibration target:** D-3: 35/35 retroactive cross-repo cite validation passes.
+**Reality (verified 2026-05-11):** `grep -rE "fitme-story[ ]?#[0-9]+|github\.com/Regevba/fitme-story" docs/case-studies/*.md | wc -l` returns **63**. The cite count grew between brainstorm-time (35) and Phase 1 ship-time as more case studies cite fitme-story PRs.
+**Action:** Update calibration target to 63/63. If any cite fails to validate, triage per the original kill criterion (likely typo'd PR number that the original silent-skip masked).
+
+### A2. D-3 regex update scope expansion: also update `integrity-check.py`
+
+**Original task scope:** Update `_PR_CITATION_PAT` regex in `scripts/check-case-study-preflight.py:74-76`.
+**Reality:** Line 74 of `check-case-study-preflight.py` has comment: `# Same regex shape as integrity-check.py (kept in sync intentionally).` — the regex is intentionally kept in sync between both scripts. Updating ONLY one would leave the cycle-time `BROKEN_PR_CITATION` check silently broken.
+**Action:** Task 1.2 implementer ALSO updates `scripts/integrity-check.py`'s parallel regex constant in the same commit. Verify by `grep -nE "_PR_CITATION_PAT|github\.com.*pull" scripts/integrity-check.py` and applying the same regex shape.
+
+### A3. `_load_pr_cache()` is morph-not-additive
+
+**Original task implication:** Add new `resolve_pr_cite()` function alongside existing `_load_pr_cache()`.
+**Reality:** Existing `_load_pr_cache()` at `check-case-study-preflight.py:190` returns `set[int] | None` (FT2-only PR numbers). The new multi-repo cache shape per spec §5.2 is incompatible.
+**Action:** Task 1.2 implementer MORPHS `_load_pr_cache()` to return the new multi-repo dict shape, OR replaces it with a new `_load_unified_pr_cache()` and updates all call sites. Review existing call sites first via `grep -n "_load_pr_cache" scripts/`. The same morphing applies to `check-state-schema.py:163` and `integrity-check.py:312` if they share the helper. NOTE: this is a non-trivial refactor — implementer should use Sonnet (not Haiku).
+
+### A4. fitme-story C-4 needs isolated worktree
+
+**Original task setup:** Switch to `/Volumes/DevSSD/fitme-story` + create branch.
+**Reality:** fitme-story working tree currently on `showcase/ios-ui-audit-p1-burndown-2026-05-11` with 10+ uncommitted modifications (auto-synced docs from FT2). Switching branches would conflict.
+**Action:** Task 1.5 implementer creates an isolated fitme-story worktree at `/Volumes/DevSSD/fitme-story-cross-repo-state-sync-phase-1/` (matches the FT2 sibling-worktree convention) on `feat/cross-repo-state-sync-phase-1` off origin/main, similar to how Phase 0 was set up for FT2.
+
+### A5. fitme-story test infrastructure: no `tests/` dir, different runner
+
+**Original task scope:** Create `tests/control-room/sync-extension.test.ts` and `tests/control-room/gate-coverage-aggregator.test.ts`.
+**Reality:** fitme-story has NO `tests/` directory. The package.json `test` script is `tsx --test 'scripts/*.test.ts' 'src/**/*.test.ts'` — picks up tests at scripts/* and src/** patterns, NOT tests/**.
+**Action:** Task 1.5/1.6 implementers either:
+- (a) Co-locate tests with sources: `src/lib/control-room/gate-coverage-aggregator.test.ts` + `scripts/sync-from-fittracker2.test.ts` — matches existing pattern, no package.json change needed.
+- (b) Update package.json `test` script to also include `tests/**/*.test.ts` AND create `tests/control-room/`.
+- **Recommend (a)** — minimal change, follows existing convention.
+
+### A6. fitme-story sync script line 313 comment must be updated
+
+**Original task scope:** Add gate-coverage.jsonl forward-sync to `sync-from-fittracker2.ts`.
+**Reality:** Line 313 of that script has a comment: `// - gate-coverage.jsonl (Mechanism A; per-repo, not synced — see §3 of spec)`. This comment was added per the original Phase C spec (`docs/superpowers/specs/2026-05-09-cross-repo-state-sync.md` §3) which explicitly excluded gate-coverage from sync. Phase 1 C-4 reverses that decision per the v7.8.3 spec §4.1.
+**Action:** Task 1.5 implementer updates the comment to reference the v7.8.3 reversal: `// - gate-coverage.jsonl: FT2's mirrored as gate-coverage-ft2.jsonl per v7.8.3 spec §4.1; fitme-story's stays per-repo (control-room aggregator reads both).` AND keeps a cross-reference to the new v7.8.3 spec.
+
+### Adjustments summary table
+
+| # | Affects | Action |
+|---|---|---|
+| A1 | Task 1.4, 1.7 calibration target | 35 → 63 |
+| A2 | Task 1.2 scope | Add `integrity-check.py` to commit |
+| A3 | Task 1.2 design | Refactor `_load_pr_cache`, not additive — use Sonnet |
+| A4 | Task 1.5 setup | Isolated fitme-story worktree at `/Volumes/DevSSD/fitme-story-cross-repo-state-sync-phase-1/` |
+| A5 | Task 1.5/1.6 file paths | Co-locate test files with source (recommended) |
+| A6 | Task 1.5 scope | Update sync script comment in addition to logic |
+
+---
+
+## Phase 2 — Schema + backfill + morphed C-5
+
+**Branch:** `feat/cross-repo-state-sync-phase-2` (off latest `main` after Phase 1 merge)
+**Single FT2 PR.** Estimated 1 day impl + 4 days calibration.
+
+### Task 2.1: state_owner gates — write failing tests
+
+**Files:**
+- Create: `tests/framework/test_state_owner_gates.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+"""Phase 2 — state_owner schema + morphed C-5.
+
+Tests STATE_OWNER_MISSING, STATE_OWNER_INVALID, STATE_OWNER_LOCATION_MISMATCH
+including the state_owner_sync_origin exemption."""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check-state-schema.py"
+
+
+def run_check(state_path: Path) -> tuple[int, str]:
+    result = subprocess.run([sys.executable, str(SCRIPT), str(state_path)],
+                            capture_output=True, text=True)
+    return result.returncode, result.stderr + result.stdout
+
+
+def test_state_owner_missing_fails(write_state):
+    """state.json without state_owner field → STATE_OWNER_MISSING."""
+    state_path = write_state("missing-feature", {
+        "name": "missing-feature",
+        "framework_version": "v7.8.3",
+        "current_phase": "research",
+    })
+    code, output = run_check(state_path)
+    assert code != 0
+    assert "STATE_OWNER_MISSING" in output
+
+
+def test_state_owner_invalid_value_fails(write_state):
+    """state_owner with bogus value → STATE_OWNER_INVALID."""
+    state_path = write_state("invalid-feature", {
+        "name": "invalid-feature",
+        "state_owner": "ft-2",  # typo
+        "framework_version": "v7.8.3",
+        "current_phase": "research",
+    })
+    code, output = run_check(state_path)
+    assert code != 0
+    assert "STATE_OWNER_INVALID" in output
+
+
+def test_state_owner_ft2_at_ft2_path_passes(write_state):
+    state_path = write_state("ok-feature", {
+        "name": "ok-feature",
+        "state_owner": "ft2",
+        "framework_version": "v7.8.3",
+        "current_phase": "research",
+    })
+    # write_state puts under tmp_path/.claude/features/; absolute path won't
+    # contain "/FitTracker2/" so we expect MISMATCH or PASS based on impl.
+    # If using a more flexible path-detection, this passes; if strict, may fail.
+    # See implementation note in §3.4 of spec.
+    code, output = run_check(state_path)
+    # Tolerant assert: either passes outright OR fails ONLY on MISMATCH (not other gates)
+    if code != 0:
+        assert "STATE_OWNER_LOCATION_MISMATCH" in output, \
+            f"expected only LOCATION_MISMATCH if any failure; got\n{output}"
+
+
+def test_state_owner_sync_origin_exempts_mismatch(write_state):
+    """When state_owner_sync_origin is set with -reverse suffix, mismatch is exempted."""
+    state_path = write_state("synced-feature", {
+        "name": "synced-feature",
+        "state_owner": "fitme-story",
+        "state_owner_sync_origin": "fitme-story-reverse",
+        "state_owner_sync_origin_commit": "abc123",
+        "framework_version": "v7.8.3",
+        "current_phase": "research",
+    })
+    code, output = run_check(state_path)
+    # Should NOT contain LOCATION_MISMATCH
+    assert "STATE_OWNER_LOCATION_MISMATCH" not in output, \
+        f"sync_origin marker should exempt; got\n{output}"
+
+
+def test_state_owner_fitme_story_at_ft2_path_without_marker_fails(write_state, monkeypatch, tmp_path):
+    """Without sync_origin marker, fitme-story state.json at FT2 path → MISMATCH."""
+    # Create state under a path that contains "/FitTracker2/"
+    fake_ft2 = tmp_path / "FitTracker2-clone" / ".claude" / "features" / "wrong-place"
+    fake_ft2.mkdir(parents=True)
+    state_path = fake_ft2 / "state.json"
+    state_path.write_text(json.dumps({
+        "name": "wrong-place",
+        "state_owner": "fitme-story",
+        "framework_version": "v7.8.3",
+        "current_phase": "research",
+    }, indent=2) + "\n")
+    code, output = run_check(state_path)
+    # Note: may need to set CWD or pass full path with /FitTracker2/ substring
+    # The test may need adjustment based on how check_state_owner_location_match
+    # detects FT2 vs fitme-story paths
+    # Spec §3.4: detection via "/FitTracker2/" or "/fitme-story/" substring in absolute path
+    assert "STATE_OWNER_LOCATION_MISMATCH" in output or code == 0, \
+        f"path-detection logic test; got\n{output}"
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: at least the first 2 tests FAIL (no state_owner gates yet).
+
+### Task 2.2: state_owner gates — implement
+
+**Files:**
+- Modify: `scripts/check-state-schema.py`
+
+- [ ] **Step 1: Add gate functions**
+
+In `scripts/check-state-schema.py`, add (per spec §3.4):
+
+```python
+VALID_STATE_OWNERS = {"ft2", "fitme-story"}
+
+
+def check_state_owner(state, file_path, *, coverage=None):
+    """Phase 2 v7.8.3: required state_owner field with valid enum value."""
+    state_owner = state.get("state_owner")
+    if state_owner is None:
+        return Finding(
+            severity="FAIL",
+            code="STATE_OWNER_MISSING",
+            message=f"{file_path}: state.json missing required state_owner field",
+        )
+    if state_owner not in VALID_STATE_OWNERS:
+        return Finding(
+            severity="FAIL",
+            code="STATE_OWNER_INVALID",
+            message=f"{file_path}: state_owner='{state_owner}' not in {sorted(VALID_STATE_OWNERS)}",
+        )
+    return None
+
+
+def check_state_owner_location_match(state, file_path, *, coverage=None):
+    """Morphed C-5: file location must match state_owner; sync mirrors are exempt."""
+    state_owner = state.get("state_owner")
+    sync_origin = state.get("state_owner_sync_origin")
+    if state_owner is None or state_owner not in VALID_STATE_OWNERS:
+        return None  # caught by check_state_owner
+    if sync_origin and isinstance(sync_origin, str) and sync_origin.endswith("-reverse"):
+        return None  # sync mirror; exempted
+    abs_path = os.path.abspath(file_path)
+    is_ft2_path = "/FitTracker2/" in abs_path or abs_path.startswith("/Volumes/DevSSD/FitTracker2/")
+    is_fs_path = "/fitme-story/" in abs_path
+    if state_owner == "ft2" and is_fs_path:
+        return Finding(
+            severity="FAIL",
+            code="STATE_OWNER_LOCATION_MISMATCH",
+            message=f"{file_path}: state_owner='ft2' but file at fitme-story path. Commit to FT2 instead, OR update state_owner='fitme-story' if migrating canonical home.",
+        )
+    if state_owner == "fitme-story" and is_ft2_path:
+        return Finding(
+            severity="FAIL",
+            code="STATE_OWNER_LOCATION_MISMATCH",
+            message=f"{file_path}: state_owner='fitme-story' but file at FT2 path. Commit to fitme-story instead, OR update state_owner='ft2' if migrating canonical home.",
+        )
+    return None
+```
+
+- [ ] **Step 2: Wire into the main gate loop**
+
+Find where existing gates (e.g., `check_schema_drift`, `check_pr_number_resolved`) are called for each state.json. Add the two new gates to that call sequence:
+
+```python
+GATES = [
+    check_schema_drift,
+    check_pr_number_resolved,
+    check_phase_transition_no_log,
+    check_phase_transition_no_timing,
+    check_cache_hits_auto_instrumentation_drift,  # V2 from Phase 0
+    check_state_owner,                             # NEW Phase 2
+    check_state_owner_location_match,              # NEW Phase 2
+    # ... other existing gates ...
+]
+```
+
+(Adjust based on actual structure.)
+
+- [ ] **Step 3: Update Mechanism D version stamp**
+
+```python
+__SCHEMA_CHECKER_VERSION__ = "v7.8.3-phase2"  # bumped from v7.8.3 (Phase 0)
+__SCHEMA_CHECKER_LAST_MODIFIED__ = "2026-05-13"  # adjust to actual ship date
+```
+
+- [ ] **Step 4: Run failing tests — should pass now**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_state_owner_gates.py -v
+```
+
+Expected: ALL tests PASS.
+
+### Task 2.3: backfill-state-owner.py — write failing test + implement
+
+**Files:**
+- Create: `tests/framework/test_backfill_script.py`
+- Create: `scripts/backfill-state-owner.py`
+
+- [ ] **Step 1: Write failing test for backfill script**
+
+```python
+"""Phase 2 — backfill-state-owner.py.
+
+One-shot mechanical script that adds state_owner: 'ft2' to all 47 existing
+state.json files. Tests idempotency + correctness."""
+from __future__ import annotations
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill-state-owner.py"
+
+
+def test_backfill_adds_state_owner_to_missing(test_repo: Path, monkeypatch):
+    """Features without state_owner get state_owner: 'ft2'."""
+    # Create 3 features, 2 missing state_owner, 1 already set
+    feat_a = test_repo / ".claude" / "features" / "feat-a"
+    feat_a.mkdir(parents=True)
+    (feat_a / "state.json").write_text(json.dumps({"name": "feat-a", "current_phase": "research"}, indent=2) + "\n")
+    feat_b = test_repo / ".claude" / "features" / "feat-b"
+    feat_b.mkdir()
+    (feat_b / "state.json").write_text(json.dumps({"name": "feat-b", "current_phase": "complete"}, indent=2) + "\n")
+    feat_c = test_repo / ".claude" / "features" / "feat-c"
+    feat_c.mkdir()
+    (feat_c / "state.json").write_text(json.dumps({"name": "feat-c", "state_owner": "ft2", "current_phase": "complete"}, indent=2) + "\n")
+
+    monkeypatch.chdir(test_repo)
+    result = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    # feat-a + feat-b should now have state_owner=ft2
+    assert json.loads((feat_a / "state.json").read_text())["state_owner"] == "ft2"
+    assert json.loads((feat_b / "state.json").read_text())["state_owner"] == "ft2"
+    # feat-c should be unchanged
+    assert json.loads((feat_c / "state.json").read_text())["state_owner"] == "ft2"
+
+
+def test_backfill_idempotent(test_repo: Path, monkeypatch):
+    """Running twice doesn't change anything."""
+    feat = test_repo / ".claude" / "features" / "feat-x"
+    feat.mkdir(parents=True)
+    state_path = feat / "state.json"
+    state_path.write_text(json.dumps({"name": "feat-x", "current_phase": "research"}, indent=2) + "\n")
+
+    monkeypatch.chdir(test_repo)
+    subprocess.run([sys.executable, str(SCRIPT)], check=True, capture_output=True)
+    after_first = state_path.read_text()
+    subprocess.run([sys.executable, str(SCRIPT)], check=True, capture_output=True)
+    after_second = state_path.read_text()
+    assert after_first == after_second
+
+
+def test_backfill_inserts_after_name_field(test_repo: Path, monkeypatch):
+    """state_owner is inserted as second key (after 'name')."""
+    feat = test_repo / ".claude" / "features" / "feat-y"
+    feat.mkdir(parents=True)
+    (feat / "state.json").write_text(json.dumps({"name": "feat-y", "current_phase": "research", "framework_version": "v7.8.3"}, indent=2) + "\n")
+
+    monkeypatch.chdir(test_repo)
+    subprocess.run([sys.executable, str(SCRIPT)], check=True, capture_output=True)
+    state = json.loads((feat / "state.json").read_text())
+    keys = list(state.keys())
+    assert keys[0] == "name"
+    assert keys[1] == "state_owner"
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: FAIL — script doesn't exist.
+
+- [ ] **Step 3: Implement backfill script**
+
+Per spec §3.3. Save to `scripts/backfill-state-owner.py`:
+
+```python
+#!/usr/bin/env python3
+"""One-shot backfill: insert state_owner: 'ft2' into all .claude/features/*/state.json.
+
+Phase 2 v7.8.3 deliverable per spec §3.3.
+Idempotent: features already having state_owner are skipped."""
+from __future__ import annotations
+import json
+import glob
+import sys
+
+
+def main() -> int:
+    backfilled = []
+    already_set = []
+    for path in sorted(glob.glob(".claude/features/*/state.json")):
+        with open(path) as f:
+            state = json.load(f)
+        if "state_owner" in state:
+            already_set.append(path)
+            continue
+        # Insert state_owner as second key (after "name")
+        new_state = {}
+        inserted = False
+        for k, v in state.items():
+            new_state[k] = v
+            if k == "name" and not inserted:
+                new_state["state_owner"] = "ft2"
+                inserted = True
+        if not inserted:  # defensive: append if no name field
+            new_state["state_owner"] = "ft2"
+        with open(path, "w") as f:
+            json.dump(new_state, f, indent=2)
+            f.write("\n")
+        backfilled.append(path)
+
+    print(f"Backfilled: {len(backfilled)}")
+    print(f"Already set: {len(already_set)}")
+    if backfilled:
+        for p in backfilled:
+            print(f"  + {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests — should pass**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 -m pytest tests/framework/test_backfill_script.py -v
+```
+
+Expected: PASS.
+
+### Task 2.4: Run backfill on real .claude/features/
+
+- [ ] **Step 1: Count features pre-backfill**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && ls -1 .claude/features/ | wc -l
+```
+
+Expected: ~47-60 (count from session start active features list was ~60; subset have state.json).
+
+- [ ] **Step 2: Run backfill**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 scripts/backfill-state-owner.py
+```
+
+Expected: prints "Backfilled: N" + "Already set: 0" (if first run).
+
+- [ ] **Step 3: Verify all state.json files now have state_owner**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && for f in .claude/features/*/state.json; do
+  python3 -c "import json,sys; s=json.load(open('$f')); assert s.get('state_owner')=='ft2', '$f'" || echo "FAIL: $f"
+done
+echo "All passed."
+```
+
+Expected: "All passed." with no FAIL lines.
+
+- [ ] **Step 4: Run gates over all backfilled features**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && python3 scripts/check-state-schema.py 2>&1 | tail -10
+```
+
+Expected: 0 NEW STATE_OWNER_* failures.
+
+### Task 2.5: Synthetic mismatch test (manual pre-flight)
+
+- [ ] **Step 1: Copy a real state.json to wrong-named path + test gate**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && mkdir -p /tmp/fitme-story-fake/.claude/features/wrong-place
+cp .claude/features/$(ls .claude/features | head -1)/state.json /tmp/fitme-story-fake/.claude/features/wrong-place/state.json
+python3 scripts/check-state-schema.py /tmp/fitme-story-fake/.claude/features/wrong-place/state.json 2>&1 | head -5
+```
+
+Expected: STATE_OWNER_LOCATION_MISMATCH FAIL (state_owner='ft2' but path contains '/fitme-story/').
+
+- [ ] **Step 2: Cleanup synthetic mismatch test**
+
+```bash
+rm -rf /tmp/fitme-story-fake
+```
+
+### Task 2.6: Update CLAUDE.md describing state_owner
+
+- [ ] **Step 1: Add section to CLAUDE.md**
+
+In the v7.8.3 section added in Task 0.9, append a paragraph about state_owner:
+
+```markdown
+### v7.8.3 Phase 2 — state_owner schema
+
+Every state.json in either repo carries a top-level `state_owner` field
+(enum `{"ft2", "fitme-story"}`) that reflects WHERE the canonical
+state.json file lives, not where the feature's code lives. Required from
+2026-05-13 onward; backfilled to all 47 existing features in single PR.
+
+The morphed C-5 gate (`STATE_OWNER_LOCATION_MISMATCH`) cross-checks the
+field against the file's actual repo path. Reverse-sync mirrors (Phase 3+)
+carry a `state_owner_sync_origin: "fitme-story-reverse"` exemption marker.
+```
+
+- [ ] **Step 2: Update integrity schema if exists**
+
+```bash
+test -f .claude/integrity/schemas/state.schema.json && echo "schema exists" || echo "no schema file"
+```
+
+If exists: open it + add `state_owner` to required fields + enum.
+
+### Task 2.7: Commit Phase 2 + open PR + merge
+
+- [ ] **Step 1: Commit everything**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add tests/framework/test_state_owner_gates.py tests/framework/test_backfill_script.py
+git add scripts/check-state-schema.py scripts/backfill-state-owner.py
+git add .claude/features/*/state.json
+git add CLAUDE.md
+[ -f .claude/integrity/schemas/state.schema.json ] && git add .claude/integrity/schemas/state.schema.json
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): Phase 2 — state_owner schema + 47-feature backfill + morphed C-5
+
+Per spec §3 + §6.3. Adds:
+- 3 new gates: STATE_OWNER_MISSING, STATE_OWNER_INVALID, STATE_OWNER_LOCATION_MISMATCH
+- state_owner_sync_origin exemption for reverse-sync mirrors (Phase 3 prerequisite)
+- scripts/backfill-state-owner.py one-shot mechanical backfill
+- 47 existing state.json files backfilled to state_owner: 'ft2'
+- tests/framework/test_state_owner_gates.py + test_backfill_script.py
+- CLAUDE.md state_owner paragraph
+
+Calibration: 47/47 backfill mechanical correctness + synthetic mismatch
+test passes + ≥3 new features post-Phase-2 set state_owner correctly.
+
+Bumps __SCHEMA_CHECKER_VERSION__ to v7.8.3-phase2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Push + open PR**
+
+```bash
+git push -u origin feat/cross-repo-state-sync-phase-2
+gh pr create --title "v7.8.3 Phase 2 — state_owner schema + 47-feature backfill + morphed C-5" --body "Per spec §3 + §6.3. 47-file mechanical backfill diff + 3 new gates.
+
+Test plan:
+- [ ] tests/framework/ all green
+- [ ] make verify-local passes
+- [ ] make integrity-check 0 hard findings
+- [ ] No integrity-cycle regression on >5 features in 72h post-merge"
+```
+
+- [ ] **Step 3: Wait for CI; user approves; merge squash**
+
+- [ ] **Step 4: After merge — snapshot Phase 2 → 3 transition**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && git checkout main && git pull origin main
+make snapshot-phase PHASE=phase-2-complete-pre-phase-3
+```
+
+---
+
+## Phase 3 — D-1 reverse-sync GitHub Action
+
+**Branch (in fitme-story):** `feat/cross-repo-state-sync-phase-3`
+**Single fitme-story PR.** Estimated 1-2 days impl.
+
+### Task 3.1: Operator setup — provision FT2_REPO_TOKEN
+
+- [ ] **Step 1: Generate PAT (manual operator step)**
+
+Operator visits https://github.com/settings/tokens?type=beta and creates a fine-grained PAT scoped to `Regevba/FitTracker2` with `Contents: write` + `Pull requests: write` permissions. Expiration: 90 days (set calendar reminder for rotation).
+
+- [ ] **Step 2: Add as fitme-story repo secret**
+
+```bash
+# Operator runs locally:
+gh secret set FT2_REPO_TOKEN --repo Regevba/fitme-story
+# Pastes the PAT when prompted
+```
+
+- [ ] **Step 3: Verify secret exists (without revealing value)**
+
+```bash
+gh secret list --repo Regevba/fitme-story | grep FT2_REPO_TOKEN
+```
+
+Expected: `FT2_REPO_TOKEN  <date>`
+
+### Task 3.2: Write the workflow YAML
+
+**Files:**
+- Create: `.github/workflows/reverse-sync-fitme-story-to-ft2.yml` (in fitme-story repo)
+
+- [ ] **Step 1: Create workflow file**
+
+```bash
+cd /Volumes/DevSSD/fitme-story
+git checkout main && git pull origin main
+git checkout -b feat/cross-repo-state-sync-phase-3
+```
+
+Save to `.github/workflows/reverse-sync-fitme-story-to-ft2.yml`:
+
+```yaml
+name: Reverse-sync fitme-story-native state.json to FT2
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude/features/**/state.json'
+
+jobs:
+  reverse-sync:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.FT2_REPO_TOKEN != '' }}
+    steps:
+      - name: Checkout fitme-story
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need previous commit for diff
+
+      - name: Detect changed fitme-story-native state.json files
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- '.claude/features/*/state.json' || true)
+          NATIVE_FILES=()
+          for f in $CHANGED; do
+            owner=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('state_owner',''))" "$f" 2>/dev/null || echo "")
+            if [ "$owner" = "fitme-story" ]; then
+              NATIVE_FILES+=("$f")
+            fi
+          done
+          if [ ${#NATIVE_FILES[@]} -eq 0 ]; then
+            echo "No fitme-story-native state.json modified; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${NATIVE_FILES[@]}" > /tmp/native-files.txt
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "count=${#NATIVE_FILES[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout FT2
+        if: steps.detect.outputs.skip == 'false'
+        uses: actions/checkout@v4
+        with:
+          repository: Regevba/FitTracker2
+          token: ${{ secrets.FT2_REPO_TOKEN }}
+          path: ft2-checkout
+          fetch-depth: 1
+
+      - name: Mirror state.json files into FT2 with sync_origin marker
+        if: steps.detect.outputs.skip == 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH="reverse-sync/from-fitme-story/${SHORT_SHA}"
+          cd ft2-checkout
+          git config user.email "noreply@github.com"
+          git config user.name "fitme-story reverse-sync bot"
+          git checkout -b "$BRANCH"
+          while IFS= read -r src_file; do
+            dest_file="${src_file}"
+            mkdir -p "$(dirname "$dest_file")"
+            python3 -c "
+import json, sys
+src_path = '../${src_file}'
+with open(src_path) as f:
+    state = json.load(f)
+state['state_owner_sync_origin'] = 'fitme-story-reverse'
+state['state_owner_sync_origin_commit'] = '${{ github.sha }}'
+state['state_owner_sync_origin_pr_url'] = 'pending'
+with open('$dest_file', 'w') as f:
+    json.dump(state, f, indent=2)
+    f.write('\n')
+"
+          done < /tmp/native-files.txt
+          git add .
+          git commit -m "Reverse-sync: mirror fitme-story-native state.json from ${SHORT_SHA}"
+          git push -u origin "$BRANCH"
+
+      - name: Open PR against FT2
+        if: steps.detect.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.FT2_REPO_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH="reverse-sync/from-fitme-story/${SHORT_SHA}"
+          cd ft2-checkout
+          gh pr create \
+            --repo Regevba/FitTracker2 \
+            --base main \
+            --head "$BRANCH" \
+            --title "Reverse-sync: ${{ steps.detect.outputs.count }} fitme-story-native state.json from ${SHORT_SHA}" \
+            --body "Auto-PR from fitme-story reverse-sync GitHub Action (v7.8.3 D-1).
+
+Source commit: https://github.com/Regevba/fitme-story/commit/${{ github.sha }}
+Source files: $(cat /tmp/native-files.txt)
+
+Each state.json carries state_owner_sync_origin: 'fitme-story-reverse' marker.
+Morphed C-5 gate exempts these files from STATE_OWNER_LOCATION_MISMATCH.
+
+Manual operator merge required per feedback_no_auto_merge_without_approval.md."
+```
+
+### Task 3.3: Test workflow locally with `act`
+
+**Files:**
+- Create: `scripts/test-reverse-sync-action.sh` (fitme-story)
+
+- [ ] **Step 1: Write wrapper script**
+
+`scripts/test-reverse-sync-action.sh`:
+```bash
+#!/usr/bin/env bash
+# Local test wrapper for reverse-sync-fitme-story-to-ft2.yml
+# Requires: act (https://github.com/nektos/act)
+set -euo pipefail
+
+if ! command -v act >/dev/null; then
+  echo "act not installed; install via: brew install act"
+  exit 1
+fi
+
+EVENT_FILE=$(mktemp)
+trap "rm -f $EVENT_FILE" EXIT
+
+cat > "$EVENT_FILE" <<EOF
+{
+  "ref": "refs/heads/main",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "abcdef1234567890",
+  "commits": [
+    {
+      "id": "abcdef1234567890",
+      "modified": [".claude/features/test-fs-native/state.json"]
+    }
+  ]
+}
+EOF
+
+# Dry-run (won't actually push or create PR)
+act push -e "$EVENT_FILE" --workflows .github/workflows/reverse-sync-fitme-story-to-ft2.yml --dryrun
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x scripts/test-reverse-sync-action.sh
+```
+
+- [ ] **Step 3: Run actionlint on workflow YAML**
+
+```bash
+cd /Volumes/DevSSD/fitme-story && actionlint .github/workflows/reverse-sync-fitme-story-to-ft2.yml
+```
+
+Expected: zero errors. (If actionlint not installed: `brew install actionlint`.)
+
+- [ ] **Step 4: Run dry-run via act**
+
+```bash
+cd /Volumes/DevSSD/fitme-story && ./scripts/test-reverse-sync-action.sh
+```
+
+Expected: workflow steps execute in dry-run mode without errors (won't actually open PR; just prints the steps it would run).
+
+### Task 3.4: Document reverse-sync flow in fitme-story README
+
+**Files:**
+- Modify: `fitme-story/.claude/README.md`
+
+- [ ] **Step 1: Add reverse-sync section**
+
+Append to `fitme-story/.claude/README.md`:
+
+```markdown
+## Reverse-sync flow (Phase 3 v7.8.3)
+
+When a fitme-story-native feature's state.json is committed (with `state_owner: "fitme-story"`),
+the `.github/workflows/reverse-sync-fitme-story-to-ft2.yml` GitHub Action
+automatically opens a PR against the FT2 repo mirroring the state.json
+into `FT2/.claude/features/<name>/state.json` with a `state_owner_sync_origin`
+marker.
+
+**Operator setup (one-time):** Provision `FT2_REPO_TOKEN` repo secret with
+fine-grained PAT scoped to `Regevba/FitTracker2` Contents:write +
+Pull-requests:write. Set 90-day expiration with calendar rotation reminder.
+
+**Manual merge required:** PRs do NOT auto-merge per
+`feedback_no_auto_merge_without_approval.md`.
+
+**Local testing:** `./scripts/test-reverse-sync-action.sh` (requires `act`).
+```
+
+### Task 3.5: Commit + open PR + merge
+
+- [ ] **Step 1: Commit Phase 3**
+
+```bash
+cd /Volumes/DevSSD/fitme-story
+git add .github/workflows/reverse-sync-fitme-story-to-ft2.yml scripts/test-reverse-sync-action.sh .claude/README.md
+git commit -m "$(cat <<'EOF'
+feat(v7.8.3): D-1 reverse-sync GitHub Action
+
+Per FT2 spec §6.4 Phase 3. When fitme-story commits modify
+.claude/features/**/state.json with state_owner='fitme-story', the workflow
+auto-opens a PR against FT2 main mirroring the state.json with
+state_owner_sync_origin: 'fitme-story-reverse' marker.
+
+Manual operator merge required (no auto-merge per
+feedback_no_auto_merge_without_approval.md).
+
+Adds:
+- .github/workflows/reverse-sync-fitme-story-to-ft2.yml
+- scripts/test-reverse-sync-action.sh (local act wrapper)
+- .claude/README.md reverse-sync flow documentation
+
+Phase 3 calibration: workflow YAML lints + act dry-run produces valid
+PR-template payload + FT2_REPO_TOKEN provisioned. End-to-end calibration
+deferred to Phase 4 cutover.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/cross-repo-state-sync-phase-3
+gh pr create --title "v7.8.3 Phase 3 — D-1 reverse-sync GitHub Action" --body "Per FT2 spec §6.4. End-to-end calibration deferred to Phase 4 cutover.
+
+Test plan:
+- [ ] actionlint passes
+- [ ] act dry-run produces valid PR-template
+- [ ] FT2_REPO_TOKEN secret provisioned (operator)"
+```
+
+- [ ] **Step 2: Wait for CI; user approves; merge squash**
+
+- [ ] **Step 3: Snapshot Phase 3 → 4 transition**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && make snapshot-phase PHASE=phase-3-complete-pre-phase-4
+```
+
+---
+
+## Phase 4 — Cutover ceremony
+
+**Branch:** `feat/cross-repo-state-sync-phase-4-cutover` (FT2) + corresponding fitme-story branch
+**Cross-repo coordination.** Estimated 2-3 days.
+
+### Task 4.1: Pick first fitme-story-native feature candidate
+
+- [ ] **Step 1: Identify candidate**
+
+Criteria (per spec §6.5): small public-site enhancement, no FT2 surface, low-risk. Discuss with user; document choice in `~/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_phase4_cutover_choice.md`.
+
+Examples to consider: a future fitme-story-only enhancement (e.g., a new control-room widget, a new public-site page section, a glossary expansion).
+
+### Task 4.2: Create the fitme-story-native state.json
+
+Once candidate locked in (call it `<fs-native>`):
+
+```bash
+cd /Volumes/DevSSD/fitme-story
+git checkout main && git pull origin main
+git checkout -b feat/cross-repo-state-sync-phase-4-cutover
+
+mkdir -p .claude/features/<fs-native>
+cat > .claude/features/<fs-native>/state.json <<'EOF'
+{
+  "name": "<fs-native>",
+  "state_owner": "fitme-story",
+  "framework_version": "v7.8.3",
+  "current_phase": "research",
+  "work_type": "Feature",
+  "created_at": "2026-05-19T00:00:00Z",
+  "case_study_link": "docs/case-studies/<fs-native>-case-study.md"
+}
+EOF
+```
+
+Adjust dates + work_type as appropriate.
+
+### Task 4.3: Push to fitme-story main + verify reverse-sync Action fires
+
+- [ ] **Step 1: Commit + push**
+
+```bash
+cd /Volumes/DevSSD/fitme-story
+git add .claude/features/<fs-native>/
+git commit -m "feat(<fs-native>): create first fitme-story-native state.json (Phase 4 cutover)"
+git push origin feat/cross-repo-state-sync-phase-4-cutover
+
+# Open + merge PR to fitme-story main
+gh pr create --title "Phase 4 cutover: first fitme-story-native state.json" --body "Triggers reverse-sync GitHub Action."
+# Wait for user approval + merge
+```
+
+- [ ] **Step 2: Watch GitHub Action fire**
+
+```bash
+gh run watch --repo Regevba/fitme-story
+```
+
+Expected: workflow runs successfully + opens a PR against FT2.
+
+- [ ] **Step 3: Verify FT2-side PR**
+
+```bash
+gh pr list --repo Regevba/FitTracker2 --search "reverse-sync"
+```
+
+Expected: 1 open PR titled "Reverse-sync: …".
+
+- [ ] **Step 4: Inspect the synced state.json carries marker**
+
+```bash
+gh pr view --repo Regevba/FitTracker2 <pr-number> --json files
+gh pr diff --repo Regevba/FitTracker2 <pr-number> | head -30
+```
+
+Expected: file at `.claude/features/<fs-native>/state.json` with both `state_owner: "fitme-story"` AND `state_owner_sync_origin: "fitme-story-reverse"` fields.
+
+### Task 4.4: Operator manually merges FT2-side PR
+
+- [ ] **Step 1: User reviews the auto-opened PR**
+
+- [ ] **Step 2: User approves; merge squash**
+
+```bash
+gh pr merge <pr-number> --repo Regevba/FitTracker2 --squash
+```
+
+### Task 4.5: Verify forward-sync mirrors back
+
+After Vercel rebuilds fitme-story (triggered by next FT2 push):
+
+```bash
+cd /Volumes/DevSSD/fitme-story && git pull origin main
+ls -la src/data/features/<fs-native>.json
+```
+
+Expected: file exists; matches the FT2 state.json content.
+
+### Task 4.6: Write source case study
+
+**Files:**
+- Create: `docs/case-studies/cross-repo-state-sync-impl-case-study.md`
+
+- [ ] **Step 1: Draft case study**
+
+Per existing case study templates + the spec §11 cross-references. Required sections per `CASE_STUDY_MISSING_FIELDS` gate:
+
+```markdown
+---
+title: Cross-Repo State Sync (v7.8.3) Implementation
+date: 2026-05-XX
+work_type: Feature
+framework_version: v7.8.3
+dispatch_pattern: sequential-phased
+success_metrics:
+  - 100% state.json have state_owner within 14 days of Phase 2 ship
+  - V2 fires ≥1 production fire without false positive
+  - Phase 4 cutover round-trip succeeds end-to-end
+kill_criteria:
+  - Reverse-sync gate-firing storm >10 false positives
+  - state_owner backfill regression on >5 features
+  - V2 false positives >3 in 24h
+kill_criteria_resolution:
+  - All 3 kill criteria checked; none triggered
+tier_tags_present: true
+related_prs:
+  - "PR #<phase-0>"
+  - "PR #<phase-1-d3>"
+  - "PR #<phase-1-c4>" (fitme-story)
+  - "PR #<phase-2>"
+  - "PR #<phase-3>" (fitme-story)
+  - "PR #<phase-4-cutover>"
+  - "[fitme-story#<phase-4-fs-pr>]"
+case_study_showcase: ../../fitme-story/content/04-case-studies/<NN>-cross-repo-state-sync-impl.mdx
+---
+
+# Cross-Repo State Sync (v7.8.3) Implementation
+
+(Body covers all 5 phases narratively, with quantitative T1 metrics tagged.)
+```
+
+### Task 4.7: Add showcase MDX in fitme-story
+
+**Files:**
+- Create: `fitme-story/content/04-case-studies/<NN>-cross-repo-state-sync-impl.mdx`
+
+- [ ] **Step 1: Determine slot number**
+
+Per CLAUDE.md chronological-order rule, slot N reflects v7.8.3 era. Look at existing slot numbering in `fitme-story/content/04-case-studies/` and pick the next slot AFTER the latest v7.8.2 case study.
+
+- [ ] **Step 2: Create MDX**
+
+Per dual-outlet pattern (mirrors source case study but adds showcase-specific metadata):
+
+```mdx
+---
+title: "Cross-Repo State Sync v7.8.3"
+slug: cross-repo-state-sync-impl
+version: '7.8.3'
+date: '2026-05-XX'
+timeline_position:
+  era: framework-v7-8-x
+  order: <next-after-v7.8.2>
+---
+
+(Body summarizes for public showcase.)
+```
+
+### Task 4.8: Transition feature to current_phase=complete
+
+- [ ] **Step 1: Update FT2 state.json (the umbrella feature, not the fs-native one)**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+# Create the cross-repo-state-sync-impl feature state.json (since this work is the umbrella)
+mkdir -p .claude/features/cross-repo-state-sync-impl
+cat > .claude/features/cross-repo-state-sync-impl/state.json <<'EOF'
+{
+  "name": "cross-repo-state-sync-impl",
+  "state_owner": "ft2",
+  "framework_version": "v7.8.3",
+  "current_phase": "complete",
+  "work_type": "Feature",
+  "created_at": "2026-05-11T00:00:00Z",
+  "case_study_link": "docs/case-studies/cross-repo-state-sync-impl-case-study.md",
+  "case_study_showcase": "../../fitme-story/content/04-case-studies/<NN>-cross-repo-state-sync-impl.mdx",
+  "phases": {
+    "merge": { "pr_number": <umbrella-pr-or-null> }
+  },
+  "tasks": [
+    { "id": "phase-0", "status": "done", "pr_number": <p0> },
+    { "id": "phase-1-d3", "status": "done", "pr_number": <p1-d3> },
+    { "id": "phase-1-c4-fs", "status": "done", "related_prs": ["[fitme-story#<p1-c4>]"] },
+    { "id": "phase-2", "status": "done", "pr_number": <p2> },
+    { "id": "phase-3-fs", "status": "done", "related_prs": ["[fitme-story#<p3>]"] },
+    { "id": "phase-4-cutover", "status": "done", "pr_number": <p4> }
+  ]
+}
+EOF
+```
+
+(This triggers `FEATURE_CLOSURE_COMPLETENESS` advisory — verify all 7 frontmatter fields present + kill_criteria_resolution + PR-list parity.)
+
+### Task 4.9: Commit closure + open Phase 4 PR + merge
+
+```bash
+cd /Volumes/DevSSD/FitTracker2
+git add docs/case-studies/cross-repo-state-sync-impl-case-study.md .claude/features/cross-repo-state-sync-impl/
+git commit -m "feat(cross-repo-state-sync-impl): Phase 4 closure — current_phase=complete"
+git push -u origin feat/cross-repo-state-sync-phase-4-cutover
+gh pr create --title "v7.8.3 Phase 4 — cutover complete + case study + closure" --body "All 5 phases shipped; framework certified end-to-end. Unblocks HADF Phase 2-bis Sub-exp 1."
+# User approval + merge
+```
+
+### Task 4.10: After cutover — final snapshot
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && git checkout main && git pull origin main
+make snapshot-phase PHASE=phase-4-cutover-complete-framework-certified
+```
+
+### Task 4.11: Verify HADF Phase 2-bis unblocks
+
+- [ ] **Step 1: Run framework verification**
+
+```bash
+cd /Volumes/DevSSD/FitTracker2 && make verify-local && make integrity-check
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Check calibration targets met**
+
+Per spec §3.5.2:
+- [ ] V2: ≥1 production fire without false positive (verify in `gate-coverage.jsonl`)
+- [ ] V9: ≥1 real merge-conflict resolved (synthetic test + natural occurrence)
+- [ ] D-3: 35/35 retroactive cross-repo cites pass + ≥3 forward
+- [ ] C-4: aggregator visually correct
+- [ ] Phase 2: 47/47 backfill + synthetic mismatch test + ≥3 new features clean
+- [ ] Phase 4: round-trip succeeds
+
+If all ✓: **HADF Phase 2-bis Sub-exp 1 is UNBLOCKED**. Transition memory file `project_phase2bis_brainstorm_paused_2026_05_11.md` from "paused" to "ready to start".
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** All 11 spec sections (§1 Overview, §2 Architecture, §3 Schema, §3.5 HADF gating, §4 Sync mechanisms, §5 PR cite cache, §6 Rollout, §7 Testing, §8 Out-of-scope, §9 Dogfooding, §10 Snapshot protocol, §11 Cross-references) have at least one task implementing them. ✓
+
+**2. Placeholder scan:** No "TBD/TODO/PLACEHOLDER/FIXME" strings in plan. The few `<fs-native>` and `<NN>` placeholders ARE intentional — they get filled in during Phase 4 Task 4.1 + 4.7 based on operator decisions. The `<phase-N-pr-number>` placeholders in Phase 4 Task 4.8 are filled at closure time when PRs are merged.
+
+**3. Type consistency:** Function names consistent across tasks: `check_state_owner` + `check_state_owner_location_match` defined in Task 2.2, used in Task 2.7 commit. `aggregateGateCoverage` + `countEventsBySource` defined + used in Task 1.6. `resolve_pr_cite` + `_PR_CITATION_PAT` + `REPO_MAP` consistent across Tasks 1.1-1.3.
+
+**4. Phase ordering enforced via branch dependencies:** Each phase branch is created off `main` after the prior phase's PR merges. Phase 1's two PRs can run in parallel (FT2 D-3 + fitme-story C-4). Phase 4 requires Phase 3 to ship first (cutover triggers reverse-sync Action).
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — Dispatch a fresh subagent per task; review between tasks; fast iteration. Particularly suited to this plan since each phase is independent and each task is well-bounded.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans; batch execution with checkpoints for user review.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md
+++ b/docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md
@@ -1,0 +1,801 @@
+# Cross-Repo State Sync — Implementation Design (v7.8.3 Release Umbrella)
+
+**Created:** 2026-05-11
+**Feature name:** `cross-repo-state-sync-impl`
+**Framework version (immutable on this feature's state.json):** `v7.8.3`
+**Predecessors:**
+- [`2026-05-09-cross-repo-state-sync.md`](2026-05-09-cross-repo-state-sync.md) — Phase C contract (FT2-canonical-writer / fitme-story-canonical-reader); Phase D candidates D-1/D-2/D-3 surfaced
+- [`2026-05-08-cross-repo-gate-asymmetry.md`](2026-05-08-cross-repo-gate-asymmetry.md) §8 reversal addendum — F7/F8 closed via Phase B port; v7.8.2 disposition stands for `_session-*.events.jsonl`
+- [`2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`](2026-05-02-framework-v7-8-and-v7-9-bridge-design.md) — v7.8 Mechanisms A-F; V1 GATE_COVERAGE_ZERO meta-check planned for v7.9
+- [`2026-05-07-branch-isolation-out-of-scope.md`](2026-05-07-branch-isolation-out-of-scope.md) — 7 v8.0+ candidates (out of scope here)
+- fitme-story PR #72 (Phase B framework port, 2026-05-09)
+- FT2 PR #271 + fitme-story PR #74 (Phase C-1/C-2/C-3 ship, 2026-05-10)
+
+**Brainstorm artifact:** `/Users/regevbarak/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_phase2bis_brainstorm_paused_2026_05_11.md` (HADF Phase 2-bis brainstorm, paused awaiting this Feature's completion) and `/Users/regevbarak/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_phase_c_brainstorm_2026_05_11.md` (this Feature's brainstorm 6 design decisions).
+
+---
+
+## §1 Overview + Scope
+
+This Feature implements all deferred Phase C and Phase D items from the 2026-05-09 cross-repo state-sync spec, bundled with two additional v7.9 candidates (V2 + V9) that extend the v7.5-v7.8.2 framework hardening line into a unified v7.8.3 release. It is also the gate that unblocks HADF Phase 2-bis: that campaign cannot start until every framework deliverable below ships AND each phase's calibration target is met.
+
+### §1.1 Why one umbrella Feature (not two parallel tracks)
+
+The original 2026-05-11 sequencing decision (Q1) chose to land cross-repo state sync BEFORE HADF Phase 2-bis. The cross-reference audit then surfaced two specific v7.9 candidates (V2 Mechanism C writer-path enforcement, V9 Mechanism E driver extension to feature logs) that match the same theme — cross-repo / cross-tool integrity hardening — and naturally bundle into the same release. A single PM-workflow Feature with a 5-phase rollout produces one coordinated PR sequence, one case study, and one validated framework state instead of two parallel tracks competing for the shared touch-surface (`scripts/`, `.claude/shared/`, `.claude/features/*/state.json`, `.githooks/`).
+
+### §1.2 Scope inclusions (5 phases)
+
+| Phase | Deliverable | Risk |
+|---|---|---|
+| **0** | v7.8.3 framework gate promotions: V2 (`CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` enforced) + V9 (Mechanism E driver covers `<feature>.log.json`) + snapshot protocol script | LOW — both gate promotions have calibration data; snapshot is operator tooling |
+| **1** | Telemetry foundations: D-3 unified cross-repo PR cite cache + C-4 control-room cross-repo gate-coverage aggregator + forward-sync extension for `gate-coverage-ft2.jsonl` | LOW — read-only telemetry |
+| **2** | `state_owner` schema marker + 47-feature backfill + morphed C-5 location-mismatch validator | MED — schema change with backfill; integrity-cycle regression risk |
+| **3** | D-1 reverse-sync infrastructure: GitHub Action opens auto-PR against FT2 when fitme-story-native state.json changes | MED-HIGH — new infra; reverse-sync conflict-with-forward-sync risk |
+| **4** | Cutover ceremony: pick first fitme-story-native feature, mark, round-trip end-to-end, document case study + showcase MDX | LOW — validation only |
+
+### §1.3 Scope exclusions
+
+Explicit non-scope items are listed exhaustively in §8. Notable: HADF Phase 2-bis itself is OUT (its spec lives separately and is gated on this Feature's completion), real-time bi-directional sync is DEFERRED, cross-org PR cite validation is DEFERRED, V1 `GATE_COVERAGE_ZERO` meta-check ships as a separate v7.9 promotion.
+
+### §1.4 Primary success metrics
+
+1. 100% of state.json files in either repo have `state_owner` field within 14 days of Phase 2 ship
+2. V2 Mechanism C writer-path enforcement firing on at least one production commit before HADF Phase 2-bis Sub-exp 1 launch
+3. All 4 framework calibration targets (per §3.5) achieved before HADF Phase 2-bis Sub-exp 1 launch
+4. Phase 4 cutover round-trip succeeds end-to-end (the cutover IS the framework certification)
+
+### §1.5 Kill criteria
+
+- If reverse-sync PRs (Phase 3) create a gate-firing storm (>10 false-positive failures in first week of Phase 3 production) → halt Phase 3, fall back to manual sync-back
+- If `state_owner` backfill (Phase 2) triggers integrity-cycle regression on >5 features within 72h post-merge → roll back schema change
+- If V2 enforcement (Phase 0) fires on >3 already-shipped features (false positives) → revert V2 to advisory and add 7-day calibration period
+- HADF Phase 2-bis Sub-exp 1 launch is BLOCKED until all 5 phases ship AND each phase's calibration targets are met. If calibration targets aren't met within 21 days of Phase 4 cutover, escalate the calibration gap to a separate work item before HADF starts.
+
+---
+
+## §2 Architecture + data flow diagram
+
+### §2.1 Component layout (what lives where, who writes it, who reads it)
+
+```
+FitTracker2 (canonical writer for FT2-owned + cross-repo features)
+├── .claude/features/<name>/state.json          [state_owner: "ft2" — written here, mirrored to fitme-story]
+├── .claude/logs/<feature>.log.json             [Tier 2.2 stream — written here, mirrored to fitme-story]
+├── .claude/shared/*.json                       [framework ledgers — written here, mirrored to fitme-story]
+│   ├── measurement-adoption-history.json       [Mechanism E driver: union-dedup]
+│   ├── documentation-debt.json                 [Mechanism E driver: union-dedup]
+│   └── gate-coverage.jsonl                     [per-repo — NOT synced bidirectionally; control-room reads both]
+├── docs/case-studies/*.md                      [canonical source — written here, mirrored to fitme-story]
+├── .githooks/pre-commit                        [V2 enforces CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT]
+└── scripts/
+    ├── observe-cache-hit.py                    [writer-path source for Mechanism C — V2 enforces output validity]
+    ├── merge-driver-dedup.py                   [V9 extends to cover .claude/logs/*.log.json]
+    ├── unified-pr-cite-cache.py                [NEW Phase 1 — bidirectional cross-repo gh cache]
+    ├── snapshot-phase-completion.sh            [NEW Phase 0 — operator snapshot tooling]
+    ├── refresh-pr-cache.py                     [NEW Phase 1 — populates .cache/gh-pr-cache.json]
+    ├── backfill-state-owner.py                 [NEW Phase 2 — one-shot mechanical backfill]
+    └── check-{state-schema,case-study-preflight}.py
+                                                [V2 + D-3 + morphed C-5 + state_owner gates]
+
+fitme-story (canonical reader for FT2-owned; canonical writer for fitme-story-native)
+├── src/data/{features,logs,shared,integrity,docs}/  [synced mirrors of FT2 — read-only]
+├── content/04-case-studies/*.mdx               [showcase — NOT mirror; dual-outlet pattern]
+├── .claude/features/<fs-native>/state.json     [NEW Phase 4 onward — state_owner: "fitme-story"]
+├── .claude/logs/<fs-native>.log.json           [NEW Phase 4 onward]
+├── .claude/logs/gate-coverage.jsonl            [per-repo — accumulates locally; empty today, populated as fitme-story commits hit gates]
+├── .githooks/pre-commit                        [Phase B port + V2 enforce + morphed C-5]
+├── src/lib/control-room/gate-coverage-aggregator.ts  [NEW Phase 1 — reads both repos' gate-coverage]
+└── scripts/sync-from-fittracker2.ts            [forward sync — prebuild + Vercel build]
+
+GitHub Actions (cross-repo orchestration)
+├── .github/workflows/pr-integrity-check.yml    [v7.6 per-PR review bot — already shipped]
+├── .github/workflows/framework-status-weekly.yml  [v7.6 weekly cron — already shipped]
+└── .github/workflows/reverse-sync-fitme-story-to-ft2.yml  [NEW Phase 3]
+```
+
+### §2.2 Data flow diagram
+
+```
+                        ┌─────────────────────────────────────────────┐
+                        │  FitTracker2 (canonical writer)             │
+                        │                                             │
+                        │  /pm-workflow + manual edits write here.    │
+                        │  All state.json with state_owner="ft2"      │
+                        │  AND all cross-repo features live here.     │
+                        └────────────────┬──────────┬─────────────────┘
+                                         │          │
+                                         │          │ sync-from-fittracker2.ts
+                          gate-coverage  │          │ (forward, build-time)
+                          .jsonl writes  │          │
+                          locally,       │          ▼
+                          control-room   │   ┌────────────────────────────────────────┐
+                          aggregator     │   │  fitme-story (reader + native writer)  │
+                          reads BOTH     │   │                                        │
+                          repos at       │   │  src/data/* mirrors FT2 (read-only).   │
+                          build time     │   │  Native features: state_owner=         │
+                          (NEW Phase 1)  │   │  "fitme-story" → reverse-sync to FT2.  │
+                                         │   └─────────────┬──────────────────────────┘
+                                         │                 │
+                                         │                 │ reverse-sync GH Action
+                                         │                 │ (NEW Phase 3 — opens PR
+                                         │                 │  against FT2 main)
+                                         │                 │
+                                         │                 ▼
+                                         │   ┌────────────────────────────────────────┐
+                                         │   │  FT2 PR review (full gate stack)       │
+                                         │   │  + manual operator merge → loops top   │
+                                         │   └────────────────────────────────────────┘
+                                         │
+                                         ▼
+                        ┌─────────────────────────────────────────────┐
+                        │  control-room cross-repo aggregator          │
+                        │  (reads FT2 + fitme-story gate-coverage,     │
+                        │   PR-cite cache; renders /control-room/*)    │
+                        │  (NEW Phase 1)                               │
+                        └─────────────────────────────────────────────┘
+```
+
+### §2.3 Per-commit gate firing sequence
+
+**FT2 commit (canonical-writer path):**
+1. Pre-commit hook → `check-state-schema.py` runs ~15 mechanical gates including NEW V2 (`CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` enforced)
+2. Pre-commit hook → `check-case-study-preflight.py` runs case-study gates
+   - **NEW Phase 1:** `BROKEN_PR_CITATION` resolves both `PR #N` (FT2) AND `[fitme-story#N]` / URL form via unified PR cache
+   - **NEW Phase 2:** `STATE_OWNER_LOCATION_MISMATCH` — FT2 commit modifying `state_owner: "fitme-story"` (without sync_origin marker) → reject
+3. Mechanism A → `gate-coverage.jsonl` appended for every gate fire (existing behavior)
+4. Commit succeeds
+5. (Asynchronously) Push triggers fitme-story Vercel rebuild → `sync-from-fittracker2.ts` mirrors changed FT2 artifacts into `fitme-story/src/data/`
+
+**fitme-story commit (canonical-reader path + occasional native writer):**
+1. Pre-commit hook (Phase B port) runs the same gate stack including V2
+2. **NEW Phase 2:** `STATE_OWNER_LOCATION_MISMATCH` — fitme-story commit modifying `state_owner: "ft2"` file → reject (must come from FT2)
+3. fitme-story's local `.claude/logs/gate-coverage.jsonl` appended
+4. Commit succeeds
+5. (If fitme-story-native state.json modified) Push to fitme-story `main` triggers reverse-sync GitHub Action
+6. Action opens PR against FT2 with synced state.json under `.claude/features/<fs-native>/state.json` (carries `state_owner_sync_origin: "fitme-story-reverse"` marker)
+7. PR runs through full FT2 gate stack (Mechanism A, integrity gates, morphed C-5 — exempted via sync_origin marker) before manual merge
+
+### §2.4 Sync trigger summary
+
+| Direction | Mechanism | Trigger | Latency | Phase |
+|---|---|---|---|---|
+| FT2 → fitme-story (state, logs, shared, docs) | `sync-from-fittracker2.ts` prebuild | `npm run prebuild` (local) | Immediate | Pre-Phase-C |
+| FT2 → fitme-story (same artifacts) | `sync-from-fittracker2.ts` Vercel build | `buildCommand` (prod) | ~minutes | Pre-Phase-C |
+| FT2 → fitme-story (`<feature>.log.json`) | sync extension | Same as above | Same | C-1 (shipped 2026-05-10) |
+| FT2 → fitme-story (`gate-coverage-ft2.jsonl`) | sync extension | Same as above | Same | NEW Phase 1 |
+| fitme-story → FT2 (native state.json + sync_origin marker) | GitHub Action `reverse-sync-fitme-story-to-ft2.yml` | Push to fitme-story `main` modifying `.claude/features/**/state.json` | ~minutes (Action queue) + manual operator merge | NEW Phase 3 |
+| `gate-coverage.jsonl` (per-repo, NO sync) | Pre-commit hook fire | Per commit | Immediate (read by aggregator at build time) | NEW Phase 1 (aggregator only; no sync) |
+| Control-room aggregator | Build-time computation + hourly cron | Per Vercel deploy / hourly | ~minutes | NEW Phase 1 |
+| `<feature>.log.json` merge-driver auto-resolution | git merge | Per merge with conflict | Immediate | NEW Phase 0 (V9) |
+
+### §2.5 Deliberate non-features
+
+- No real-time bi-directional sync (PR-based with manual merge IS the safety net)
+- No `<feature>.log.json` reverse-sync for fitme-story-native features (logs stay in fitme-story)
+- No cross-repo `gate-coverage.jsonl` sync (per-repo; aggregator reads both)
+- No fitme-story write of `state_owner: "ft2"` files (morphed C-5 enforces this)
+- No automatic rollback of failed reverse-sync PRs (operator manual triage per `feedback_no_auto_merge_without_approval.md`)
+
+---
+
+## §3 Schema + state_owner field + 47-feature backfill
+
+### §3.1 Field shape
+
+Simple string enum, top-level position (immediately after `name`, before `framework_version`):
+
+```json
+{
+  "name": "feature-name",
+  "state_owner": "ft2",
+  "framework_version": "v7.8.3",
+  "current_phase": "...",
+  ...
+}
+```
+
+Valid values: `{"ft2", "fitme-story"}`. Required from Phase 2 onward.
+
+### §3.2 Backfill heuristic
+
+`state_owner` reflects **where the state.json file LIVES**, not where the feature's code lives. Empirical test: every existing FT2 feature lives at `FT2/.claude/features/<name>/state.json`. Therefore all 47 backfill mechanically to `state_owner: "ft2"`. Cross-repo features (UCC, fitme-story-public-enhancements, etc.) are no exception — their state lives in FT2.
+
+The ONLY way a feature gets `"fitme-story"` is if its state.json lives at `fitme-story/.claude/features/<name>/state.json`. Today: zero such features. Phase 4 cutover creates the first one.
+
+### §3.3 Backfill mechanics
+
+`scripts/backfill-state-owner.py` runs once during Phase 2:
+
+```python
+import json, glob, sys
+
+backfilled = []
+already_set = []
+for path in sorted(glob.glob(".claude/features/*/state.json")):
+    with open(path) as f:
+        state = json.load(f)
+    if "state_owner" in state:
+        already_set.append(path)
+        continue
+    new_state = {}
+    for k, v in state.items():
+        new_state[k] = v
+        if k == "name":
+            new_state["state_owner"] = "ft2"
+    if "name" not in state:  # defensive: append if no name field
+        new_state["state_owner"] = "ft2"
+    with open(path, "w") as f:
+        json.dump(new_state, f, indent=2)
+        f.write("\n")
+    backfilled.append(path)
+
+print(f"Backfilled {len(backfilled)}; {len(already_set)} already had state_owner")
+sys.exit(0 if backfilled or already_set else 1)
+```
+
+**Commit strategy:** one-shot PR, single commit. Uniform mechanical diff (47× one-line addition) is the cleanest signal.
+
+### §3.4 New gates
+
+Added to `scripts/check-state-schema.py`:
+
+```python
+VALID_STATE_OWNERS = {"ft2", "fitme-story"}
+
+def check_state_owner(state, file_path):
+    """Phase 2 forward: required field, valid enum value."""
+    state_owner = state.get("state_owner")
+    if state_owner is None:
+        return Finding("FAIL", "STATE_OWNER_MISSING", "state.json missing required state_owner field")
+    if state_owner not in VALID_STATE_OWNERS:
+        return Finding("FAIL", "STATE_OWNER_INVALID",
+                       f"state_owner='{state_owner}' not in {VALID_STATE_OWNERS}")
+    return None
+
+def check_state_owner_location_match(state, file_path):
+    """Morphed C-5: file location must match state_owner; sync mirrors are exempt."""
+    state_owner = state.get("state_owner")
+    sync_origin = state.get("state_owner_sync_origin")
+    if state_owner is None or state_owner not in VALID_STATE_OWNERS:
+        return None  # caught by check_state_owner
+    if sync_origin and sync_origin.endswith("-reverse"):
+        return None  # sync mirror; exempted
+    abs_path = os.path.abspath(file_path)
+    is_ft2_path = "/FitTracker2/" in abs_path or abs_path.startswith("/Volumes/DevSSD/FitTracker2/")
+    is_fs_path = "/fitme-story/" in abs_path
+    if state_owner == "ft2" and is_fs_path:
+        return Finding("FAIL", "STATE_OWNER_LOCATION_MISMATCH",
+                       "state_owner='ft2' but file at fitme-story path. "
+                       "Commit to FT2 instead, OR update state_owner='fitme-story' "
+                       "if migrating canonical home.")
+    if state_owner == "fitme-story" and is_ft2_path:
+        return Finding("FAIL", "STATE_OWNER_LOCATION_MISMATCH",
+                       "state_owner='fitme-story' but file at FT2 path. "
+                       "Commit to fitme-story instead, OR update state_owner='ft2' "
+                       "if migrating canonical home.")
+    return None
+```
+
+### §3.5 HADF Phase 2-bis gating + calibration data acquisition plan
+
+#### §3.5.1 The principle
+
+Phase 2's contamination root cause was launching a 15-day measurement campaign on framework infrastructure that hadn't been exercised in real-world conditions. Phase 2-bis must NOT repeat this. Each new framework gate / driver / sync mechanism shipped in this Feature must accumulate proof-of-real-world-correctness from natural feature work BEFORE HADF Sub-exp 1 fires.
+
+#### §3.5.2 Per-phase calibration targets
+
+| Phase | New mechanism | Calibration target | Calibration source |
+|---|---|---|---|
+| 0 | V2 Mechanism C writer-path enforced | ≥1 production fire without false positive (proves writer-path wires up); soft target ≥10 fires across ≥5 features | Natural state.json mutations from in-flight features (`ios-ui-audit-p1-burndown`, `fitme-story-public-enhancements`, `ios-code-connect`, this Feature itself) |
+| 0 | V9 Mechanism E driver extension | Driver auto-resolves ≥1 real merge conflict on `<feature>.log.json` | Natural; if no conflict in 7 days, manufacture synthetic test |
+| 1 | D-3 unified PR cite cache | (a) Retroactive: 35/35 existing cross-repo cites validate; (b) Forward: ≥3 new case study commits with cross-repo cites pass the gate | (a) mechanical (run cache build over existing corpus); (b) natural case study writing |
+| 1 | C-4 control-room aggregator | Aggregator renders correct counts from both repos' gate-coverage.jsonl | Visual confirmation in `/control-room/framework` |
+| 2 | state_owner schema + backfill | 47/47 backfill success + 0 integrity-cycle regressions in 72h | Mechanical (the backfill PR itself is the calibration) |
+| 2 | Morphed C-5 location-mismatch | Gate catches deliberate mismatch | Synthetic test — explicit pre-flight check |
+| 3 | D-1 reverse-sync GitHub Action | Workflow YAML lints; first real trigger opens valid PR | NO calibration possible until Phase 4 cutover |
+| 4 | Cutover ceremony | First fitme-story-native feature round-trips end-to-end | THE cutover IS the calibration |
+
+#### §3.5.3 Estimated calibration windows
+
+| Phase | Ship date estimate | Calibration window | Calibration end estimate |
+|---|---|---|---|
+| 0 | Day 1-2 | 5-7 days natural feature work | Day 9 |
+| 1 | Day 2-3 | 3-5 days (retroactive validation mechanical) | Day 8 |
+| 2 | Day 4-5 | 3-4 days (backfill mechanical + synthetic test) | Day 9 |
+| 3 | Day 6-7 | 0 days (deferred to Phase 4) | Day 7 |
+| 4 cutover | Day 8-9 | 1-3 days end-to-end verification | Day 12 |
+
+**Total framework + calibration: ~12 days. HADF Phase 2-bis Sub-exp 1 earliest start: 2026-05-23.**
+
+#### §3.5.4 Failure modes + escalation
+
+| Failure | Escalation |
+|---|---|
+| V2 doesn't fire even once in 7 days | Manufacture synthetic state.json mutation that should trigger V2; verify gate fires; only then declare calibration met |
+| D-3 cache build fails on >0 of the 35 retroactive cites | Triage failing cites; either fix cache routing OR mark specific cites as exempt; do NOT lower target |
+| Backfill triggers integrity-cycle regression on >5 features | Per existing kill criterion in §1, roll back schema change + re-design |
+| Phase 4 cutover round-trip fails | HADF blocked indefinitely; reverse-sync infrastructure is the linchpin |
+| Calibration window extends past 21 days post-Phase-4 cutover | Spawn dedicated work item to investigate before HADF starts; document in `framework-calibration-failure` memory entry |
+
+---
+
+## §4 Sync mechanisms
+
+### §4.1 Forward sync — UNCHANGED behavior + ONE Phase 1 extension
+
+The existing `fitme-story/scripts/sync-from-fittracker2.ts` (342 lines) is canonical. Behavior unchanged for all currently-synced artifacts:
+
+- `.claude/shared/*.json` → `src/data/shared/*.json` (already shipped pre-Phase-C)
+- `.claude/features/<name>/state.json` → `src/data/features/<name>.json` (already shipped pre-Phase-C)
+- `.claude/integrity/snapshots/*.json` → `src/data/integrity/snapshots/*.json` (already shipped pre-Phase-C)
+- `docs/**` → `src/data/docs/**` (already shipped pre-Phase-C)
+- `.claude/logs/<feature>.log.json` → `src/data/logs/<name>.log.json` (C-1 shipped 2026-05-10)
+
+**ONE Phase 1 extension (NEW):**
+- `FT2/.claude/logs/gate-coverage.jsonl` → `fitme-story/src/data/integrity/gate-coverage-ft2.jsonl`
+
+The destination filename is suffixed `-ft2` to disambiguate from fitme-story's own `gate-coverage.jsonl` at `fitme-story/.claude/logs/gate-coverage.jsonl` (read directly, no sync).
+
+**Trigger points (unchanged):** `npm run prebuild` (local) + Vercel `buildCommand` (prod).
+
+### §4.2 Reverse sync — NEW Phase 3 GitHub Action
+
+**File:** `.github/workflows/reverse-sync-fitme-story-to-ft2.yml` (lives in fitme-story repo)
+
+**Trigger:** `push` to fitme-story `main` where any file matches `.claude/features/**/state.json`.
+
+**Job sequence:**
+1. **Detect changed fitme-story-native state.json files.** `git diff` between push HEAD and previous main; filter for `.claude/features/<name>/state.json`; for each, parse JSON and validate `state_owner == "fitme-story"`. Files where `state_owner != "fitme-story"` are skipped (would never legitimately exist; if they do, they're a morphed-C-5 false negative — log warning).
+2. **Compute mirror destination.** Mirror to `FT2/.claude/features/<name>/state.json` with two added fields:
+   ```json
+   {
+     "state_owner": "fitme-story",
+     "state_owner_sync_origin": "fitme-story-reverse",
+     "state_owner_sync_origin_commit": "<fitme-story-commit-sha>",
+     "state_owner_sync_origin_pr_url": "<github-pr-url-of-this-reverse-sync-pr>",
+     ... (rest of state.json unchanged)
+   }
+   ```
+3. **Open a PR against FT2 main** via `gh pr create` (requires `FT2_REPO_TOKEN` secret with write access to FT2). Branch: `reverse-sync/from-fitme-story/<short-sha>`.
+4. **PR runs through full FT2 gate stack.** morphed C-5 sees `state_owner: "fitme-story"` + path is FT2, but `state_owner_sync_origin` marker exempts the file.
+5. **Manual operator merge.** No auto-merge per `feedback_no_auto_merge_without_approval.md`.
+
+**Idempotency:** if same fitme-story commit pushed twice, Action checks for existing open PR with same source SHA and updates instead of duplicating.
+
+**Failure modes:**
+| Failure | Handling |
+|---|---|
+| `FT2_REPO_TOKEN` missing/expired | Action fails with clear error; operator regenerates; no records lost |
+| FT2 main diverged | Action attempts fresh branch from current FT2 main; if conflicts persist, marks PR draft |
+| Gates reject PR | PR stays open + failing; operator triages |
+
+### §4.3 Telemetry aggregator (C-4)
+
+Two `gate-coverage.jsonl` sources (per-repo, NEVER synced bidirectionally):
+| Source | Read path | Today's volume | Growth |
+|---|---|---|---|
+| FT2 commits | `fitme-story/src/data/integrity/gate-coverage-ft2.jsonl` (Phase 1 sync extension) | 1734 lines | Fast |
+| fitme-story commits | `fitme-story/.claude/logs/gate-coverage.jsonl` (read directly) | 0 lines today | Slow today; grows post-Phase-B port |
+
+**Aggregator:** new `fitme-story/src/lib/control-room/gate-coverage-aggregator.ts` reads both at build time, parses each line as JSON event, tags with `source_repo`, combines time-sorted, renders in `/control-room/framework` with per-source filter chips + aggregate counts + per-gate breakdown. Updates per Vercel deploy + hourly cron.
+
+### §4.4 The `state_owner_sync_origin` exemption marker
+
+This is the contract that lets D-1 reverse-sync coexist with morphed C-5. The marker is set ONLY by the D-1 GitHub Action's deterministic mirror writes. A human commit would have no `state_owner_sync_origin` field → location-mismatch fires → reject. The marker also creates audit traceability via the `_commit` and `_pr_url` sub-fields. The marker stays on the FT2 mirror permanently; if the feature is later migrated back to FT2 ownership, the marker is dropped in the same commit that sets the new ownership.
+
+---
+
+## §5 Unified PR cite cache (D-3)
+
+### §5.1 What's broken today
+
+`scripts/check-case-study-preflight.py:74-76` has two bugs:
+- **B1 Silent skip:** regex matches `PR #N` and `github.com/X/Y/pull/N` URL form, but `[fitme-story#42]` syntax doesn't match either alternation. Cross-repo cites pass without validation. **Volume: 35 `fitme-story#N` cites in `docs/case-studies/`.**
+- **B2 URL-form mis-routes:** when `github.com/Regevba/fitme-story/pull/42` is found, gate validates against LOCAL FT2-only `gh pr list` cache → false positive `BROKEN_PR_CITATION`.
+
+D-3 closes both in one shot.
+
+### §5.2 Cache architecture
+
+Single file at `.cache/gh-pr-cache.json` (FT2-resident; gitignored; rebuilt on demand).
+
+```json
+{
+  "schema_version": 1,
+  "last_refreshed_at": "2026-05-11T09:30:00Z",
+  "repos": {
+    "Regevba/FitTracker2": {
+      "open":   [{"number": 290, "title": "...", "state": "OPEN"}, ...],
+      "merged": [...],
+      "closed": [...]
+    },
+    "Regevba/fitme-story": {
+      "open": [...], "merged": [...], "closed": [...]
+    }
+  }
+}
+```
+
+**Refresh script:** new `scripts/refresh-pr-cache.py` runs `gh pr list --repo X --state all --json number,title,state --limit 500` for each repo in `REPOS = ["Regevba/FitTracker2", "Regevba/fitme-story"]`. **TTL:** 5 minutes. **Triggers:** lazy refresh on pre-commit hook if cache stale + `make refresh-pr-cache` (manual) + per-PR CI.
+
+### §5.3 Updated regex + REPO_MAP
+
+Replaces lines 74-76 of `check-case-study-preflight.py`:
+
+```python
+_PR_CITATION_PAT = re.compile(
+    r"(?:PR\s*#(\d+))"                              # group 1: FT2 default
+    r"|(?:\[?([\w-]+)\s*#(\d+)\]?)"                 # groups 2+3: cross-repo short form
+    r"|(?:github\.com/([\w-]+)/([\w-]+)/pull/(\d+))"  # groups 4+5+6: URL form
+)
+REPO_MAP = {
+    "fitme-story": "Regevba/fitme-story",
+    "FitTracker2": "Regevba/FitTracker2",
+    "ft2": "Regevba/FitTracker2",
+}
+```
+
+### §5.4 Cache routing logic
+
+```python
+def resolve_pr_cite(match, cache):
+    if match.group(1):
+        repo = "Regevba/FitTracker2"
+        pr_num = int(match.group(1))
+    elif match.group(2):
+        repo_short = match.group(2)
+        repo = REPO_MAP.get(repo_short)
+        if repo is None:
+            return Finding("FAIL", "BROKEN_PR_CITATION",
+                f"unknown repo short name '{repo_short}'; valid: {sorted(REPO_MAP.keys())}")
+        pr_num = int(match.group(3))
+    elif match.group(4):
+        repo = f"{match.group(4)}/{match.group(5)}"
+        pr_num = int(match.group(6))
+
+    if repo not in cache["repos"]:
+        return Finding("FAIL", "BROKEN_PR_CITATION",
+            f"no cache for repo '{repo}'; refresh cache or add to REPO_MAP")
+    repo_cache = cache["repos"][repo]
+    all_prs = repo_cache.get("open", []) + repo_cache.get("merged", []) + repo_cache.get("closed", [])
+    if not any(pr["number"] == pr_num for pr in all_prs):
+        return Finding("FAIL", "BROKEN_PR_CITATION",
+            f"PR #{pr_num} not found in {repo} (cache last refreshed {cache['last_refreshed_at']})")
+    return None
+```
+
+### §5.5 Retroactive validation pass (Phase 1 calibration target)
+
+`make validate-existing-cites` runs `check-case-study-preflight.py` against every case study under `docs/case-studies/` using the new cache. **Expected:** 35/35 existing cross-repo cites validate cleanly + 0 false positives on existing FT2 cites. Failures indicate a real bug (typo'd PR number that the original silent-skip masked).
+
+---
+
+## §6 5-phase rollout + per-phase success criteria + rollback
+
+### §6.1 Phase 0 — v7.8.3 framework gate promotions + snapshot protocol
+
+**Deliverables (single PR):**
+- V2: promote `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT` advisory → enforced
+- V9: extend `merge-driver-dedup.py` to handle `.claude/logs/<feature>.log.json` + update `.gitattributes`
+- NEW `scripts/snapshot-phase-completion.sh` + `make snapshot-phase` Makefile target (per §10)
+- Bump CLAUDE.md framework version reference to v7.8.3
+
+**Branch:** `feat/cross-repo-state-sync-phase-0` (per OQ-2: per-phase branches).
+**Immediate success criteria:** `make verify-local` passes; Mechanism D header self-audit passes; `make integrity-check` reports 0 hard findings.
+**Calibration targets:** V2 ≥1 production fire (soft ≥10 across ≥5 features); V9 ≥1 real merge-conflict resolved (manufacture synthetic if no natural conflict in 7 days).
+**Rollback:** V2 false positives >3 in 24h → revert to advisory in 5-line hotfix; V9 corruption → revert `.gitattributes`, restore log file from git history.
+**Wall-clock:** ship Day 1-2; calibration Days 2-9.
+**Blocks:** Phases 1-4.
+
+### §6.2 Phase 1 — Telemetry foundations (D-3 + C-4 + forward-sync extension)
+
+**Deliverables (two PRs — one FT2, one fitme-story):**
+- D-3 (FT2): `scripts/refresh-pr-cache.py` + `.cache/gh-pr-cache.json` (gitignored) + `Makefile` `refresh-pr-cache` target + updated regex/REPO_MAP/`resolve_pr_cite` + retroactive validation script + `make validate-existing-cites` target
+- C-4 (fitme-story): forward-sync extension for `gate-coverage-ft2.jsonl` + `src/lib/control-room/gate-coverage-aggregator.ts` + `/control-room/framework` page extension
+
+**Branches:** `feat/cross-repo-state-sync-phase-1` (FT2) + `feat/cross-repo-state-sync-phase-1` (fitme-story).
+**Immediate success:** both PRs merge; `make validate-existing-cites` passes 35/35 retroactive; control-room renders aggregated count visually correct.
+**Calibration:** D-3 35/35 retroactive + ≥3 forward; C-4 0 build errors + visually correct.
+**Rollback:** D-3 regex regression → revert; C-4 build error → revert aggregator + remove from page.
+**Wall-clock:** ship Day 2-3; calibration Days 3-8.
+**Blocks:** Phase 4 (cutover case study cites cross-repo PRs); HADF Phase 2-bis case studies.
+
+### §6.3 Phase 2 — Schema + backfill + morphed C-5
+
+**Deliverables (single FT2 PR):**
+- New `state_owner` enum schema field
+- New gates `STATE_OWNER_MISSING`, `STATE_OWNER_INVALID`, `STATE_OWNER_LOCATION_MISMATCH` in `check-state-schema.py`
+- `.claude/integrity/schemas/state.schema.json` update (if exists)
+- `scripts/backfill-state-owner.py` + execution producing 47-file diff
+- CLAUDE.md update describing the field + morphed C-5
+
+**Branch:** `feat/cross-repo-state-sync-phase-2`.
+**Immediate success:** 47/47 backfill in single commit; PR merges; new gates fire on backfill commit (validates backward-compat); `make integrity-check` 0 hard findings.
+**Calibration:** 47/47 mechanical correctness; synthetic mismatch test passes; ≥3 new features post-Phase-2 set state_owner correctly.
+**Rollback:** integrity-cycle regression on >5 features → revert schema change in single commit.
+**Wall-clock:** ship Day 4-5; calibration Days 5-9.
+**Blocks:** Phase 3.
+
+### §6.4 Phase 3 — D-1 reverse-sync GitHub Action
+
+**Deliverables (single fitme-story PR):**
+- `.github/workflows/reverse-sync-fitme-story-to-ft2.yml`
+- Operator setup doc for `FT2_REPO_TOKEN` secret (PAT with `repo` scope, scoped to FitTracker2 only)
+- `state_owner_sync_origin` exemption logic in morphed C-5 (added Phase 2; activation here)
+- README addition documenting reverse-sync flow
+
+**Branch:** `feat/cross-repo-state-sync-phase-3`.
+**Immediate success:** YAML lints; operator confirms token scope; `act` dry-run produces valid PR-template payload.
+**Calibration:** deferred to Phase 4 (no fitme-story-native features exist yet).
+**Rollback:** disable workflow file (`.yml.disabled` rename); no state migration needed.
+**Wall-clock:** ship Day 6-7; calibration deferred.
+**Blocks:** Phase 4.
+
+### §6.5 Phase 4 — Cutover ceremony
+
+**Deliverables (cross-repo coordination):**
+- Pick first fitme-story-native feature (criteria: small public-site enhancement, no FT2 surface, low-risk)
+- Create `fitme-story/.claude/features/<fs-native>/state.json` with `state_owner: "fitme-story"`
+- Push to fitme-story main → trigger reverse-sync Action → verify PR opens against FT2 with sync_origin marker
+- Operator manually merges FT2-side PR
+- Verify forward-sync mirrors back to `fitme-story/src/data/features/<fs-native>.json` on next Vercel build
+- Source case study at `docs/case-studies/cross-repo-state-sync-impl-case-study.md`
+- Showcase MDX at `fitme-story/content/04-case-studies/<NN>-cross-repo-state-sync-impl.mdx` (slot N matching v7.8.3 era)
+
+**Branch:** `feat/cross-repo-state-sync-phase-4-cutover` (FT2) + corresponding fitme-story branch.
+**Immediate success:** round-trip succeeds; all 5 phases verifiable; case study + showcase MDX ship through `FEATURE_CLOSURE_COMPLETENESS`.
+**Calibration:** THE cutover IS the calibration. Successful round-trip = framework certified → HADF Phase 2-bis Sub-exp 1 unblocks.
+**Rollback:** PR fails → leave fs-native state.json in fitme-story; manually create FT2 mirror; document workaround; investigate Action bug; re-cutover later.
+**Wall-clock:** ship Day 8-9; verification Days 9-12.
+**Blocks:** HADF Phase 2-bis Sub-exp 1 launch.
+
+### §6.6 Cumulative timeline + HADF gating
+
+| Day | Activity | Status |
+|---|---|---|
+| 1-2 | Phase 0 PR ships | V2 enforced + V9 driver extended + snapshot protocol live |
+| 2-3 | Phase 1 PRs ship | D-3 cache + C-4 aggregator deployed |
+| 3-9 | Phase 0 + 1 calibration windows | V2/V9/D-3 calibrated by Day 9 |
+| 4-5 | Phase 2 PR ships | 47-feature backfill complete + morphed C-5 enforced |
+| 5-9 | Phase 2 calibration | Synthetic mismatch test + ≥3 new features clean |
+| 6-7 | Phase 3 PR ships | Reverse-sync workflow deployed (untriggered) |
+| 8-9 | Phase 4 cutover | First round-trip succeeds; framework certified |
+| 9-12 | Phase 4 case study + showcase MDX | All 5 phases shipped + closed |
+| **13** | **HADF Phase 2-bis Sub-exp 1 EARLIEST start** | All framework calibration met |
+
+**Total: ~12 days framework + calibration. HADF Phase 2-bis Sub-exp 1 earliest start: 2026-05-23.**
+
+### §6.7 Cross-phase nuclear-option rollback
+
+If multiple phases need simultaneous rollback OR Phase 4 round-trip fails repeatedly: revert all phase commits in reverse order (4 → 3 → 2 → 1 → 0); state.json files lose `state_owner` (acceptable; back to pre-Phase-2 state); reverse-sync workflow disabled; V2 reverts to advisory; V9 driver reverts to ledger-only; spawn new design session; HADF Phase 2-bis blocked indefinitely. Probability low — per-phase rollbacks should catch issues earlier.
+
+---
+
+## §7 Testing strategy
+
+### §7.1 Per-phase test surface
+
+| Phase | Unit tests | Integration smoke | End-to-end |
+|---|---|---|---|
+| 0 V2 + V9 | V2 logic on synthetic state.json + cache_hits[] inputs; V9 driver on synthetic conflicting feature logs | V2 fires on real pre-commit hook in test repo; V9 resolves real `git merge` conflict | V2 fires on actual feature work (calibration); V9 resolves at least one real conflict |
+| 1 D-3 + C-4 | Regex parametrized for 3 cite forms + edges; resolve_pr_cite routing; cache refresh shape | Pre-commit hook + test case study with mix of cites; aggregator on synthetic gate-coverage pair | Retroactive 35/35 validation; control-room visual confirmation post-deploy |
+| 2 Schema + morphed C-5 | All gate branches + sync_origin exemption; backfill script + idempotency | Backfill on real `.claude/features/`; pre-commit on backfill commit | Synthetic mismatch test (`cp` to wrong path → REJECT) |
+| 3 D-1 GH Action | Detect-changed-files; mirror state.json marker injection | `act` local runner produces valid PR-template; `actionlint` YAML check | Phase 4 cutover IS the end-to-end test |
+| 4 Cutover | N/A | N/A | Real round-trip end-to-end |
+
+### §7.2 Test infrastructure additions
+
+**FT2 pytest** (new `tests/framework/`): `test_state_owner_gates.py`, `test_pr_cite_cache.py`, `test_v2_writer_path.py`, `test_v9_merge_driver.py`, `test_backfill_script.py`. Run in `make verify-local` + per-PR CI.
+
+**fitme-story Node tests** (new `tests/control-room/`): `gate-coverage-aggregator.test.ts`, `sync-extension.test.ts`.
+
+**GitHub Action local emulation**: new `scripts/test-reverse-sync-action.sh` wrapping `act push` against test event payload + `actionlint` YAML check.
+
+### §7.3 Test coverage philosophy
+
+- Every new gate has unit tests for every pass/fail branch
+- Integration smoke tests catch wiring regressions
+- End-to-end tests ARE the calibration targets from §3.5
+- No mocking of `gh pr list` in integration tests (mock-vs-prod divergence is the Phase 2 contamination class)
+- No flaky tests permitted — anything intermittent is a bug, not skipped
+
+---
+
+## §8 Out-of-scope + locked decisions
+
+### §8.1 Explicit non-scope items
+
+| Item | Reason for deferral |
+|---|---|
+| Real-time bi-directional state (webhook-based) | PR-based reverse-sync with manual merge IS the safety net |
+| Auto-categorization heuristics for `state_owner` | All 47 are ft2; `/pm-workflow` asks the question for new features |
+| Migration of existing FT2 features to fitme-story-native | Phase 4 cutover picks ONE first feature; bulk migration is separate |
+| `_session-*.events.jsonl` cross-repo sync | Per-cwd per v7.8.2 cross-repo asymmetry disposition |
+| V1 `GATE_COVERAGE_ZERO` meta-check | Separate v7.9 promotion (calibration data already met) |
+| V4 `experiment_outcome` enum on `tasks[]` | Per Q2 answer (V2 only); accept stress-test workaround |
+| V5 `make complete-feature --dry-run` | Per Q2 answer; accept friction at P2-bis closures |
+| V14 `BRANCH_ISOLATION_HISTORICAL` enforced | Forward-only audit; doesn't intersect Phase C |
+| V15 `BRANCH_ISOLATION_LAUNCHD_DRIFT` enforced | P2-bis Fix #3 supersedes for the campaign use case |
+| V17 `kill_criteria_resolution` backfill on 61 grandfathered case studies | Independent; affects pre-existing data |
+| Cross-org PR cites (e.g., `vercel/next.js#12345`) | URL form works without validation |
+| Issue cites (`#42` for issues) | Out of scope; only PR cites validated |
+| Cite-in-code-block exclusion list | Author discipline mitigation |
+| Rollback automation for failed reverse-sync PRs | Manual triage per `feedback_no_auto_merge_without_approval.md` |
+| HADF Phase 2-bis itself | Design happens AFTER framework calibration window |
+| Performance / load testing | Per-commit timescales; no SLA |
+| Snapshot testing for control-room render | Visual confirmation IS calibration target |
+| Cross-OS testing | macOS-only repo convention |
+
+### §8.2 Locked decisions (per OQ-1, OQ-2, OQ-3)
+
+- **OQ-1:** Spec at `docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md`; Feature name `cross-repo-state-sync-impl`. v7.8.3 framework version explained in spec body but not in filename.
+- **OQ-2:** Per-phase branches: `feat/cross-repo-state-sync-phase-{0,1,2,3,4-cutover}`. Each merges as separate PR.
+- **OQ-3:** `framework_version: "v7.8.3"` immutable on this Feature's state.json. CLAUDE.md tracks current framework version separately.
+
+---
+
+## §9 Dogfooding compliance — this Feature runs through ALL existing v7.5→v7.8.2 gates
+
+Every Phase 0-4 commit is subject to the full framework stack. No exemptions added by this Feature. Coverage map:
+
+### §9.1 Write-time gates (pre-commit hook)
+
+| Gate | Source | Fires on this Feature? |
+|---|---|---|
+| `SCHEMA_DRIFT` | v7.5 | YES |
+| `PR_NUMBER_UNRESOLVED` | v7.5 | YES (post-Phase-1 cross-repo via D-3) |
+| `PHASE_TRANSITION_NO_LOG` | v7.6 | YES on every phase transition |
+| `PHASE_TRANSITION_NO_TIMING` | v7.6 | YES |
+| `BROKEN_PR_CITATION` | v7.6 + Phase 1 D-3 extension | YES |
+| `CASE_STUDY_MISSING_TIER_TAGS` | v7.6 | YES on Phase 4 case study |
+| `CACHE_HITS_EMPTY_POST_V6` | v7.7 + Phase 0 V2 enforcement | YES — Mechanism C captures session attribution |
+| `CU_V2_INVALID` | v7.7 | YES |
+| `STATE_NO_CASE_STUDY_LINK` | v7.7 | YES on Phase 4 closure |
+| `CASE_STUDY_MISSING_FIELDS` | v7.7 | YES on Phase 4 case study |
+| `ISOLATION_OPT_OUT_REASON_MISSING` | v7.8.1 | N/A (does NOT opt out) |
+| `BRANCH_ISOLATION_VIOLATION` (Mode B) | v7.8.1 advisory → v7.9 enforced ~2026-05-21 | YES advisory; possibly enforced by Phase 4 |
+| `FEATURE_CLOSURE_COMPLETENESS` | v7.8.1 advisory → v7.9 enforced | YES on Phase 4 closure |
+| `STATE_OWNER_MISSING / INVALID / LOCATION_MISMATCH` | NEW Phase 2 | YES — own state.json must comply |
+
+### §9.2 Cycle-time gates (72h via GitHub Actions)
+
+All 16 check codes apply: `PHASE_LIE`, `TASK_LIE`, `NO_CS_LINK`, `V2_FILE_MISSING`, `PARTIAL_SHIP_TERMINAL`, `NO_STATE`, `INVALID_JSON`, `NO_PHASE`, `SCHEMA_DRIFT`, `PR_NUMBER_UNRESOLVED`, `BROKEN_PR_CITATION`, `CASE_STUDY_MISSING_TIER_TAGS`, `CU_V2_INVALID`, `BRANCH_ISOLATION_HISTORICAL`, `BRANCH_ISOLATION_LAUNCHD_DRIFT`, `FEATURE_CLOSURE_COMPLETENESS` cycle-time mirror.
+
+### §9.3 v7.8 Bridge mechanisms (advisory but emitting telemetry)
+
+| Mechanism | Coverage on this Feature |
+|---|---|
+| **A** Coverage-asserting gates → `gate-coverage.jsonl` | Every gate fire emits to ledger; calibration data for V1 future enforcement |
+| **B** Schema field-rename detection + dual-read | `state_owner` is a Mechanism B candidate (new field); backward-compat handled |
+| **C** PostToolUse:Read hook → `_session-<id>.events.jsonl` | Captures every Read during this Feature's Claude Code sessions; populates `cache_hits[]` automatically |
+| **D** Pre-commit hook header self-audit | NEW gates V2 + V9 + Phase 2 schema gates carry header version stamps; Mechanism D validates them |
+| **E** Custom git merge driver | Covers `measurement-adoption-history.json` + `documentation-debt.json`; Phase 0 V9 EXTENDS to `<feature>.log.json` (this Feature's own log gets driver coverage) |
+| **F** Membrane-status advisory | `make membrane-status` + SessionStart hook surfaces this Feature as active in-flight work |
+
+### §9.4 v7.6 per-PR + weekly defenses
+
+`pr-integrity-check.yml` runs per-PR on each phase's PR; `framework-status-weekly.yml` Mondays appends snapshot to measurement-adoption-history capturing this Feature's progress.
+
+### §9.5 Case study monitoring
+
+- Source case study at `docs/case-studies/cross-repo-state-sync-impl-case-study.md` — subject to all case-study gates
+- Showcase MDX at `fitme-story/content/04-case-studies/<NN>-cross-repo-state-sync-impl.mdx` — subject to dual-outlet pattern + chronological-order rule (slot N reflecting v7.8.3 era)
+- The (paused/unbuilt) "Case Study Monitoring Extension" memory entry refers to a forward-only trigger that's not yet shipped; if it ships before Phase 4, this Feature's case study fires it. Currently no-op.
+
+### §9.6 v7.8.2 cross-repo telemetry asymmetry
+
+Doesn't impact this Feature (FT2 commits hit gates; fitme-story commits hit gates per Phase B port). Documented exemption stays valid.
+
+### §9.7 Net assessment
+
+Zero new exemptions added by this Feature. The Feature is the dogfood test of its own framework additions + every prior framework gate.
+
+---
+
+## §10 Per-phase snapshot protocol
+
+### §10.1 Why this is in scope
+
+Phase 2's contamination AND this very session's VS Code shutdown both demonstrate empirical loss-of-work risk. The SSD has documented disconnect risk per `reference_devssd_hardware_issue.md`. This Feature has 5 phases × ~12 days wall-clock with significant per-phase work product. The snapshot protocol is a safety net, not a feature; cheap to add (~50 lines of bash + Makefile target). Generalizable: same script works for any future Feature that wants per-phase snapshots.
+
+### §10.2 Snapshot triggers
+
+- Phase 0 → 1 transition (after Phase 0 PR merges + V2/V9 calibration target met)
+- Phase 1 → 2 transition (after D-3 retroactive 35/35 + C-4 deploy)
+- Phase 2 → 3 transition (after backfill PR + morphed C-5 synthetic test passes)
+- Phase 3 → 4 transition (after reverse-sync workflow YAML lints + token verified)
+- Phase 4 cutover completion
+- **Session pause** (if work spans multiple sessions, regardless of phase position)
+
+### §10.3 Snapshot contents (matches `2026-05-08-hadf-preservation/` pattern)
+
+- All `.claude/features/cross-repo-state-sync-impl/` files (state.json, prd.md, tasks.md, log.json mirror)
+- All Phase-relevant scripts modified or added
+- All Phase-relevant test files
+- All Phase-relevant case study + showcase MDX (Phase 4 onward)
+- Current commit SHA + branch name + PR number(s)
+- `MANIFEST.md` (provenance + restoration recipe)
+- `CHECKSUMS.sha256` (sha256 of every file)
+
+### §10.4 Destination
+
+Internal Mac storage at `~/Documents/FitTracker2-backups/<date>-cross-repo-state-sync-impl-<phase-or-pause>/`. Examples:
+- `~/Documents/FitTracker2-backups/2026-05-13-cross-repo-state-sync-impl-phase-0-complete/`
+- `~/Documents/FitTracker2-backups/2026-05-15-cross-repo-state-sync-impl-pause-end-of-session/`
+
+NOT on the SSD (per existing SSD-disconnect remediation pattern from `reference_devssd_hardware_issue.md`).
+
+### §10.5 New helper script `scripts/snapshot-phase-completion.sh`
+
+```bash
+#!/usr/bin/env bash
+# Usage: ./scripts/snapshot-phase-completion.sh <phase-or-pause-id> <feature-name>
+# Example: ./scripts/snapshot-phase-completion.sh phase-0-complete cross-repo-state-sync-impl
+set -euo pipefail
+
+PHASE_ID="${1:?phase-or-pause-id required}"
+FEATURE_NAME="${2:?feature-name required}"
+DATE=$(date +%Y-%m-%d)
+BACKUP_DIR="$HOME/Documents/FitTracker2-backups/${DATE}-${FEATURE_NAME}-${PHASE_ID}"
+
+mkdir -p "$BACKUP_DIR"
+cp -p ".claude/features/${FEATURE_NAME}"/* "$BACKUP_DIR/" 2>/dev/null || true
+cp -p ".claude/logs/${FEATURE_NAME}.log.json" "$BACKUP_DIR/" 2>/dev/null || true
+# Phase-specific files (caller can extend via env var EXTRA_FILES)
+for f in ${EXTRA_FILES:-}; do
+    cp -p "$f" "$BACKUP_DIR/" 2>/dev/null || true
+done
+
+# Generate manifest
+cd "$BACKUP_DIR"
+shasum -a 256 *.* > CHECKSUMS.sha256 2>/dev/null || true
+cat > MANIFEST.md <<EOF
+# Snapshot — ${FEATURE_NAME} ${PHASE_ID}
+
+**Created:** $(date -u +%FT%TZ)
+**Branch:** $(cd - >/dev/null && git branch --show-current)
+**Commit SHA:** $(cd - >/dev/null && git rev-parse HEAD)
+**Feature:** ${FEATURE_NAME}
+**Phase/Pause ID:** ${PHASE_ID}
+
+## Restoration
+
+\`\`\`bash
+shasum -a 256 -c CHECKSUMS.sha256
+\`\`\`
+
+EOF
+
+echo "Snapshot created: $BACKUP_DIR"
+echo "Files: $(ls "$BACKUP_DIR" | wc -l)"
+```
+
+### §10.6 Makefile target
+
+```make
+snapshot-phase:
+	./scripts/snapshot-phase-completion.sh $(PHASE) cross-repo-state-sync-impl
+```
+
+Operator runs `make snapshot-phase PHASE=phase-0-complete` after each milestone.
+
+### §10.7 Retention
+
+Indefinite (matches V2-rule HISTORICAL file retention policy in CLAUDE.md). Old snapshots accumulate but each is small (<100 KB typical). Operator-managed.
+
+---
+
+## §11 Cross-references
+
+- Phase C contract: [`2026-05-09-cross-repo-state-sync.md`](2026-05-09-cross-repo-state-sync.md)
+- v7.8 Bridge design: [`2026-05-02-framework-v7-8-and-v7-9-bridge-design.md`](2026-05-02-framework-v7-8-and-v7-9-bridge-design.md)
+- v7.8.1 spec: [`framework-v7-8-branch-isolation/prd.md`](../../../.claude/features/framework-v7-8-branch-isolation/prd.md)
+- v7.8.2 cross-repo asymmetry disposition: [`2026-05-08-cross-repo-gate-asymmetry.md`](2026-05-08-cross-repo-gate-asymmetry.md)
+- Branch isolation out-of-scope (v8.0+ candidates): [`2026-05-07-branch-isolation-out-of-scope.md`](2026-05-07-branch-isolation-out-of-scope.md)
+- HADF Phase 2-bis brainstorm + 3 cross-references (the gated Feature): `/Users/regevbarak/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_phase2bis_brainstorm_paused_2026_05_11.md`
+- This Feature's brainstorm 6 design decisions: `/Users/regevbarak/.claude/projects/-Volumes-DevSSD-FitTracker2/memory/project_phase_c_brainstorm_2026_05_11.md`
+- Off-SSD audit backup (created during this brainstorm): `~/Documents/FitTracker2-backups/2026-05-11-phase2bis-brainstorm-audit/`
+- Forward-sync canonical: [`fitme-story/scripts/sync-from-fittracker2.ts`](https://github.com/Regevba/fitme-story/blob/main/scripts/sync-from-fittracker2.ts)
+- BROKEN_PR_CITATION gate today: [`scripts/check-case-study-preflight.py`](../../../scripts/check-case-study-preflight.py) (lines 74-76)
+- Existing Mechanism E driver: [`scripts/merge-driver-dedup.py`](../../../scripts/merge-driver-dedup.py)
+- Existing Mechanism C source: [`scripts/observe-cache-hit.py`](../../../scripts/observe-cache-hit.py)


### PR DESCRIPTION
Fixes a dangling-reference issue surfaced during the 2026-06-07 branch reconciliation.

**Problem:** The `cross-repo-state-sync-impl` feature shipped (v7.8.3, `current_phase=complete`), but its design spec + implementation plan were authored on `chore/cross-repo-state-sync-impl-spec` and **never merged to main** — while CLAUDE.md, infra-master-plan, data-integrity-and-rollback master plan, backlog, and several audit bundles all link to both paths. The links resolve to 404 in main.

**Fix:** Restore the two documents:
- `docs/superpowers/specs/2026-05-11-cross-repo-state-sync-impl-design.md` (801 lines)
- `docs/superpowers/plans/2026-05-11-cross-repo-state-sync-impl.md` (2,776 lines)

Content taken verbatim from the source branch tip (3 commits: umbrella spec + 5-phase plan + A1–A6 plan-vs-codebase deltas).

**Follow-up:** once merged, `chore/cross-repo-state-sync-impl-spec` (local + remote) becomes safe to delete — it was deliberately kept during cleanup because it held this unmerged content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)