### PR TITLE
docs(docket): mark F13 shipped (reverse-sync source_commit + full-scan)

### DIFF
--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -10,7 +10,7 @@
 | 1 | **F12** ✅ SHIPPED | `actionlint` warn-only CI (`.github/workflows/actionlint.yml`) + `make actionlint` — reclassified CI linter (like R18), not a state.json gate | **100.0** | ~0.2w | CI linter | yes (`.github/workflows/`) |
 | 2 | **F11** | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | 40.0 | ~0.3w | Cycle-time gate | yes (`scripts/`) |
 | 3 | **F10** ✅ SHIPPED | `experiment_outcome` enum on `tasks[]` (documented + advisory; not a gate) | 32.0 | ~0.3w | Schema extension | yes (`scripts/` schema) |
-| 4 | **F13** | `source_commit` `workflow_dispatch` input | 32.0 | ~0.4w | GH Actions infra | yes (`.github/workflows/`) |
+| 4 | **F13** ✅ SHIPPED | `source_commit` `workflow_dispatch` input + full-repo-scan fallback | 32.0 | ~0.4w | GH Actions infra (fitme-story) | fitme-story PR #221 |
 | 5 | **F4** | Auto-update `framework_version` on protocol writes | 32.0 | ~0.5w | Write-time/migration | yes (`scripts/`) |
 | 6 | **F5** ✅ SHIPPED | `scope_change` Tier 2.2 vocabulary event (advisory note) | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
 | 7 | **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -42,7 +42,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | F11 | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | Cycle-time gate | 40.0 | none |
 | F4 | Auto-update `framework_version` on protocol writes | Write-time/migration | 32.0 | partial — `FRAMEWORK_VERSION_FORMAT` + `tracking-drift-check` (#659) cover part |
 | ~~F10~~ ✅ | `experiment_outcome` enum on `tasks[]` (documented, advisory — not a blocking gate) | Schema | 32.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
-| F13 | `source_commit` `workflow_dispatch` input | GH Actions | 32.0 | none |
+| ~~F13~~ ✅ | `source_commit` `workflow_dispatch` input + full-repo-scan fallback (reverse-sync) | GH Actions | 32.0 | **SHIPPED** (fitme-story PR #221 — reverse-sync workflow lives in fitme-story) |
 | ~~F5~~ ✅ | `scope_change` Tier 2.2 vocabulary event (advisory KNOWN_EVENT_TYPES note) | Vocabulary | 20.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | F1 | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | Cycle-time gate | 19.2 | none |
 | F3 | Phase 2 dependency-graph cycle check | Workflow gate | 14.4 | none |


### PR DESCRIPTION
Marks **F13** shipped in the v8.x docket + ready-now workplan. F13's substance shipped via **fitme-story PR #221** (the reverse-sync workflow lives in fitme-story). 4 of 8 ready-now items now done: F12, F10, F5, F13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)