### PR TITLE
chore(shared): refresh source-health ledgers from 2026-06-15 live probe

### DIFF
--- a/.claude/shared/external-sync-status.json
+++ b/.claude/shared/external-sync-status.json
@@ -1,11 +1,13 @@
 {
-  "version": "1.0",
-  "updated": "2026-05-17T19:35:00Z",
+  "version": "1.1",
+  "updated": "2026-06-15T00:00:00Z",
   "description": "Live external-tool sync snapshot for the FitMe PM framework. Captures the current state of GitHub, Linear, Notion, Vercel, and analytics/observability so the dashboard can compare repo truth against workspace truth without relying on narrative docs alone.",
   "aggregate": {
     "healthy": true,
     "alerts": 0,
-    "source_truth_score": 95
+    "source_truth_score": 95,
+    "last_live_probe": "2026-06-15",
+    "last_live_probe_note": "Refreshed 2026-06-15 via gh CLI (GitHub) + Linear/Notion/Vercel/GA4/Supabase MCP. Per-source summary numbers (Linear counts, Vercel deploys, Notion timestamps, GA4 DAU) updated to live values; older narrative findings retained for history."
   },
   "sources": {
     "github": {
@@ -13,15 +15,19 @@
       "alerts": 0,
       "repo": "Regevba/FitTracker2",
       "repo_summary": {
-        "current_branch": "main",
-        "remote_branch": "origin/main",
+        "current_branch": "docs/audit-remaining-fixes-spec",
+        "remote_branch": "origin/docs/audit-remaining-fixes-spec",
         "remote_sync": "aligned",
-        "working_tree_changes": 0,
-        "local_branches": 8,
-        "remote_branches": 7,
-        "live_issue_api_connected": false
+        "working_tree_changes": 6,
+        "local_branches": 15,
+        "remote_branches": 31,
+        "open_prs_ft2": 1,
+        "open_prs_fitme_story": 0,
+        "live_issue_api_connected": true,
+        "as_of": "2026-06-15"
       },
       "findings": [
+        "2026-06-15 live probe: on branch docs/audit-remaining-fixes-spec (aligned with origin), 6 working-tree changes (shared ledger JSON). 1 open PR FT2 (#716 weekly framework-status snapshot), 0 open fitme-story. 15 local / 31 remote branches. Framework v7.10 shipped 2026-06-10; 102/106 features complete.",
         "Repo is on main, aligned with origin/main. 44 shipped features, 197+ tests passing.",
         "Full Linear + Notion sync completed 2026-04-15 with 42 Linear issues and 8 Notion pages aligned.",
         "Dashboard tab navigation and case study link bugs fixed and deployed to production.",
@@ -39,33 +45,29 @@
       "workspace_team": "Fitme project",
       "project": {
         "name": "FitTracker Roadmap",
-        "status": "Started",
-        "updated_at": "2026-04-26T05:00:00Z",
+        "status": "In Progress",
+        "updated_at": "2026-06-15T00:00:00Z",
         "url": "https://linear.app/fitme-project/project/fittracker-roadmap-cf39fc387606"
       },
       "issue_summary": {
-        "total": 49,
+        "total": 48,
         "todo": 9,
-        "backlog": 2,
-        "in_progress": 6,
-        "done": 28,
-        "canceled": 4
+        "backlog": 15,
+        "in_progress": 1,
+        "done": 23,
+        "canceled": 4,
+        "as_of": "2026-06-15",
+        "note": "Live counts via list_issues 2026-06-15 (excludes 4 canceled from the 48 active total). Prior snapshot 2026-05-17 read 49 total / 28 done / 6 in_progress / 2 backlog."
       },
       "milestones": [
-        {
-          "name": "Milestone 1 \u2014 Foundations",
-          "progress": "67%"
-        },
-        {
-          "name": "Milestone 3 \u2014 Experience cleanup",
-          "progress": "33%"
-        },
-        {
-          "name": "Milestone 5 \u2014 Brand and release readiness",
-          "progress": "0%"
-        }
+        { "name": "Milestone 1 \u2014 Foundations", "progress": "100%" },
+        { "name": "Milestone 2 \u2014 Clinical data foundation", "progress": "0%" },
+        { "name": "Milestone 3 \u2014 Experience cleanup", "progress": "33%" },
+        { "name": "Milestone 4 \u2014 Health intelligence and insights", "progress": "0%" },
+        { "name": "Milestone 5 \u2014 Brand and release readiness", "progress": "13%" }
       ],
       "findings": [
+        "2026-06-15 live probe: 48 active issues \u2014 23 Done, 15 Backlog, 9 Todo, 1 In Progress (+4 canceled). Milestones: M1 Foundations 100%, M2 Clinical data 0%, M3 Experience cleanup 33%, M4 Health intelligence 0%, M5 Brand/release 13%.",
         "Full sync completed 2026-04-15: 42 issues total, 18 Done, 7 In Progress, 11 Todo, 4 Canceled (FIT-1\u2013FIT-4 onboarding stubs).",
         "14 new Done issues created for shipped v2 screens, cards, formulas, and infrastructure (FIT-27 through FIT-40).",
         "FIT-41 (User Profile Settings) and FIT-42 (Smart Reminders) created for active/planned work.",
@@ -173,7 +175,10 @@
       "page_summary": {
         "tracked_pages": 9,
         "status_pages": 7,
-        "pages_with_known_drift": 0
+        "pages_with_known_drift": 0,
+        "as_of": "2026-06-15",
+        "roadmap_last_updated": "2026-06-15T16:24:00Z",
+        "live_probe_note": "2026-06-15 search confirmed Roadmap page updated today (2026-06-15 16:24Z); 'Framework v7.9 — Promotion Release' page last touched 2026-06-07; Project Hub + Product Hub reachable."
       },
       "tracked_pages": [
         {
@@ -250,6 +255,16 @@
       "healthy": true,
       "alerts": 0,
       "team": "regevba-3729's projects",
+      "live_probe_2026_06_15": {
+        "active_project": "fitme-story",
+        "project_id": "prj_poCIThWeTrYTMtarke0OxEu7CZMB",
+        "latest_production_deploy": "dpl_ce3zRFfoC5zPD6TqGYY4yBpirerG",
+        "latest_production_state": "READY",
+        "latest_production_commit": "fix(control-room): update framework version badge v7.8 -> v7.10 (#223)",
+        "latest_production_ref": "main",
+        "control_room_url": "https://fitme-story.vercel.app/control-room",
+        "note": "2026-06-15: fitme-story is now the sole active Vercel project (legacy fit-tracker2 + dashboard Astro projects superseded by the Next.js control-room migration). Latest production deploy READY. A few ERROR builds 2026-06-09->06-10 (caseStudyHref type error #218) were resolved same-day; current prod healthy."
+      },
       "projects": {
         "fit_tracker2": {
           "name": "fit-tracker2",
@@ -320,7 +335,10 @@
         "requires_external": 5
       },
       "runtime_health": {
-        "firebase": "connected",
+        "firebase": "live",
+        "ga4_active_users_last_probe": { "as_of": "2026-06-15", "trailing_7d": { "20260608": 6, "20260609": 2, "20260610": 13, "20260611": 10, "20260612": 2, "20260614": 4, "20260615": 13 } },
+        "supabase": "live",
+        "supabase_security_advisors": 0,
         "crash_free_rate": "unknown",
         "ci_pass_rate": "100%",
         "fit_tracker2_runtime_logs_last_1h": 0,

--- a/.claude/shared/health-status.json
+++ b/.claude/shared/health-status.json
@@ -1,26 +1,33 @@
 {
-  "version": "1.1",
-  "updated": "2026-04-15",
-  "note": "Operational monitoring not yet wired. Values below reflect local verification only — runtime infrastructure checks require deployed services and credentials.",
+  "version": "1.2",
+  "updated": "2026-06-15",
+  "note": "Live-probe refresh 2026-06-15: Supabase + GA4/Firebase + Vercel now confirmed live via MCP. Railway + CloudKit remain unprobed (no live MCP/credentials path). Sentry + runtime quality-gate metrics still require deployed-runtime instrumentation. See live_probe block for what was actually checked this run.",
+  "live_probe": {
+    "ran_at": "2026-06-15",
+    "method": "MCP source probes (Supabase, GA4, Vercel) + gh CLI (GitHub) — source-refresh session",
+    "probed_live": ["supabase", "firebase_ga4", "vercel", "github"],
+    "not_probed": ["railway", "cloudkit", "sentry"],
+    "not_probed_reason": "Railway: FastAPI URL not configured + no Railway MCP. CloudKit: requires device/CKTool. Sentry: MCP not connected (adapter exists, unwired)."
+  },
   "infrastructure": {
-    "railway": { "status": "unknown", "service": "AI Engine (FastAPI)", "url": null, "last_check": null },
-    "supabase": { "status": "configured", "service": "PostgreSQL + Realtime + Storage", "project": "hwbbdzwaismlajtfsbed", "region": "ap-northeast-1 (Tokyo)", "region_note": "Will migrate to eu-west-1 (Ireland) before launch — region is permanent per project, requires new project + migration", "last_check": "2026-04-15", "project_name": "FitmeBe&AI engine15042026", "note": "Canonical project: cohort_stats + sync_records + cardio_assets + user_profiles + cardio-images bucket + Email/Google auth. Info.plist still has placeholders — local credential injection needed for runtime verification." },
-    "cloudkit": { "status": "unknown", "service": "iCloud Private DB", "last_check": null },
-    "firebase": { "status": "unknown", "service": "Analytics (GA4)", "last_check": null, "note": "GoogleService-Info.plist not in repo — local file required" },
-    "vercel_website": { "status": "deployed", "service": "Marketing Website", "url": "fitme.app", "last_check": "2026-04-15", "note": "Built and deployed but has launch blockers (placeholder GA4 IDs, placeholder App Store links)" },
-    "vercel_dashboard": { "status": "live", "service": "Operations Control Room", "url": "https://fit-tracker2.vercel.app", "last_check": "2026-04-15", "note": "Live at fit-tracker2.vercel.app. Tab navigation and case study links fixed 2026-04-15." }
+    "railway": { "status": "unknown", "service": "AI Engine (FastAPI)", "url": null, "last_check": null, "note": "Not probed 2026-06-15 — no Railway MCP and no configured service URL. Live status genuinely unknown." },
+    "supabase": { "status": "live", "service": "PostgreSQL + Realtime + Storage", "project": "hwbbdzwaismlajtfsbed", "region": "ap-northeast-1 (Tokyo)", "region_note": "Will migrate to eu-west-1 (Ireland) before launch — region is permanent per project, requires new project + migration", "last_check": "2026-06-15", "project_name": "FitmeBe&AI engine15042026", "advisors": { "security": 0, "checked": "2026-06-15" }, "note": "MCP get_advisors returned 0 security lints 2026-06-15 — project reachable and healthy. Canonical project: cohort_stats + sync_records + cardio_assets + user_profiles + cardio-images bucket + Email/Google auth. Info.plist still has placeholders — local credential injection still needed for iOS-runtime verification." },
+    "cloudkit": { "status": "unknown", "service": "iCloud Private DB", "last_check": null, "note": "Not probeable from CLI/MCP — requires device or CKTool session." },
+    "firebase": { "status": "live", "service": "Analytics (GA4)", "last_check": "2026-06-15", "ga4_active_users_7d": { "20260608": 6, "20260609": 2, "20260610": 13, "20260611": 10, "20260612": 2, "20260614": 4, "20260615": 13 }, "note": "GA4 MCP returned live activeUsers/newUsers for the trailing 7 days 2026-06-15 — analytics pipeline is flowing. (Prior 'unknown' status reflected missing local GoogleService-Info.plist for the iOS build, not the GA4 property itself.)" },
+    "vercel_website": { "status": "deployed", "service": "Marketing Website", "url": "fitme.app", "last_check": "2026-06-15", "note": "Built and deployed; pre-launch blockers persist (placeholder GA4 IDs, placeholder App Store links). Not individually re-probed this run." },
+    "vercel_dashboard": { "status": "live", "service": "Operations Control Room (UCC)", "url": "https://fitme-story.vercel.app/control-room", "legacy_url": "https://fit-tracker2.vercel.app", "last_check": "2026-06-15", "last_production_deploy": { "id": "dpl_ce3zRFfoC5zPD6TqGYY4yBpirerG", "state": "READY", "commit": "fix(control-room): update framework version badge v7.8 -> v7.10 (#223)", "ref": "main", "created": "2026-06-15" }, "note": "Live. Latest production deploy READY 2026-06-15 (#223). Control Room migrated FROM the legacy Astro dashboard at fit-tracker2.vercel.app TO Next.js at fitme-story.vercel.app/control-room (basic-auth gated). Note: a few ERROR preview/prod builds 2026-06-09->06-10 (caseStudyHref type error #218) were resolved; current prod is healthy." }
   },
   "ci": {
-    "last_build": { "status": null, "branch": null, "timestamp": null },
+    "last_build": { "status": null, "branch": null, "timestamp": null, "note": "Not re-run this probe session — local-only signal; CI truth lives in GitHub Actions." },
     "tokens_check": { "status": "passing", "last_run": "2026-04-15" },
-    "xcode_build": { "status": "passing", "last_run": "2026-04-15", "note": "verified via xcodebuild build" },
-    "xcode_test": { "status": "passing", "tests": 197, "last_run": "2026-04-15", "note": "197 tests pass including 29 eval tests" }
+    "xcode_build": { "status": "passing", "last_run": "2026-04-15", "note": "verified via xcodebuild build (stale — last local verification 2026-04-15)" },
+    "xcode_test": { "status": "passing", "tests": 197, "last_run": "2026-04-15", "note": "Stale snapshot (2026-04-15, 197 tests). Current suite is larger (~672 iOS per 2026-06-10 self-test) — re-run make verify-local to refresh." }
   },
   "quality_gates": {
     "crash_free_rate": { "current": null, "target": 99.5, "alert_threshold": 99.0, "source": "sentry", "note": "requires Sentry SDK + MCP — see docs/setup/sentry-setup-guide.md" },
     "cold_start_ms": { "current": null, "target": 2000, "alert_threshold": 3000, "note": "requires instrumented launch" },
     "sync_success_rate": { "current": null, "target": 99, "alert_threshold": 95, "note": "requires signed-in runtime" },
-    "ci_pass_rate": { "current": "100%", "target": 95, "alert_threshold": 85, "note": "local make verify-local passing" }
+    "ci_pass_rate": { "current": "100%", "target": 95, "alert_threshold": 85, "note": "local make verify-local passing (last local run; not CI-sourced)" }
   },
   "error_tracking": {
     "source": "sentry",
@@ -31,7 +38,7 @@
     "affected_users": null,
     "top_issues": [],
     "last_pull": null,
-    "note": "Sentry adapter exists at .claude/integrations/sentry/ but MCP is not connected yet. Run setup guide to wire."
+    "note": "Sentry adapter exists at .claude/integrations/sentry/ but MCP is not connected yet. Run setup guide to wire. (Deferred to pre-launch per project plan.)"
   },
   "incidents": [],
   "cost": {


### PR DESCRIPTION
## What

Refreshes the two operator source-of-truth ledgers from a 2026-06-15 live probe of all reachable sources. They had gone stale (`health-status.json` last written 2026-04-15; `external-sync-status.json` 2026-05-17) because no source is queried at runtime — the control-room renders a build-time snapshot of these files.

## Changes

- **`health-status.json` v1.1 → v1.2** — Supabase + Firebase/GA4 + Vercel confirmed **live** via MCP (Supabase 0 security advisors; GA4 7-day DAU 2–13; Vercel prod `READY` #223). Railway + CloudKit honestly left `unknown` (no live MCP/credential path). Adds a `live_probe` block recording exactly what was / wasn't checked.
- **`external-sync-status.json` v1.0 → v1.1** — live GitHub / Linear / Notion / Vercel / GA4 counts (Linear 48 issues, 23 Done; Notion roadmap edited 2026-06-15; GA4 DAU). Older narrative findings retained for history.

## Why it's on a clean branch

These are `.claude/shared/*` infra files. Committed via an **isolated worktree off `origin/main`** so the refresh lands cleanly without the unrelated auto-churn ledgers in the shared working tree, and without carrying the (separately-merged) bot-ledger fix.

## Relationship

Feeds the control-room snapshot baseline (`sync-from-fittracker2.ts` mirrors these into `fitme-story/src/data/shared` at build). Companion to **fitme-story PR #224** (UCC live-feed Phase 1, which makes these panels live at request time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)