### PR TITLE
feat(f10+f5): experiment_outcome enum + scope_change event (non-gate formalizations)

### DIFF
--- a/.claude/features/v8-f10-f5-schema-vocab/state.json
+++ b/.claude/features/v8-f10-f5-schema-vocab/state.json
@@ -1,0 +1,56 @@
+{
+  "feature_name": "v8-f10-f5-schema-vocab",
+  "current_phase": "implementation",
+  "platforms_tested": {},
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "created_at": "2026-06-15T13:00:00Z",
+  "updated_at": "2026-06-15T13:00:00Z",
+  "framework_version": "v7.10",
+  "work_type": "Chore",
+  "work_subtype": "framework_feature",
+  "has_ui": false,
+  "requires_analytics": false,
+  "state_owner": "ft2",
+  "branch": "feature/v8-f10-f5-schema-vocab",
+  "scheduled_after": null,
+  "primary_metric": "Two v8.x ready-now non-gate formalizations bundled (per #627 precedent): F10 experiment_outcome enum on tasks[] (documented + advisory) + F5 scope_change Tier 2.2 vocabulary event (documented + advisory KNOWN_EVENT_TYPES note). Neither adds a blocking gate \u2014 no calibration walk required.",
+  "success_metrics": [
+    "F10: experiment_outcome {shipped|deferred|cancelled|superseded} documented as an optional tasks[] field in the schema doc + dev-guide; advisory-only (T1, doc + example presence)",
+    "F5: scope_change documented as an official Tier 2.2 event_type in contemporaneous-logging.md; append-feature-log.py emits an informational (non-blocking) note when event_type is outside KNOWN_EVENT_TYPES (T1, presence)",
+    "docket + ready-now workplan F10 + F5 rows marked shipped (T1, section presence)"
+  ],
+  "kill_criteria": [
+    "Advisory note becomes noisy \u2014 mitigated: KNOWN_EVENT_TYPES is a generous allowlist; note is stderr-only and never changes exit code",
+    "experiment_outcome conflicts with existing tasks[].status \u2014 mitigated: experiment_outcome is orthogonal (records the disposition of a task whose work is finished: shipped vs deferred vs cancelled vs superseded), documented as complementary to status"
+  ],
+  "dispatch_pattern": "agent-driven (1 script advisory + 2 doc updates + example backfill)",
+  "spec": "docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md Batch 2 (F10 + F5) + v8-x-build-docket-2026-06-15.md \u00a70.B",
+  "scope_summary": "Bundles the two non-gate v8.x ready-now formalizations. F10: define experiment_outcome enum on tasks[] (doc + advisory, no blocking validator). F5: formalize scope_change as a Tier 2.2 event_type (doc + advisory KNOWN_EVENT_TYPES note in append-feature-log.py). Explicitly NOT new gates \u2014 no Mechanism A coverage, no calibration walk, no try-repo fixture (same posture as documentation formalizations).",
+  "related_prs": [],
+  "timing": {
+    "phases": {
+      "implementation": {
+        "started_at": "2026-06-15T13:00:00Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "F5: add scope_change to KNOWN_EVENT_TYPES advisory note in append-feature-log.py + document in contemporaneous-logging.md",
+      "status": "complete"
+    },
+    {
+      "id": "T2",
+      "description": "F10: document experiment_outcome enum on tasks[] in schema doc/dev-guide (advisory, optional field)",
+      "status": "complete"
+    },
+    {
+      "id": "T3",
+      "description": "Mark F10 + F5 shipped in docket + ready-now workplan",
+      "status": "complete"
+    }
+  ],
+  "worktree_path": "/Volumes/DevSSD/FitTracker2-infra-f5-schema-vocab",
+  "updated": "2026-06-15T12:28:31Z"
+}

--- a/.claude/logs/v8-f10-f5-schema-vocab.log.json
+++ b/.claude/logs/v8-f10-f5-schema-vocab.log.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0",
+  "feature": "v8-f10-f5-schema-vocab",
+  "title": "v8 f10 f5 schema vocab",
+  "work_type": null,
+  "current_phase": null,
+  "framework_version": null,
+  "started_at": "2026-06-15T12:30:26Z",
+  "updated_at": "2026-06-15T12:32:41Z",
+  "events": [
+    {
+      "timestamp": "2026-06-15T12:30:26Z",
+      "event_type": "scope_change",
+      "phase": "implementation",
+      "summary": "smoke: scope_change is now a known event_type",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-06-15T12:30:26Z",
+      "event_type": "frobnicate",
+      "phase": "implementation",
+      "summary": "smoke: unknown type triggers advisory",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-06-15T12:32:41Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "F10+F5 formalization bundle \u2014 implementation (worktree); ready to commit",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/docs/architecture/dev-guide-v1-to-v7-7.md
+++ b/docs/architecture/dev-guide-v1-to-v7-7.md
@@ -845,6 +845,16 @@ The hub creates `.claude/features/widget-customization/state.json` with:
 
 It also creates `.claude/logs/widget-customization.log.json` with a `phase_started` event.
 
+**`tasks[].experiment_outcome` (F10, v8.x — optional, advisory).** Each task in
+`tasks[]` may carry an `experiment_outcome` enum recording the *disposition* of a
+task whose work has concluded: `"shipped"` / `"deferred"` / `"cancelled"` /
+`"superseded"`. This is orthogonal to `tasks[].status` (`pending`/`in_progress`/
+`complete`) — `status` tracks execution state; `experiment_outcome` records *why*
+a non-shipped task ended (a deferred task and a cancelled one are both "not
+complete" but mean different things). Previously this distinction lived only in
+case-study prose. The field is **optional and advisory** — no blocking gate
+validates it (it is a vocabulary formalization, not a new enforcement layer).
+
 ### 13.2 Phase progression
 
 For each phase transition (e.g., `research → prd`):

--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -9,10 +9,10 @@
 |---|---|---|---|---|---|---|
 | 1 | **F12** | `actionlint` in pre-commit + CI | **100.0** | ~0.2w | Write-time gate | yes (`.githooks/`, `.github/workflows/`) |
 | 2 | **F11** | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | 40.0 | ~0.3w | Cycle-time gate | yes (`scripts/`) |
-| 3 | **F10** | `experiment_outcome` enum on `tasks[]` | 32.0 | ~0.3w | Schema extension | yes (`scripts/` schema) |
+| 3 | **F10** ✅ SHIPPED | `experiment_outcome` enum on `tasks[]` (documented + advisory; not a gate) | 32.0 | ~0.3w | Schema extension | yes (`scripts/` schema) |
 | 4 | **F13** | `source_commit` `workflow_dispatch` input | 32.0 | ~0.4w | GH Actions infra | yes (`.github/workflows/`) |
 | 5 | **F4** | Auto-update `framework_version` on protocol writes | 32.0 | ~0.5w | Write-time/migration | yes (`scripts/`) |
-| 6 | **F5** | `scope_change` Tier 2.2 vocabulary event | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
+| 6 | **F5** ✅ SHIPPED | `scope_change` Tier 2.2 vocabulary event (advisory note) | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
 | 7 | **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |
 | 8 | **F3** | Phase 2 dependency-graph cycle check | 14.4 | ~0.5w | Workflow gate | yes (`scripts/`) |
 

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -41,9 +41,9 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | F12 | `actionlint` in pre-commit stack | Write-time gate | **100.0 (highest)** | none — ready |
 | F11 | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | Cycle-time gate | 40.0 | none |
 | F4 | Auto-update `framework_version` on protocol writes | Write-time/migration | 32.0 | partial — `FRAMEWORK_VERSION_FORMAT` + `tracking-drift-check` (#659) cover part |
-| F10 | `experiment_outcome` enum on `tasks[]` | Schema | 32.0 | none |
+| ~~F10~~ ✅ | `experiment_outcome` enum on `tasks[]` (documented, advisory — not a blocking gate) | Schema | 32.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | F13 | `source_commit` `workflow_dispatch` input | GH Actions | 32.0 | none |
-| F5 | `scope_change` Tier 2.2 vocabulary event | Vocabulary | 20.0 | none |
+| ~~F5~~ ✅ | `scope_change` Tier 2.2 vocabulary event (advisory KNOWN_EVENT_TYPES note) | Vocabulary | 20.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | F1 | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | Cycle-time gate | 19.2 | none |
 | F3 | Phase 2 dependency-graph cycle check | Workflow gate | 14.4 | none |
 | T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** |

--- a/docs/process/contemporaneous-logging.md
+++ b/docs/process/contemporaneous-logging.md
@@ -57,7 +57,11 @@ Every event should try to answer four questions:
 Recommended fields:
 
 - `timestamp`
-- `event_type`
+- `event_type` — free-form, but the known Tier 2.2 vocabulary (F5) is:
+  `phase_started`, `phase_completed`, `test_run`, `decision`, `blocker`,
+  **`scope_change`** (a deliberate mid-lifecycle scope change — formerly logged
+  as `note`), `note`, `milestone`, `metric_captured`. Values outside this set
+  still log, but `append-feature-log.py` prints an informational note.
 - `phase`
 - `summary`
 - `artifacts`

--- a/scripts/append-feature-log.py
+++ b/scripts/append-feature-log.py
@@ -22,6 +22,23 @@ FEATURES_DIR = REPO_ROOT / ".claude" / "features"
 VALID_CACHE_LEVELS = {"L1", "L2", "L3"}
 VALID_CACHE_HIT_TYPES = {"exact", "adapted", "miss"}
 
+# F5 (v8.x ready-now): Tier 2.2 event_type vocabulary. event_type stays
+# free-form (no choices= constraint, to preserve existing usage), but a value
+# outside this allowlist emits an informational stderr note so the vocabulary
+# stays discoverable. `scope_change` is formalized here: a deliberate change to
+# a feature's scope mid-lifecycle (previously logged as event_type "note").
+KNOWN_EVENT_TYPES = {
+    "phase_started",
+    "phase_completed",
+    "test_run",
+    "decision",
+    "blocker",
+    "scope_change",
+    "note",
+    "milestone",
+    "metric_captured",
+}
+
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -205,6 +222,17 @@ def main() -> int:
         }
     events.append(event)
     log["updated_at"] = utc_now()
+
+    # F5 (advisory, non-blocking): nudge toward the known event_type vocabulary
+    # without rejecting free-form values. Never changes the exit code.
+    if args.event_type not in KNOWN_EVENT_TYPES:
+        import sys as _sys_note
+        print(
+            f"note: event_type '{args.event_type}' is outside the known Tier 2.2 "
+            f"vocabulary ({', '.join(sorted(KNOWN_EVENT_TYPES))}). "
+            "If this is a recurring kind, consider adding it to KNOWN_EVENT_TYPES.",
+            file=_sys_note.stderr,
+        )
 
     # v7.8 Mechanism I scaffolding: flock-protect the log write too.
     import sys as _sys


### PR DESCRIPTION
## Summary

Second + third items from the **v8.x ready-now workplan**, bundled (per the #627 multi-item precedent). Both are **non-gate formalizations** — no §3.5 calibration walk, no F16 try-repo fixture, same posture as documentation.

### F10 — `experiment_outcome` enum on `tasks[]` (RICE 32)
Documents an optional `{shipped|deferred|cancelled|superseded}` field in the dev-guide state.json schema section. Orthogonal to `tasks[].status` (status = execution state; experiment_outcome = *disposition* of a concluded task). Advisory/optional — **no blocking validator**.

### F5 — `scope_change` Tier 2.2 vocabulary event (RICE 20)
- `append-feature-log.py`: `KNOWN_EVENT_TYPES` allowlist (incl. `scope_change`) + an **informational stderr note** for event_types outside it. `event_type` stays free-form (no `choices=` constraint) so existing usage never breaks; the note never changes the exit code.
- Documented the vocabulary in `contemporaneous-logging.md`.

## Verification
Smoke-tested both paths: known type silent; unknown type prints the advisory and still writes the log. Docket + ready-now workplan F10/F5 rows marked shipped. Shipped in an isolated worktree per enforced BRANCH_ISOLATION Mode B.

## Note
Branched before F12 #719 merged; if #719 lands first I'll rebase (the only overlap is separate rows in the docket/workplan tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)