### PR TITLE
chore(ledger): 2026-06-09 daily digest — measurement-adoption + doc-debt snapshot

### DIFF
--- a/.claude/shared/documentation-debt.json
+++ b/.claude/shared/documentation-debt.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-08T06:04:18Z",
+  "updated": "2026-06-09T06:03:44Z",
   "description": "Baseline documentation-debt report for case-study structure, state linkage, and integrity-cycle readiness.",
   "summary": {
     "case_studies_scanned": 101,

--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -1231,7 +1231,48 @@
           "post_v6_percent": 22.7
         }
       }
+    },
+    {
+      "date": "2026-06-09",
+      "generated_at": "2026-06-09T06:03:45Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 100,
+        "features_post_v6": 66,
+        "features_pre_v6": 34,
+        "fully_adopted": 3,
+        "partial_adopted": 61,
+        "zero_adopted": 36,
+        "fully_adopted_post_v6": 3,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 17,
+          "overall_percent": 17.0,
+          "post_v6_present": 17,
+          "post_v6_percent": 25.8
+        },
+        "per_phase_timing": {
+          "overall_present": 63,
+          "overall_percent": 63.0,
+          "post_v6_present": 60,
+          "post_v6_percent": 90.9
+        },
+        "cache_hits": {
+          "overall_present": 28,
+          "overall_percent": 28.0,
+          "post_v6_present": 27,
+          "post_v6_percent": 40.9
+        },
+        "cu_v2": {
+          "overall_present": 15,
+          "overall_percent": 15.0,
+          "post_v6_present": 15,
+          "post_v6_percent": 22.7
+        }
+      }
     }
   ],
-  "updated": "2026-06-08T06:04:19Z"
+  "updated": "2026-06-09T06:03:45Z"
 }

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-08T06:04:19Z",
+  "updated": "2026-06-09T06:03:45Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {
@@ -27,10 +27,10 @@
       "post_v6_percent": 90.9
     },
     "cache_hits": {
-      "overall_present": 26,
-      "overall_percent": 26.0,
-      "post_v6_present": 25,
-      "post_v6_percent": 37.9
+      "overall_present": 28,
+      "overall_percent": 28.0,
+      "post_v6_present": 27,
+      "post_v6_percent": 40.9
     },
     "cu_v2": {
       "overall_present": 15,
@@ -68,7 +68,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       }
     },
@@ -518,7 +518,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       }
     },
@@ -884,7 +884,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       },
       "fully_adopted": false,
@@ -2046,7 +2046,7 @@
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
-        "cache_hits": false,
+        "cache_hits": true,
         "cu_v2": false
       },
       "fully_adopted": false,


### PR DESCRIPTION
Daily ledger snapshot generated by the 09:00 IDT scheduled digest agent.

## What
- Appends 2026-06-09 Tier 1.1 snapshot to `measurement-adoption-history.json` (31st total)
- Refreshes `measurement-adoption.json`: 100 features, 66 post-v6, 3 fully adopted
  - `cache_hits` post-v6: **40.9%** (+3pp from yesterday — ai-user-feedback-loop + trend-alerts-hrv backfill landed in #670)
  - `per_phase_timing`: 90.9% | `timing_wall_time`: 25.8% | `cu_v2`: 22.7%
- Refreshes `documentation-debt.json` (1 open item: `kill_criteria_resolution`, 59 case studies, LOW severity)

## Context
Same pattern as #667 (2026-06-08 daily ledger). Side-effect of `make measurement-adoption` + `make documentation-debt` run by the scheduled digest.

https://claude.ai/code/session_011bVXwBi2BhkH5dH9YFg9wZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011bVXwBi2BhkH5dH9YFg9wZ)_