### PR TITLE
docs(master-plan): extract v8.x docket into dedicated sub-plan + ready-now workplan

### DIFF
--- a/docs/master-plan/README.md
+++ b/docs/master-plan/README.md
@@ -42,7 +42,10 @@
 
 | File | Date | Purpose |
 |---|---|---|
-| `infra-master-plan-2026-05-12.md` | 2026-05-12 | **CURRENT infra plan.** Forward-looking framework master plan covering v7.9 promotion docket, v8.x candidate ranking (F1–F13 + 7 icebox items), HADF Phase 2-bis pre-launch calendar, and the date-gated roadmap through Q3 2026. Separate from product master plan. |
+| `infra-master-plan-2026-05-12.md` | 2026-05-12 · refreshed 2026-06-15 | **CURRENT infra plan.** Forward-looking framework master plan. §3.5 Calibration Protocol + §3.6 Forward Plan v7.9→v8.2 + HADF Phase 2-bis calendar. The v8.x candidate docket was extracted 2026-06-15 → see sub-plan below. |
+| `v8-x-build-docket-2026-06-15.md` | 2026-06-15 | **CURRENT v8.x build docket** (sub-plan of infra plan). Reconciled candidate status (shipped/open/icebox), F-series + V8-I tables, T29 decision, theme distribution. |
+| `v8-0-ready-now-workplan-2026-06-15.md` | 2026-06-15 | **Ready-now execution plan** — the 8 ungated open v8.x items (F1/F3/F4/F5/F10/F11/F12/F13), sequenced into 3 batches with calibration + isolated-worktree constraints. |
+| `v8-0-docket-ranking-2026-05-13.md` | 2026-05-13 · decided 2026-05-21 | Frozen T29 RICE ranking artifact (historical). Superseded for live status by the v8.x build docket sub-plan above. |
 | `master-plan-2026-04-15.md` | 2026-04-15 · updated 2026-05-12 | **CURRENT product master plan.** Adds all v4.3 → v7.8.4 work, M-series decomposition sprints, audit remediation, cross-repo state-sync, and pre-v7.9 telemetry calibration patch. |
 | `master-plan-2026-04-06.md` | 2026-04-06 | DEPRECATED — superseded by 2026-04-15. Kept as a historical snapshot. |
 | `_archive/master-plan-reconciled-2026-04-05.md` | 2026-04-05 | DEPRECATED — superseded by 2026-04-06, then 2026-04-15. **Archived 2026-05-24 to `_archive/` per D-PLAN-9** (38+ days SUPERSEDED). |

--- a/docs/master-plan/infra-master-plan-2026-05-12.md
+++ b/docs/master-plan/infra-master-plan-2026-05-12.md
@@ -225,101 +225,13 @@ If any criterion fails for a given gate, that gate stays advisory and re-evaluat
 
 ---
 
-### 3.1 v7.9 Candidate Features (F-series) — Surfaced from Three Sources
+### 3.1–3.4 v8.x Candidate Docket → extracted to dedicated sub-plan (2026-06-15)
 
-**Source A — Roadmap stress-test (2026-05-07 session, [case study](../case-studies/roadmap-stress-test-2026-05-07-case-study.md) §99):**
-
-| ID | Item | Class | RICE-est | Source notes |
-|---|---|---|---|---|
-| **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory — detect pre-v7.6 features with empty `tasks[]` despite shipped work | Cycle-time gate | M (R=6 I=2 C=80% E=0.5w → 19.2) | Surfaced when 5-of-10 stress-test sub-features had this drift |
-| **F2** | Phase 0 sub-step: reality-check completed work against current state before scheduling | Workflow gate | M (R=8 I=2 C=80% E=0.3w → 42.7) | Roadmap had 1 step done as "TODO" |
-| **F3** | Phase 2 dependency-graph cycle/mismatch check for multi-feature roadmaps | Workflow gate | M (R=6 I=2 C=60% E=0.5w → 14.4) | 1 dep-cycle caught manually post-hoc |
-| **F4** | Auto-update `framework_version` on protocol-touching writes OR explicit migration pass | Write-time gate or migration | H (R=10 I=2 C=80% E=0.5w → 32.0) | 9 features had stale `framework_version` post-v7.6 |
-| **F5** | Formalize `scope_change` event in Tier 2.2 vocabulary | Vocabulary extension | L (R=4 I=1 C=100% E=0.2w → 20.0) | Currently logged as `event: "note"` |
-| **F6** | Document B_medium tier in CLAUDE.md: PRD/tasks/UX optional; formalize skipped-phase reasons | CLAUDE.md doc | L (R=6 I=1 C=100% E=0.2w → 30.0) | Currently ambiguous between Feature and Enhancement |
-
-**Source B — Stress-test closure session (2026-05-07 evening):**
-
-| ID | Item | Class | RICE-est | Source notes |
-|---|---|---|---|---|
-| **F9** | `make complete-feature` pre-flight OR gate-batch mode for closure UX | Workflow ergonomics | H (R=8 I=2 C=100% E=0.4w → 40.0) | 3 closure PRs required ≥3 commit retries each |
-| **F10** | Formalize `experiment_outcome` enum (`shipped`/`deferred`/`cancelled`/`superseded`) on `tasks[]` | Schema extension | M (R=6 I=2 C=80% E=0.3w → 32.0) | Deferred tasks currently distinguished only by case-study prose |
-
-**Source C — v7.8.3 cutover ceremony (2026-05-11, [case study](../case-studies/cross-repo-state-sync-impl-case-study.md)):**
-
-| ID | Layer | Item | Class | RICE-est |
-|---|---|---|---|---|
-| **F11** | Cycle-time advisory | Extend `BRANCH_ISOLATION_HISTORICAL` allowlist to `reverse-sync/*` branches OR morph to read `state_owner_sync_origin` | Cycle-time gate | M (R=6 I=2 C=100% E=0.3w → 40.0) |
-| **F12** | Pre-commit gate | Add `actionlint` to pre-commit stack | Write-time gate | H (R=10 I=2 C=100% E=0.2w → 100.0) |
-| **F13** | Workflow bootstrap | `source_commit` input on `workflow_dispatch` OR full-repo scan fallback for unmirrored fitme-story-native state.json files | GH Actions infra | M (R=8 I=2 C=80% E=0.4w → 32.0) |
-
-**Source D — PR #317 + test-suite audit + external research (2026-05-12 session, [v7.9 candidates spec §2](../superpowers/specs/2026-05-08-framework-v7-9-candidates.md)):**
-
-| ID | Layer | Item | Class | RICE-est |
-|---|---|---|---|---|
-| **F14** ✅ **SHIPPED 2026-05-22 → 05-23** | Test infrastructure | Per-gate `test_main_dispatch_<gate_id>()` requirement — every write-time gate must have ≥1 test driving `main()` end-to-end (Semgrep `rule.yml↔rule.test.yml` enforced-pairing pattern). 4 gates covered: `CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT`, `CU_V2_INVALID`, `STATE_NO_CASE_STUDY_LINK`, `CASE_STUDY_MISSING_FIELDS`. Shipped via PRs #451 (`86084c4`) + #452 (`3686f98`) + closure #455 (`98ca1ad7`). Layer-stacking constraint relaxed (see §3.6.2 below) — in-repo monkey-patch pattern from PR #317 proved sufficient without waiting on F16 try-repo harness. | Test discipline (write-time) | H (R=10 I=3 C=80% E=0.5w → 48.0) |
-| **F15** ✅ **SHIPPED 2026-05-22 → 05-23** | Test infrastructure | Unit tests for 5 zero-coverage gates — `PHASE_TRANSITION_NO_LOG` + `PHASE_TRANSITION_NO_TIMING` (highest risk, guard most frequent state mutation), `BRANCH_ISOLATION_HISTORICAL`, `BRANCH_ISOLATION_LAUNCHD_DRIFT`, `PR_CACHE_STALE`. Shipped via same feature `framework-f14-f15-dispatch-test-coverage` (joint scope). Combined coverage delta: write-time 1/16→8/16=50%; cycle-time 0/3→2/3=67%; total 1/19→10/19=53%. T1 GATE_TEST_MISSING meta-gate (RICE 53.3) opened as successor — depends on F14 reaching Phase E (T+90d post-ship = 2026-08-22). | Test discipline (Class B closure) | H (R=10 I=2 C=100% E=0.5w → 40.0) |
-| **F16** | Test infrastructure | pre-commit `try-repo`-style end-to-end harness — spawn throwaway git repo, stage fixtures from `tests/fixtures/<gate-id>/{positive,negative}/`, run real `.githooks/pre-commit` via subprocess, assert each gate fires/skips per fixture. Run in CI nightly. **Highest-leverage single change** per external research synthesis. | Test infrastructure foundation | H (R=10 I=3 C=80% E=0.5w → 48.0) |
-| **F17** | Telemetry materialization | Per-gate `last_fired_at` derived nightly index — `scripts/refresh-gate-last-fired.py` writes `.claude/shared/gate-last-fired.json` from `gate-coverage.jsonl`. AWS Config Rules `LastSuccessfulInvocationTime` pattern. Enables planned `GATE_COVERAGE_ZERO` meta-check at O(1) instead of O(records × gates). | Telemetry materialization | H (R=10 I=2 C=100% E=0.3w → 66.7) |
-| **F18** | Test infrastructure | Nightly mutation testing on dispatcher files (`mutmut run --paths-to-mutate scripts/check-state-schema.py,scripts/check-case-study-preflight.py,scripts/integrity-check.py`). Pitest "Remove Conditionals" + "Statement Deletion" operators surface surviving mutants on early-return patterns like PR #317's. Calibrate baseline 7d, then fail PR if surviving mutants on touched files rise vs main. | Mutation testing (advisory → enforced) | M (R=8 I=2 C=60% E=0.7w → 13.7) |
-
-**Source E — post-v7.9 candidate plan (2026-05-20 session):**
-
-| ID | Layer | Item | Class | RICE-est |
-|---|---|---|---|---|
-| **F19** | Analytics observability | Phase 1.B GA4 conversions (D-2) + dashboard wiring for `dashboard_*` event call-sites in `/control-room/*` | Production telemetry wiring | M (deferred to v7.9.1 — `analytics-observability` Phase 3.B; gated on Phase E exit ~2026-06-04) |
-| **F20** | Analytics observability | Phase 1.B conversion event mapping + Firebase event-name cleanup (D-4) | Schema cleanup | L (deferred to v7.9.1 build window) |
-| ~~**F21**~~ | ~~Error tracking~~ | ~~Sentry full integration (SDK init + `/ops health` crash-free rate read + 1 test event)~~ | ~~Production observability~~ | **PAUSED 2026-05-21 → pre-launch trigger** ([PR #418](https://github.com/Regevba/FitTracker2/pull/418)). Pre-launch context: iOS app is TestFlight beta only — crash data is not actionable until App Store launch. Resume preconditions: App Store submission ≤2 weeks + `ConsentManager.crashScreenshotConsent` decision finalized. |
-| **F22** | Product analytics | Funnel Analysis Dashboards — GA4 funnel exploration + `/control-room/analytics` page + per-funnel metric definitions (onboarding, training, nutrition, home engagement, AI recommendation, readiness) | Product observability | M (depends on F19 Phase 3.B; post-Phase-E ~2026-06-04+; ~5-7 days) |
-| **F23** | Stakeholder ops | `/ops digest` skill — weekly stakeholder summary (DAU/WAU trend, top funnel breaks, P0/P1 audit drift, framework version, advisory ledger snapshot) | Skill extension | M (depends on F22 + Sentry pre-launch resume; ~3-4 days) |
-
-**Resolved already (no v7.9 promotion needed):**
-
-| ID | Item | Resolution |
-|---|---|---|
-| **F7** | Cross-repo gate parity (Tier 2.2 per-phase emission for fitme-story) | RESOLVED v7.8.2 — documented exemption in [2026-05-08-cross-repo-gate-asymmetry.md](../superpowers/specs/2026-05-08-cross-repo-gate-asymmetry.md) |
-| **F8** | Mechanism A `gate-coverage.jsonl` parity for fitme-story | RESOLVED v7.8.2 — documented exemption + hook cwd-guard fix in PR #258 |
-
-### 3.2 v8.0 Icebox (7 items from `branch-isolation-out-of-scope.md`)
-
-Source: [`docs/superpowers/specs/2026-05-07-branch-isolation-out-of-scope.md`](../superpowers/specs/2026-05-07-branch-isolation-out-of-scope.md). Each gated on its own re-evaluation trigger; default disposition is "not promoted to v8.0 unless trigger fires."
-
-| ID | Item | cu_v2 | Re-eval trigger | Disposition |
-|---|---|---|---|---|
-| **V8-I1** | Agent Smartlog UI — `/control-room/agents` live awareness + path-overlap detection | 2.2 (B_med) | ≥5 concurrent active features for 7+ days | Visibility layer; prevention is gated already |
-| **V8-I2** | Op-log Replay — jj-style per-session rollback + GC | 2.9 (A_high) | ≥3 manual-cleanup incidents in 90d OR `git stash list` >5 for 30d | Recovery primitive; v7.8.3 `--no-verify` ledger is bridge |
-| **V8-I3** | Vercel Sandbox / Firecracker microVM | 3.1 (A_high) | Untrusted-code-execution use case emerges | Overkill for cooperative agents |
-| **V8-I4** | FS kernel sandboxing — Linux Landlock / macOS App Sandbox | 3.05 (A_high) | Regulatory mandate (HIPAA audit trail) | OS-specific; multi-tenant context needed |
-| **V8-I5** | inotify/fsevents broadcast mediator | 1.9 (B_med) | ≥2 concurrent-write collisions in 60d w/ >30min reconciliation | Detection-only; additive to existing gates |
-| **V8-I6** | Cross-feature dependency analysis | 2.0 (B_med) | `path-reducers.json` ≥20 entries + ≥2 conflicts surface organically | Requires path-reducer registry to mature |
-| **V8-I7** | Auto-rollback on kill-criteria fire | 3.05 (A_high) | T+7d telemetry of clean firing + ≥2 manual dry-run successes | Safety verification needed |
-
-### 3.3 v8.0 Docket Decision (2026-05-21 — T29 Phase 9 prioritization pass)
-
-The 2026-05-21 prioritization pass at `framework-v7-8-branch-isolation` Phase 9 closure produces the final v8.0 docket by:
-
-1. **Ranking** F1–F6 + F9–F18 + V8-I1 through V8-I7 (23 candidates after F7/F8 resolution) by RICE × 7-day telemetry signal strength
-2. **Top-3-per-theme rule** (relaxed 2026-05-12 from prior "top-3 absolute") — pick top 3 by RICE within each theme so v8.0 covers breadth, not just the highest-RICE items. With 7 themes (A roadmap, B cross-repo asymmetry RESOLVED, C schema, D vocabulary, E ergonomics, F v7.8.3 cutover, G test discipline), v8.0 max docket = 18 items. Rest defer to v8.1.
-3. **Companion case study** — Phase 9 produces `framework-v7-8-branch-isolation-case-study.md` with the prioritization decision recorded in Section 99 + ranked output to `docs/superpowers/specs/2026-05-21-v8-0-docket.md` (new file)
-4. **Sub-experiment with hold-out** — if telemetry suggests *zero* F-items warrant promotion (rare but possible), v8.0 ships as a pure protocol patch and v8.x deferred to v8.1
-5. **Test-discipline foundation precedence (added 2026-05-12)** — Theme G items (F14, F15, F16, F17, F18) have a dependency graph among themselves: F16 (try-repo harness) is foundation; F14 (per-gate dispatch tests) and F18 (mutation testing) depend on it; F15 is independent; F17 is independent. If ANY Theme G item enters v8.0, F16 MUST also enter v8.0 OR ship earlier as v7.9.1.
-
-The Phase 9 task is tracked as **T29** in [`.claude/features/framework-v7-8-branch-isolation/state.json`](../../.claude/features/framework-v7-8-branch-isolation/state.json).
-
-### 3.4 Theme distribution (after 2026-05-12 expansion)
-
-| Theme | Items | Open count | Notes |
-|---|---|---|---|
-| **A — Roadmap/multi-feature realism** | F1, F2, F3 | 3 | Stress-test session |
-| **B — Cross-repo asymmetry** | F7, F8 | 0 (both RESOLVED v7.8.2) | Documented exemption |
-| **C — Schema drift / migration** | F4, F10 | 2 | `framework_version` + `experiment_outcome` enum |
-| **D — Vocabulary / latitude** | F5, F6 | 2 | `scope_change` event + B_medium tier doc |
-| **E — Workflow ergonomics** | F9 | 1 | `make complete-feature` pre-flight |
-| **F — v7.8.3 cutover follow-up** | F11, F12, F13 | 3 | All independent |
-| **G — Test discipline** (NEW 2026-05-12; expanded 2026-05-13) | F14, F15, F16, F17, F18, F19, F20 | 7 | F16 is foundation for F14 + F18; F19/F20 from analytics-observability ride on F16 harness |
-| **H — Application-layer test coverage** (NEW 2026-05-13; see [`test-coverage-master-plan-2026-05-13.md`](test-coverage-master-plan-2026-05-13.md)) | T1–T16 | 16 | iOS + web + backend + AI + analytics test discipline; T6 (Web PR gate) RICE 200; T14 (platform-parity field) RICE 160; full ranking at 2026-05-21 |
-| **Icebox** | V8-I1 through V8-I7 | 7 | Each gated on own re-eval trigger |
-| **TOTAL** | 43 | **41 open** | F7/F8 resolved; 41 in 2026-05-21 ranking (+16 from test-coverage sub-doc) |
+> **The full v8.x candidate docket — F-series tables (Sources A–E), V8-I icebox, the T29 decision process, and the theme distribution — now lives in its own sub-plan: → [`v8-x-build-docket-2026-06-15.md`](v8-x-build-docket-2026-06-15.md)**
+>
+> This was separated 2026-06-15 to mirror how `test-coverage-master-plan`, `data-integrity-and-rollback`, and `analytics-master-plan` are standalone sub-plans under this parent. The **§3.0 reconciled roll-up above remains the at-a-glance**; the sub-plan is authoritative for per-candidate detail. The frozen T29 ranking stays at [`v8-0-docket-ranking-2026-05-13.md`](v8-0-docket-ranking-2026-05-13.md); the ready-now execution sequence is at [`v8-0-ready-now-workplan-2026-06-15.md`](v8-0-ready-now-workplan-2026-06-15.md).
+>
+> **§3.5 (Calibration Protocol for new layers) and §3.6 (Forward Plan v7.9 → v8.2) remain below in this parent** — they are general process/timeline content referenced by name across the doc tree, not part of the candidate docket.
 
 ---
 

--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -1,0 +1,59 @@
+# v8.0 Ready-Now Workplan — 2026-06-15
+
+> **Scope:** the open v8.x docket items that have **no gating dependency** and can start immediately. Source: [`v8-x-build-docket-2026-06-15.md`](v8-x-build-docket-2026-06-15.md) §0.B.
+> **Excluded (gated — not "ready now"):** T1 `GATE_TEST_MISSING` (F14 Phase E 2026-08-22) · F18 mutation testing (F16 Phase E, post 2026-06-18) · F19/F20/F22/F23 (GA4 / Sentry / launch signal) · T4 Swift snapshot (scaffold only) · F-CONTRACT consumer (cross-repo session).
+
+## The 8 ready-now items
+
+| # | ID | Item | RICE | Effort | Class | Infra-glob? |
+|---|---|---|---|---|---|---|
+| 1 | **F12** | `actionlint` in pre-commit + CI | **100.0** | ~0.2w | Write-time gate | yes (`.githooks/`, `.github/workflows/`) |
+| 2 | **F11** | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | 40.0 | ~0.3w | Cycle-time gate | yes (`scripts/`) |
+| 3 | **F10** | `experiment_outcome` enum on `tasks[]` | 32.0 | ~0.3w | Schema extension | yes (`scripts/` schema) |
+| 4 | **F13** | `source_commit` `workflow_dispatch` input | 32.0 | ~0.4w | GH Actions infra | yes (`.github/workflows/`) |
+| 5 | **F4** | Auto-update `framework_version` on protocol writes | 32.0 | ~0.5w | Write-time/migration | yes (`scripts/`) |
+| 6 | **F5** | `scope_change` Tier 2.2 vocabulary event | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
+| 7 | **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |
+| 8 | **F3** | Phase 2 dependency-graph cycle check | 14.4 | ~0.5w | Workflow gate | yes (`scripts/`) |
+
+**Total effort:** ~2.9 engineer-weeks. All 8 touch infra-glob paths.
+
+## Non-negotiable constraints (apply to every item)
+
+1. **Isolated worktree (enforced).** Every item touches `scripts/` / `.githooks/` / `.github/workflows/` → `BRANCH_ISOLATION_VIOLATION` Mode B fires (enforced at v7.9). Work each in an isolated worktree via `scripts/create-isolated-worktree.py` (or `superpowers:using-git-worktrees`). Do **not** commit infra-glob changes from a non-isolated branch.
+2. **Calibration Protocol (§3.5, mandatory for new gates).** Each NEW gate (F1, F4, F5, F11, F12, F3) ships **advisory first** with Phase A artifacts authored BEFORE code: `function_name`, `emission_key`, dispatch site, expected skip reasons, **1 positive + 1 negative fixture**, and a regression test asserting coverage fires. Then walk B (advisory + measure 7d) → C (calibration 7d) → D (promote decision) → E (validate 7d). **Min 22 days per gate to enforced.** F10 (pure schema) + F13 (workflow input) are not gates → no calibration walk, but still need tests.
+3. **F16 try-repo fixture pair (mandatory for new write-time gates).** Per CLAUDE.md F16 discipline, F12 + F4 (write-time) MUST ship a `tests/fixtures/<GATE_ID>/{positive,negative}/state.overrides.json` pair + a per-gate test in the appropriate `test_try_repo_*_gates.py` bucket. (Cycle-time gates F1/F11/F3 use the unit + dispatch test layers.)
+4. **Soak-window discipline.** F16's own advisory→enforced flip is 2026-06-18. The layer-stacking rule (§3.5.2) forbids building a new layer on one not yet in Phase E — none of these 8 stack on F16, so they're clear, but do not start F18 (which depends on F16 Phase E).
+5. **Full PM lifecycle by work-type.** Each is a `chore` or `fix` (gate/schema add) → Implement → Test → Merge; no PRD needed. Use `/pm-workflow {name}` and select work-type.
+
+## Recommended sequencing (3 batches, low-risk-first within RICE order)
+
+**Batch 1 — CI/lint infra (no schema risk):**
+- **F12 actionlint** (RICE 100, highest) — add `actionlint` to `.githooks/pre-commit` + a CI job; warn-only first, then enforce after calibration. Catches the workflow-YAML error class that F13 also touches.
+- **F13 source_commit input** — `workflow_dispatch` input + full-repo scan fallback. Pairs naturally with F12 (both GH-Actions surface) → consider one worktree, two PRs.
+
+**Batch 2 — schema + vocabulary (coordinated, low risk):**
+- **F10 experiment_outcome enum** — add enum to `tasks[]` schema + backfill existing deferred tasks + validator. Not a gate.
+- **F5 scope_change event** — add to Tier 2.2 vocabulary + `append-feature-log.py`. Not a gate.
+- **F4 framework_version auto-update** — partial coverage exists (`FRAMEWORK_VERSION_FORMAT` + `tracking-drift-check` #659); scope to the *auto-update on protocol-touching writes* gap. Write-time → calibration + try-repo fixture.
+
+**Batch 3 — cycle-time advisories (read-only, lowest risk to commits):**
+- **F11 reverse-sync allowlist** — extend `BRANCH_ISOLATION_HISTORICAL` to read `state_owner_sync_origin` / `reverse-sync/*`.
+- **F1 STATE_TASKS_FILESYSTEM_DRIFT** — cycle-time advisory; detect empty `tasks[]` despite shipped work (cross-check git/PR evidence, à la F2 reality-check).
+- **F3 dependency-graph cycle check** — Phase 2 multi-feature dep-cycle detector (lowest RICE; do last).
+
+## Calendar interaction
+
+- **2026-06-18** — F16 advisory→enforced flip (scheduled separately). Batches 1–2 can proceed in parallel; nothing here blocks on it.
+- **2026-06-18** — v8.0 build kickoff target. These 8 items ARE the early v8.0 build.
+- Each new advisory gate's 22-day calibration clock starts at its advisory ship; expect first enforced flips ~mid-July at the earliest.
+
+## Suggested first action
+
+Start **F12 (actionlint)** — highest RICE, smallest effort, lowest schema risk, and it hardens the very CI-workflow surface the other infra items edit. `scripts/create-isolated-worktree.py` → `/pm-workflow f12-actionlint-gate` (work-type: chore) → Phase A artifacts → advisory ship.
+
+## Cross-references
+- Docket: [`v8-x-build-docket-2026-06-15.md`](v8-x-build-docket-2026-06-15.md)
+- Calibration Protocol: [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) §3.5
+- F16 try-repo fixture discipline: [`../../CLAUDE.md`](../../CLAUDE.md) "v7.9.1 F16" section
+- Canonical current state: [`../FRAMEWORK-FACTS.md`](../FRAMEWORK-FACTS.md)

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -1,0 +1,161 @@
+# v8.x Build Docket — Sub-Plan
+
+> **Status:** CURRENT · Extracted 2026-06-15 from [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) §3.1–§3.4 to give the v8.x feature docket its own home (mirrors how `test-coverage-master-plan`, `data-integrity-and-rollback`, and `analytics-master-plan` are separate sub-plans under the infra master plan).
+>
+> **Parent:** [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) — §3.5 (Calibration Protocol for new layers) and §3.6 (Forward Plan v7.9 → v8.2) **stay in the parent** (heavily cross-referenced); this sub-plan is authoritative for the **candidate docket** (what's queued, what shipped, what's iceboxed).
+> **Predecessor ranking artifact:** [`v8-0-docket-ranking-2026-05-13.md`](v8-0-docket-ranking-2026-05-13.md) (frozen T29 prioritization, 2026-05-21).
+> **Ready-now execution plan:** [`v8-0-ready-now-workplan-2026-06-15.md`](v8-0-ready-now-workplan-2026-06-15.md).
+> **Canonical current state:** [`../FRAMEWORK-FACTS.md`](../FRAMEWORK-FACTS.md).
+
+---
+
+## 0. Reconciled Status (2026-06-15)
+
+Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (shipped 2026-06-10).
+
+**A. Shipped since the docket opened — no longer v8.0 candidates:**
+
+| ID | Item | Shipped | PR(s) |
+|---|---|---|---|
+| F2 | Phase 0 reality-check sub-step | v7.9.1 | #618 |
+| F6 | B_medium tier documented in CLAUDE.md | done | CLAUDE.md "Impact tier labels" § + "Work Item Types" |
+| F9 | `make close-feature` closure automation | shipped | #591 + #711 (sub-phase normalize) |
+| F14 | Per-gate dispatch tests | 2026-05-22/23 | #451 / #452 / #455 |
+| F15 | Zero-coverage gate unit tests | 2026-05-22/23 | (same feature) |
+| F16 | try-repo harness | v7.9.1 | #607–#612 · **advisory→enforced 2026-06-18** |
+| F17 | `last_fired_at` index (+ T13 `last_failed_at`) | v7.9.1 / v7.10 | #617 / #694 |
+| — | GATE_COVERAGE_ZERO meta-check | v7.10 | #673 + #689 |
+| T3 | SignInService passkey/WebAuthn tests | v7.10 | #695 |
+| T5 | mock-protocol drift registry | v7.10 | #698 |
+| T10 | AI golden-set evals | v7.10 | #691 |
+| T14 | `platforms_tested` field + advisory gate | 2026-06-07 | #662 · calibration B15 2026-06-21 |
+| V8-I | Style-Dictionary v3→v5 migration | 2026-06-10 | #677 (was icebox L417/L435) |
+| F-DEPLOYED-URL-PROBE | FT2 substrate (`scripts/probe-deployed-url.sh`) | v7.9.1 | fitme-story integration still open |
+| F-CONTRACT-FIXTURE-SAMPLING | FT2 substrate + producer sampling | 2026-06-07 | #664 · consumer adoption still open |
+| F-LAUNCHD-DRIFT-EXTENSION | all 3 sub-fixes | v7.9.1 | #621–#624 |
+
+**B. Open — carried into the v8.0 build (kickoff ~2026-06-18, after F16 enforce flip):**
+
+| ID | Item | Class | RICE-est | Gating |
+|---|---|---|---|---|
+| F12 | `actionlint` in pre-commit stack | Write-time gate | **100.0 (highest)** | none — ready |
+| F11 | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | Cycle-time gate | 40.0 | none |
+| F4 | Auto-update `framework_version` on protocol writes | Write-time/migration | 32.0 | partial — `FRAMEWORK_VERSION_FORMAT` + `tracking-drift-check` (#659) cover part |
+| F10 | `experiment_outcome` enum on `tasks[]` | Schema | 32.0 | none |
+| F13 | `source_commit` `workflow_dispatch` input | GH Actions | 32.0 | none |
+| F5 | `scope_change` Tier 2.2 vocabulary event | Vocabulary | 20.0 | none |
+| F1 | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | Cycle-time gate | 19.2 | none |
+| F3 | Phase 2 dependency-graph cycle check | Workflow gate | 14.4 | none |
+| T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** |
+| F18 | Mutation testing on dispatcher files | Test infra | 13.7 | F16 Phase E (post 2026-06-18) + F14 |
+| F22 | Funnel Analysis Dashboards | Product observability | M | F19 + GA4 data |
+| F23 | `/ops digest` skill | Skill extension | M | F22 + Sentry resume |
+| F19/F20 | Analytics Phase 1.B GA4 conversions + gates (`CSV_TAXONOMY_DRIFT`, `GA4_MCP_DISCONNECTED`) | Telemetry/gates | M / L | D-2 operator (GA4) + post-launch signal |
+| T4 | Swift snapshot testing | iOS test infra | — | Phase A scaffold shipped (#700); build pending |
+| F-CONTRACT (consumer) | fitme-story consumer adoption + weekly re-sample → promote CI gate to blocking | Cross-repo | — | cross-repo session |
+
+**C. Paused / launch-gated:** F21 Sentry (pre-launch trigger; PR #418) · F-AUTH-LATENCY-SERVER-METRIC shipped FT2-side (fitme-story #208).
+
+**D. Operator decision open:** W-MISTRAL-VERCEL-FREE-TIER-BURST (API-tier choice for multi-provider HADF experiments).
+
+**Roll-up:** of the original 18 F-candidates, **8 shipped** (F2, F6, F9, F14, F15, F16, F17 + GATE_COVERAGE_ZERO) + 2 resolved-by-exemption (F7, F8) → **8 F-items remain open** (F1, F3, F4, F5, F10, F11, F12, F13) + F18 + F19–F23. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
+
+---
+
+## 1. F-series Candidate Features — Original Source Tables (audit trail)
+
+> Retained verbatim from the original docket for provenance. Read live statuses through §0 above.
+
+**Source A — Roadmap stress-test (2026-05-07 session, [case study](../case-studies/roadmap-stress-test-2026-05-07-case-study.md) §99):**
+
+| ID | Item | Class | RICE-est | Source notes |
+|---|---|---|---|---|
+| **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory — detect pre-v7.6 features with empty `tasks[]` despite shipped work | Cycle-time gate | 19.2 | Surfaced when 5-of-10 stress-test sub-features had this drift |
+| **F2** ✅ | Phase 0 sub-step: reality-check completed work against current state before scheduling | Workflow gate | 42.7 | SHIPPED v7.9.1 (#618) |
+| **F3** | Phase 2 dependency-graph cycle/mismatch check for multi-feature roadmaps | Workflow gate | 14.4 | 1 dep-cycle caught manually post-hoc |
+| **F4** | Auto-update `framework_version` on protocol-touching writes OR explicit migration pass | Write-time/migration | 32.0 | 9 features had stale `framework_version` post-v7.6 |
+| **F5** | Formalize `scope_change` event in Tier 2.2 vocabulary | Vocabulary extension | 20.0 | Currently logged as `event: "note"` |
+| **F6** ✅ | Document B_medium tier in CLAUDE.md | CLAUDE.md doc | 30.0 | DONE — "Impact tier labels" section |
+
+**Source B — Stress-test closure session (2026-05-07 evening):**
+
+| ID | Item | Class | RICE-est | Source notes |
+|---|---|---|---|---|
+| **F9** ✅ | `make complete-feature` pre-flight / closure UX | Workflow ergonomics | 40.0 | SHIPPED — `make close-feature` (#591 + #711) |
+| **F10** | Formalize `experiment_outcome` enum (`shipped`/`deferred`/`cancelled`/`superseded`) on `tasks[]` | Schema extension | 32.0 | Deferred tasks distinguished only by case-study prose |
+
+**Source C — v7.8.3 cutover ceremony (2026-05-11):**
+
+| ID | Item | Class | RICE-est |
+|---|---|---|---|
+| **F11** | Extend `BRANCH_ISOLATION_HISTORICAL` allowlist to `reverse-sync/*` OR read `state_owner_sync_origin` | Cycle-time gate | 40.0 |
+| **F12** | Add `actionlint` to pre-commit stack | Write-time gate | **100.0** |
+| **F13** | `source_commit` input on `workflow_dispatch` OR full-repo scan fallback | GH Actions infra | 32.0 |
+
+**Source D — PR #317 + test-suite audit (2026-05-12):**
+
+| ID | Item | Class | RICE-est | Status |
+|---|---|---|---|---|
+| **F14** ✅ | Per-gate `test_main_dispatch_<gate_id>()` requirement | Test discipline | 48.0 | SHIPPED #451/#452/#455 |
+| **F15** ✅ | Unit tests for 5 zero-coverage gates | Test discipline | 40.0 | SHIPPED (joint w/ F14) |
+| **F16** ✅ | try-repo end-to-end harness | Test infra foundation | 48.0 | SHIPPED v7.9.1 #607–#612 · enforce flip 2026-06-18 |
+| **F17** ✅ | Per-gate `last_fired_at` derived index | Telemetry materialization | 66.7 | SHIPPED v7.9.1 #617 (+T13 #694) |
+| **F18** | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | OPEN — gated on F16 Phase E + F14 |
+
+**Source E — post-v7.9 candidate plan (2026-05-20):**
+
+| ID | Item | Class | RICE-est | Status |
+|---|---|---|---|---|
+| **F19** | Analytics Phase 1.B GA4 conversions (D-2) + dashboard wiring | Telemetry wiring | M | OPEN — D-2 operator + post-launch signal |
+| **F20** | Phase 1.B conversion event mapping + Firebase cleanup (D-4) | Schema cleanup | L | OPEN |
+| ~~**F21**~~ | ~~Sentry full integration~~ | — | — | **PAUSED → pre-launch** (PR #418) |
+| **F22** | Funnel Analysis Dashboards | Product observability | M | OPEN — depends on F19 + GA4 data |
+| **F23** | `/ops digest` skill | Skill extension | M | OPEN — depends on F22 + Sentry resume |
+
+**Resolved by exemption (v7.8.2):** F7 (cross-repo gate parity) + F8 (`gate-coverage.jsonl` parity) — documented exemptions.
+
+---
+
+## 2. v8.0 Icebox (V8-I — re-eval on trigger)
+
+Source: [`docs/superpowers/specs/2026-05-07-branch-isolation-out-of-scope.md`](../superpowers/specs/2026-05-07-branch-isolation-out-of-scope.md). Default disposition: "not promoted unless trigger fires."
+
+| ID | Item | cu_v2 | Re-eval trigger |
+|---|---|---|---|
+| **V8-I1** | Agent Smartlog UI — `/control-room/agents` live awareness + path-overlap detection | 2.2 (B_med) | ≥5 concurrent active features for 7+ days |
+| **V8-I2** | Op-log Replay — jj-style per-session rollback + GC | 2.9 (A_high) | ≥3 manual-cleanup incidents in 90d OR `git stash list` >5 for 30d |
+| **V8-I3** | Vercel Sandbox / Firecracker microVM | 3.1 (A_high) | Untrusted-code-execution use case emerges |
+| **V8-I4** | FS kernel sandboxing — Landlock / App Sandbox | 3.05 (A_high) | Regulatory mandate (HIPAA audit trail) |
+| **V8-I5** | inotify/fsevents broadcast mediator | 1.9 (B_med) | ≥2 concurrent-write collisions in 60d w/ >30min reconciliation |
+| **V8-I6** | Cross-feature dependency analysis | 2.0 (B_med) | `path-reducers.json` ≥20 entries + ≥2 conflicts organically |
+| **V8-I7** | Auto-rollback on kill-criteria fire | 3.05 (A_high) | T+7d clean firing + ≥2 manual dry-run successes |
+
+> The 8th former icebox item (Style-Dictionary v5 migration) **SHIPPED 2026-06-10 (#677)** and is removed from the icebox.
+
+---
+
+## 3. v8.0 Docket Decision Process (T29, 2026-05-21)
+
+The 2026-05-21 prioritization pass at `framework-v7-8-branch-isolation` Phase 9 froze the candidate set via: (1) RICE × 7-day telemetry ranking; (2) top-3-per-theme rule (breadth over pure RICE); (3) companion case study; (4) hold-out sub-experiment; (5) Theme-G dependency precedence (F16 foundation). Full ranking: [`v8-0-docket-ranking-2026-05-13.md`](v8-0-docket-ranking-2026-05-13.md).
+
+**Theme distribution (open counts as of 2026-06-15):**
+
+| Theme | Open items | Notes |
+|---|---|---|
+| A — Roadmap realism | F1, F3 | F2 shipped |
+| C — Schema drift | F4, F10 | |
+| D — Vocabulary | F5 | F6 shipped |
+| E — Ergonomics | — | F9 shipped |
+| F — v7.8.3 cutover | F11, F12, F13 | F12 highest-RICE (100) |
+| G — Test discipline | F18, F19, F20, T1 | F14/F15/F16/F17 shipped |
+| H — App-layer test coverage | T1, T4 (+ T-series, see [`test-coverage-master-plan-2026-05-13.md`](test-coverage-master-plan-2026-05-13.md)) | T3/T5/T10/T13/T14 shipped |
+| Icebox | V8-I1–V8-I7 | trigger-gated |
+
+---
+
+## 4. Cross-references
+- Parent docket framing + §3.5 Calibration Protocol + §3.6 Forward Plan: [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md)
+- T29 frozen ranking: [`v8-0-docket-ranking-2026-05-13.md`](v8-0-docket-ranking-2026-05-13.md)
+- Ready-now execution plan: [`v8-0-ready-now-workplan-2026-06-15.md`](v8-0-ready-now-workplan-2026-06-15.md)
+- Test-coverage Theme H: [`test-coverage-master-plan-2026-05-13.md`](test-coverage-master-plan-2026-05-13.md)
+- Canonical current state: [`../FRAMEWORK-FACTS.md`](../FRAMEWORK-FACTS.md)


### PR DESCRIPTION
## Summary

Separates the **v8.x candidate docket** out of the infra master plan into its own sub-plan (mirrors `test-coverage-master-plan` / `data-integrity-and-rollback` / `analytics-master-plan`), and adds an execution plan for the ungated open items.

> Replaces #714 (auto-closed when its stacked base #713 was squash-merged + branch deleted). Rebased onto current main → single clean commit.

## Changes
- **ADD** `v8-x-build-docket-2026-06-15.md` — v8.x candidate docket: reconciled status (shipped/open/icebox) + F-series Source A–E tables + V8-I icebox + T29 decision + theme distribution.
- **ADD** `v8-0-ready-now-workplan-2026-06-15.md` — the 8 ungated open items (F1/F3/F4/F5/F10/F11/F12/F13) in 3 batches with isolated-worktree + §3.5 calibration + F16 try-repo fixture constraints. First action: **F12 actionlint (RICE 100)**.
- `infra-master-plan` §3.1–3.4 → pointer to sub-plan; §3.0 roll-up kept; §3.5 Calibration + §3.6 Forward Plan stay (heavily cross-referenced).
- `master-plan/README.md` index updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)