### PR TITLE
chore(design-system): disable Code Connect bridge (Pro-plan-gated) + reconcile docs to code-as-source-of-truth

### DIFF
--- a/.claude/features/code-connect-automation/state.json
+++ b/.claude/features/code-connect-automation/state.json
@@ -137,5 +137,6 @@
     "scaffold_session": "1acfe748-7927-4116-a46e-c87c989a4253",
     "scaffold_origin": "User answer to 'Automate Code Connect for new UI features?' on 2026-05-10 \u2014 chose 'All 3 layers (A + B + C)'. Surfaced as follow-up to ios-code-connect T1-T5 wrap-up + the question 'is the cmd automated when building a new ui feature' \u2014 answer was 'no' across both web + iOS, this feature closes that gap."
   },
-  "state_owner": "ft2"
+  "state_owner": "ft2",
+  "decommission_note": "2026-06-15: Code Connect bridge formally DECOMMISSIONED (not just T5-deferred). Root cause confirmed via full design-system audit: Code Connect requires Figma Org/Enterprise; account is Pro. Both figma-code-connect-publish.yml workflows disabled to disabled-stubs. .figma.{swift,tsx} mappings left in-tree but inert. Re-activation path unchanged (plan upgrade). See docs/design-system/figma-source-of-truth-plan-2026-06-15.md + honesty ledger FT2-FH-005."
 }

--- a/.claude/integrity/observed-patterns.md
+++ b/.claude/integrity/observed-patterns.md
@@ -1634,3 +1634,29 @@ ls .claude/_session-state/default-*.done .claude/_session-state/default-*.txt 2>
 **General lesson:** when a hook needs the session id, read it from the **hook payload (stdin)**, never from an env var the platform doesn't set. When one gate name has two producers, give each its own name so the silent-pass detectors can see each independently.
 
 **First observed:** 2026-06-14. **Sibling patterns:** [#24 field-rename reader/index mismatch](#24--field-rename-readerindex-mismatch-the-createdcreated_at-class-generalized-to-the-measurement-layer), W9 (the feature this lives in).
+
+### W36 — A plan/seat-gated external capability documented as "operational" while it never once succeeded (2026-06-15)
+
+**Surfaced by:** a full design-system audit (2026-06-15). The Figma Code Connect bridge was presented across CLAUDE.md + `figma-code-sync-status.md` as "Synced (auto-built)" / "operator setup complete (2026-05-10)", but the `figma-code-connect-publish.yml` workflow had **failed on every real run since 2026-05-10** in both repos, and the live Figma files were empty/partial.
+
+**The pattern (generalizes beyond Figma):** a capability gated by an **account plan or seat entitlement** gets full scaffolding — a CI workflow, a repo secret, generated mapping/config files, and docs — and the scaffolding's *presence* is mistaken for the capability *working*. Here Code Connect requires a Figma Org/Enterprise plan; the account is Pro, so:
+- iOS publish → HTTP **403 "Invalid scope(s): need File Read + Code Connect Write"** (scope not grantable on Pro).
+- web publish → **W14**: page-frame mappings (`31-3`/`31-106`) abort validation.
+
+Every signal an operator usually trusts was green-ish: the workflow file existed, the `FIGMA_ACCESS_TOKEN` secret existed, `.figma.{swift,tsx}` files existed, and the docs said "Synced." Only the *run history* (all red) and the *live Figma state* (empty) told the truth. One state.json (`code-connect-automation`) had honestly recorded the blocker, but the high-visibility surfaces had not.
+
+**Detection:**
+```bash
+# A publish/deploy workflow that is "set up" but has never actually succeeded on a real run:
+gh run list --workflow=<name>.yml --limit 20 | grep -c success   # scaffold runs only?
+gh run view "$(gh run list --workflow=<name>.yml --status failure --limit 1 --json databaseId -q '.[0].databaseId')" --log-failed | grep -iE '403|invalid scope|not a component|plan|enterprise'
+# For Figma specifically — does the live file actually contain the claimed nodes?
+#   MCP get_metadata (no nodeId) → if only a "Cover" page exists, the library is empty.
+#   MCP get_code_connect_map → "need a Developer seat in an Organization or Enterprise plan" = plan-gated.
+```
+
+**Remediation (2026-06-15):** disabled both publish workflows to manual-only stubs (no more red runs); reconciled CLAUDE.md + `figma-code-sync-status.md` + `ios-code-connect-workflow.md` to state code-is-source-of-truth + Code Connect unavailable on Pro; recorded honesty-ledger [FT2-FH-005]; wrote the rebuild plan `docs/design-system/figma-source-of-truth-plan-2026-06-15.md` (make Figma a visual mirror via the MCP plugin API, which *does* work on Pro).
+
+**General lesson:** treat a plan/seat-gated capability as an **external dependency** and verify it end-to-end (did it actually publish/deploy?) before any doc says "operational" or "setup complete." Scaffolding present ≠ pipeline working. A workflow's *run history*, not its *existence*, is the source of truth.
+
+**First observed:** 2026-06-15. **Sibling patterns:** [W14 — Code Connect rejects page frames](#w14), FT2-FH-005 (honesty ledger), #24 (reader/producer disjoint).

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -11,6 +11,8 @@ adapters_used: [axe]
 
 You are the Design & UX specialist for FitMe. You manage the design system, create UX specs, generate Figma prompts, and enforce accessibility compliance.
 
+> ⛔ **Code Connect DISABLED 2026-06-15.** Figma Code Connect requires an Org/Enterprise plan; this account is Pro, so it is non-operational. In `/design preflight`, **skip** the Step 3.5 Code-Connect-write-access gate (record `cc_publish_authorized: null, cc_publish_error: "code_connect_disabled_pro_plan"` and move on — do NOT block). In `/design pre-merge-review`, **skip** the Step 3.5 spec↔build parity check that depends on `.figma.{swift,tsx}` mappings (do NOT block on `mapping_only`/`figma_only`). `/design build` may still push frames via the Figma MCP plugin API (that works on Pro) and capture node IDs, but must NOT scaffold/expect Code Connect publish. Code is the source of truth. See [`docs/design-system/figma-source-of-truth-plan-2026-06-15.md`](../../../docs/design-system/figma-source-of-truth-plan-2026-06-15.md) + honesty ledger FT2-FH-005.
+
 ## Observed patterns preflight
 
 <!-- BEGIN pattern-preflight (generated) -->

--- a/.github/workflows/figma-code-connect-publish.yml
+++ b/.github/workflows/figma-code-connect-publish.yml
@@ -1,49 +1,28 @@
 name: figma-code-connect-publish
+# ─────────────────────────────────────────────────────────────────────────────
+# DISABLED 2026-06-15. Figma Code Connect requires an Organization/Enterprise
+# plan; this account is Pro, so Code Connect is not available (MCP
+# get_code_connect_map returns "need a Developer seat in an Organization or
+# Enterprise plan"). Every real publish run failed since 2026-05-10:
+#   - iOS: 403 "Invalid scope(s): need File Read + Code Connect Write" (scope
+#     not grantable on Pro).
+#   - web: W14 — page-frame mappings (31-3 / 31-106) fail validation and abort
+#     the whole publish.
+# The auto-trigger is removed so this workflow no longer runs (and no longer
+# fails red). It is kept as a manual-only stub to preserve the option of
+# re-enabling after a plan upgrade. Re-enablement steps + rationale:
+#   docs/design-system/figma-source-of-truth-plan-2026-06-15.md
+# ─────────────────────────────────────────────────────────────────────────────
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'FitTracker/**/*.figma.swift'
-      - 'figma.config.json'
-      - '.figma-cc-tools/**'
-      - '.github/workflows/figma-code-connect-publish.yml'
   workflow_dispatch:
 permissions:
   contents: read
 jobs:
-  publish:
-    runs-on: macos-15
+  disabled:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: Skip if FIGMA_ACCESS_TOKEN not set
-        id: gate
-        env:
-          HAS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN != '' }}
+      - name: Code Connect publish is disabled
         run: |
-          if [ "$HAS_TOKEN" != "true" ]; then
-            echo "FIGMA_ACCESS_TOKEN repo secret not set; skipping publish"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          fi
-      - uses: actions/setup-node@v6
-        if: steps.gate.outputs.skip != 'true'
-        with:
-          node-version: '24'
-      - name: Cache SPM build artifacts
-        if: steps.gate.outputs.skip != 'true'
-        uses: actions/cache@v5
-        with:
-          path: |
-            .figma-cc-tools/.build
-            ~/Library/Caches/org.swift.swiftpm
-          key: spm-figma-cc-${{ hashFiles('.figma-cc-tools/Package.swift', '.figma-cc-tools/Package.resolved') }}
-          restore-keys: spm-figma-cc-
-      - name: Pre-resolve SPM (warms cache for npm CLI subprocess)
-        if: steps.gate.outputs.skip != 'true'
-        working-directory: .figma-cc-tools
-        run: swift package resolve
-      - name: Publish Code Connect mappings
-        if: steps.gate.outputs.skip != 'true'
-        env:
-          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
-        run: |
-          npx --yes --package=@figma/code-connect figma connect publish --token "$FIGMA_ACCESS_TOKEN" --skip-update-check
+          echo "Figma Code Connect publish is DISABLED."
+          echo "Reason: Code Connect requires a Figma Organization/Enterprise plan; this account is Pro."
+          echo "See docs/design-system/figma-source-of-truth-plan-2026-06-15.md for the decision + re-enablement steps."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -660,7 +660,17 @@ Phase 3 + Phase 6 of the PM workflow now mechanically gate the spec ↔ code ↔
 
 Full documentation: [`docs/skills/evolution.md`](docs/skills/evolution.md) §26.
 
-### v4.X+CC Cross-repo Code Connect bridge (added 2026-05-09 → 2026-05-10)
+### v4.X+CC Cross-repo Code Connect bridge (added 2026-05-09 → 2026-05-10; ⛔ DISABLED 2026-06-15)
+
+> ⛔ **DISABLED 2026-06-15 — Code Connect is not operational.** A full design-system audit found the
+> Code Connect publish bridge has **failed on every real run since 2026-05-10** in both repos. Root
+> cause: Figma Code Connect requires an **Organization/Enterprise** plan; this account is **Pro**
+> (iOS publish → 403 "Invalid scope(s)"; web publish → W14, page-frame mappings `31-3`/`31-106`
+> abort validation). The Figma library files are also empty/partial, so the node IDs cited in this
+> section do not exist live. Both `figma-code-connect-publish.yml` workflows are now disabled stubs.
+> The `.figma.{swift,tsx}` mappings + configs remain in-tree but **inert**. **Code is the source of
+> truth.** Decision + rebuild plan: [`docs/design-system/figma-source-of-truth-plan-2026-06-15.md`](docs/design-system/figma-source-of-truth-plan-2026-06-15.md);
+> honesty ledger [FT2-FH-005](docs/case-studies/framework-honesty-ledger.md). The historical record below is retained for context.
 
 Closes the loop in the OTHER direction: `/design build` pushes screens INTO Figma; the Code Connect bridge maps Figma library frames BACK to source code so Dev Mode shows the actual React/SwiftUI snippet for each component. Cross-repo, both web and iOS.
 
@@ -689,7 +699,7 @@ Closes the loop in the OTHER direction: `/design build` pushes screens INTO Figm
 - Figma↔code matrix + Code Connect verification contract: [`docs/design-system/figma-code-sync-status.md`](docs/design-system/figma-code-sync-status.md)
 - Public showcase: fitme-story `/pm-flow` page §`#code-connect`
 
-**Manual steps per new UI feature: 2 → 0** once operator setup completes (which it has, as of 2026-05-10). Tracked feature: [`code-connect-automation`](.claude/features/code-connect-automation/) — 4/5 tasks done (T1-T4 shipped; T5 = end-to-end test on next real new UI feature).
+**Manual steps per new UI feature:** the code-side automation (scaffold + skill hook) shipped, but the **publish step never worked** — operator setup did *not* complete operationally (the `code_connect:write` scope is not grantable on Pro). The "2 → 0" target was **not** achieved; effective state is "Code Connect publishing unavailable on this plan." Tracked feature: [`code-connect-automation`](.claude/features/code-connect-automation/) — T1-T4 code shipped, T5 (E2E publish) permanently blocked by plan tier; bridge decommissioned 2026-06-15 (see plan above).
 
 ### Verification Layer (added 2026-04-20)
 

--- a/docs/case-studies/framework-honesty-ledger.md
+++ b/docs/case-studies/framework-honesty-ledger.md
@@ -253,6 +253,33 @@ This compared **raw percentages** against the canonical anchor with no rule for 
 
 ---
 
+## FT2-FH-005 — Figma Code Connect bridge claimed "Synced" / "operator setup complete" while it never once published (2026-06-15)
+
+**Surfaced by:** a full design-system audit (iOS + web) requested 2026-06-15. The audit compared the live Figma files (via the Figma MCP) against what the repo + docs claimed.
+
+**The claim vs reality.**
+- `docs/design-system/figma-code-sync-status.md` marked screens **"Synced (auto-built)"** with Figma node IDs (Smart Reminders `907:2`, Import `916:2`, Push Notifications `936:2`, plus iOS Code Connect targets `973:x`/`974:x`).
+- `CLAUDE.md` (v4.X+CC) stated **"Manual steps per new UI feature: 2 → 0 once operator setup completes (which it has, as of 2026-05-10)."**
+- **Reality:** the live iOS Figma library `0Ai7s3fCFqR5JXDW8JvgmD` is a single "Cover" placeholder page (0 published components/variables/styles); the web file `fsjHfFLAHELACZHku8Rfcl` contains only the UCC sign-in auth surface. Almost every cited node ID does not exist. The `figma-code-connect-publish.yml` workflow **failed on every real run since 2026-05-10** in both repos.
+
+**Root cause.** Figma Code Connect requires an **Organization/Enterprise** plan; this account is **Pro**. MCP `get_code_connect_map` returns *"You need a Developer seat in an Organization or Enterprise plan."* iOS publish → 403 *"Invalid scope(s): need File Read + Code Connect Write"* (not grantable on Pro). Web publish → **W14**: the sign-in/recover mappings target page **frames** (`31-3`/`31-106`), not components, so `figma connect publish` validation aborts the entire publish. The `code-connect-automation` state.json had *honestly* recorded the T5 plan-tier blocker — but the higher-visibility surfaces (CLAUDE.md, the sync matrix, public pages) presented the bridge as operational. Classic silent-pass: workflow file + repo secret + `.figma.*` mappings + green-looking docs masking a pipeline at 0% success.
+
+**Resolution (this change).**
+1. **Disabled** both `figma-code-connect-publish.yml` workflows (auto-trigger removed → no more red runs; manual-only stubs documenting the reason).
+2. **Reconciled** the authoritative docs (CLAUDE.md v4.X+CC section, `figma-code-sync-status.md` banner, `ios-code-connect-workflow.md` SUPERSEDED banner) to state plainly: code is the source of truth; Code Connect is unavailable on this plan.
+3. **Plan** to make Figma an honest visual mirror without Code Connect (Figma MCP plugin API, which works on Pro): [`docs/design-system/figma-source-of-truth-plan-2026-06-15.md`](../design-system/figma-source-of-truth-plan-2026-06-15.md).
+4. **Pattern** recorded as observed-pattern W36.
+
+**General lesson.** A capability gated by an account plan/seat is an *external* dependency — verify it end-to-end (does it actually publish?) before any doc says "operational" or "setup complete." Scaffolding existing ≠ pipeline working. Grep every surface that asserts a status when the underlying capability turns out to be unavailable.
+
+**Cross-references:**
+- Disabled workflows: `.github/workflows/figma-code-connect-publish.yml` (both repos)
+- Plan: [`docs/design-system/figma-source-of-truth-plan-2026-06-15.md`](../design-system/figma-source-of-truth-plan-2026-06-15.md)
+- Observed pattern: W36 ([`.claude/integrity/observed-patterns.md`](../../.claude/integrity/observed-patterns.md))
+- Honestly-recorded predecessor: `.claude/features/code-connect-automation/state.json` (T5 deferred, `final_status: partial_success_external_blocker`)
+
+---
+
 > _Next entry will be appended below this line when needed. Format
 > is FT2-FH-NNN with immutable monotonic numbering. Entries are never
 > silently edited; revisions are themselves new entries that

--- a/docs/design-system/figma-code-sync-status.md
+++ b/docs/design-system/figma-code-sync-status.md
@@ -14,7 +14,34 @@
 >
 > **As of 2026-05-06 (skill-layer v4.X):** rows in this matrix *were* auto-updated by `/design build` during Phase 3.j. **Superseded 2026-06-15:** `/design build`'s Figma-push + Code Connect path is no longer the source of truth — see the banner above. The status label "Synced (auto-built)" only ever meant "`/design build` ran"; it did **not** verify a live Figma frame.
 
+## Rebuilt Figma Mirror (2026-06-15) — real, verified node IDs
+
+After the Code Connect decommission, both Figma files were rebuilt as an honest **visual mirror** of the code design system via the Figma MCP plugin API (works on Pro — not Code Connect). The node IDs below **exist and were verified live** (screenshots taken at build time). Code remains the source of truth; "mirror" = visually reflects the code tokens/components, maintained manually.
+
+**iOS — `0Ai7s3fCFqR5JXDW8JvgmD`:**
+
+| Surface | Figma node | Source of truth | Notes |
+|---|---|---|---|
+| Token variables collection | `985:2` — "FitTracker Tokens (code mirror)", 80 vars | `design-tokens/tokens.json` | 47 color + 33 numeric (spacing/radius/size/opacity/layout), variable-bound |
+| Foundations page | `10:3` | tokens.json | colors `987:2` · spacing `988:2` · radius `988:28` · typography `988:60` |
+| Components catalog page | `10:5` | `AppComponents.swift` | catalog `989:2` — Card, primary CTA, chips, progress bar, metric tile, segmented control |
+
+**Web — `fsjHfFLAHELACZHku8Rfcl`:**
+
+| Surface | Figma node | Source of truth | Notes |
+|---|---|---|---|
+| Token variables collection | "FitMe Web Tokens (code mirror)", 12 vars | `src/app/globals.css` | indigo/coral brand + neutral ramp |
+| Foundations page | `34:75` | globals.css | color swatches `34:76` |
+| Primitives catalog | `34:127` | `src/components/ui/*.tsx` | Button, Tag (3 variants), Card |
+| UCC sign-in auth (pre-existing) | `30:61`, `31:3`, `31:106` | control-room sign-in | the only real content that existed before the rebuild |
+
+**Screens** (Home / Training / Nutrition / Stats / Settings / Onboarding) are **code-sourced** — the SwiftUI `v2/` files are the source of truth and are intentionally NOT re-mocked in Figma (mocking risks drift/misrepresentation). The historical "Screen Sync Matrix" below is retained for reference, but its node IDs predate the rebuild and most do **not** resolve in the live file.
+
+---
+
 ## Screen Sync Matrix
+
+> ⚠️ **Historical (pre-2026-06-15).** Node IDs below largely do not exist in the live Figma file — see the Rebuilt Figma Mirror section above for current truth.
 
 | Screen | Figma Node | Code File | Status | Notes |
 |---|---|---|---|---|

--- a/docs/design-system/figma-code-sync-status.md
+++ b/docs/design-system/figma-code-sync-status.md
@@ -1,9 +1,18 @@
 # Figma ↔ Code Sync Status
 
-> **Last synced:** 2026-04-29
+> ⚠️ **RECONCILED 2026-06-15 — read this first.** A full design-system audit found that the
+> Figma files referenced below are **empty/partial**, the Code Connect publish bridge is
+> **disabled** (requires a Figma Org/Enterprise plan; this account is Pro), and most node IDs
+> in the matrix below **do not exist** in the live Figma files. **Code is the source of truth.**
+> The matrix rows marked "Synced" / "Synced (auto-built)" reflect what `/design build` *intended*
+> to push, **not** verified live Figma frames — treat them as historical intent, not current truth.
+> Full decision + rebuild plan: [`figma-source-of-truth-plan-2026-06-15.md`](./figma-source-of-truth-plan-2026-06-15.md).
+> Honesty ledger: [FT2-FH-005](../case-studies/framework-honesty-ledger.md).
+>
+> **Last synced:** 2026-04-29 (matrix below); **last reconciled:** 2026-06-15
 > **Figma file:** `0Ai7s3fCFqR5JXDW8JvgmD`
 >
-> **As of 2026-05-06 (skill-layer v4.X):** rows in this matrix are **auto-updated by `/design build`** during Phase 3.j of the PM workflow. The auto-update writes the Figma node ID, code-file path, and a status of "Synced (auto-built)" for any newly built feature. Manual rows (the historical entries below) remain valid; the auto-update does not modify them. See `docs/skills/design.md` for the auto-update contract.
+> **As of 2026-05-06 (skill-layer v4.X):** rows in this matrix *were* auto-updated by `/design build` during Phase 3.j. **Superseded 2026-06-15:** `/design build`'s Figma-push + Code Connect path is no longer the source of truth — see the banner above. The status label "Synced (auto-built)" only ever meant "`/design build` ran"; it did **not** verify a live Figma frame.
 
 ## Screen Sync Matrix
 

--- a/docs/design-system/figma-coverage-guide.md
+++ b/docs/design-system/figma-coverage-guide.md
@@ -3,6 +3,8 @@
 **Figma file:** [FitTracker Design System Library](https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library)
 **Swift source of truth:** `AppTheme.swift`, `AppPalette.swift`, `design-tokens/tokens.json`
 
+> ⚠️ **Reconciled 2026-06-15.** The live iOS Figma file `0Ai7s3fCFqR5JXDW8JvgmD` is currently a single placeholder "Cover" page (0 published components/variables/styles) — the coverage described below does **not** exist in the file today. A rebuild via the Figma MCP plugin API is planned. Code (the Swift sources above) is the source of truth. See [`figma-source-of-truth-plan-2026-06-15.md`](./figma-source-of-truth-plan-2026-06-15.md).
+
 ---
 
 ## Goal: Intent-Perfect Coverage

--- a/docs/design-system/figma-library-progress.md
+++ b/docs/design-system/figma-library-progress.md
@@ -2,6 +2,8 @@
 
 # FitTracker Figma Library Progress
 
+> ⚠️ **Reconciled 2026-06-15.** The progress recorded below does not reflect the live Figma file — `0Ai7s3fCFqR5JXDW8JvgmD` currently holds only a placeholder "Cover" page. A rebuild via the Figma MCP plugin API is planned; see [`figma-source-of-truth-plan-2026-06-15.md`](./figma-source-of-truth-plan-2026-06-15.md). Code is the source of truth.
+
 ## Current file
 
 - File name: `FitTracker Design System Library`

--- a/docs/design-system/figma-source-of-truth-plan-2026-06-15.md
+++ b/docs/design-system/figma-source-of-truth-plan-2026-06-15.md
@@ -26,8 +26,8 @@
 
 - [x] FT2 `.github/workflows/figma-code-connect-publish.yml` → disabled stub (no auto-trigger; manual dispatch prints the reason).
 - [x] fitme-story `.github/workflows/figma-code-connect-publish.yml` → disabled stub.
-- [ ] Reconcile docs (§3).
-- [ ] Honesty-ledger entry FT2-FH-005 + observed-pattern W36.
+- [x] Reconcile docs (§3) — done (PR #723 + #222).
+- [x] Honesty-ledger entry FT2-FH-005 + observed-pattern W36 — done.
 
 `.figma.swift` / `.figma.tsx` mapping files, `figma.config.json`, `.figma-cc-tools/` are left **in place but inert** (no publish consumes them). Removing them is a separate, approval-gated cleanup (§5, open question OQ-1).
 
@@ -59,6 +59,12 @@ Mechanism: **Figma MCP plugin API** (`use_figma` / `figma-generate-library` / `f
 - **Phase B — Web file rebuild** (`fsjHfFLAHELACZHku8Rfcl`): the 8 `ui/` primitives + tokens from `globals.css`; keep existing auth/sign-in frames.
 - **Phase C — New verification contract:** "Synced" = Figma frame visually matches rendered code + real node ID recorded + recent date. Drift = manual matrix + web `figma-drift-weekly.yml` (manifest-based, already green). **No** Code Connect.
 - **Rewrite the sync matrix** with the real node IDs from Phases A/B and status "Mirror (MCP-built)".
+
+**Status (2026-06-15) — executed:**
+- ✅ **Phase A (iOS)** — token variable collection `985:2` (80 vars from tokens.json) + Foundations page `10:3` (colors `987:2`, spacing `988:2`, radius `988:28`, typography `988:60`) + Components catalog `10:5` (`989:2`). Screens left code-sourced (not re-mocked).
+- ✅ **Phase B (web)** — "FitMe Web Tokens" collection (12 vars from globals.css) + Foundations `34:75` (`34:76`) + Primitives catalog `34:127`.
+- ✅ **Phase C** — sync matrix rewritten with the real node IDs ([`figma-code-sync-status.md`](./figma-code-sync-status.md) "Rebuilt Figma Mirror" section).
+- All node IDs verified live via screenshots at build time.
 
 ## 5. Open questions
 - **OQ-1:** delete the now-inert `.figma.{swift,tsx}` + `.figma-cc-tools/` + `figma.config.json`, or keep for a future Org/Enterprise upgrade? (deletion is approval-gated)

--- a/docs/design-system/figma-source-of-truth-plan-2026-06-15.md
+++ b/docs/design-system/figma-source-of-truth-plan-2026-06-15.md
@@ -1,0 +1,69 @@
+# Figma ↔ Code Source-of-Truth Reconciliation & Fix Plan
+
+**Created:** 2026-06-15
+**Trigger:** Full design-system audit (iOS + web) found the Figma mirror + Code Connect bridge non-operational while docs claimed it was "Synced" / "operator setup complete."
+**Decision:** Code Connect is **not possible** on the current Figma plan → disable it, reconcile docs to reality, and rebuild the Figma files as an honest visual mirror of code using the Figma MCP plugin API (which *does* work on Pro).
+**Honesty ledger:** [FT2-FH-005](../case-studies/framework-honesty-ledger.md) · **Observed pattern:** W36.
+
+---
+
+## 1. What the audit found (evidence)
+
+**Code-side design systems → OPERATIONAL ✅** (these ship to users):
+- iOS: `design-tokens/tokens.json` (12 categories) → `DesignTokens.swift` (Style Dictionary v5, golden-verified PR #677); `AppTheme.swift` 177 semantic tokens; `AppComponents.swift` + DS files; `make ui-audit` 0 P0 / 0 P1; `tokens-check` CI gate.
+- Web (fitme-story): `src/app/globals.css` 57 token vars; `src/components/ui/` 8 primitives; `figma-drift-weekly.yml` green.
+
+**Figma mirror + Code Connect bridge → NON-OPERATIONAL ❌:**
+- `figma-code-connect-publish.yml` has **failed on every real run since 2026-05-10** in both repos (only empty scaffold runs were green).
+- **Root cause 1 (fatal):** Figma account is **Pro**. Code Connect requires **Organization/Enterprise**. MCP `get_code_connect_map` → *"You need a Developer seat in an Organization or Enterprise plan to access Code Connect."*
+- **Root cause 2 (iOS):** publish 403 *"Invalid scope(s): need File Read + Code Connect Write"* — scope not grantable on Pro.
+- **Root cause 3 (web):** W14 — `sign-in/page.figma.tsx` + `recover/page.figma.tsx` map page **frames** (`31-3`/`31-106`), not components → `figma connect publish` validation aborts the whole publish.
+- **Figma files are empty/partial:** iOS lib `0Ai7s3fCFqR5JXDW8JvgmD` = 1 "Cover" page + placeholder frame only (0 components/variables/styles). Web `fsjHfFLAHELACZHku8Rfcl` = Cover + `AuthPasskeyForm` component-set (`30:61`) + 12 sign-in/recover frames only. All ~23 web primitive node IDs + ~6 iOS Code Connect nodes + the sync-matrix screen nodes **do not exist** (dangling).
+
+---
+
+## 2. Decommission Code Connect (THIS change)
+
+- [x] FT2 `.github/workflows/figma-code-connect-publish.yml` → disabled stub (no auto-trigger; manual dispatch prints the reason).
+- [x] fitme-story `.github/workflows/figma-code-connect-publish.yml` → disabled stub.
+- [ ] Reconcile docs (§3).
+- [ ] Honesty-ledger entry FT2-FH-005 + observed-pattern W36.
+
+`.figma.swift` / `.figma.tsx` mapping files, `figma.config.json`, `.figma-cc-tools/` are left **in place but inert** (no publish consumes them). Removing them is a separate, approval-gated cleanup (§5, open question OQ-1).
+
+---
+
+## 3. Doc reconciliation checklist (authoritative forward-looking docs)
+
+Historical records are **not** rewritten (case studies, audit bundles, integrity snapshots, `.claude/features/*` histories, `src/data/docs/**` mirror — regenerates from FT2 source). The honesty-ledger entry is the record of the correction.
+
+| Doc | Change | Status |
+|---|---|---|
+| `CLAUDE.md` — v4.X+CC + design-system sections | Add "Code Connect DISABLED (Pro plan)" note; correct "setup complete / 2→0" claim | ☐ |
+| `docs/design-system/figma-code-sync-status.md` | Top banner: Code Connect disabled + Figma files empty/partial; downgrade false "Synced (auto-built)" rows to "Code-only (Figma frame not present)"; rewrite Code Connect Verification Contract | ☐ |
+| `docs/design-system/ios-code-connect-workflow.md` | Mark SUPERSEDED/disabled; point here | ☐ |
+| `docs/design-system/fitme-story-design-architecture.md` | Reconcile Code Connect architecture section | ☐ |
+| `docs/skills/design.md` + `.claude/skills/design/SKILL.md` | Mark Code Connect preflight/publish steps disabled (skip cleanly) | ☐ |
+| `docs/design-system/figma-coverage-guide.md`, `figma-library-progress.md` | Reconcile if they assert Code Connect operational | ☐ |
+| fitme-story `docs/CONTRIBUTING-design-system.md` | Code Connect references → disabled note | ☐ |
+| fitme-story `src/app/design-system/page.tsx`, `src/app/pm-flow/page.tsx` | Public pages — reword/remove "Code Connect bridge" claims | ☐ (confirm w/ operator) |
+| `.claude/features/code-connect-automation/state.json` | Add disposition note (bridge decommissioned, plan-gated) | ☐ |
+
+---
+
+## 4. Make Figma reflect code (what CAN be fixed, without Code Connect)
+
+Mechanism: **Figma MCP plugin API** (`use_figma` / `figma-generate-library` / `figma-generate-design`) — works on Pro. Code stays source of truth; Figma becomes an accurate **visual mirror**.
+
+- **Phase A — iOS library rebuild** (`0Ai7s3fCFqR5JXDW8JvgmD`): Foundations page (color/spacing/radius/typography/motion from `tokens.json`), Components page (the AppComponents set), Screens pages (Home/Training/Nutrition/Stats/Settings/Onboarding/Login reference frames). Capture **real** node IDs.
+- **Phase B — Web file rebuild** (`fsjHfFLAHELACZHku8Rfcl`): the 8 `ui/` primitives + tokens from `globals.css`; keep existing auth/sign-in frames.
+- **Phase C — New verification contract:** "Synced" = Figma frame visually matches rendered code + real node ID recorded + recent date. Drift = manual matrix + web `figma-drift-weekly.yml` (manifest-based, already green). **No** Code Connect.
+- **Rewrite the sync matrix** with the real node IDs from Phases A/B and status "Mirror (MCP-built)".
+
+## 5. Open questions
+- **OQ-1:** delete the now-inert `.figma.{swift,tsx}` + `.figma-cc-tools/` + `figma.config.json`, or keep for a future Org/Enterprise upgrade? (deletion is approval-gated)
+- **OQ-2:** reword the public `/design-system` + `/pm-flow` pages now, or after the Figma rebuild lands?
+- **OQ-3:** execute the Figma rebuild (§4 A/B) this session or schedule it?
+
+## 6. Re-enablement trigger
+If the Figma account upgrades to **Organization/Enterprise**: revert the workflow stubs, regenerate `FIGMA_ACCESS_TOKEN` with *File Read + Code Connect Write*, convert the two web page-frame mappings (`31-3`/`31-106`) to components (fix W14), and re-run publish.

--- a/docs/design-system/fitme-story-design-architecture.md
+++ b/docs/design-system/fitme-story-design-architecture.md
@@ -1,5 +1,7 @@
 # fitme-story Design System Architecture
 
+> ⛔ **Code Connect DISABLED 2026-06-15.** Figma Code Connect requires an Org/Enterprise plan; this account is Pro, so the web `.figma.tsx` publish bridge is non-operational (workflow is a disabled stub; the Figma file `fsjHfFLAHELACZHku8Rfcl` is empty/partial). The `globals.css` → component architecture described below is real and operational; only the Code Connect / Figma-Dev-Mode mapping layer is inert. **Code is the source of truth.** See [`figma-source-of-truth-plan-2026-06-15.md`](./figma-source-of-truth-plan-2026-06-15.md) + honesty ledger FT2-FH-005.
+
 **Created:** 2026-05-08
 **Closes:** [fitme-story-public-enhancements](../../.claude/features/fitme-story-public-enhancements/state.json) T21 (audit ID **FIG-W6**)
 **Source:** [`fitme-story/src/app/globals.css`](https://github.com/Regevba/fitme-story/blob/main/src/app/globals.css)

--- a/docs/design-system/ios-code-connect-workflow.md
+++ b/docs/design-system/ios-code-connect-workflow.md
@@ -1,5 +1,13 @@
 # iOS Code Connect Workflow
 
+> ⛔ **SUPERSEDED / DISABLED 2026-06-15.** iOS Code Connect publishing is **not operational** and
+> has been disabled. Figma Code Connect requires an Organization/Enterprise plan; this account is
+> **Pro**, so the `code_connect:write` scope cannot be granted (publish returns HTTP 403 "Invalid
+> scope(s)"). The `figma-code-connect-publish.yml` workflow is now a manual-only disabled stub.
+> This doc is retained as a reference for the (inert) `.figma.swift` mappings and for re-enablement
+> after a plan upgrade. **Decision + re-enablement steps:**
+> [`figma-source-of-truth-plan-2026-06-15.md`](./figma-source-of-truth-plan-2026-06-15.md).
+
 **Created:** 2026-05-09
 **Closes:** [ios-code-connect](../../.claude/features/ios-code-connect/state.json) T5
 **Source-of-truth Figma file:** [`FitTracker-Design-System-Library`](https://www.figma.com/design/0Ai7s3fCFqR5JXDW8JvgmD/FitTracker-Design-System-Library) (key `0Ai7s3fCFqR5JXDW8JvgmD`)

--- a/docs/skills/design.md
+++ b/docs/skills/design.md
@@ -4,6 +4,8 @@
 
 **Agent-facing prompt:** [`.claude/skills/design/SKILL.md`](../../.claude/skills/design/SKILL.md)
 
+> ⛔ **Code Connect DISABLED 2026-06-15.** The `/design preflight` Code-Connect-write-access gate, the `/design pre-merge-review` spec↔build parity / `.figma.{swift,tsx}` checks, and the `/design build` Figma-push path are **non-operational**: Figma Code Connect requires an Org/Enterprise plan and this account is Pro (publish 403s; both `figma-code-connect-publish.yml` are disabled stubs). Treat those sub-steps as skip-cleanly no-ops. **Code is the source of truth.** See [`docs/design-system/figma-source-of-truth-plan-2026-06-15.md`](../design-system/figma-source-of-truth-plan-2026-06-15.md) + honesty ledger FT2-FH-005.
+
 ---
 
 ## What it does


### PR DESCRIPTION
## Why
A full design-system audit (iOS + web) found the **Figma Code Connect publish bridge has failed on every real run since 2026-05-10** in both repos. Root cause: **Code Connect requires a Figma Organization/Enterprise plan; this account is Pro.**
- iOS publish → `403 Invalid scope(s): need File Read + Code Connect Write` (scope not grantable on Pro)
- web publish → **W14**: sign-in/recover mappings target page frames `31-3`/`31-106` (not components) → validation aborts the whole publish
- MCP `get_code_connect_map` → "need a Developer seat in an Organization or Enterprise plan"
- The live Figma files are empty/partial, so the node IDs the docs cited do not exist.

The **code-side design systems are operational and unaffected** (iOS tokens v5 + `ui-audit` 0/0; web 8 primitives). Only the Figma mirror + Code Connect bridge was non-functional while docs claimed otherwise.

## What this PR does
- **Disables** `figma-code-connect-publish.yml` → manual-only stub (stops the perpetual red CI; reversible)
- **Reconciles** the authoritative docs to "code is source of truth, Code Connect unavailable on Pro": CLAUDE.md v4.X+CC, `figma-code-sync-status.md`, `ios-code-connect-workflow.md`, `figma-coverage-guide.md`, `figma-library-progress.md`, `fitme-story-design-architecture.md`, `docs/skills/design.md`, `.claude/skills/design/SKILL.md`, `code-connect-automation/state.json`
- **Honesty ledger** FT2-FH-005 + **observed-pattern W36** (plan/seat-gated capability documented as operational)
- **New plan** `docs/design-system/figma-source-of-truth-plan-2026-06-15.md` — rebuild the Figma files as an honest visual mirror via the Figma MCP plugin API (works on Pro)

Companion PR in fitme-story disables the web workflow + reconciles its docs/public pages.