### PR TITLE
fix(backend): enforce k-anonymity floor in cohort_stats RLS (DB-layer)

### DIFF
--- a/backend/supabase/migrations/000010_cohort_stats_k_anon_rls.sql
+++ b/backend/supabase/migrations/000010_cohort_stats_k_anon_rls.sql
@@ -1,0 +1,30 @@
+-- Migration 000010: enforce the k-anonymity floor in cohort_stats authenticated RLS
+--
+-- Fixes a privacy gap found in the 2026-06-15 audit. Migration 000003's
+-- authenticated SELECT policy used `USING (true)`, so ANY logged-in user could
+-- read sub-threshold cohort buckets directly via PostgREST
+-- (`GET /rest/v1/cohort_stats`) with their own JWT — bypassing the k>=50
+-- anonymity floor that previously lived ONLY in AI-engine app code
+-- (`cohort_service.get_cohort_totals`). This pushes the k-anonymity guarantee
+-- down to the database layer, where it cannot be bypassed.
+--
+-- The AI engine is UNAFFECTED: it reads via the `service_role` key, which
+-- bypasses RLS (covered by `cohort_stats_service_role_all`) and continues to
+-- apply the same floor in app code.
+--
+-- NOTE: the threshold 50 is hardcoded to match `settings.k_anonymity_floor`'s
+-- default. RLS cannot read app config; if that setting is ever changed, update
+-- this policy in a follow-up migration to keep the two in lockstep.
+
+DROP POLICY IF EXISTS "cohort_stats_authenticated_read" ON cohort_stats;
+
+CREATE POLICY "cohort_stats_authenticated_read_k_anon"
+  ON cohort_stats
+  FOR SELECT
+  TO authenticated
+  USING (frequency >= 50);  -- k-anonymity floor
+
+COMMENT ON POLICY "cohort_stats_authenticated_read_k_anon" ON cohort_stats IS
+  'Authenticated reads limited to buckets with frequency >= 50 (k-anonymity '
+  'floor). Sub-threshold buckets are visible only to service_role (AI engine), '
+  'which applies the same floor in app code. Closes the 000003 USING(true) bypass.';


### PR DESCRIPTION
## Privacy gap (audit 2026-06-15, P1)
Migration `000003`'s authenticated SELECT policy on `cohort_stats` used `USING (true)` — so **any logged-in user** could read sub-threshold cohort buckets directly via `GET /rest/v1/cohort_stats` with their own JWT, bypassing the **k≥50** anonymity floor that lived only in AI-engine app code (`cohort_service.get_cohort_totals`).

## Fix
`000010` replaces the policy with `USING (frequency >= 50)` — pushing the k-anonymity guarantee down to the DB layer where it can't be bypassed.

- **AI engine unaffected** — it reads via `service_role` (bypasses RLS, covered by `cohort_stats_service_role_all`) and keeps applying the floor in app code.
- Threshold hardcoded to `50` to match `settings.k_anonymity_floor`'s default; comment notes the two must stay in lockstep.

## Notes for the operator
- **Applying to the live DB is a deploy/migration step** (this PR only adds the file). Backend CI validates it compiles + RLS stays enabled, but the CI stub uses a fixed `auth.uid()` and does **not** behaviorally test the policy.
- Quick sanity to confirm no client relies on direct sub-threshold reads: the iOS app is expected to read cohort data only through the service-role AI engine. If anything reads `cohort_stats` directly with a user JWT expecting <50 buckets, it would now see fewer rows (which is the intended privacy behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)