### PR TITLE
feat(v7.10): cycle-time gate coverage + GATE_COVERAGE_ZERO mis-wire detection

### DIFF
--- a/.claude/integrity/observed-patterns.md
+++ b/.claude/integrity/observed-patterns.md
@@ -427,6 +427,22 @@ Each entry follows the format:
 
 ---
 
+### #24 Field-rename silent-pass in a READER/INDEX (measurement layer) — generalization of #7/#9
+
+**Trigger:** A report, index, or meta-check reads a state/ledger field under one name while the producer writes it under a *different* name. No gate fires; the metric silently under- or mis-counts. Distinct from #7/#9 (which were `state.json` write-time gates reading the renamed field) — this is the same bug class in the *measurement/observability* layer, where there is no failing gate to surface it.
+
+**Why expected:** schema-drift. A field is renamed/forked (`created`→`created_at`; top-level `cu_v2` object vs legacy `complexity.cu_version`; coverage rows keyed `timestamp` vs the W9 hook's `ts`) but only one producer/consumer is updated. The two representations co-exist and are often nearly disjoint, so the reader sees ~half the data and reports it as truth.
+
+**Distinguishing real signal:** a coverage/adoption number that "feels low," OR two field shapes in the corpus where `grep -l '"new_field"'` and `grep -l '"old_field"'` return nearly-disjoint sets. Confirm by counting both: if `READ-field` count ≪ `WRITTEN-field` count, the reader is on the wrong field.
+
+**Silence path:** make the reader accept BOTH representations (`d.get("new") or d.get("legacy")`), add a unit test pinning both, and prefer canonical going forward. NOT a per-feature exemption — it's a one-line reader fix.
+
+**First observed:** 2026-06-10 audit — `measurement-adoption-report.py::has_cu_v2` read only legacy `complexity.cu_version` (15 feats) not canonical top-level `cu_v2` (12 feats), halving adoption (fixed PR #687); `refresh-gate-last-fired.py` read only `timestamp`, dropping 30 `w9.auto_isolate` rows keyed `ts` (fixed PR #688). Predecessor incident: `created`/`created_at` `CACHE_HITS_EMPTY_POST_V6` 0%-coverage (#7/#9, 2026-05-01).
+
+**Notes:** v7.10. **Lesson: when you rename or fork a field, grep EVERY reader (`grep -rn '.get("<oldname>"' scripts/`) in the same change.** Related: #7, #9, #20 (the 3-cycle-time-check coverage gap was closed alongside this — `GATE_COVERAGE_ZERO` gained a 0-candidate mis-wire detector + the three cycle-time checks `BROKEN_PR_CITATION` / `CASE_STUDY_MISSING_TIER_TAGS` / `PATTERN_SKILL_UNMAPPED` now emit Mechanism A coverage so reader/writer drift is itself observable).
+
+---
+
 ## Section 2 — Workflow / operational patterns
 
 Non-gate patterns: situations where operator action (or inaction) causes confusion.

--- a/.claude/shared/pattern-skill-map.json
+++ b/.claude/shared/pattern-skill-map.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "#1",
-    "title": "BRANCH_ISOLATION_HISTORICAL \u2014 squash-merge + branch-cleanup artifact",
+    "title": "BRANCH_ISOLATION_HISTORICAL — squash-merge + branch-cleanup artifact",
     "section": "gate",
     "blocker": false,
     "detector": "scripts/integrity-check.py",
@@ -13,7 +13,7 @@
   },
   {
     "id": "#2",
-    "title": "CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE \u2014 Mechanism C captured, writer-path manual",
+    "title": "CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE — Mechanism C captured, writer-path manual",
     "section": "gate",
     "blocker": false,
     "detector": "scripts/integrity-check.py",
@@ -26,7 +26,7 @@
   },
   {
     "id": "#3",
-    "title": "BRANCH_ISOLATION_VIOLATION Mode B \u2014 infra-only commit on non-feature branch",
+    "title": "BRANCH_ISOLATION_VIOLATION Mode B — infra-only commit on non-feature branch",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -38,7 +38,7 @@
   },
   {
     "id": "#4",
-    "title": "BRANCH_ISOLATION_VIOLATION Mode C \u2014 state.json current_phase mutation off-branch",
+    "title": "BRANCH_ISOLATION_VIOLATION Mode C — state.json current_phase mutation off-branch",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -50,7 +50,7 @@
   },
   {
     "id": "#5",
-    "title": "ISOLATION_OPT_OUT_REASON_MISSING \u2014 opt-out without justification",
+    "title": "ISOLATION_OPT_OUT_REASON_MISSING — opt-out without justification",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -62,7 +62,7 @@
   },
   {
     "id": "#6",
-    "title": "FEATURE_CLOSURE_COMPLETENESS \u2014 missing frontmatter on current_phase=complete",
+    "title": "FEATURE_CLOSURE_COMPLETENESS — missing frontmatter on current_phase=complete",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -76,7 +76,7 @@
   },
   {
     "id": "#7",
-    "title": "CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT \u2014 empty cache_hits[] post-v6",
+    "title": "CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT — empty cache_hits[] post-v6",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -89,7 +89,7 @@
   },
   {
     "id": "#8",
-    "title": "TIER_TAG_LIKELY_INCORRECT \u2014 heuristic T1/T2/T3 mismatch (advisory permanent)",
+    "title": "TIER_TAG_LIKELY_INCORRECT — heuristic T1/T2/T3 mismatch (advisory permanent)",
     "section": "gate",
     "blocker": false,
     "detector": "scripts/integrity-check.py",
@@ -102,7 +102,7 @@
   },
   {
     "id": "#9",
-    "title": "SCHEMA_DRIFT_LEGACY_CREATED \u2014 legacy `created` key",
+    "title": "SCHEMA_DRIFT_LEGACY_CREATED — legacy `created` key",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -114,7 +114,7 @@
   },
   {
     "id": "#10",
-    "title": "FRAMEWORK_VERSION_FORMAT \u2014 unprefixed numeric values",
+    "title": "FRAMEWORK_VERSION_FORMAT — unprefixed numeric values",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -126,7 +126,7 @@
   },
   {
     "id": "#11",
-    "title": "STATE_OWNER_* (MISSING / INVALID / LOCATION_MISMATCH) \u2014 cross-repo schema",
+    "title": "STATE_OWNER_* (MISSING / INVALID / LOCATION_MISMATCH) — cross-repo schema",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -138,7 +138,7 @@
   },
   {
     "id": "#12",
-    "title": "PR_CACHE_STALE \u2014 empty/stale cache \u2192 cascading false positives",
+    "title": "PR_CACHE_STALE — empty/stale cache → cascading false positives",
     "section": "gate",
     "blocker": false,
     "detector": "scripts/ensure-pr-cache-fresh.py",
@@ -151,7 +151,7 @@
   },
   {
     "id": "#13",
-    "title": "BROKEN_PR_CITATION \u2014 unresolved PR cite (graceful fallback when gh unavailable)",
+    "title": "BROKEN_PR_CITATION — unresolved PR cite (graceful fallback when gh unavailable)",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -164,7 +164,7 @@
   },
   {
     "id": "#14",
-    "title": "CASE_STUDY_MISSING_TIER_TAGS \u2014 forward-only on case studies dated >=2026-04-21",
+    "title": "CASE_STUDY_MISSING_TIER_TAGS — forward-only on case studies dated >=2026-04-21",
     "section": "gate",
     "blocker": false,
     "detector": "scripts/integrity-check.py",
@@ -176,7 +176,7 @@
   },
   {
     "id": "#15",
-    "title": "PARTIAL_SHIP_TERMINAL \u2014 decision fork on completion",
+    "title": "PARTIAL_SHIP_TERMINAL — decision fork on completion",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -188,7 +188,7 @@
   },
   {
     "id": "#16",
-    "title": "CASE_STUDY_MISSING_FIELDS \u2014 required frontmatter validation",
+    "title": "CASE_STUDY_MISSING_FIELDS — required frontmatter validation",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -201,7 +201,7 @@
   },
   {
     "id": "#17",
-    "title": "CU_V2_INVALID \u2014 schema-only check (presence, not magnitude)",
+    "title": "CU_V2_INVALID — schema-only check (presence, not magnitude)",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -214,7 +214,7 @@
   },
   {
     "id": "#18",
-    "title": "STATE_NO_CASE_STUDY_LINK \u2014 terminal phase requires case_study or exemption",
+    "title": "STATE_NO_CASE_STUDY_LINK — terminal phase requires case_study or exemption",
     "section": "gate",
     "blocker": true,
     "detector": "scripts/integrity-check.py",
@@ -234,11 +234,11 @@
     "skills": [
       "pm-workflow"
     ],
-    "remediation": "No action \u2014 gates auto-exempt features with created_at < 2026-05-02."
+    "remediation": "No action — gates auto-exempt features with created_at < 2026-05-02."
   },
   {
     "id": "#20",
-    "title": "GATE_COVERAGE_ZERO \u2014 meta-check for silent-pass detection",
+    "title": "GATE_COVERAGE_ZERO — meta-check for silent-pass detection",
     "section": "gate",
     "blocker": false,
     "detector": "scripts/integrity-check.py",
@@ -250,7 +250,7 @@
   },
   {
     "id": "#21",
-    "title": "case_study_type exemption tags \u2014 bypass scope",
+    "title": "case_study_type exemption tags — bypass scope",
     "section": "gate",
     "blocker": false,
     "detector": "manual",
@@ -262,7 +262,7 @@
   },
   {
     "id": "#22",
-    "title": "v7.5 pipeline regression test decay \u2014 fixture rot",
+    "title": "v7.5 pipeline regression test decay — fixture rot",
     "section": "gate",
     "blocker": false,
     "detector": "manual",
@@ -284,6 +284,19 @@
       "dev"
     ],
     "remediation": "Commit periodic gate-coverage / session-ledger snapshots to non-gitignored paths so remote agents can audit."
+  },
+  {
+    "id": "#24",
+    "title": "Field-rename silent-pass in a READER/INDEX (measurement layer) — generalization of #7/#9",
+    "section": "gate",
+    "blocker": false,
+    "detector": "manual (audit) — no gate; surfaced by adoption/coverage cross-count",
+    "autoheal": false,
+    "skills": [
+      "pm-workflow",
+      "dev"
+    ],
+    "remediation": "Make the reader accept BOTH field representations (d.get('new') or d.get('legacy')); add a unit test pinning both; grep every reader of a renamed field in the same change."
   },
   {
     "id": "W1",
@@ -308,7 +321,7 @@
       "pm-workflow",
       "brainstorm-pm"
     ],
-    "remediation": "Never silently rewrite published artifacts; add a Correction Note / \u00a799 addendum instead."
+    "remediation": "Never silently rewrite published artifacts; add a Correction Note / §99 addendum instead."
   },
   {
     "id": "W3",
@@ -484,7 +497,7 @@
   },
   {
     "id": "W17",
-    "title": "Stale-base branches \u2014 cherry-pick onto fresh main is ground truth",
+    "title": "Stale-base branches — cherry-pick onto fresh main is ground truth",
     "section": "workflow",
     "blocker": true,
     "detector": "manual",
@@ -537,7 +550,7 @@
   },
   {
     "id": "W21",
-    "title": "Swift String.contains(\"\\n\") misses CRLF graphemes \u2014 scan unicodeScalars",
+    "title": "Swift String.contains(\"\\n\") misses CRLF graphemes — scan unicodeScalars",
     "section": "workflow",
     "blocker": true,
     "detector": "manual",
@@ -563,7 +576,7 @@
   },
   {
     "id": "W23",
-    "title": "AnalyticsService.logEvent is private \u2014 callers must use a log* method",
+    "title": "AnalyticsService.logEvent is private — callers must use a log* method",
     "section": "workflow",
     "blocker": true,
     "detector": "manual",
@@ -572,7 +585,7 @@
       "dev",
       "qa"
     ],
-    "remediation": "logEvent is private \u2014 add a named log* method, or use #if DEBUG print for can't-happen paths."
+    "remediation": "logEvent is private — add a named log* method, or use #if DEBUG print for can't-happen paths."
   },
   {
     "id": "W24",
@@ -584,11 +597,11 @@
     "skills": [
       "dev"
     ],
-    "remediation": "Resolve pbxproj merge conflicts additively \u2014 keep all branches' distinct PBXBuildFile/FileReference entries."
+    "remediation": "Resolve pbxproj merge conflicts additively — keep all branches' distinct PBXBuildFile/FileReference entries."
   },
   {
     "id": "W25",
-    "title": "@MainActor propagates to statics \u2014 test class must be @MainActor",
+    "title": "@MainActor propagates to statics — test class must be @MainActor",
     "section": "workflow",
     "blocker": true,
     "detector": "manual",
@@ -680,7 +693,7 @@
   },
   {
     "id": "W32",
-    "title": "scripts/close-feature.py requires --force-incomplete when merged PR was the only phase (implementation \u2192 complete directly, no testing phase)",
+    "title": "scripts/close-feature.py requires --force-incomplete when merged PR was the only phase (implementation → complete directly, no testing phase)",
     "section": "workflow",
     "blocker": true,
     "detector": "manual",
@@ -702,6 +715,6 @@
       "dev",
       "ops"
     ],
-    "remediation": "Verify the cache window covers the historically-cited PR range: `python3 -c \"import json; v=json.load(open('.cache/gh-pr-cache.json'))['repos']['Regevba/FitTracker2']; ns=sorted({x['number'] for b in('open','merged','closed') for x in v[b]}); print('floor',ns[0],'ceil',ns[-1],'count',len(ns))\"`. If the floor is far above 1 while citations reference numbers below it, the `gh pr list --limit N` window is truncated. Fix: raise `--limit` in `scripts/refresh-pr-cache.py` (shipped 2026-06-05 PR #631 raised it to 2000 \u2014 covers FT2's 571 PRs + headroom). Sibling patterns: #12 PR_CACHE_STALE (empty cache), W11 (incomplete repo set)."
+    "remediation": "Verify the cache window covers the historically-cited PR range: `python3 -c \"import json; v=json.load(open('.cache/gh-pr-cache.json'))['repos']['Regevba/FitTracker2']; ns=sorted({x['number'] for b in('open','merged','closed') for x in v[b]}); print('floor',ns[0],'ceil',ns[-1],'count',len(ns))\"`. If the floor is far above 1 while citations reference numbers below it, the `gh pr list --limit N` window is truncated. Fix: raise `--limit` in `scripts/refresh-pr-cache.py` (shipped 2026-06-05 PR #631 raised it to 2000 — covers FT2's 571 PRs + headroom). Sibling patterns: #12 PR_CACHE_STALE (empty cache), W11 (incomplete repo set)."
   }
 ]

--- a/.claude/skills/dev/SKILL.md
+++ b/.claude/skills/dev/SKILL.md
@@ -21,6 +21,7 @@ The [pattern↔skill map](../../shared/pattern-skill-map.json) tracks **51 work-
 | `#12` | PR_CACHE_STALE — empty/stale cache → cascading false positives *(probed)* | no | Auto-refreshes via scripts/ensure-pr-cache-fresh.py; run make refresh-pr-cache if findings persist. |
 | `#13` | BROKEN_PR_CITATION — unresolved PR cite (graceful fallback when gh unavailable) *(probed)* | yes | Fix the PR citation or add pr_citation_exempt frontmatter; skipped gracefully when gh is unavailable. |
 | `#23` | .gitignore blocks Mechanism A / Mechanism C remote-agent visibility | no | Commit periodic gate-coverage / session-ledger snapshots to non-gitignored paths so remote agents can audit. |
+| `#24` | Field-rename silent-pass in a READER/INDEX (measurement layer) — generalization of #7/#9 *(probed)* | no | Make the reader accept BOTH field representations (d.get('new') or d.get('legacy')); add a unit test pinning both; grep every reader of a renamed field in the same change. |
 | `W1` | SSH signing requires loaded agent before headless commits *(probed)* | no | Run ssh-add ~/.ssh/id_ed25519 before headless commits; verify with ssh-add -l. |
 | `W3` | Check CI before local-build panic | no | Check CI status (gh run list) before deep local-build debugging. |
 | `W4` | No auto-merge without explicit approval | yes | Never auto-merge; surface PR + checks and wait for explicit approval. |
@@ -41,7 +42,7 @@ The [pattern↔skill map](../../shared/pattern-skill-map.json) tracks **51 work-
 | `W32` | scripts/close-feature.py requires --force-incomplete when merged PR was the only phase (implementation → complete directly, no testing phase) | yes | For single-phase framework features (e.g., sub-fixes shipping their own unit tests in-phase), call `python3 scripts/close-feature.py <feature> --force-incomplete` directly. The `make close-feature` target does NOT pass --force-incomplete through. Durable script-heuristic patch queued in backlog Framework hygiene. |
 | `W34` | PR cache window truncation past the 500-PR limit *(probed)* | yes | Verify the cache window covers the historically-cited PR range: `python3 -c "import json; v=json.load(open('.cache/gh-pr-cache.json'))['repos']['Regevba/FitTracker2']; ns=sorted({x['number'] for b in('open','merged','closed') for x in v[b]}); print('floor',ns[0],'ceil',ns[-1],'count',len(ns))"`. If the floor is far above 1 while citations reference numbers below it, the `gh pr list --limit N` window is truncated. Fix: raise `--limit` in `scripts/refresh-pr-cache.py` (shipped 2026-06-05 PR #631 raised it to 2000 — covers FT2's 571 PRs + headroom). Sibling patterns: #12 PR_CACHE_STALE (empty cache), W11 (incomplete repo set). |
 
-At activation run `make skill-preflight SKILL=dev` — probes the 6 mechanized blockers for this work type; clear any before proceeding.
+At activation run `make skill-preflight SKILL=dev` — probes the 7 mechanized blockers for this work type; clear any before proceeding.
 
 **Mandatory** (CLAUDE.md §v7.8.5): any novel pattern surfaced this session MUST be appended to [`observed-patterns.md`](../../integrity/observed-patterns.md) before the feature closes — then re-run `make gen-skill-preflight`.
 <!-- END pattern-preflight -->

--- a/.claude/skills/pm-workflow/SKILL.md
+++ b/.claude/skills/pm-workflow/SKILL.md
@@ -38,6 +38,7 @@ The [pattern↔skill map](../../shared/pattern-skill-map.json) tracks **51 work-
 | `#19` | MECHANISM_C_SHIP_DATE auto-exemption | no | No action — gates auto-exempt features with created_at < 2026-05-02. |
 | `#20` | GATE_COVERAGE_ZERO — meta-check for silent-pass detection *(probed)* | no | Diagnose root cause (predicate too strict / schema drift / never-fires-by-design); fix or document advisory-permanent. |
 | `#21` | case_study_type exemption tags — bypass scope | no | Apply the correct case_study_type tag + case_study_exempt_reason; framework versions cannot use framework_meta_retroactive post-v7.9. |
+| `#24` | Field-rename silent-pass in a READER/INDEX (measurement layer) — generalization of #7/#9 *(probed)* | no | Make the reader accept BOTH field representations (d.get('new') or d.get('legacy')); add a unit test pinning both; grep every reader of a renamed field in the same change. |
 | `W2` | Publish verbatim, then remediate | no | Never silently rewrite published artifacts; add a Correction Note / §99 addendum instead. |
 | `W6` | Measurement case-study impartiality | no | Backfill/exempt measurement adoption all-or-none; document any exemption explicitly. |
 | `W20` | Stale-session-state inventory drift | no | Run make freshness-check before any 'what's open' inventory or before editing recently-shipped files. |
@@ -45,7 +46,7 @@ The [pattern↔skill map](../../shared/pattern-skill-map.json) tracks **51 work-
 | `W30` | Q6 PR-list parity gate's minimal YAML parser silently strips list items lacking # | yes | In case-study related_prs frontmatter, use either string form (- "PR #623") OR inline bracket form (related_prs: [621, 623]). Bare YAML integers under dashed lists get silently dropped by _parse_case_study_frontmatter at scripts/check-state-schema.py:1149. Durable parser patch queued in backlog Framework hygiene. |
 | `W32` | scripts/close-feature.py requires --force-incomplete when merged PR was the only phase (implementation → complete directly, no testing phase) | yes | For single-phase framework features (e.g., sub-fixes shipping their own unit tests in-phase), call `python3 scripts/close-feature.py <feature> --force-incomplete` directly. The `make close-feature` target does NOT pass --force-incomplete through. Durable script-heuristic patch queued in backlog Framework hygiene. |
 
-At activation run `make skill-preflight SKILL=pm-workflow` — probes the 18 mechanized blockers for this work type; clear any before proceeding.
+At activation run `make skill-preflight SKILL=pm-workflow` — probes the 19 mechanized blockers for this work type; clear any before proceeding.
 
 **Mandatory** (CLAUDE.md §v7.8.5): any novel pattern surfaced this session MUST be appended to [`observed-patterns.md`](../../integrity/observed-patterns.md) before the feature closes — then re-run `make gen-skill-preflight`.
 <!-- END pattern-preflight -->

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -48,6 +48,20 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FEATURES_DIR = REPO_ROOT / ".claude" / "features"
 CASE_STUDIES_DIR = REPO_ROOT / "docs" / "case-studies"
+LOGS_DIR = REPO_ROOT / ".claude" / "logs"
+GATE_COVERAGE_LEDGER = LOGS_DIR / "gate-coverage.jsonl"
+
+# v7.10 cycle-time coverage (built 2026-06-10): the write-time gates emit
+# Mechanism A coverage from check-state-schema.py, but three cycle-time checks
+# (BROKEN_PR_CITATION, CASE_STUDY_MISSING_TIER_TAGS, PATTERN_SKILL_UNMAPPED) ran
+# WITHOUT emitting any coverage row — so the F17 index + GATE_COVERAGE_ZERO
+# meta-check could not see them. If one silently stopped checking, nothing
+# detected it (a silent-pass blind spot surfaced by the 2026-06-10 audit). We
+# instrument them with the same GateCoverage tracker the write-time gates use,
+# tagged mode="cycle" so the downstream index distinguishes cycle-time coverage
+# from staged/explicit write-time coverage.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gate_coverage import GateCoverage  # noqa: E402
 
 # v7.9.1 F-LAUNCHD-DRIFT-EXTENSION sub-fix (b):
 # When ensure-pr-cache-fresh.py fails in cron context, it writes this sentinel.
@@ -454,7 +468,7 @@ def _resolve_pr_cite_integrity(match: re.Match, cache: dict) -> str | None:
     return None
 
 
-def audit_case_study_citations(pr_cache: dict | None) -> list[dict]:
+def audit_case_study_citations(pr_cache: dict | None, coverage: "GateCoverage | None" = None) -> list[dict]:
     """Scan every case study .md for PR citations; flag broken ones.
 
     If pr_cache is None, skip gracefully (gh not available). Returns findings
@@ -465,19 +479,33 @@ def audit_case_study_citations(pr_cache: dict | None) -> list[dict]:
     in their prose is meta-reference, not a real evidentiary claim.
 
     v7.8.3 D-3: uses resolve_pr_cite() for cross-repo routing via REPO_MAP.
+    v7.10: emits Mechanism A coverage (gate BROKEN_PR_CITATION) when `coverage`
+    is supplied — every candidate .md is checked unless filtered out.
     """
     if pr_cache is None or not CASE_STUDIES_DIR.exists():
+        if coverage is not None:
+            coverage.skip("BROKEN_PR_CITATION", "no_pr_cache_or_dir")
         return []
     findings: list[dict] = []
     for f in sorted(CASE_STUDIES_DIR.rglob("*.md")):
+        if coverage is not None:
+            coverage.candidate("BROKEN_PR_CITATION")
         if f.name in SKIP_CASE_STUDY_FILES:
+            if coverage is not None:
+                coverage.skip("BROKEN_PR_CITATION", "skip_listed_file")
             continue
         if "meta-analysis" in f.relative_to(CASE_STUDIES_DIR).parts:
+            if coverage is not None:
+                coverage.skip("BROKEN_PR_CITATION", "meta_analysis_prose")
             continue
         try:
             text = f.read_text()
         except Exception:
+            if coverage is not None:
+                coverage.skip("BROKEN_PR_CITATION", "unreadable")
             continue
+        if coverage is not None:
+            coverage.checked("BROKEN_PR_CITATION")
         for m in _PR_CITATION_PAT.finditer(text):
             err = _resolve_pr_cite_integrity(m, pr_cache)
             if err is not None:
@@ -1005,6 +1033,36 @@ def check_gate_coverage_zero() -> list[dict]:
     for gate, stats in sorted(gates.items()):
         if not isinstance(stats, dict):
             continue
+
+        # v7.10 refinement — the MIS-WIRE signature (distinct from the staleness
+        # case below). A gate REGISTERED in the index but whose every counter is
+        # zero (candidates == checked == skipped == firings == 0) has a check
+        # site that runs but never reaches a single candidate — the classic
+        # "gate function present, emission key wrong / loop unreachable" bug the
+        # cache_hits keying incident was. NOT the same as a healthy zero-firing
+        # gate (e.g. STATE_OWNER_MISSING: thousands of candidates, zero
+        # violations) — those have non-zero candidates and are silent here.
+        # Checked BEFORE the MIN_CANDIDATES filter, which would otherwise skip it.
+        if (
+            stats.get("total_candidates", 0) == 0
+            and stats.get("total_checked", stats.get("total_firings", 0)) == 0
+            and stats.get("total_skips", 0) == 0
+        ):
+            findings.append({
+                "feature": "—",
+                "severity": "ADVISORY",
+                "code": "GATE_COVERAGE_ZERO",
+                "message": (
+                    f"GATE_COVERAGE_ZERO: gate `{gate}` is registered in the "
+                    f"coverage index but every counter is zero "
+                    f"(candidates=0, checked=0, skipped=0) — its check site runs "
+                    f"but never reaches a candidate. Likely mis-wired emission "
+                    f"key or an unreachable loop (cache_hits-keying bug class). "
+                    f"Advisory; v7.10 enforcement candidate."
+                ),
+            })
+            continue
+
         if stats.get("total_candidates", 0) < MIN_CANDIDATES:
             continue
         last = activities.get(gate)
@@ -1062,7 +1120,7 @@ def check_tier_tags_advisory() -> list[dict]:
         }]
 
 
-def audit_case_study_tier_tags() -> list[dict]:
+def audit_case_study_tier_tags(coverage: "GateCoverage | None" = None) -> list[dict]:
     """Flag post-2026-04-21 case studies that lack any T1/T2/T3 tier tag.
 
     Added 2026-04-24 per Gemini audit Tier 2.3 enforcement follow-through.
@@ -1075,27 +1133,47 @@ def audit_case_study_tier_tags() -> list[dict]:
     Exempt: files under `docs/case-studies/meta-analysis/`, the template,
     README, data-quality-tiers.md itself, and any case study whose extracted
     "Date written:" header is older than 2026-04-21 (forward-only policy).
+
+    v7.10: emits Mechanism A coverage (gate CASE_STUDY_MISSING_TIER_TAGS) when
+    `coverage` is supplied — a candidate becomes `checked` only once it passes
+    the forward-only date filter (post-convention dated case studies).
     """
     if not CASE_STUDIES_DIR.exists():
+        if coverage is not None:
+            coverage.skip("CASE_STUDY_MISSING_TIER_TAGS", "no_dir")
         return []
     findings: list[dict] = []
     for f in sorted(CASE_STUDIES_DIR.rglob("*.md")):
+        if coverage is not None:
+            coverage.candidate("CASE_STUDY_MISSING_TIER_TAGS")
         if f.name in SKIP_CASE_STUDY_FILES or f.name == "data-quality-tiers.md":
+            if coverage is not None:
+                coverage.skip("CASE_STUDY_MISSING_TIER_TAGS", "skip_listed_file")
             continue
         if "meta-analysis" in f.relative_to(CASE_STUDIES_DIR).parts:
+            if coverage is not None:
+                coverage.skip("CASE_STUDY_MISSING_TIER_TAGS", "meta_analysis_prose")
             continue
         try:
             text = f.read_text()
         except Exception:
+            if coverage is not None:
+                coverage.skip("CASE_STUDY_MISSING_TIER_TAGS", "unreadable")
             continue
         # Extract date_written from the header (same regex family as
         # documentation-debt-report.py uses, plus explicit capture).
         date_match = _DATE_WRITTEN_PAT.search(text)
         if not date_match:
+            if coverage is not None:
+                coverage.skip("CASE_STUDY_MISSING_TIER_TAGS", "no_date_header")
             continue  # No date extracted — can't determine if post-convention
         date_written = date_match.group(1) or date_match.group(2)
         if not date_written or date_written < _TIER_CONVENTION_DATE:
+            if coverage is not None:
+                coverage.skip("CASE_STUDY_MISSING_TIER_TAGS", "pre_convention_date")
             continue  # Pre-convention — grandfathered by the forward-only policy
+        if coverage is not None:
+            coverage.checked("CASE_STUDY_MISSING_TIER_TAGS")
         if not _TIER_TAG_PAT.search(text):
             findings.append({
                 "feature": str(f.relative_to(REPO_ROOT)),
@@ -1108,7 +1186,7 @@ def audit_case_study_tier_tags() -> list[dict]:
     return findings
 
 
-def check_pattern_skill_unmapped() -> list[dict]:
+def check_pattern_skill_unmapped(coverage: "GateCoverage | None" = None) -> list[dict]:
     """Advisory: Observed-Patterns-Catalog IDs missing from pattern-skill-map.json.
 
     v7.9.1 pattern↔skill overlay. Parses every pattern ID from the catalog
@@ -1120,25 +1198,36 @@ def check_pattern_skill_unmapped() -> list[dict]:
 
     Severity: ADVISORY only — never affects finding_count or exit code.
     Silent when either file is missing (degrades gracefully).
+
+    v7.10: emits Mechanism A coverage (gate PATTERN_SKILL_UNMAPPED) when
+    `coverage` is supplied — one candidate per catalog pattern ID evaluated.
     """
     catalog = REPO_ROOT / ".claude" / "integrity" / "observed-patterns.md"
     map_path = REPO_ROOT / ".claude" / "shared" / "pattern-skill-map.json"
     if not catalog.exists() or not map_path.exists():
+        if coverage is not None:
+            coverage.skip("PATTERN_SKILL_UNMAPPED", "catalog_or_map_missing")
         return []
 
     import re as _re
     try:
         text = catalog.read_text()
     except OSError:
+        if coverage is not None:
+            coverage.skip("PATTERN_SKILL_UNMAPPED", "catalog_unreadable")
         return []
     # Section headings: "### #12 ..." (gate) or "### W9 — ..." (workflow).
     catalog_ids = set(_re.findall(r"^### (#\d+|W\d+)\b", text, flags=_re.MULTILINE))
     if not catalog_ids:
+        if coverage is not None:
+            coverage.skip("PATTERN_SKILL_UNMAPPED", "no_catalog_ids")
         return []
 
     try:
         entries = json.loads(map_path.read_text())
     except (OSError, json.JSONDecodeError):
+        if coverage is not None:
+            coverage.skip("PATTERN_SKILL_UNMAPPED", "map_unreadable")
         return []
     mapped = {e.get("id"): e.get("skills", []) for e in entries}
 
@@ -1152,6 +1241,9 @@ def check_pattern_skill_unmapped() -> list[dict]:
 
     findings: list[dict] = []
     for pid in sorted(catalog_ids - SELF_DOC_EXEMPT, key=lambda x: (x[0] != "#", x)):
+        if coverage is not None:
+            coverage.candidate("PATTERN_SKILL_UNMAPPED")
+            coverage.checked("PATTERN_SKILL_UNMAPPED")
         if pid not in mapped:
             findings.append({
                 "feature": "pattern-skill-map",
@@ -1235,10 +1327,20 @@ def build_snapshot(snapshot_trigger: str) -> dict:
                 f"Investigate `gh auth status` under cron context."
             ),
         })
+    # v7.10: cycle-time Mechanism A coverage tracker. The three cycle-time
+    # checks below previously emitted NO coverage, so the F17 index +
+    # GATE_COVERAGE_ZERO meta-check were blind to them. mode="cycle"
+    # distinguishes these full-corpus scans from the write-time gates'
+    # staged/explicit coverage. Tests opt out via GATE_COVERAGE_LEDGER_DISABLED=1.
+    cycle_coverage = GateCoverage(mode="cycle")
+
+    if pr_cache_failed_advisory:
+        # Cache known-stale: BROKEN_PR_CITATION was deliberately not run.
+        cycle_coverage.skip("BROKEN_PR_CITATION", "pr_cache_refresh_failed")
     else:
         # Auditor Agent case-study citation checks
-        findings.extend(audit_case_study_citations(_PR_CACHE))
-    findings.extend(audit_case_study_tier_tags())
+        findings.extend(audit_case_study_citations(_PR_CACHE, coverage=cycle_coverage))
+    findings.extend(audit_case_study_tier_tags(coverage=cycle_coverage))
 
     # v7.7 M3 T18: advisory tier-tag correctness heuristic (14th check code).
     # v7.8 M2 PR-3 T11: advisory cache_hits auto-instrumentation early-warning
@@ -1252,10 +1354,19 @@ def build_snapshot(snapshot_trigger: str) -> dict:
         + check_tier_tags_advisory()
         + check_cache_hits_auto_instrumentation_inactive()
         + pr_cache_failed_advisory  # v7.9.1 F-LAUNCHD-DRIFT-EXTENSION sub-fix (b)
-        + check_pattern_skill_unmapped()  # v7.9.1 pattern↔skill overlay advisory
+        + check_pattern_skill_unmapped(coverage=cycle_coverage)  # v7.9.1 overlay
         + check_gate_coverage_zero()  # v7.10 candidate (built 2026-06-08, advisory)
     )
     all_findings = findings + advisory_findings
+
+    # v7.10: persist cycle-time coverage so the F17 index + GATE_COVERAGE_ZERO
+    # can observe these three checks. Best-effort: a write failure must never
+    # break the integrity scan (the findings above are the load-bearing output).
+    if os.environ.get("GATE_COVERAGE_LEDGER_DISABLED") != "1":
+        try:
+            cycle_coverage.write_jsonl(GATE_COVERAGE_LEDGER)
+        except OSError:
+            pass
 
     non_advisory_count = len(findings)
 

--- a/scripts/tests/test_gate_coverage_zero.py
+++ b/scripts/tests/test_gate_coverage_zero.py
@@ -77,3 +77,55 @@ def test_all_recent_no_findings(tmp_path, monkeypatch):
 def test_missing_index_safe(tmp_path, monkeypatch):
     monkeypatch.setattr(ic, "REPO_ROOT", tmp_path)  # no index file
     assert ic.check_gate_coverage_zero() == []
+
+
+# --- v7.10 mis-wire (0-candidate) detection -------------------------------
+
+def test_miswire_zero_candidate_gate_flagged(tmp_path, monkeypatch):
+    """A gate registered in the index but with ALL counters zero = mis-wired."""
+    now = datetime.now(timezone.utc)
+    gates = {
+        "ACTIVE_GATE": {"total_candidates": 200, "last_checked_at": _iso(now),
+                        "last_skipped_at": _iso(now)},
+        "MISWIRED_GATE": {"total_candidates": 0, "total_checked": 0, "total_skips": 0,
+                          "total_firings": 0},
+    }
+    findings = _run(tmp_path, gates, monkeypatch)
+    msgs = " ".join(f["message"] for f in findings)
+    assert "MISWIRED_GATE" in msgs
+    assert "every counter is zero" in msgs
+    assert all(f["code"] == "GATE_COVERAGE_ZERO" for f in findings)
+
+
+def test_healthy_zero_firing_gate_not_flagged(tmp_path, monkeypatch):
+    """STATE_OWNER_MISSING shape: thousands of candidates, 0 firings — HEALTHY.
+
+    The gate runs on every commit and never finds a violation; it must NOT be
+    flagged as mis-wired (it has non-zero candidates) nor as stale (its activity
+    is current).
+    """
+    now = datetime.now(timezone.utc)
+    gates = {
+        "ACTIVE_GATE": {"total_candidates": 200, "last_checked_at": _iso(now),
+                        "last_skipped_at": _iso(now)},
+        "STATE_OWNER_MISSING": {"total_candidates": 1936, "total_firings": 0,
+                                "total_skips": 1936,
+                                "last_checked_at": _iso(now),
+                                "last_skipped_at": _iso(now)},
+    }
+    findings = _run(tmp_path, gates, monkeypatch)
+    flagged = {f["message"].split("`")[1] for f in findings if "`" in f["message"]}
+    assert "STATE_OWNER_MISSING" not in flagged
+
+
+def test_miswire_does_not_double_flag_as_stale(tmp_path, monkeypatch):
+    """A 0-candidate gate produces exactly one finding (mis-wire), not also stale."""
+    now = datetime.now(timezone.utc)
+    gates = {
+        "ACTIVE_GATE": {"total_candidates": 200, "last_checked_at": _iso(now),
+                        "last_skipped_at": _iso(now)},
+        "MISWIRED_GATE": {"total_candidates": 0, "total_checked": 0, "total_skips": 0},
+    }
+    findings = _run(tmp_path, gates, monkeypatch)
+    miswire = [f for f in findings if "MISWIRED_GATE" in f["message"]]
+    assert len(miswire) == 1

--- a/scripts/tests/test_integrity_cycle_coverage.py
+++ b/scripts/tests/test_integrity_cycle_coverage.py
@@ -1,0 +1,62 @@
+"""v7.10 — the three cycle-time checks must emit Mechanism A coverage.
+
+Before v7.10, BROKEN_PR_CITATION / CASE_STUDY_MISSING_TIER_TAGS /
+PATTERN_SKILL_UNMAPPED ran without emitting any coverage row, so the F17 index
+and GATE_COVERAGE_ZERO meta-check were blind to them. These tests pin the
+emission + the candidates == checked + skipped balance invariant.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_SCRIPTS))
+from gate_coverage import GateCoverage  # noqa: E402
+
+_SPEC = importlib.util.spec_from_file_location("integrity_check", _SCRIPTS / "integrity-check.py")
+ic = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(ic)
+
+
+def _balance(cov, gate):
+    b = cov.gates[gate]
+    assert b["candidates"] == b["checked"] + b["skipped"], (
+        f"{gate}: candidates {b['candidates']} != checked {b['checked']} + skipped {b['skipped']}")
+    return b
+
+
+def test_tier_tags_emits_balanced_coverage():
+    cov = GateCoverage(mode="cycle")
+    ic.audit_case_study_tier_tags(coverage=cov)
+    b = _balance(cov, "CASE_STUDY_MISSING_TIER_TAGS")
+    assert b["candidates"] >= 1  # live corpus has case studies
+
+
+def test_pattern_skill_emits_coverage():
+    cov = GateCoverage(mode="cycle")
+    ic.check_pattern_skill_unmapped(coverage=cov)
+    b = cov.gates["PATTERN_SKILL_UNMAPPED"]
+    assert b["candidates"] >= 1
+    assert b["candidates"] == b["checked"]  # every pattern id is evaluated
+
+
+def test_citations_emits_balanced_coverage_with_cache():
+    cov = GateCoverage(mode="cycle")
+    # minimal non-None cache so the function runs the scan loop
+    ic.audit_case_study_citations({"repos": {}}, coverage=cov)
+    b = _balance(cov, "BROKEN_PR_CITATION")
+    assert b["candidates"] >= 1
+
+
+def test_citations_no_cache_emits_skip():
+    cov = GateCoverage(mode="cycle")
+    ic.audit_case_study_citations(None, coverage=cov)
+    b = cov.gates["BROKEN_PR_CITATION"]
+    assert b["skipped"] == 1 and b["checked"] == 0
+
+
+def test_coverage_optional_no_crash_when_absent():
+    # back-compat: all three run with coverage=None (the pre-v7.10 call shape)
+    ic.audit_case_study_tier_tags()
+    ic.check_pattern_skill_unmapped()
+    ic.audit_case_study_citations(None)


### PR DESCRIPTION
First v7.10 deliverable — closes the observability blind spot the **2026-06-10 data-integrity audit** surfaced via the observed-patterns bug hunt.

## Problem
Three cycle-time checks in `integrity-check.py` (`BROKEN_PR_CITATION`, `CASE_STUDY_MISSING_TIER_TAGS`, `PATTERN_SKILL_UNMAPPED`) ran **without emitting any Mechanism A coverage** — so the F17 index + the (already-shipped, #673) `GATE_COVERAGE_ZERO` meta-check were blind to them. If one silently stopped checking, nothing would detect it.

## A — cycle-time coverage emission
The three checks now emit per-gate `{candidates, checked, skipped, skip_reasons}` via the same `GateCoverage` tracker the write-time gates use, tagged `mode="cycle"`. Live run:

| Gate | candidates | checked | skipped |
|---|---|---|---|
| `BROKEN_PR_CITATION` | 127 | 109 | 18 |
| `CASE_STUDY_MISSING_TIER_TAGS` | 127 | 5 | 122 |
| `PATTERN_SKILL_UNMAPPED` | 56 | 56 | 0 |

All above `MIN_CANDIDATES` (20), so `GATE_COVERAGE_ZERO` can now watch them for a silent stop. Ledger write is best-effort (never breaks the scan); `GATE_COVERAGE_LEDGER_DISABLED=1` opt-out for tests.

## B — `GATE_COVERAGE_ZERO` mis-wire detector
New **0-candidate signature**: a gate registered in the index with every counter zero (`candidates==checked==skipped==0`) has a check site that runs but never reaches a candidate — the `cache_hits`-keying / unreachable-loop bug class. Checked **before** the `MIN_CANDIDATES` filter that previously hid it. Distinct from a healthy zero-firing gate (`STATE_OWNER_MISSING`: 1936 candidates, 0 violations — has candidates, stays silent).

## C — observed-patterns catalog
New pattern **#24** (field-rename silent-pass in a READER/INDEX — generalization of #7/#9; the `cu_v2` + `w9`-`ts` bugs fixed earlier today in #687/#688) + `pattern-skill-map.json` entry + regenerated skill-preflight tables.

## Tests
+8 (`test_integrity_cycle_coverage.py` ×5: emission + balance invariant + back-compat; `test_gate_coverage_zero.py` ×3: mis-wire vs healthy-zero). **51/51 pass** in the coverage suite; integrity **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)