### PR TITLE
ci(tokens): run tokens-check on token-pipeline dependency changes (W29 fix)

### DIFF
--- a/.github/workflows/ci-docs-skip.yml
+++ b/.github/workflows/ci-docs-skip.yml
@@ -32,6 +32,13 @@ on:
       - 'scripts/ui-audit.py'
       - '.github/workflows/ci.yml'
       - 'Package.swift'
+      # Mirror of ci.yml's token-pipeline drivers (W29 fix). These are NOT
+      # docs-skippable: an edit here must reach the heavy ci.yml pipeline so
+      # `make tokens-check` runs. Keep in exact sync with ci.yml's paths.
+      - 'package.json'
+      - 'package-lock.json'
+      - 'sd.config.js'
+      - 'scripts/check-tokens.js'
 
 # ci-docs-skip.yml-specific concurrency group. Hardcoded prefix (NOT the
 # workflow-name expression) because ci.yml also has `name: CI` — sharing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ on:
       - 'scripts/ui-audit.py'
       - '.github/workflows/ci.yml'
       - 'Package.swift'
+      # Token-pipeline drivers: a bump/edit here must run `make tokens-check`,
+      # not get the synthetic ci-docs-skip green. Closes the W29 silent-pass
+      # where a style-dictionary major bump (PR #668) passed PR CI but breaks
+      # `make tokens` on the post-merge `push: main` run. Keep in exact sync
+      # with ci-docs-skip.yml's paths-ignore mirror.
+      - 'package.json'
+      - 'package-lock.json'
+      - 'sd.config.js'
+      - 'scripts/check-tokens.js'
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem (root cause of the #668 hold)

`ci.yml` is the **only** workflow that runs `make tokens-check`, but its `paths:` allowlist did **not** include the token-pipeline driver files. So a dependency bump like **Dependabot #668** (`style-dictionary 3.9.2 → 5.4.3`) — which touches only `package.json` + `package-lock.json` — matched neither `ci.yml`'s allowlist nor its mirror in `ci-docs-skip.yml`'s `paths-ignore:`. The PR therefore got the **synthetic `Build and Test` green** from `ci-docs-skip.yml`, and `make tokens-check` **never ran**.

The break only surfaces **post-merge** on `ci.yml`'s `push: main` full pipeline — textbook **W29** ("Dependabot major-bump CI passes but breaks main post-merge"). For #668 specifically, our `sd.config.js` is pure Style-Dictionary v3 API (ESM-only `require()` throw + `matcher`/`transformer`/`formatter`/`name/cti/camel` renames in v5), so `make tokens` would fail on `main`.

## Fix

Add the four token-pipeline driver files to **both** lists, kept **byte-identical** so exactly one workflow fires per PR (no neither/both gap → no deadlock):

- `package.json`
- `package-lock.json`
- `sd.config.js`
- `scripts/check-tokens.js`

Now a style-dictionary (or any root design-token dep) bump runs the real `make tokens-check` at **PR time**, catching the v3→v5 break before merge instead of after.

## Verification

- Mutual-exclusion invariant asserted: `ci.yml::paths` == `ci-docs-skip.yml::paths-ignore` (byte-identical, both parse as valid YAML).
- This PR edits `.github/workflows/ci.yml`, which is in `ci.yml`'s own allowlist → it triggers the **full** ci.yml pipeline (iOS Build+Test **+ `make tokens-check`**) against current `main` (v3 style-dictionary), self-validating the fix.
- Scope: `package-lock.json` glob matches **root only** (the `fittracker-design-tokens` package); subdir locks (`website/`) are unaffected.

## Does NOT change
No `run:` steps, no telemetry/integrity producers, no schema. Strictly **more** CI coverage — a path-filter that previously let token-dep bumps through now routes them to the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)