### PR TITLE
fix(framework): permit prereg lock-introducing commit (F-LOCK-INTRODUCING-COMMIT-PERMIT)

### DIFF
--- a/.claude/shared/v7-9-1-candidates.md
+++ b/.claude/shared/v7-9-1-candidates.md
@@ -439,12 +439,12 @@ To be filled when shipped.
 
 ---
 
-## F-LOCK-INTRODUCING-COMMIT-PERMIT
+## ~~F-LOCK-INTRODUCING-COMMIT-PERMIT~~ — **CLOSED 2026-06-07**
 
 **Discovered:** 2026-05-30 (Sub-exp 2 lock ceremony + Sub-exp 1B lock ceremony during HADF Phase 2-bis replication launch).
-**Status:** queued.
-**Owner:** TBD.
-**Effort:** ~1h (pre-commit hook conditional check + 1 test).
+**Status:** **SHIPPED 2026-06-07** via PR (this PR, branch `fix/lock-introducing-commit-permit`). Lock check extracted from `.githooks/pre-commit` into a dedicated, unit-tested script `scripts/check-prereg-lock.sh` with the lock-introducing exemption added; 5 isolation tests in `scripts/tests/test_check_prereg_lock.py` (lock-introducing permit / sha-mismatch block / forward-edit block / unlock permit / unrelated no-op) all pass. The next lock ceremony (Sub-exp 3 etc.) no longer requires `--no-verify`.
+**Owner:** N/A (closed).
+**Effort:** ~1h actual (matched estimate).
 
 ### Problem
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -110,19 +110,14 @@ if [[ "$failed" -ne 0 ]]; then
 fi
 
 # ── HADF Phase 2-bis prereg lock check (added v7.8.3+ HADF P2-bis Task A6) ──
-# Reject commits that modify a locked preregistration JSON unless the .lock file is also removed
-for prereg in $(git diff --cached --name-only | grep -E "^\.claude/shared/hadf/preregistration-phase2bis-subexp[1-3]\.json$" || true); do
-    lock="${prereg}.lock"
-    # If prereg modified AND lock still exists → block
-    if [ -f "$lock" ]; then
-        # Check if lock is being removed in this commit
-        if ! git diff --cached --name-only --diff-filter=D | grep -q "^${lock}$"; then
-            echo "ERROR: $prereg is locked at $lock — refusing to modify without removing the lock"
-            echo "       To unlock: git rm $lock + audit-log entry, then re-stage prereg edit"
-            exit 1
-        fi
-    fi
-done
+# Reject commits that modify a locked preregistration JSON. Extracted to a
+# dedicated, unit-tested script (v7.9.1 F-LOCK-INTRODUCING-COMMIT-PERMIT) which
+# now ALSO permits the lock-introducing commit itself (lock added + sha256
+# matches staged prereg) without requiring --no-verify.
+PREREG_LOCK_CHECK="$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/check-prereg-lock.sh"
+if [ -f "$PREREG_LOCK_CHECK" ]; then
+    bash "$PREREG_LOCK_CHECK" || exit 1
+fi
 
 # ── GitHub Security Tier S (added 2026-05-21) ──────────────────────────────
 # Pre-commit checks for: (1) file-size limit (>5MB rejected), (2) high-confidence

--- a/scripts/check-prereg-lock.sh
+++ b/scripts/check-prereg-lock.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# check-prereg-lock — HADF Phase 2-bis preregistration lock gate.
+#
+# Rejects commits that modify a LOCKED preregistration JSON, with one
+# exemption (F-LOCK-INTRODUCING-COMMIT-PERMIT, v7.9.1):
+#
+#   * UNLOCK commit — the same commit removes the `<prereg>.lock` file → allow.
+#   * LOCK-INTRODUCING commit — the same commit ADDS the `<prereg>.lock` file
+#     AND the sha256 recorded in that staged lock matches the sha256 of the
+#     staged prereg content → allow. This is exactly the commit produced by
+#     scripts/hadf-phase2bis-lock-prereg.sh; before this exemption it could
+#     only land with --no-verify (observed 2026-05-30 on bd0db7e + 6cad3c7).
+#   * FORWARD EDIT — lock pre-exists and the prereg is modified without an
+#     unlock → block (the original contract).
+#
+# Operates on the staged index (git diff --cached). Exit 0 = ok, 1 = violation.
+set -u
+
+PREREG_RE='^\.claude/shared/hadf/preregistration-phase2bis-subexp[1-3]\.json$'
+
+rc=0
+for prereg in $(git diff --cached --name-only | grep -E "$PREREG_RE" || true); do
+    lock="${prereg}.lock"
+    [ -f "$lock" ] || continue
+
+    # UNLOCK: lock being removed in this commit → legitimate unlock.
+    if git diff --cached --name-only --diff-filter=D | grep -q "^${lock}$"; then
+        continue
+    fi
+
+    # LOCK-INTRODUCING: lock being ADDED in this commit, sha256 matches staged
+    # prereg content → the lock ceremony's own commit. Permit.
+    if git diff --cached --name-only --diff-filter=A | grep -q "^${lock}$"; then
+        staged_prereg_sha=$(git show ":${prereg}" | shasum -a 256 | awk '{print $1}')
+        lock_sha=$(git show ":${lock}" | python3 -c \
+            "import sys,json; print(json.load(sys.stdin).get('sha256',''))" 2>/dev/null)
+        if [ -n "$lock_sha" ] && [ "$staged_prereg_sha" = "$lock_sha" ]; then
+            echo "OK: lock-introducing commit for $prereg (sha256=$(echo "$lock_sha" | cut -c1-12)…) — permitted"
+            continue
+        fi
+        echo "ERROR: $lock is being added but its sha256 does not match the staged $prereg content."
+        echo "       lock=$lock_sha"
+        echo "       staged=$staged_prereg_sha"
+        echo "       Re-run scripts/hadf-phase2bis-lock-prereg.sh so the lock records the final content."
+        rc=1
+        continue
+    fi
+
+    # FORWARD EDIT against an existing lock → block.
+    echo "ERROR: $prereg is locked at $lock — refusing to modify without removing the lock"
+    echo "       To unlock: git rm $lock + audit-log entry, then re-stage prereg edit"
+    rc=1
+done
+
+exit "$rc"

--- a/scripts/tests/test_check_prereg_lock.py
+++ b/scripts/tests/test_check_prereg_lock.py
@@ -1,0 +1,110 @@
+"""Isolation tests for scripts/check-prereg-lock.sh.
+
+Spawns a throwaway git repo at tmp_path, stages canonical scenarios, and runs
+the REAL check script via subprocess against the staged index — the same
+"test the real script" philosophy as the F16 try-repo harness. Covers the four
+branches: lock-introducing (permit), unlock (permit), forward-edit (block),
+and sha-mismatch lock (block).
+"""
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "check-prereg-lock.sh"
+PREREG_REL = ".claude/shared/hadf/preregistration-phase2bis-subexp1.json"
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True)
+
+
+def _init(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    (repo / ".claude/shared/hadf").mkdir(parents=True)
+    return repo
+
+
+def _write_prereg(repo, content):
+    p = repo / PREREG_REL
+    p.write_text(content)
+    return p
+
+
+def _lock_for(content, **overrides):
+    sha = hashlib.sha256(content.encode()).hexdigest()
+    d = {"sha256": sha, "locked_at": "2026-06-07T00:00:00Z",
+         "locked_by": "t@t.t", "locked_commit": "deadbeef"}
+    d.update(overrides)
+    return json.dumps(d, indent=2) + "\n"
+
+
+def _run(repo):
+    return subprocess.run(["bash", str(SCRIPT)], cwd=repo,
+                          capture_output=True, text=True)
+
+
+def test_lock_introducing_commit_permitted(tmp_path):
+    repo = _init(tmp_path)
+    content = '{"experiment": "subexp1"}\n'
+    _write_prereg(repo, content)
+    (repo / f"{PREREG_REL}.lock").write_text(_lock_for(content))
+    _git(repo, "add", PREREG_REL, f"{PREREG_REL}.lock")
+    r = _run(repo)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "permitted" in r.stdout
+
+
+def test_lock_introducing_sha_mismatch_blocked(tmp_path):
+    repo = _init(tmp_path)
+    content = '{"experiment": "subexp1"}\n'
+    _write_prereg(repo, content)
+    # Lock records a sha for DIFFERENT content → mismatch.
+    bad = _lock_for('{"experiment": "tampered"}\n')
+    (repo / f"{PREREG_REL}.lock").write_text(bad)
+    _git(repo, "add", PREREG_REL, f"{PREREG_REL}.lock")
+    r = _run(repo)
+    assert r.returncode == 1
+    assert "does not match" in r.stdout
+
+
+def test_forward_edit_against_existing_lock_blocked(tmp_path):
+    repo = _init(tmp_path)
+    content = '{"experiment": "subexp1"}\n'
+    _write_prereg(repo, content)
+    (repo / f"{PREREG_REL}.lock").write_text(_lock_for(content))
+    _git(repo, "add", PREREG_REL, f"{PREREG_REL}.lock")
+    _git(repo, "commit", "-q", "--no-verify", "-m", "lock")
+    # Now modify the prereg while the lock stays in place.
+    _write_prereg(repo, '{"experiment": "subexp1", "edited": true}\n')
+    _git(repo, "add", PREREG_REL)
+    r = _run(repo)
+    assert r.returncode == 1
+    assert "is locked at" in r.stdout
+
+
+def test_unlock_commit_permitted(tmp_path):
+    repo = _init(tmp_path)
+    content = '{"experiment": "subexp1"}\n'
+    _write_prereg(repo, content)
+    (repo / f"{PREREG_REL}.lock").write_text(_lock_for(content))
+    _git(repo, "add", PREREG_REL, f"{PREREG_REL}.lock")
+    _git(repo, "commit", "-q", "--no-verify", "-m", "lock")
+    # Unlock: remove the lock AND edit the prereg in the same commit.
+    (repo / f"{PREREG_REL}.lock").unlink()
+    _write_prereg(repo, '{"experiment": "subexp1", "edited": true}\n')
+    _git(repo, "add", "-A")
+    r = _run(repo)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_unrelated_commit_noop(tmp_path):
+    repo = _init(tmp_path)
+    (repo / "README.md").write_text("hi\n")
+    _git(repo, "add", "README.md")
+    r = _run(repo)
+    assert r.returncode == 0


### PR DESCRIPTION
## Summary

Closes the v7.9.1 docket item **F-LOCK-INTRODUCING-COMMIT-PERMIT**. The pre-commit prereg-lock check rejected *any* commit touching a locked preregistration JSON when a `.lock` sidecar existed — including the lock ceremony's **own** commit (writes prereg + new `.lock` together). That commit could previously only land with `--no-verify`, violating the no-skip-hooks rule via the very script meant to honor the lock contract (observed 2026-05-30 on `bd0db7e` + `6cad3c7`).

## Change

- **Extracts** the lock check from `.githooks/pre-commit` into a dedicated, unit-testable `scripts/check-prereg-lock.sh` (the F16 "test the real script" philosophy).
- **Adds the lock-introducing exemption:** if the same commit ADDS `<prereg>.lock` AND the lock's recorded `sha256` matches the staged prereg content → permit. Everything else preserved:
  - forward edit against an existing lock → **block** (original contract)
  - lock added with a sha256 that does *not* match staged content → **block**
  - unlock (lock removed in same commit) → permit

## Tests

`scripts/tests/test_check_prereg_lock.py` — 5 isolation tests in a throwaway git repo running the real script via subprocess: lock-introducing permit / sha-mismatch block / forward-edit block / unlock permit / unrelated no-op. **5/5 pass.**

## Files
- `scripts/check-prereg-lock.sh` (new)
- `.githooks/pre-commit` — calls the extracted script
- `scripts/tests/test_check_prereg_lock.py` (new)
- `.claude/shared/v7-9-1-candidates.md` — docket item marked CLOSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)