### PR TITLE
docs: truth-up stale counts, version labels, line-refs, docket math

### DIFF
--- a/.claude/features/garmin-health-connection/state.json
+++ b/.claude/features/garmin-health-connection/state.json
@@ -19,7 +19,7 @@
     },
     "total": 2.0,
     "tier_class": "B_medium",
-    "rationale": "New multi-source Data Sources Settings v2 screen + AIInputAdapter source-presence protocol + HKSource attribution probe + thin GarminAdapter (Tier-2 seam). No high-risk files touched (read-only HealthKit, additive Settings surface, no Domain/Encryption/Sync/Auth/AI). Complexity moderate (new pattern, not a deep refactor). Blast radius low-medium (user-facing Settings, but isolated). Novelty medium (first source-attribution surface; establishes the shared adapter contract for the Fitbit/Whoop/Oura siblings). Verification medium-high: device-free unit tests cover the probe + adapter, but true connect-flow verification requires a physical Garmin device + Apple-Health export (Tier 2.1 area) — ships uninstrumented for connect-rate."
+    "rationale": "New multi-source Data Sources Settings v2 screen + AIInputAdapter source-presence protocol + HKSource attribution probe + thin GarminAdapter (Tier-2 seam). No high-risk files touched (read-only HealthKit, additive Settings surface, no Domain/Encryption/Sync/Auth/AI). Complexity moderate (new pattern, not a deep refactor). Blast radius low-medium (user-facing Settings, but isolated). Novelty medium (first source-attribution surface; establishes the shared adapter contract for the Fitbit/Whoop/Oura siblings). Verification medium-high: device-free unit tests cover the probe + adapter, but true connect-flow verification requires a physical Garmin device + Apple-Health export (Tier 2.1 area) \u2014 ships uninstrumented for connect-rate."
   },
   "has_ui": true,
   "requires_analytics": true,
@@ -76,7 +76,7 @@
       "started_at": "2026-06-12T19:11:27Z",
       "ended_at": "2026-06-14T13:43:07Z",
       "approved_by": "operator",
-      "approval_signal": "post-merge closure batch — case study + showcase MDX shipped (FT2 #709 + fitme-story #219)"
+      "approval_signal": "post-merge closure batch \u2014 case study + showcase MDX shipped (FT2 #709 + fitme-story #219)"
     },
     "metrics": {
       "primary": {
@@ -98,13 +98,13 @@
       "instrumentation_ready": false,
       "first_review_date": "2026-06-26",
       "kill_criteria": "If <20% of users who open Data Sources with a Garmin device complete a connection within 60 days, reassess Tier 1 UX value vs jumping to a Tier-2 demand signal.",
-      "kill_criteria_resolution": "not_yet_evaluated — pre-registered threshold: <20% of Garmin-device users who open Data Sources complete a connection within 60 days. First review 14d post-launch; kill checkpoint at 60d. Tier-1 ships uninstrumented for connect-rate; baseline 0."
+      "kill_criteria_resolution": "not_yet_evaluated \u2014 pre-registered threshold: <20% of Garmin-device users who open Data Sources complete a connection within 60 days. First review 14d post-launch; kill checkpoint at 60d. Tier-1 ships uninstrumented for connect-rate; baseline 0."
     },
     "docs": {
       "started_at": "2026-06-12T19:11:27Z",
       "ended_at": "2026-06-14T13:43:07Z",
       "approved_by": "operator",
-      "approval_signal": "(post-merge closure batch — case study + backlog strike shipped in feature PR)"
+      "approval_signal": "(post-merge closure batch \u2014 case study + backlog strike shipped in feature PR)"
     },
     "complete": {
       "started_at": "2026-06-14T13:43:07Z",
@@ -222,7 +222,7 @@
       "to": "review",
       "at": "2026-06-11T16:44:18Z",
       "approved": true,
-      "note": "backfill — review entered post-testing"
+      "note": "backfill \u2014 review entered post-testing"
     },
     {
       "from": "review",
@@ -253,11 +253,11 @@
       "from": "docs",
       "to": "complete",
       "at": "2026-06-14T13:43:07Z",
-      "reason": "Feature CLOSED via close-feature.py on chore/garmin-health-connection-post-merge-closure. Closes the testing→complete drift-pattern documented across 5+ instances by automating the post-merge audit trail."
+      "reason": "Feature CLOSED via close-feature.py on chore/garmin-health-connection-post-merge-closure. Closes the testing\u2192complete drift-pattern documented across 5+ instances by automating the post-merge audit trail."
     }
   ],
   "sibling_feature": "fitbit-health-connection",
-  "parent_backlog": "Task 10 — Health API connections (Garmin/Whoop/Oura/Samsung/Fitbit)",
+  "parent_backlog": "Task 10 \u2014 Health API connections (Garmin/Whoop/Oura/Samsung/Fitbit)",
   "timing": {
     "session_start": "2026-06-10T17:09:49Z",
     "phases": {
@@ -319,7 +319,7 @@
     "ai": false
   },
   "platforms_tested_provenance": "authored",
-  "implementation_note": "Offline-verified: 6 new files swiftc -parse clean; ui-audit P0=0 + DataSourcesScreen 0 findings. Full xcodebuild NOT runnable locally (SPM binary artifacts unresolved + offline) — CI enforces build+test. T9 tests written (device-free), CI-verification pending.",
+  "implementation_note": "Offline-verified: 6 new files swiftc -parse clean; ui-audit P0=0 + DataSourcesScreen 0 findings. Full xcodebuild NOT runnable locally (SPM binary artifacts unresolved + offline) \u2014 CI enforces build+test. T9 tests written (device-free), CI-verification pending.",
   "cache_hits": [
     {
       "ts": "2026-06-12T04:11:38Z",
@@ -345,5 +345,6 @@
   "merge_commit_sha": "c8ba2993bf6986825bff97dde91af319997686a3",
   "merged_at": "2026-06-12T19:11:27Z",
   "case_study": "docs/case-studies/garmin-health-connection-case-study.md",
-  "feature_branch_merged": "feature/garmin-health-connection"
+  "feature_branch_merged": "feature/garmin-health-connection",
+  "linear_issue": "FIT-199"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable FitTracker milestones are summarized here in human-readable form.
 
 This changelog is intentionally lightweight. It is not a commit dump and it is not a replacement for the README or the full walkthrough.
 
+> **Framework work (v7.5 → v7.10, 2026-04-24 → 2026-06-10) is tracked elsewhere, not here.** This changelog froze at 2026-04-07 for the product app; the Data Integrity Framework's per-version history lives in the version sections of [`CLAUDE.md`](CLAUDE.md), the cold-start summaries in [`.claude/entrypoints/`](.claude/entrypoints/), the per-feature case studies in [`docs/case-studies/`](docs/case-studies/), and the canonical machine-derived gate counts in [`docs/FRAMEWORK-FACTS.md`](docs/FRAMEWORK-FACTS.md). Product-app feature changes resume below.
+
 ## 2026-04-07 — Onboarding v2 UX Alignment + 4-Day Branch Consolidation
 
 PR #59 — squash-merged to main as `66e42cf`. Pilot run for the sequential UX alignment initiative; first feature in the feature-by-feature pass against `docs/design-system/ux-foundations.md`. Also consolidates 4 days of unmerged design system, UX foundations, marketing website, GDPR, GA4, and skills ecosystem work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Backlog rows + v7.9.1+ docket entries carry an **impact tier label** like `(cu_v
 
 **Why this taxonomy:** before v7.9.1, the Feature/Enhancement/Fix/Chore taxonomy left an ambiguous middle for "this is bigger than a chore but doesn't need a PRD because the scope is mechanical (e.g. add a schema field + backfill)." Operators had to pick Feature (heavy) or Enhancement (technically requires parent PRD — which doesn't exist for net-new framework scaffolding). B_medium formalizes that middle: a `Feature` work_type with `work_subtype: b_medium` may skip PRD/tasks/UX phases as long as the skip reason is documented in `phases.<skipped>.skip_reason` per the existing skipped-phase audit-trail mechanism.
 
-**Forward-only:** existing backlog rows with `B_medium` labels (e.g. v8.x icebox L417 style-dictionary v5 migration) retain their label. New work items use the table above to choose. Old rows are not retroactively re-labeled.
+**Forward-only:** existing backlog rows with `B_medium` labels (e.g. the v8.x icebox style-dictionary v5 migration — since shipped 2026-06-08 via PR #677) retain their label. New work items use the table above to choose. Old rows are not retroactively re-labeled.
 
 ## Branching Strategy
 
@@ -316,7 +316,7 @@ v7.8.6 ships observability surfaces that close the **96-hour drift window** betw
 
 ## v7.9 Promotion Release (shipped 2026-05-21)
 
-v7.9 is the **enforcement-flip release** for the three v7.8.1 advisory gates that completed their 14-day Mechanism A telemetry window on 2026-05-21. No new gate code; no new schema fields; no new observability surfaces. The single change is `BRANCH_ISOLATION_ADVISORY_MODE = True → False` at [`scripts/check-state-schema.py:132`](scripts/check-state-schema.py), which controls all three gates simultaneously.
+v7.9 is the **enforcement-flip release** for the three v7.8.1 advisory gates that completed their 14-day Mechanism A telemetry window on 2026-05-21. No new gate code; no new schema fields; no new observability surfaces. The single change is `BRANCH_ISOLATION_ADVISORY_MODE = True → False` at [`scripts/check-state-schema.py:149`](scripts/check-state-schema.py), which controls all three gates simultaneously.
 
 **Promotion decision criteria (per [infra master plan §2.2](docs/master-plan/infra-master-plan-2026-05-12.md)):** all four required for each candidate.
 
@@ -352,7 +352,7 @@ v7.9 is the **enforcement-flip release** for the three v7.8.1 advisory gates tha
 - **2026-05-28** — B2 post-v7.9 baseline snapshot via `make snapshot-phase PHASE=post-v7-9-baseline FEATURE=framework-v7-8-branch-isolation`
 - **~2026-06-04** — Phase E exit; v7.9.1 build window opens
 
-**Reversibility runbook:** if a regression surfaces during Phase E soak, flip back via single-line edit at [`scripts/check-state-schema.py:132`](scripts/check-state-schema.py) (`BRANCH_ISOLATION_ADVISORY_MODE = True`), commit on `chore/v7-9-rollback`, merge to main. <5 min end-to-end.
+**Reversibility runbook:** if a regression surfaces during Phase E soak, flip back via single-line edit at [`scripts/check-state-schema.py:149`](scripts/check-state-schema.py) (`BRANCH_ISOLATION_ADVISORY_MODE = True`), commit on `chore/v7-9-rollback`, merge to main. <5 min end-to-end.
 
 **Case study:** [`docs/case-studies/framework-v7-9-promotion-case-study.md`](docs/case-studies/framework-v7-9-promotion-case-study.md).
 **Cold-start entrypoint:** [`.claude/entrypoints/framework-v7-9.md`](.claude/entrypoints/framework-v7-9.md).
@@ -629,8 +629,8 @@ This app is data-driven at every level:
 
 The design system is a **living, evolving framework** — not a static constraint. It should serve the product.
 
-- ~125 semantic tokens in `FitTracker/Services/AppTheme.swift`
-- 13 reusable components in `FitTracker/DesignSystem/`
+- ~175 semantic tokens in `FitTracker/Services/AppTheme.swift`
+- 17 reusable components in `FitTracker/DesignSystem/`
 - Token pipeline: `design-tokens/tokens.json` → Style Dictionary → `DesignTokens.swift`
 - CI gate: `make tokens-check` prevents token drift
 - Always use semantic tokens (AppColor, AppText, AppSpacing) — never raw literals
@@ -719,8 +719,8 @@ colorset.
   (Gap-A: `Color("name")` in AppTheme without a backing colorset).
 - **Baseline:** `docs/design-system/ui-audit-baseline.md` (regenerate
   with `make ui-audit-baseline`). Baseline snapshot: 0 P0 + 103 P1
-  (P0 burndown completed 2026-05-05); current live: 0 P0 + 108 P1
-  (P1 drift +5 since baseline, fix-as-you-touch active).
+  (P0 burndown completed 2026-05-05); current live: 0 P0 + 0 P1
+  (P1 burndown fully completed since baseline; verify with `make ui-audit`).
 - **Fix-as-you-touch rule:** any PR touching a file with findings should
   clear that file's findings as part of the change. `ui-audit` is now a
   hard gate within `verify-local` (achieved 2026-05-05 once P0 baseline
@@ -875,7 +875,7 @@ The rule applies prospectively from 2026-04-08. Existing events that pre-date th
 - Handoff archive: `docs/master-plan/` (all session summaries, stabilization reports, branch reviews)
 
 ### Skills ecosystem
-- **DEV-only framework guide (v1.0 → v7.8):** [`docs/architecture/dev-guide-v1-to-v7-7.md`](docs/architecture/dev-guide-v1-to-v7-7.md) — start here if you are a developer onboarding to the framework. Covers the 4 enforcement layers, `state.json` schema, phase lifecycle, dispatch model, cache architecture, measurement protocol, integrity check codes (12 write-time + 13 cycle-time + 3 advisory in v7.8), §2.4 v7.8 bridge mechanisms (A–F), and operational walkthroughs (adding a feature, extending a check code, bumping the framework version). Filename retained at `-v7-7` for ref-stability across 16+ cross-references in FT2 + fitme-story; content tracks v7.8 (last bumped 2026-05-07).
+- **DEV-only framework guide (v1.0 → v7.9.1):** [`docs/architecture/dev-guide-v1-to-v7-7.md`](docs/architecture/dev-guide-v1-to-v7-7.md) — start here if you are a developer onboarding to the framework. Covers the 4 enforcement layers, `state.json` schema, phase lifecycle, dispatch model, cache architecture, measurement protocol, integrity check codes, §2.4 bridge mechanisms (A–F), and operational walkthroughs (adding a feature, extending a check code, bumping the framework version). Filename retained at `-v7-7` for ref-stability across 16+ cross-references in FT2 + fitme-story; content tracks v7.9.1. **Current framework state is v7.10 (shipped 2026-06-10); for canonical, machine-derived gate counts always defer to [`docs/FRAMEWORK-FACTS.md`](docs/FRAMEWORK-FACTS.md)** — the per-version count prose scattered through this file is an accurate record of each era, not necessarily current state.
 - **Lifecycle event catalog (companion to dev-guide):** [`docs/architecture/feature-lifecycle-event-catalog.md`](docs/architecture/feature-lifecycle-event-catalog.md) — answers "at any point in a feature's lifecycle, what should be triggered, logged, measured, and persisted, and which gate enforces it?" 12 sections + 2 mermaid flow diagrams (L0 phase lifecycle + per-commit fan-out across all 4 loops). Authoritative spec source for the planned `FEATURE_CLOSURE_COMPLETENESS` gate ([`framework-v7-8-branch-isolation`](.claude/features/framework-v7-8-branch-isolation/state.json)).
 - Skills one-pager: `docs/skills/README.md`
 - Skills architecture deep-dive: `docs/skills/architecture.md` (merged from former skills-ecosystem.md + skills-ecosystem-analysis.md)

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -58,7 +58,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 
 **D. Operator decision open:** W-MISTRAL-VERCEL-FREE-TIER-BURST (API-tier choice for multi-provider HADF experiments).
 
-**Roll-up:** of the original 18 F-candidates, **8 shipped** (F2, F6, F9, F14, F15, F16, F17 + GATE_COVERAGE_ZERO) + 2 resolved-by-exemption (F7, F8) → **8 F-items remain open** (F1, F3, F4, F5, F10, F11, F12, F13) + F18 + F19–F23. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
+**Roll-up:** of the original 18 F-candidates, **13 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 — the last five all merged to main 2026-06-15 via PRs #719/#720/#721/#722) + 2 resolved-by-exemption (F7, F8) → **3 F-items remain open** (F1, F3, F4) + F18 + F19–F23. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
 
 ---
 


### PR DESCRIPTION
Doc-vs-reality drift found in the 2026-06-15 full-system audit that survived the v7.10 doc-alignment (#712).

**CLAUDE.md**
- Design-system counts: `~125→~175` tokens, `13→17` components (verified actual)
- ui-audit baseline `0 P0 + 108 P1` → `0 P0 + 0 P1` (P1 burndown completed; `make ui-audit` confirms)
- `check-state-schema.py:132` → `:149` (×2, incl. the <5-min rollback runbook ref — was pointing at the wrong line)
- dev-guide label `v7.8` → `v7.9.1` + first pointer to `docs/FRAMEWORK-FACTS.md` as the canonical gate-count source (CLAUDE.md had **0** references to it)
- style-dictionary v5 "icebox" example marked shipped (#677)

**v8-x-build-docket** — roll-up math `8 shipped / 8 open` → `13 shipped / 3 open (F1,F3,F4)`. F5/F10/F11/F12/F13 all merged 2026-06-15 but prose still listed them open (the F2 reality-check drift class, in a doc).

**CHANGELOG.md** (frozen 2026-04-07) — pointer noting framework v7.5→v7.10 history lives in CLAUDE.md / entrypoints / case-studies / FRAMEWORK-FACTS.

**state.json** — garmin `linear_issue = FIT-199` (issue created today to close the no-Linear-footprint gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)