### PR TITLE
fix(sync): guard mergeDailyLog against clobbering unsaved local edits

### DIFF
--- a/FitTracker/Services/Encryption/EncryptionService.swift
+++ b/FitTracker/Services/Encryption/EncryptionService.swift
@@ -1137,6 +1137,7 @@ final class EncryptedDataStore: ObservableObject {
         if let i = dailyLogs.firstIndex(where: {
             $0.resolvedLogicDayKey == remoteLogicDayKey
         }) {
+            guard !dailyLogs[i].needsSync else { return }  // local unsaved — skip (parity with mergeWeeklySnapshot)
             if remote.lastModified > dailyLogs[i].lastModified {
                 dailyLogs[i] = remote
             }


### PR DESCRIPTION
## Bug (audit 2026-06-15, P2)
`EncryptionService.mergeDailyLog` did last-write-wins purely on `remote.lastModified`, with **no `needsSync` check**. A Supabase pull arriving with a newer server timestamp could overwrite a local daily-log edit the user hadn't pushed yet — silent data loss.

The sibling `mergeWeeklySnapshot` already guards this (`guard !needsSync`), and the CloudKit `fetchChanges` path checks `needsSync` too. Only the Supabase daily-log merge was exposed — an asymmetry, not a deliberate choice.

## Fix
Add the same guard so an unsynced local log wins until it's pushed (then `needsSync` clears and remote merges normally via the existing timestamp LWW).

```swift
guard !dailyLogs[i].needsSync else { return }  // local unsaved — skip
```

⚠️ **HIGH-RISK area** (`EncryptionService`) — requests extra review per CLAUDE.md. CI runs the EncryptionService sync suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)