### PR TITLE
feat(f11): reverse-sync exemption for BRANCH_ISOLATION_HISTORICAL advisory

### DIFF
--- a/.claude/features/f11-reverse-sync-historical-exempt/state.json
+++ b/.claude/features/f11-reverse-sync-historical-exempt/state.json
@@ -1,0 +1,57 @@
+{
+  "feature_name": "f11-reverse-sync-historical-exempt",
+  "current_phase": "implementation",
+  "platforms_tested": {},
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "created_at": "2026-06-15T14:00:00Z",
+  "updated_at": "2026-06-15T14:00:00Z",
+  "framework_version": "v7.10",
+  "work_type": "Chore",
+  "work_subtype": "framework_feature",
+  "has_ui": false,
+  "requires_analytics": false,
+  "state_owner": "ft2",
+  "branch": "feature/f11-reverse-sync-historical-exempt",
+  "scheduled_after": null,
+  "primary_metric": "BRANCH_ISOLATION_HISTORICAL no longer false-positives on reverse-sync-mirrored fitme-story-native state.json (state_owner_sync_origin ends with '-reverse'). F11 from the v8.x ready-now docket \u2014 additive narrowing of an existing advisory (no new calibration window; same posture as F-LAUNCHD sub-fix (a)).",
+  "success_metrics": [
+    "check_branch_isolation_historical() exempts any feature whose state_owner_sync_origin ends with '-reverse' (reverse-sync mirror) \u2014 verified by a new unit test (T1, test pass)",
+    "reverse-sync/* branch refs also count as legitimate origin in the ref-walk (secondary signal) (T1)",
+    "existing BRANCH_ISOLATION_HISTORICAL dispatch test still passes (no regression) (T1)",
+    "docket + ready-now workplan F11 row marked shipped (T1, section presence)"
+  ],
+  "kill_criteria": [
+    "Exemption too broad \u2014 silences real isolation violations. Mitigated: exemption keyed strictly on the '-reverse' suffix of state_owner_sync_origin (only the reverse-sync bot writes it) + the existing forward-only/opt-out/merge-PR guards remain.",
+    "Reverse-sync marker spoofable to bypass the advisory. Accepted: BRANCH_ISOLATION_HISTORICAL is ADVISORY (non-blocking); gaming an advisory has no enforcement payoff, and the morphed C-5 write-time gate already governs the same marker at commit time."
+  ],
+  "dispatch_pattern": "agent-driven (1 advisory narrowing in integrity-check.py + 1 unit test)",
+  "spec": "docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md Batch 3 (F11) + v8-x-build-docket-2026-06-15.md \u00a70.B; original Source C F11",
+  "scope_summary": "F11: extend the BRANCH_ISOLATION_HISTORICAL cycle-time advisory to exempt reverse-sync-mirrored fitme-story-native state.json. The reverse-sync bot writes files on a reverse-sync/* branch with state_owner_sync_origin ending in '-reverse'; those legitimately never touch a feature/* or chore/* branch in FT2 (the isolation discipline lives in the source repo), so the historical advisory false-positives on them. Adds (a) an early skip when state_owner_sync_origin ends with '-reverse', and (b) 'reverse-sync/' as a recognized origin ref. Additive narrowing of an existing advisory \u2014 no new gate, no calibration window; ships with a unit test.",
+  "related_prs": [],
+  "timing": {
+    "phases": {
+      "implementation": {
+        "started_at": "2026-06-15T14:00:00Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "Add reverse-sync exemption to check_branch_isolation_historical() (state_owner_sync_origin '-reverse' skip + reverse-sync/ ref signal)",
+      "status": "complete"
+    },
+    {
+      "id": "T2",
+      "description": "Add unit test asserting reverse-sync-mirrored state.json is exempt; confirm existing dispatch test still passes",
+      "status": "complete"
+    },
+    {
+      "id": "T3",
+      "description": "Mark F11 shipped in docket + ready-now workplan",
+      "status": "complete"
+    }
+  ],
+  "worktree_path": "/Volumes/DevSSD/FitTracker2-infra-sync-historical-exempt",
+  "updated": "2026-06-15T13:24:59Z"
+}

--- a/.claude/logs/f11-reverse-sync-historical-exempt.log.json
+++ b/.claude/logs/f11-reverse-sync-historical-exempt.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "f11-reverse-sync-historical-exempt",
+  "title": "f11 reverse sync historical exempt",
+  "work_type": "Chore",
+  "current_phase": "implementation",
+  "framework_version": "v7.10",
+  "started_at": "2026-06-15T13:24:57Z",
+  "updated_at": "2026-06-15T13:24:57Z",
+  "events": [
+    {
+      "timestamp": "2026-06-15T13:24:57Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "F11 reverse-sync exemption for BRANCH_ISOLATION_HISTORICAL \u2014 implementation start",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -10,7 +10,7 @@
 | 1 | **F12** ✅ SHIPPED | `actionlint` warn-only CI (`.github/workflows/actionlint.yml`) + `make actionlint` — reclassified CI linter (like R18), not a state.json gate | **100.0** | ~0.2w | CI linter | yes (`.github/workflows/`) |
 | 2 | **F11** | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | 40.0 | ~0.3w | Cycle-time gate | yes (`scripts/`) |
 | 3 | **F10** ✅ SHIPPED | `experiment_outcome` enum on `tasks[]` (documented + advisory; not a gate) | 32.0 | ~0.3w | Schema extension | yes (`scripts/` schema) |
-| 4 | **F13** | `source_commit` `workflow_dispatch` input | 32.0 | ~0.4w | GH Actions infra | yes (`.github/workflows/`) |
+| 4 | **F13** ✅ SHIPPED | `source_commit` `workflow_dispatch` input + full-repo-scan fallback | 32.0 | ~0.4w | GH Actions infra (fitme-story) | fitme-story PR #221 |
 | 5 | **F4** | Auto-update `framework_version` on protocol writes | 32.0 | ~0.5w | Write-time/migration | yes (`scripts/`) |
 | 6 | **F5** ✅ SHIPPED | `scope_change` Tier 2.2 vocabulary event (advisory note) | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
 | 7 | **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |

--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -8,7 +8,7 @@
 | # | ID | Item | RICE | Effort | Class | Infra-glob? |
 |---|---|---|---|---|---|---|
 | 1 | **F12** ✅ SHIPPED | `actionlint` warn-only CI (`.github/workflows/actionlint.yml`) + `make actionlint` — reclassified CI linter (like R18), not a state.json gate | **100.0** | ~0.2w | CI linter | yes (`.github/workflows/`) |
-| 2 | **F11** | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | 40.0 | ~0.3w | Cycle-time gate | yes (`scripts/`) |
+| 2 | **F11** ✅ SHIPPED | `BRANCH_ISOLATION_HISTORICAL` reverse-sync exemption (advisory narrowing, no calibration) | 40.0 | ~0.3w | Cycle-time gate | yes (`scripts/`) |
 | 3 | **F10** ✅ SHIPPED | `experiment_outcome` enum on `tasks[]` (documented + advisory; not a gate) | 32.0 | ~0.3w | Schema extension | yes (`scripts/` schema) |
 | 4 | **F13** ✅ SHIPPED | `source_commit` `workflow_dispatch` input + full-repo-scan fallback | 32.0 | ~0.4w | GH Actions infra (fitme-story) | fitme-story PR #221 |
 | 5 | **F4** | Auto-update `framework_version` on protocol writes | 32.0 | ~0.5w | Write-time/migration | yes (`scripts/`) |

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -42,7 +42,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | F11 | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | Cycle-time gate | 40.0 | none |
 | F4 | Auto-update `framework_version` on protocol writes | Write-time/migration | 32.0 | partial — `FRAMEWORK_VERSION_FORMAT` + `tracking-drift-check` (#659) cover part |
 | ~~F10~~ ✅ | `experiment_outcome` enum on `tasks[]` (documented, advisory — not a blocking gate) | Schema | 32.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
-| F13 | `source_commit` `workflow_dispatch` input | GH Actions | 32.0 | none |
+| ~~F13~~ ✅ | `source_commit` `workflow_dispatch` input + full-repo-scan fallback (reverse-sync) | GH Actions | 32.0 | **SHIPPED** (fitme-story PR #221 — reverse-sync workflow lives in fitme-story) |
 | ~~F5~~ ✅ | `scope_change` Tier 2.2 vocabulary event (advisory KNOWN_EVENT_TYPES note) | Vocabulary | 20.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | F1 | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | Cycle-time gate | 19.2 | none |
 | F3 | Phase 2 dependency-graph cycle check | Workflow gate | 14.4 | none |

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -39,7 +39,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | ID | Item | Class | RICE-est | Gating |
 |---|---|---|---|---|
 | ~~F12~~ ✅ | `actionlint` warn-only CI on `.github/workflows/**` + `make actionlint` | ~~Write-time gate~~ → **CI linter** (reclassified: warn-only tooling like R18, not a state.json gate → no calibration walk) | **100.0 (highest)** | **SHIPPED** (feature `f12-actionlint-gate`; `.github/workflows/actionlint.yml` + Makefile target) |
-| F11 | `BRANCH_ISOLATION_HISTORICAL` reverse-sync allowlist | Cycle-time gate | 40.0 | none |
+| ~~F11~~ ✅ | `BRANCH_ISOLATION_HISTORICAL` reverse-sync exemption (state_owner_sync_origin '-reverse' + reverse-sync/ ref) | Cycle-time gate | 40.0 | **SHIPPED** (feature `f11-reverse-sync-historical-exempt`; advisory narrowing — no calibration window) |
 | F4 | Auto-update `framework_version` on protocol writes | Write-time/migration | 32.0 | partial — `FRAMEWORK_VERSION_FORMAT` + `tracking-drift-check` (#659) cover part |
 | ~~F10~~ ✅ | `experiment_outcome` enum on `tasks[]` (documented, advisory — not a blocking gate) | Schema | 32.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | ~~F13~~ ✅ | `source_commit` `workflow_dispatch` input + full-repo-scan fallback (reverse-sync) | GH Actions | 32.0 | **SHIPPED** (fitme-story PR #221 — reverse-sync workflow lives in fitme-story) |

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -633,6 +633,16 @@ def check_branch_isolation_historical() -> list[dict]:
         if state.get("isolation_opt_out") is True:
             continue
 
+        # F11: exempt reverse-sync-mirrored files. The reverse-sync bot mirrors
+        # fitme-story-native state.json into FT2 on a `reverse-sync/*` branch and
+        # stamps `state_owner_sync_origin` ending in "-reverse". Such files
+        # legitimately never touch an FT2 `feature/*` or `chore/*` branch — the
+        # isolation discipline lives in the source repo — so the historical
+        # advisory would false-positive on them.
+        sync_origin = state.get("state_owner_sync_origin", "")
+        if isinstance(sync_origin, str) and sync_origin.endswith("-reverse"):
+            continue
+
         # Skip features that have a recorded merge PR — the PR existed on a
         # feature branch even if squash-merge erased the attribution from
         # `git log --source`. The advisory targets features that never had
@@ -675,7 +685,9 @@ def check_branch_isolation_historical() -> list[dict]:
             parts = line.split(None, 2)
             if len(parts) >= 2:
                 ref = parts[1] if "/" in parts[1] else ""
-                if "feature/" in ref or "chore/" in ref:
+                # F11: reverse-sync/* is also a legitimate origin (secondary
+                # signal alongside the state_owner_sync_origin "-reverse" skip).
+                if "feature/" in ref or "chore/" in ref or "reverse-sync/" in ref:
                     on_feature_branch = True
                     break
 

--- a/scripts/tests/test_integrity_check_dispatch.py
+++ b/scripts/tests/test_integrity_check_dispatch.py
@@ -144,6 +144,50 @@ def test_main_dispatch_branch_isolation_historical(monkeypatch, tmp_path, capsys
     )
 
 
+# ─── F11: reverse-sync exemption for BRANCH_ISOLATION_HISTORICAL ───────────
+
+
+def test_branch_isolation_historical_reverse_sync_exempt(monkeypatch, tmp_path):
+    """F11 — a reverse-sync-mirrored fitme-story-native state.json (with
+    state_owner_sync_origin ending in '-reverse') must NOT trigger the
+    BRANCH_ISOLATION_HISTORICAL advisory, while a normal direct-on-main
+    feature still does. Proves the exemption narrows, not silences, the gate.
+    """
+    tmp_repo = tmp_path / "repo"
+    features_dir = tmp_repo / ".claude" / "features"
+    features_dir.mkdir(parents=True)
+
+    # Reverse-synced mirror — should be EXEMPT
+    _make_feature_state(
+        features_dir,
+        "reverse-synced-feature",
+        created_at="2026-05-15T00:00:00Z",
+        extra={"state_owner_sync_origin": "fitme-story-reverse"},
+    )
+    # Normal direct-on-main feature — should still be FLAGGED
+    _make_feature_state(
+        features_dir,
+        "direct-on-main-feature",
+        created_at="2026-05-15T00:00:00Z",
+    )
+
+    monkeypatch.setattr(_mod, "REPO_ROOT", tmp_repo)
+    monkeypatch.setattr(_mod, "FEATURES_DIR", features_dir)
+    monkeypatch.setattr(_mod, "CASE_STUDIES_DIR", tmp_repo / "docs" / "case-studies")
+    # Force git to report no feature/* or chore/* branch so the advisory would
+    # fire for any non-exempt feature.
+    monkeypatch.setattr(_mod.subprocess, "check_output", lambda cmd, **kw: "")
+
+    findings = _mod.check_branch_isolation_historical()
+    flagged = {f["feature"] for f in findings}
+    assert "reverse-synced-feature" not in flagged, (
+        f"F11: reverse-synced feature must be exempt; got flagged: {flagged}"
+    )
+    assert "direct-on-main-feature" in flagged, (
+        f"F11: normal direct-on-main feature must still be flagged; got: {flagged}"
+    )
+
+
 # ─── T9: BRANCH_ISOLATION_LAUNCHD_DRIFT dispatch test ──────────────────────
 
 


### PR DESCRIPTION
## Summary

**F11** from the v8.x ready-now docket — additive narrowing of the **existing** `BRANCH_ISOLATION_HISTORICAL` cycle-time advisory.

**Problem:** the reverse-sync bot mirrors fitme-story-native `state.json` into FT2 on a `reverse-sync/*` branch with `state_owner_sync_origin` ending in `-reverse`. Those files legitimately never touch an FT2 `feature/*`/`chore/*` branch (isolation discipline lives in the source repo), so the forward-only historical advisory **false-positives** on them.

**Fix:**
- Skip any feature whose `state_owner_sync_origin` ends with `-reverse`.
- Accept `reverse-sync/` as a legitimate origin ref in the ref-walk (secondary signal).

**Posture:** additive narrowing of an existing advisory → **no new gate, no new calibration window** (same as F-LAUNCHD sub-fix (a)). It only *reduces* false positives.

**Test:** new `test_branch_isolation_historical_reverse_sync_exempt` proves the exemption **narrows** (reverse-synced feature exempt) but does **not silence** (a normal direct-on-main feature is still flagged). 2/2 historical-gate tests pass locally.

Docket + ready-now workplan F11 rows marked shipped. **5 of 8 ready-now items now done** (F12, F10, F5, F13, F11). Remaining F4/F1/F3 being scheduled as daily cloud routines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)