### PR TITLE
fix(measurement): count cu_v2 in both field representations — closes systematic undercount

### DIFF
--- a/scripts/measurement-adoption-report.py
+++ b/scripts/measurement-adoption-report.py
@@ -73,12 +73,28 @@ def has_cache_hits(d: dict) -> bool:
 
 
 def has_cu_v2(d: dict) -> bool:
-    """True if complexity.cu_version is 2 (or "v2")."""
+    """True if the feature carries CU v2 data in EITHER canonical representation.
+
+    Two field shapes coexist in the corpus and the adoption metric must count both,
+    or it systematically undercounts (the `created`/`created_at` bug class — a
+    measurement reading a field that's not where the data is written):
+
+      1. The v7.7+ canonical top-level ``cu_v2`` object — ``{factors, total,
+         tier_class}`` — i.e. the exact structure the ``CU_V2_INVALID`` write-time
+         gate validates. This is where new features write CU v2 data.
+      2. The legacy v6.0-era ``complexity.cu_version == 2`` marker, retained for
+         back-compat with features that predate the top-level object.
+
+    These two sets are nearly disjoint (only a handful of features carry both), so
+    reading only one silently halves real cu_v2 adoption.
+    """
+    cu = d.get("cu_v2")
+    if isinstance(cu, dict) and cu.get("total") is not None:
+        return True
     c = d.get("complexity")
-    if not isinstance(c, dict):
-        return False
-    v = c.get("cu_version")
-    return v in (2, "2", "v2")
+    if isinstance(c, dict) and c.get("cu_version") in (2, "2", "v2"):
+        return True
+    return False
 
 
 def classify_feature(d: dict) -> dict:

--- a/scripts/tests/test_measurement_adoption_report.py
+++ b/scripts/tests/test_measurement_adoption_report.py
@@ -1,0 +1,82 @@
+"""Tests for scripts/measurement-adoption-report.py adoption-dimension detectors.
+
+Focus: the `has_cu_v2` field-mismatch fix. The adoption metric must count CU v2
+data in BOTH representations that coexist in the corpus — the v7.7+ canonical
+top-level `cu_v2` object AND the legacy `complexity.cu_version == 2` marker —
+or it systematically undercounts (the `created`/`created_at` bug class).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "scripts" / "measurement-adoption-report.py"
+    spec = importlib.util.spec_from_file_location("measurement_adoption_report", src)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["measurement_adoption_report"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load_module()
+
+
+# --- has_cu_v2: both representations + negatives ---------------------------
+
+def test_cu_v2_canonical_toplevel_object(mod):
+    """v7.7+ canonical shape: top-level cu_v2 object with a total."""
+    d = {"cu_v2": {"factors": {"complexity": 0.4}, "total": 1.6, "tier_class": "B_medium"}}
+    assert mod.has_cu_v2(d) is True
+
+
+def test_cu_v2_legacy_complexity_marker(mod):
+    """v6.0-era legacy marker still counts (back-compat)."""
+    assert mod.has_cu_v2({"complexity": {"cu_version": 2}}) is True
+    assert mod.has_cu_v2({"complexity": {"cu_version": "v2"}}) is True
+
+
+def test_cu_v2_either_representation_alone_is_enough(mod):
+    """The two field shapes are nearly disjoint in the corpus; either suffices."""
+    only_toplevel = {"cu_v2": {"total": 2.0}}
+    only_legacy = {"complexity": {"cu_version": 2}}
+    assert mod.has_cu_v2(only_toplevel) is True
+    assert mod.has_cu_v2(only_legacy) is True
+
+
+def test_cu_v2_absent(mod):
+    assert mod.has_cu_v2({}) is False
+    assert mod.has_cu_v2({"complexity": {"cu_version": 1}}) is False
+    assert mod.has_cu_v2({"complexity": {}}) is False
+
+
+def test_cu_v2_toplevel_object_without_total_does_not_count(mod):
+    """An empty/partial cu_v2 stub without a total is not adoption."""
+    assert mod.has_cu_v2({"cu_v2": {}}) is False
+    assert mod.has_cu_v2({"cu_v2": {"factors": {"complexity": 0.4}}}) is False
+
+
+def test_cu_v2_malformed_types_are_safe(mod):
+    assert mod.has_cu_v2({"cu_v2": "not-an-object"}) is False
+    assert mod.has_cu_v2({"complexity": "not-an-object"}) is False
+
+
+# --- regression guards on the other detectors ------------------------------
+
+def test_timing_wall_time_requires_positive_minutes(mod):
+    assert mod.has_timing_wall_time({"timing": {"total_wall_time_minutes": 12}}) is True
+    assert mod.has_timing_wall_time({"timing": {"total_wall_time_minutes": 0}}) is False
+    assert mod.has_timing_wall_time({"timing": {}}) is False
+
+
+def test_cache_hits_populated_list(mod):
+    assert mod.has_cache_hits({"cache_hits": [{"path": "x"}]}) is True
+    assert mod.has_cache_hits({"cache_hits": []}) is False
+    assert mod.has_cache_hits({}) is False


### PR DESCRIPTION
## The bug

The Tier 1.1 adoption report (`scripts/measurement-adoption-report.py::has_cu_v2`) read **only** the legacy v6.0-era `complexity.cu_version == 2` marker. But the **v7.7+ canonical CU v2 schema** — the top-level `cu_v2 {factors, total, tier_class}` object that the `CU_V2_INVALID` write-time gate validates — lives in a **different field**.

The two representations are nearly disjoint in the corpus (only ~2 features carry both), so the report **silently halved real cu_v2 adoption**. This is the same bug class as the documented `created`/`created_at` `CACHE_HITS_EMPTY_POST_V6` 0%-coverage incident: a measurement reading a field that isn't where the data is written.

## The fix

`has_cu_v2` now returns `True` for **either** representation:
- top-level `cu_v2` object with a non-null `total` (canonical, v7.7+)
- legacy `complexity.cu_version in (2, "2", "v2")` (back-compat)

## Impact (live corpus, no data changed — only counting)

| Metric | Before | After |
|---|---|---|
| `cu_v2` dimension (post-v6) | 15 (22.4%) | **24 (35.8%)** |
| Fully-adopted (post-v6) | 3 | **6** |

## What this does NOT fix (deliberately)

The remaining ceiling on "fully adopted" is **real**, not a field bug:
- `timing_wall_time` (17/67) — no gate requires the rolled-up `total_wall_time_minutes` aggregate; agents log per-phase timing (gated) but not the sum.
- `cache_hits` #140 writer-path on pre-Mechanism-C features.

Left untouched so the metric stays honest about genuine gaps.

## Tests

`scripts/tests/test_measurement_adoption_report.py` — **8 tests** pinning both cu_v2 representations + negatives (empty stub, wrong version, malformed types) + regression guards on `has_timing_wall_time` / `has_cache_hits`. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)