### PR TITLE
feat(f1): STATE_TASKS_FILESYSTEM_DRIFT cycle-time advisory (v8.x docket Theme A)

### DIFF
--- a/.claude/features/f1-state-tasks-filesystem-drift/calibration-artifacts.md
+++ b/.claude/features/f1-state-tasks-filesystem-drift/calibration-artifacts.md
@@ -1,0 +1,76 @@
+# F1 — STATE_TASKS_FILESYSTEM_DRIFT — Phase A Calibration Artifacts
+
+> Authored BEFORE code per infra-master-plan §3.5 Calibration Protocol.
+> Cycle-time advisory → uses the unit + dispatch test layers (no try-repo
+> fixture pair; that discipline applies to write-time gates only).
+
+## 1. Identity
+
+| Field | Value |
+|---|---|
+| Gate code | `STATE_TASKS_FILESYSTEM_DRIFT` |
+| Mechanism A emission key | `STATE_TASKS_FILESYSTEM_DRIFT` |
+| Function | `check_state_tasks_filesystem_drift(coverage=None)` |
+| Location | `scripts/integrity-check.py` |
+| Dispatch site | `build_snapshot()` → `advisory_findings` tuple, `coverage=cycle_coverage` |
+| Severity | ADVISORY (never affects `finding_count` or exit code) |
+| Coverage mode | `cycle` |
+| RICE / Theme | 19.2 / Theme A (roadmap realism) |
+
+## 2. What it detects
+
+The task ledger (`state.json::tasks[]`) drifting from the work that
+actually shipped. Empirically surfaced when 5-of-10 roadmap-stress-test
+sub-features were `complete` with an empty `tasks[]` despite shipped work
+(the post-squash-merge drift class F2 catches at Phase 0; F1 is the
+standing cycle-time mirror).
+
+## 3. Candidate domain
+
+Every feature with `current_phase == "complete"` **and** an empty or
+missing `tasks[]`. (Features with a populated ledger are not candidates.)
+
+## 4. Fire predicate
+
+A candidate fires (ADVISORY finding) iff ALL hold:
+
+1. **Post-task-discipline** — `created_at[:10] >= "2026-04-25"` (v7.6 ship,
+   when task-ledger discipline began).
+2. **Not framework-meta** — see exemptions below.
+3. **Shipped artifact present** — at least one of: a case study at
+   `docs/case-studies/<feature>-case-study.md`; non-empty `related_prs`;
+   or `phases.merge.pr_number`. This is the "filesystem" half of the name:
+   the filesystem shows shipped artifacts but the ledger is empty.
+
+## 5. Skip reasons (legitimate — tracked, not bugs)
+
+| Reason | Meaning |
+|---|---|
+| `pre_task_discipline` | `created_at < 2026-04-25` — predates task discipline; bounded backfill-debt, not active drift. (~30 features at ship.) |
+| `exempt_framework_meta` | name starts with `framework-v`, OR `work_type == "framework"`, OR `work_subtype` starts with `framework`, OR `case_study_type` ∈ {pre_pm_workflow_backfill, roundup, no_case_study_required, framework_meta_retroactive}, OR `platforms_tested_provenance` starts with `exempt:`. These ship no task-decomposable product work. (~5 at ship.) |
+| `no_shipped_artifact` | complete + empty tasks but no case study / related_prs / merge PR → not "drift despite shipped work." (~1 at ship.) |
+
+Graceful degradation: missing `FEATURES_DIR`, unreadable/invalid JSON →
+skip silently (no finding, no crash), consistent with sibling cycle checks.
+
+## 6. Expected baseline at ship (snapshot — 2026-06-17)
+
+5 fires: `case-study-presentation`, `ios-ui-audit-p1-burndown`,
+`trend-alerts-hrv`, `fitme-story-design-system-p2-cleanup`,
+`smart-reminders-behavioral-learning`.
+Skips: `pre_task_discipline` ×30, `exempt_framework_meta` ×5,
+`no_shipped_artifact` ×1.
+
+## 7. Calibration walk
+
+- **Phase A** — this doc (pre-code). ✓
+- **Phase B** — advisory + measure ≥7d Mechanism A coverage.
+- **Phase C** — calibration review ~2026-07-01 → -08; confirm 0 false positives.
+- **Posture** — advisory-permanent by default (a backlog-surfacing advisory,
+  like `TIER_TAG_LIKELY_INCORRECT`). Promotion to enforced is NOT the goal;
+  this surfaces task-ledger debt for backfill, it does not block commits.
+
+## 8. Reversibility
+
+Single-line removal from the `advisory_findings` tuple in `build_snapshot()`
+(< 2 min). The function is pure/read-only; no schema or data migration.

--- a/.claude/features/f1-state-tasks-filesystem-drift/state.json
+++ b/.claude/features/f1-state-tasks-filesystem-drift/state.json
@@ -1,0 +1,63 @@
+{
+  "feature_name": "f1-state-tasks-filesystem-drift",
+  "current_phase": "implementation",
+  "platforms_tested": {},
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "created_at": "2026-06-17T00:00:00Z",
+  "updated_at": "2026-06-17T00:00:00Z",
+  "framework_version": "v7.10",
+  "work_type": "Feature",
+  "work_subtype": "framework_feature",
+  "has_ui": false,
+  "requires_analytics": false,
+  "state_owner": "ft2",
+  "isolation_opt_out": false,
+  "isolation_opt_out_reason": "",
+  "branch": "chore/f1-state-tasks-filesystem-drift",
+  "scheduled_after": null,
+  "primary_metric": "STATE_TASKS_FILESYSTEM_DRIFT advisory emits Mechanism A cycle coverage on every complete feature with an empty tasks[] ledger, across a 14-day calibration window with 0 false positives (every fire is a genuine ledger-vs-shipped-work drift).",
+  "success_metrics": [
+    "Gate appears in .claude/logs/gate-coverage.jsonl with mode=cycle + candidates>=1 on the first integrity-check run after merge (T1, set-membership)",
+    "0 false positives across the advisory window — every fire maps to a complete feature that shipped artifacts (case study / related_prs / merge PR) yet left tasks[] empty (T1, manual review of fire rows)",
+    "Skip-reason distribution is legitimate (pre_task_discipline dominates; exempt_framework_meta + no_shipped_artifact explained; not a wiring bug) (T2)",
+    "Baseline fire-set at ship is the expected 5 features (case-study-presentation, ios-ui-audit-p1-burndown, trend-alerts-hrv, fitme-story-design-system-p2-cleanup, smart-reminders-behavioral-learning) (T1, snapshot)",
+    "docket + ready-now workplan F1 row marked shipped (T1, section presence)"
+  ],
+  "kill_criteria": [
+    "Any false positive that maps to a legitimately task-less complete feature (e.g. a thin chore that genuinely had no task decomposition) -> widen exemptions before promoting; do NOT flip to enforced.",
+    "Fire count balloons past ~10 with corpus growth such that the advisory becomes noise rather than signal -> add a forward-only created_at cutoff or convert to a documentation-debt-style ledger.",
+    "Zero candidates across the entire window (gate never reaches a complete+empty-tasks feature) -> mis-wire; investigate via GATE_COVERAGE_ZERO."
+  ],
+  "kill_criteria_resolution": "Evaluated at the Phase C calibration review (~2026-07-01 -> -08). Advisory at ship; advisory-permanent unless a false positive surfaces (this is a backlog-surfacing advisory, not a promotion candidate by default). Reversibility: single-line removal from the advisory_findings tuple in build_snapshot().",
+  "dispatch_pattern": "agent-driven (single cycle-time advisory add in integrity-check.py + unit/dispatch tests)",
+  "spec": ".claude/features/f1-state-tasks-filesystem-drift/calibration-artifacts.md (Phase A); docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md Batch 3 (F1) + v8-x-build-docket-2026-06-15.md §0.B (F1, RICE 19.2, Theme A)",
+  "scope_summary": "Add the STATE_TASKS_FILESYSTEM_DRIFT cycle-time ADVISORY: for every feature with current_phase=complete and an empty/missing tasks[] ledger, fire when (a) created post-task-discipline (>=2026-04-25 v7.6) AND (b) not framework-meta AND (c) the filesystem shows shipped artifacts (a case study, related_prs, or a merge PR number). The fire means the task ledger drifted from the work that actually shipped. Surfaced when 5-of-10 roadmap-stress-test sub-features had empty tasks[] despite shipped work. Pre-v7.6 features are skipped (pre_task_discipline) as bounded backfill-debt, not active drift. Out of scope: auto-backfilling tasks[]; git-log evidence scans (filesystem artifact signal only, à la F2 reality-check but cycle-time + read-only).",
+  "related_prs": [],
+  "timing": {
+    "phases": {
+      "implementation": {
+        "started_at": "2026-06-17T00:00:00Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "check_state_tasks_filesystem_drift(coverage) advisory fn in integrity-check.py (complete + empty tasks[] + post-discipline + non-meta + has shipped artifact) with cycle-mode Mechanism A emission",
+      "status": "done",
+      "completed_at": "2026-06-17T00:00:00Z"
+    },
+    {
+      "id": "T2",
+      "description": "Wire into build_snapshot() advisory_findings tuple with coverage=cycle_coverage",
+      "status": "done",
+      "completed_at": "2026-06-17T00:00:00Z"
+    },
+    {
+      "id": "T3",
+      "description": "Unit + dispatch tests (scripts/tests/test_state_tasks_filesystem_drift.py): fire/skip per reason + dispatch wiring + coverage emission",
+      "status": "done",
+      "completed_at": "2026-06-17T00:00:00Z"
+    }
+  ]
+}

--- a/.claude/logs/f1-state-tasks-filesystem-drift.log.json
+++ b/.claude/logs/f1-state-tasks-filesystem-drift.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "f1-state-tasks-filesystem-drift",
+  "title": "f1 state tasks filesystem drift",
+  "work_type": "Feature",
+  "current_phase": "implementation",
+  "framework_version": "v7.10",
+  "started_at": "2026-06-17T05:26:54Z",
+  "updated_at": "2026-06-17T05:26:54Z",
+  "events": [
+    {
+      "timestamp": "2026-06-17T05:26:54Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "F1 STATE_TASKS_FILESYSTEM_DRIFT cycle-time advisory implemented (gate + tests + docket)",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -5,7 +5,7 @@
 
 ## The 8 ready-now items
 
-> **Status 2026-06-16:** 6 of 8 shipped (F12, F11, F10, F13, F5, **F4 ← PR #740**). **2 remain open: F1 (RICE 19.2) then F3 (14.4).**
+> **Status 2026-06-17:** 7 of 8 shipped (F12, F11, F10, F13, F5, F4, **F1 ← advisory, this branch**). **1 remains open: F3 (dep-graph cycle check, RICE 14.4).**
 
 | # | ID | Item | RICE | Effort | Class | Infra-glob? |
 |---|---|---|---|---|---|---|
@@ -15,7 +15,7 @@
 | 4 | **F13** ✅ SHIPPED | `source_commit` `workflow_dispatch` input + full-repo-scan fallback | 32.0 | ~0.4w | GH Actions infra (fitme-story) | fitme-story PR #221 |
 | 5 | **F4** ✅ SHIPPED | `FRAMEWORK_VERSION_STALE` advisory gate — stale-version detector on phase-advance (PR #740, 2026-06-16; advisory→enforced ~2026-06-30) | 32.0 | ~0.5w | Write-time gate (advisory) | yes (`scripts/`) |
 | 6 | **F5** ✅ SHIPPED | `scope_change` Tier 2.2 vocabulary event (advisory note) | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
-| 7 | **F1** | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |
+| 7 | **F1** ✅ SHIPPED | `STATE_TASKS_FILESYSTEM_DRIFT` cycle-time advisory — complete feature + empty `tasks[]` + shipped artifact = ledger drift (advisory-permanent; 5 baseline fires) | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |
 | 8 | **F3** | Phase 2 dependency-graph cycle check | 14.4 | ~0.5w | Workflow gate | yes (`scripts/`) |
 
 **Total effort:** ~2.9 engineer-weeks. All 8 touch infra-glob paths.

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -45,7 +45,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | ~~F10~~ ✅ | `experiment_outcome` enum on `tasks[]` (documented, advisory — not a blocking gate) | Schema | 32.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | ~~F13~~ ✅ | `source_commit` `workflow_dispatch` input + full-repo-scan fallback (reverse-sync) | GH Actions | 32.0 | **SHIPPED** (fitme-story PR #221 — reverse-sync workflow lives in fitme-story) |
 | ~~F5~~ ✅ | `scope_change` Tier 2.2 vocabulary event (advisory KNOWN_EVENT_TYPES note) | Vocabulary | 20.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
-| F1 | `STATE_TASKS_FILESYSTEM_DRIFT` advisory | Cycle-time gate | 19.2 | none |
+| ~~F1~~ ✅ | `STATE_TASKS_FILESYSTEM_DRIFT` cycle-time advisory — complete feature + empty `tasks[]` + shipped artifact = ledger drift | Cycle-time gate | 19.2 | **SHIPPED 2026-06-17** (feature `f1-state-tasks-filesystem-drift`; advisory-permanent, 5 baseline fires) |
 | F3 | Phase 2 dependency-graph cycle check | Workflow gate | 14.4 | none |
 | T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** |
 | F18 | Mutation testing on dispatcher files | Test infra | 13.7 | F16 Phase E (post 2026-06-18) + F14 |
@@ -59,7 +59,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 
 **D. Operator decision open:** W-MISTRAL-VERCEL-FREE-TIER-BURST (API-tier choice for multi-provider HADF experiments).
 
-**Roll-up:** of the original 18 F-candidates, **14 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 merged 2026-06-15 via PRs #719/#720/#721/#722 + **F4 shipped 2026-06-16 via PR #740**) + 2 resolved-by-exemption (F7, F8) → **2 F-items remain open** (F1, F3) + F18 + F19–F23. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
+**Roll-up:** of the original 18 F-candidates, **15 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 merged 2026-06-15 via PRs #719/#720/#721/#722 + F4 shipped 2026-06-16 via PR #740 + **F1 shipped 2026-06-17, advisory**) + 2 resolved-by-exemption (F7, F8) → **1 F-item remains open** (F3) + F18 + F19–F23. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
 
 ---
 

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -990,6 +990,104 @@ def check_feature_closure_completeness_cycle() -> list[dict]:
     return findings
 
 
+def check_state_tasks_filesystem_drift(coverage: "GateCoverage | None" = None) -> list[dict]:
+    """F1 (v8.x docket, Theme A): STATE_TASKS_FILESYSTEM_DRIFT cycle-time advisory.
+
+    Detects the task ledger (state.json::tasks[]) drifting from the work that
+    actually shipped. For every feature with current_phase=complete and an
+    empty/missing tasks[], fires when (a) the feature was created on/after the
+    v7.6 task-discipline date AND (b) it is not a framework-meta feature AND
+    (c) the filesystem shows shipped artifacts (a case study, related_prs, or a
+    merge PR number). The fire means: the work shipped, but the ledger is empty.
+
+    Empirically surfaced when 5-of-10 roadmap-stress-test sub-features were
+    `complete` with empty tasks[] despite shipped work (the post-squash-merge
+    drift class F2 catches at Phase 0; this is its standing cycle-time mirror).
+
+    Severity: ADVISORY only — never affects finding_count or exit code. This is
+    a backlog-surfacing advisory (like TIER_TAG_LIKELY_INCORRECT), not a
+    promotion candidate. Pre-task-discipline features (created < 2026-04-25) are
+    skipped as bounded backfill-debt, not active drift.
+
+    Emits Mechanism A coverage (gate STATE_TASKS_FILESYSTEM_DRIFT) when
+    `coverage` is supplied — one candidate per complete+empty-tasks feature.
+
+    Full design: .claude/features/f1-state-tasks-filesystem-drift/calibration-artifacts.md
+    """
+    GATE = "STATE_TASKS_FILESYSTEM_DRIFT"
+    TASK_DISCIPLINE_DATE = "2026-04-25"  # v7.6 ship — task-ledger discipline began
+    BACKFILL_EXEMPT = {
+        "pre_pm_workflow_backfill", "roundup",
+        "no_case_study_required", "framework_meta_retroactive",
+    }
+    findings: list[dict] = []
+    if not FEATURES_DIR.exists():
+        if coverage is not None:
+            coverage.skip(GATE, "features_dir_missing")
+        return findings
+
+    for state_path in sorted(FEATURES_DIR.glob("*/state.json")):
+        name = state_path.parent.name
+        try:
+            d = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if d.get("current_phase") != "complete":
+            continue
+        tasks = d.get("tasks") or []
+        if tasks:
+            continue  # populated ledger — not a candidate
+
+        # Candidate: complete + empty tasks[].
+        if coverage is not None:
+            coverage.candidate(GATE)
+
+        created = (d.get("created_at") or d.get("created") or "")[:10]
+        if created and created < TASK_DISCIPLINE_DATE:
+            if coverage is not None:
+                coverage.skip(GATE, "pre_task_discipline")
+            continue
+
+        if (
+            name.startswith("framework-v")
+            or (d.get("work_type") or "").lower() == "framework"
+            or (d.get("work_subtype") or "").startswith("framework")
+            or d.get("case_study_type") in BACKFILL_EXEMPT
+            or (d.get("platforms_tested_provenance") or "").startswith("exempt:")
+        ):
+            if coverage is not None:
+                coverage.skip(GATE, "exempt_framework_meta")
+            continue
+
+        # Filesystem half: is there shipped-artifact evidence?
+        if (CASE_STUDIES_DIR / f"{name}-case-study.md").exists():
+            artifact = "case study"
+        elif d.get("related_prs"):
+            artifact = "related_prs"
+        elif (d.get("phases", {}).get("merge", {}) or {}).get("pr_number"):
+            artifact = f"merge PR #{d['phases']['merge']['pr_number']}"
+        else:
+            if coverage is not None:
+                coverage.skip(GATE, "no_shipped_artifact")
+            continue
+
+        if coverage is not None:
+            coverage.checked(GATE)
+        findings.append({
+            "feature": name,
+            "severity": "ADVISORY",
+            "code": GATE,
+            "message": (
+                f"{name}: complete with shipped artifacts ({artifact}) but "
+                f"tasks[] is empty — the task ledger drifted from the work. "
+                f"Backfill tasks[] (e.g. `make close-feature FEATURE={name}`) "
+                f"or tag the feature exempt (case_study_type / framework-meta)."
+            ),
+        })
+    return findings
+
+
 def check_gate_coverage_zero() -> list[dict]:
     """GATE_COVERAGE_ZERO (advisory, v7.10 candidate — built 2026-06-08).
 
@@ -1372,6 +1470,7 @@ def build_snapshot(snapshot_trigger: str) -> dict:
         + pr_cache_failed_advisory  # v7.9.1 F-LAUNCHD-DRIFT-EXTENSION sub-fix (b)
         + check_pattern_skill_unmapped(coverage=cycle_coverage)  # v7.9.1 overlay
         + check_gate_coverage_zero()  # v7.10 candidate (built 2026-06-08, advisory)
+        + check_state_tasks_filesystem_drift(coverage=cycle_coverage)  # F1 (v8.x Theme A)
     )
     all_findings = findings + advisory_findings
 

--- a/scripts/tests/test_state_tasks_filesystem_drift.py
+++ b/scripts/tests/test_state_tasks_filesystem_drift.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Unit + dispatch tests for F1 — STATE_TASKS_FILESYSTEM_DRIFT.
+
+Cycle-time ADVISORY in `scripts/integrity-check.py`. The gate fires for a
+feature that is `complete` with an empty `tasks[]` ledger yet shows shipped
+artifacts (case study / related_prs / merge PR) and is post-task-discipline
+and not framework-meta. See
+`.claude/features/f1-state-tasks-filesystem-drift/calibration-artifacts.md`.
+
+Test layers per the v8.x ready-now workplan §3 (cycle-time gates use the
+unit + dispatch layers; no try-repo fixture pair).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "integrity_check", SCRIPTS_DIR / "integrity-check.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+GATE = "STATE_TASKS_FILESYSTEM_DRIFT"
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_feature(
+    features_dir: Path,
+    name: str,
+    *,
+    current_phase: str = "complete",
+    created_at: str = "2026-05-15T00:00:00Z",
+    tasks=None,
+    extra: dict | None = None,
+) -> Path:
+    feat_dir = features_dir / name
+    feat_dir.mkdir(parents=True, exist_ok=True)
+    content: dict = {
+        "feature_name": name,
+        "current_phase": current_phase,
+        "created_at": created_at,
+        "tasks": tasks if tasks is not None else [],
+    }
+    if extra:
+        content.update(extra)
+    p = feat_dir / "state.json"
+    p.write_text(json.dumps(content, indent=2) + "\n")
+    return p
+
+
+def _wire(monkeypatch, tmp_repo: Path):
+    features_dir = tmp_repo / ".claude" / "features"
+    features_dir.mkdir(parents=True, exist_ok=True)
+    cs_dir = tmp_repo / "docs" / "case-studies"
+    cs_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(_mod, "REPO_ROOT", tmp_repo)
+    monkeypatch.setattr(_mod, "FEATURES_DIR", features_dir)
+    monkeypatch.setattr(_mod, "CASE_STUDIES_DIR", cs_dir)
+    return features_dir, cs_dir
+
+
+def _add_case_study(cs_dir: Path, name: str):
+    (cs_dir / f"{name}-case-study.md").write_text("# case study\n")
+
+
+# ─── Unit: fire conditions ────────────────────────────────────────────────
+
+
+def test_fires_on_complete_empty_tasks_with_case_study(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "drifted-feat")
+    _add_case_study(cs, "drifted-feat")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    codes = {f["code"] for f in findings}
+    assert GATE in codes
+    assert {f["severity"] for f in findings} == {"ADVISORY"}
+    assert any(f["feature"] == "drifted-feat" for f in findings)
+
+
+def test_fires_on_related_prs_artifact(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "feat-prs",
+                  extra={"related_prs": [123]})
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert any(f["feature"] == "feat-prs" for f in findings)
+
+
+def test_fires_on_merge_pr_artifact(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "feat-merge",
+                  extra={"phases": {"merge": {"pr_number": 999}}})
+    findings = _mod.check_state_tasks_filesystem_drift()
+    msgs = [f["message"] for f in findings if f["feature"] == "feat-merge"]
+    assert msgs and "#999" in msgs[0]
+
+
+# ─── Unit: skip conditions ────────────────────────────────────────────────
+
+
+def test_skip_when_tasks_populated(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "has-tasks",
+                  tasks=[{"id": "T1", "status": "done"}])
+    _add_case_study(cs, "has-tasks")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "has-tasks" for f in findings)
+
+
+def test_skip_when_not_complete(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "in-prog",
+                  current_phase="implementation")
+    _add_case_study(cs, "in-prog")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "in-prog" for f in findings)
+
+
+def test_skip_pre_task_discipline(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "old-feat",
+                  created_at="2026-04-01T00:00:00Z")
+    _add_case_study(cs, "old-feat")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "old-feat" for f in findings)
+
+
+def test_skip_framework_meta_by_name(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "framework-v9-9-thing")
+    _add_case_study(cs, "framework-v9-9-thing")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "framework-v9-9-thing" for f in findings)
+
+
+def test_skip_framework_meta_by_subtype(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "some-infra",
+                  extra={"work_subtype": "framework_feature"})
+    _add_case_study(cs, "some-infra")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "some-infra" for f in findings)
+
+
+def test_skip_exempt_case_study_type(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "roundup-feat",
+                  extra={"case_study_type": "roundup"})
+    _add_case_study(cs, "roundup-feat")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "roundup-feat" for f in findings)
+
+
+def test_skip_no_shipped_artifact(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _wire(monkeypatch, repo)
+    # complete + empty tasks + post-discipline + non-meta, but NO artifact
+    _make_feature(repo / ".claude" / "features", "thin-feat")
+    findings = _mod.check_state_tasks_filesystem_drift()
+    assert not any(f["feature"] == "thin-feat" for f in findings)
+
+
+# ─── Coverage emission (Mechanism A) ──────────────────────────────────────
+
+
+def test_coverage_emission(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "drift-a")
+    _add_case_study(cs, "drift-a")
+    _make_feature(repo / ".claude" / "features", "old-skip",
+                  created_at="2026-04-01T00:00:00Z")
+    cov = _mod.GateCoverage(mode="cycle")
+    findings = _mod.check_state_tasks_filesystem_drift(coverage=cov)
+    assert GATE in cov.gates, "expected coverage bucket for the gate"
+    stats = cov.gates[GATE]
+    assert stats["candidates"] >= 2  # drift-a + old-skip both candidates
+    assert stats["checked"] >= 1     # drift-a checked
+    assert stats["skip_reasons"].get("pre_task_discipline", 0) >= 1  # old-skip
+    assert any(f["feature"] == "drift-a" for f in findings)
+
+
+def test_graceful_when_features_dir_missing(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"  # no .claude/features
+    monkeypatch.setattr(_mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(_mod, "FEATURES_DIR", repo / ".claude" / "features")
+    cov = _mod.GateCoverage(mode="cycle")
+    findings = _mod.check_state_tasks_filesystem_drift(coverage=cov)
+    assert findings == []
+
+
+# ─── Dispatch: wired into main() advisory_findings ────────────────────────
+
+
+def test_dispatch_via_main(monkeypatch, tmp_path, capsys):
+    repo = tmp_path / "repo"
+    _, cs = _wire(monkeypatch, repo)
+    _make_feature(repo / ".claude" / "features", "drift-dispatch")
+    _add_case_study(cs, "drift-dispatch")
+
+    def _empty_check_output(cmd, **kw):
+        return ""
+    monkeypatch.setattr(_mod.subprocess, "check_output", _empty_check_output)
+    monkeypatch.setattr(sys, "argv", ["integrity-check.py"])
+    # Don't pollute the real gate-coverage ledger from the test.
+    monkeypatch.setenv("GATE_COVERAGE_LEDGER_DISABLED", "1")
+
+    snap = _mod.build_snapshot("manual")
+    codes = {f["code"] for f in snap["findings"]}
+    assert GATE in codes, f"gate not dispatched via build_snapshot; codes={codes}"
+    # Advisory must not inflate the gating finding_count.
+    fire = [f for f in snap["findings"]
+            if f["code"] == GATE and f["feature"] == "drift-dispatch"]
+    assert fire and fire[0]["severity"] == "ADVISORY"


### PR DESCRIPTION
## What

F1 from the v8.x ready-now docket (RICE 19.2, Theme A — roadmap realism). Adds a **cycle-time ADVISORY** in `scripts/integrity-check.py` that surfaces **task-ledger drift**: a feature that is `complete` with an empty `tasks[]` ledger, yet shows shipped artifacts (a case study, `related_prs`, or a merge PR number), is post-task-discipline, and is not framework-meta.

The fire means: the work shipped, but the task ledger is empty. This is the standing cycle-time mirror of the post-squash-merge drift class that F2 catches at Phase 0 — empirically surfaced when 5-of-10 roadmap-stress-test sub-features were complete with empty `tasks[]` despite shipped work.

## Design (advisory-first, Phase A before code)

Full calibration artifacts: `.claude/features/f1-state-tasks-filesystem-drift/calibration-artifacts.md`

- **Candidate domain:** `current_phase == complete` AND empty/missing `tasks[]`
- **Fire predicate:** post-task-discipline (`created_at >= 2026-04-25`) + not framework-meta + has a shipped artifact (case study / `related_prs` / `phases.merge.pr_number`)
- **Skip reasons (Mechanism A):** `pre_task_discipline`, `exempt_framework_meta`, `no_shipped_artifact`
- **Severity:** ADVISORY → **0 gating findings, exit code unchanged**
- **Coverage:** emitted in `cycle` mode under gate `STATE_TASKS_FILESYSTEM_DRIFT` (visible to the F17 index + GATE_COVERAGE_ZERO)
- **Posture:** advisory-permanent (a backlog-surfacing advisory like `TIER_TAG_LIKELY_INCORRECT`; not a promotion candidate)

## Baseline at ship

**5 fires:** `case-study-presentation`, `ios-ui-audit-p1-burndown`, `trend-alerts-hrv`, `fitme-story-design-system-p2-cleanup`, `smart-reminders-behavioral-learning`.
**Skips:** 30 `pre_task_discipline`, 5 `exempt_framework_meta`, 1 `no_shipped_artifact`.

## Tests

`scripts/tests/test_state_tasks_filesystem_drift.py` — 13 unit + dispatch tests (fire per artifact type, skip per reason, coverage emission, graceful degradation, `build_snapshot()` dispatch). All pass; existing dispatch + cycle-coverage suites still green (cycle-time gate → unit + dispatch layers, no try-repo fixture per the ready-now workplan §3).

## Docket

`v8-0-ready-now-workplan` + `v8-x-build-docket` F1 rows marked shipped → **1 ready-now F-item remains (F3, dep-graph cycle check)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)