### PR TITLE
chore(ai-engine): document confidence-formula contract + drop dead totals param

### DIFF
--- a/ai-engine/app/services/insight_service.py
+++ b/ai-engine/app/services/insight_service.py
@@ -33,21 +33,28 @@ class InsightService:
 
         total_cohort_size = sum(cohort_totals.values())
         populated_buckets = sum(1 for v in cohort_totals.values() if v > 0)
+        # NOTE: coverage_ratio divides cohort buckets by user-field count. These
+        # are only commensurable because the production caller
+        # (CohortService.get_cohort_totals) returns exactly one bucket per user
+        # field — keyed "<field>:<value>". If a future caller passes cohort_totals
+        # with a different cardinality, this ratio loses its "coverage" meaning and
+        # confidence scores shift. Keep the 1:1 field↔bucket contract, or redesign
+        # this metric, before changing get_cohort_totals's return shape.
         coverage_ratio = populated_buckets / max(len(user_fields), 1)
 
         # ── Segment-specific rules ─────────────────────────────
 
         if segment == "training":
-            signals.extend(self._training_signals(user_fields, cohort_totals))
+            signals.extend(self._training_signals(user_fields))
 
         elif segment == "nutrition":
-            signals.extend(self._nutrition_signals(user_fields, cohort_totals))
+            signals.extend(self._nutrition_signals(user_fields))
 
         elif segment == "recovery":
-            signals.extend(self._recovery_signals(user_fields, cohort_totals))
+            signals.extend(self._recovery_signals(user_fields))
 
         elif segment == "stats":
-            signals.extend(self._stats_signals(user_fields, cohort_totals))
+            signals.extend(self._stats_signals(user_fields))
 
         # ── Confidence scoring ─────────────────────────────────
         # Coverage ratio × normalised cohort size signal
@@ -71,9 +78,7 @@ class InsightService:
 
     # ── Private rule helpers ───────────────────────────────────
 
-    def _training_signals(
-        self, fields: dict[str, str], totals: dict[str, int]
-    ) -> list[str]:
+    def _training_signals(self, fields: dict[str, str]) -> list[str]:
         signals: list[str] = []
 
         goal = fields.get("primary_goal", "")
@@ -89,9 +94,7 @@ class InsightService:
 
         return signals
 
-    def _nutrition_signals(
-        self, fields: dict[str, str], totals: dict[str, int]
-    ) -> list[str]:
+    def _nutrition_signals(self, fields: dict[str, str]) -> list[str]:
         signals: list[str] = []
 
         balance = fields.get("caloric_balance_band", "")
@@ -106,9 +109,7 @@ class InsightService:
 
         return signals
 
-    def _recovery_signals(
-        self, fields: dict[str, str], totals: dict[str, int]
-    ) -> list[str]:
+    def _recovery_signals(self, fields: dict[str, str]) -> list[str]:
         signals: list[str] = []
 
         sleep = fields.get("sleep_duration_band", "")
@@ -124,9 +125,7 @@ class InsightService:
 
         return signals
 
-    def _stats_signals(
-        self, fields: dict[str, str], totals: dict[str, int]
-    ) -> list[str]:
+    def _stats_signals(self, fields: dict[str, str]) -> list[str]:
         signals: list[str] = []
 
         consistency = fields.get("workout_consistency_band", "")


### PR DESCRIPTION
Two no-behavior-change cleanups from the 2026-06-15 audit (AI layer):

1. **Confidence formula contract** — `coverage_ratio` divides cohort buckets by user-field count; these are commensurable *only* because the production caller (`CohortService.get_cohort_totals`) returns one bucket per user field. Added a `NOTE` documenting that 1:1 contract so a future change to the return shape doesn't silently shift confidence scores. (The audit flagged this as a latent trap; output is intentionally unchanged.)
2. **Dead param** — the `totals` arg on all four `_*_signals` helpers was never read. Removed it + the 4 call sites. Helpers are internal-only (grep-verified); `generate()` signature unchanged → golden tests unaffected.

Verified locally: `py_compile` + direct `generate()` smoke run reproduce identical signals/confidence/escalate. CI runs the full golden suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)