### PR TITLE
feat(f3): DEPENDENCY_GRAPH_CYCLE cycle-time advisory (v8.x docket Theme A)

### DIFF
--- a/.claude/features/f3-dependency-graph-cycle-check/calibration-artifacts.md
+++ b/.claude/features/f3-dependency-graph-cycle-check/calibration-artifacts.md
@@ -1,0 +1,82 @@
+# F3 — DEPENDENCY_GRAPH_CYCLE — Phase A Calibration Artifacts
+
+> Authored BEFORE code per infra-master-plan §3.5 Calibration Protocol.
+> Cycle-time advisory → unit + dispatch test layers (no try-repo fixture pair).
+
+## 1. Identity
+
+| Field | Value |
+|---|---|
+| Gate code | `DEPENDENCY_GRAPH_CYCLE` |
+| Mechanism A emission key | `DEPENDENCY_GRAPH_CYCLE` |
+| Function | `check_dependency_graph_cycles(coverage=None)` |
+| Location | `scripts/integrity-check.py` |
+| Dispatch site | `build_snapshot()` → `advisory_findings` tuple, `coverage=cycle_coverage` |
+| Severity | ADVISORY (never affects `finding_count` or exit code) |
+| Coverage mode | `cycle` |
+| RICE / Theme | 14.4 / Theme A (roadmap realism) |
+
+## 2. What it detects
+
+Integrity problems in the multi-feature dependency graph: **cycles**,
+**self-loops**, and **dangling references** (an edge pointing at a feature
+that does not exist). Surfaced because one dependency cycle was caught
+manually, post-hoc, on a multi-feature roadmap.
+
+## 3. The graph
+
+Nodes = features under `.claude/features/`. Directed edge `A → B` means
+"A depends on / is scheduled after B", built from two **structured**
+fields on `A`'s state.json:
+
+- `scheduled_after` — `{"predecessor": "<feature>"}` (object form; a bare
+  string is also accepted) → edge to `<feature>`.
+- `parent_feature` — `"<feature>"` → edge to `<feature>`.
+
+**Excluded:** `depends_on`. Empirically it holds free-text prerequisites
+("PR #158 — six lifecycle analytics events…", "Existing Supabase
+cohort_stats table…"), not feature names. Parsing it as an edge would
+manufacture dangling-reference false positives. (smart-reminders-behavioral-learning
+is the witness.)
+
+## 4. Fire conditions (each → one ADVISORY finding)
+
+1. **Dangling** — an edge target is not an existing feature directory.
+2. **Self-loop** — `A → A`.
+3. **Cycle** — a directed cycle `A → B → … → A`. Reported once per distinct
+   cycle via canonical-rotation dedup (rotate the cycle so its
+   lexicographically smallest node is first; dedup on that tuple) so the
+   same cycle isn't emitted from every member.
+
+## 5. Coverage semantics (Mechanism A)
+
+- **candidate** — each feature that has ≥1 structured edge (graph participant).
+- **checked** — each such feature (its out-edges validated for dangling/self-loop).
+- **skip** — `features_dir_missing` only (graceful degradation). Features
+  with no structured edge are simply not candidates.
+
+Graceful degradation: missing `FEATURES_DIR`, unreadable/invalid JSON →
+skip silently (no finding, no crash), consistent with sibling cycle checks.
+
+## 6. Expected baseline at ship (snapshot — 2026-06-17)
+
+**0 findings** — current corpus has 0 cycles, 0 self-loops, 0 dangling refs
+across `scheduled_after` + `parent_feature` (28 features carry ≥1 edge).
+candidates ≥ 1 → a *healthy* zero-firing guard-gate (GATE_COVERAGE_ZERO
+distinguishes this from a 0-candidate mis-wire). The new
+`f3-dependency-graph-cycle-check` feature itself adds one live, valid
+`scheduled_after → f1-state-tasks-filesystem-drift` edge.
+
+## 7. Calibration walk
+
+- **Phase A** — this doc (pre-code). ✓
+- **Phase B** — advisory + measure ≥7d Mechanism A coverage.
+- **Phase C** — calibration review ~2026-07-01 → -08.
+- **Posture** — advisory-permanent (a graph-integrity guard; promotion to
+  enforced is not the goal — a future cycle/dangling ref should surface
+  loudly but never block an unrelated commit).
+
+## 8. Reversibility
+
+Single-line removal from the `advisory_findings` tuple in `build_snapshot()`
+(< 2 min). The function is pure/read-only; no schema or data migration.

--- a/.claude/features/f3-dependency-graph-cycle-check/state.json
+++ b/.claude/features/f3-dependency-graph-cycle-check/state.json
@@ -1,0 +1,70 @@
+{
+  "feature_name": "f3-dependency-graph-cycle-check",
+  "current_phase": "implementation",
+  "platforms_tested": {},
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "created_at": "2026-06-17T00:00:00Z",
+  "updated_at": "2026-06-17T00:00:00Z",
+  "framework_version": "v7.10",
+  "work_type": "Feature",
+  "work_subtype": "framework_feature",
+  "has_ui": false,
+  "requires_analytics": false,
+  "state_owner": "ft2",
+  "isolation_opt_out": false,
+  "isolation_opt_out_reason": "",
+  "branch": "chore/f3-dependency-graph-cycle-check",
+  "scheduled_after": {
+    "predecessor": "f1-state-tasks-filesystem-drift",
+    "signal": "F1 shipped 2026-06-17 via PR #752 (last-but-one v8.x ready-now item); F3 is the final ready-now docket item",
+    "captured_at": "2026-06-17T00:00:00Z",
+    "resolved_at": "2026-06-17T05:30:02Z",
+    "resolved_by_pr": [752],
+    "note": "Sequenced after F1 per the ready-now workplan Batch 3 order (F1 then F3). Doubles as a live non-dangling, non-cyclic scheduled_after edge for the gate this feature adds."
+  },
+  "primary_metric": "DEPENDENCY_GRAPH_CYCLE advisory emits Mechanism A cycle coverage over the multi-feature dependency graph (scheduled_after + parent_feature edges) every integrity-check run; 0 false positives across the calibration window (every fire is a genuine cycle, self-loop, or dangling feature reference).",
+  "success_metrics": [
+    "Gate appears in .claude/logs/gate-coverage.jsonl with mode=cycle + candidates>=1 on the first integrity-check run after merge (T1, set-membership)",
+    "Baseline at ship is 0 findings (no cycles / self-loops / dangling refs in the current corpus) while candidates>=1 — a healthy guard-gate, not a mis-wire (T1, snapshot + GATE_COVERAGE_ZERO recognises candidates>0)",
+    "depends_on free-text entries are NOT treated as feature-name edges (no false-positive dangling) (T1, unit test)",
+    "A synthetic 2-node cycle and a dangling predecessor each produce exactly one ADVISORY finding (T1, unit test)",
+    "docket + ready-now workplan F3 rows marked shipped → 0 ready-now F-items remain (T1, section presence)"
+  ],
+  "kill_criteria": [
+    "Any false positive that maps to a legitimate edge (e.g. a free-text field mis-parsed as a feature name) -> tighten edge extraction before promoting; do NOT flip to enforced.",
+    "Cycle detection reports the same cycle multiple times from different start nodes (noise) -> add canonical-rotation dedup (built in at ship; kill criterion guards regression).",
+    "Zero candidates across the window (gate never reaches a feature with a dependency edge) -> mis-wire; investigate via GATE_COVERAGE_ZERO."
+  ],
+  "kill_criteria_resolution": "Evaluated at the Phase C calibration review (~2026-07-01 -> -08). Advisory at ship; advisory-permanent (a graph-integrity guard, not a promotion candidate). Reversibility: single-line removal from the advisory_findings tuple in build_snapshot().",
+  "dispatch_pattern": "agent-driven (single cycle-time advisory add in integrity-check.py + unit/dispatch tests)",
+  "spec": ".claude/features/f3-dependency-graph-cycle-check/calibration-artifacts.md (Phase A); docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md Batch 3 (F3) + v8-x-build-docket-2026-06-15.md §0.B (F3, RICE 14.4, Theme A)",
+  "scope_summary": "Add the DEPENDENCY_GRAPH_CYCLE cycle-time ADVISORY: build a directed dependency graph across all features from the structured edges scheduled_after.predecessor + parent_feature (A depends on B => A->B), then flag (a) cycles, (b) self-loops, and (c) dangling references (an edge whose target feature does not exist). Surfaced because 1 dependency cycle was caught manually post-hoc on a multi-feature roadmap. depends_on is excluded from the graph because in practice it holds free-text prerequisites, not feature names (treating it as an edge would false-positive). Out of scope: ordering/temporal validation of scheduled_after.resolved_at; depends_on structuring.",
+  "related_prs": [],
+  "timing": {
+    "phases": {
+      "implementation": {
+        "started_at": "2026-06-17T00:00:00Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "check_dependency_graph_cycles(coverage) advisory fn in integrity-check.py — build graph from scheduled_after.predecessor + parent_feature; detect cycles + self-loops + dangling refs; canonical-rotation cycle dedup; cycle-mode Mechanism A emission",
+      "status": "done",
+      "completed_at": "2026-06-17T00:00:00Z"
+    },
+    {
+      "id": "T2",
+      "description": "Wire into build_snapshot() advisory_findings tuple with coverage=cycle_coverage",
+      "status": "done",
+      "completed_at": "2026-06-17T00:00:00Z"
+    },
+    {
+      "id": "T3",
+      "description": "Unit + dispatch tests (scripts/tests/test_dependency_graph_cycle.py): cycle / self-loop / dangling fire; depends_on free-text NOT an edge; clean graph = 0 findings; coverage emission; main() dispatch",
+      "status": "done",
+      "completed_at": "2026-06-17T00:00:00Z"
+    }
+  ]
+}

--- a/.claude/logs/f3-dependency-graph-cycle-check.log.json
+++ b/.claude/logs/f3-dependency-graph-cycle-check.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "f3-dependency-graph-cycle-check",
+  "title": "f3 dependency graph cycle check",
+  "work_type": "Feature",
+  "current_phase": "implementation",
+  "framework_version": "v7.10",
+  "started_at": "2026-06-17T05:54:05Z",
+  "updated_at": "2026-06-17T05:54:05Z",
+  "events": [
+    {
+      "timestamp": "2026-06-17T05:54:05Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "F3 DEPENDENCY_GRAPH_CYCLE cycle-time advisory implemented (gate + 12 tests + docket)",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
+++ b/docs/master-plan/v8-0-ready-now-workplan-2026-06-15.md
@@ -5,7 +5,7 @@
 
 ## The 8 ready-now items
 
-> **Status 2026-06-17:** 7 of 8 shipped (F12, F11, F10, F13, F5, F4, **F1 ← advisory, this branch**). **1 remains open: F3 (dep-graph cycle check, RICE 14.4).**
+> **Status 2026-06-17:** ✅ **8 of 8 shipped** (F12, F11, F10, F13, F5, F4, F1, **F3 ← advisory, this branch**). **0 ready-now F-items remain.** Next v8.x work is date-gated (T1 2026-08-22, F18 post-F16-Phase-E) or operator-gated (F19–F23).
 
 | # | ID | Item | RICE | Effort | Class | Infra-glob? |
 |---|---|---|---|---|---|---|
@@ -16,7 +16,7 @@
 | 5 | **F4** ✅ SHIPPED | `FRAMEWORK_VERSION_STALE` advisory gate — stale-version detector on phase-advance (PR #740, 2026-06-16; advisory→enforced ~2026-06-30) | 32.0 | ~0.5w | Write-time gate (advisory) | yes (`scripts/`) |
 | 6 | **F5** ✅ SHIPPED | `scope_change` Tier 2.2 vocabulary event (advisory note) | 20.0 | ~0.2w | Vocabulary | yes (`scripts/` + log schema) |
 | 7 | **F1** ✅ SHIPPED | `STATE_TASKS_FILESYSTEM_DRIFT` cycle-time advisory — complete feature + empty `tasks[]` + shipped artifact = ledger drift (advisory-permanent; 5 baseline fires) | 19.2 | ~0.5w | Cycle-time gate | yes (`scripts/`) |
-| 8 | **F3** | Phase 2 dependency-graph cycle check | 14.4 | ~0.5w | Workflow gate | yes (`scripts/`) |
+| 8 | **F3** ✅ SHIPPED | `DEPENDENCY_GRAPH_CYCLE` cycle-time advisory — cycles / self-loops / dangling refs across `scheduled_after` + `parent_feature` (advisory-permanent; 0 baseline findings, healthy guard) | 14.4 | ~0.5w | Cycle-time gate | yes (`scripts/`) |
 
 **Total effort:** ~2.9 engineer-weeks. All 8 touch infra-glob paths.
 

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -46,7 +46,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | ~~F13~~ ✅ | `source_commit` `workflow_dispatch` input + full-repo-scan fallback (reverse-sync) | GH Actions | 32.0 | **SHIPPED** (fitme-story PR #221 — reverse-sync workflow lives in fitme-story) |
 | ~~F5~~ ✅ | `scope_change` Tier 2.2 vocabulary event (advisory KNOWN_EVENT_TYPES note) | Vocabulary | 20.0 | **SHIPPED** (feature `v8-f10-f5-schema-vocab`) |
 | ~~F1~~ ✅ | `STATE_TASKS_FILESYSTEM_DRIFT` cycle-time advisory — complete feature + empty `tasks[]` + shipped artifact = ledger drift | Cycle-time gate | 19.2 | **SHIPPED 2026-06-17** (feature `f1-state-tasks-filesystem-drift`; advisory-permanent, 5 baseline fires) |
-| F3 | Phase 2 dependency-graph cycle check | Workflow gate | 14.4 | none |
+| ~~F3~~ ✅ | `DEPENDENCY_GRAPH_CYCLE` cycle-time advisory — cycles / self-loops / dangling refs across `scheduled_after` + `parent_feature` | Cycle-time gate | 14.4 | **SHIPPED 2026-06-17** (feature `f3-dependency-graph-cycle-check`; advisory-permanent, 0 baseline findings) |
 | T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** |
 | F18 | Mutation testing on dispatcher files | Test infra | 13.7 | F16 Phase E (post 2026-06-18) + F14 |
 | F22 | Funnel Analysis Dashboards | Product observability | M | F19 + GA4 data |
@@ -59,7 +59,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 
 **D. Operator decision open:** W-MISTRAL-VERCEL-FREE-TIER-BURST (API-tier choice for multi-provider HADF experiments).
 
-**Roll-up:** of the original 18 F-candidates, **15 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 merged 2026-06-15 via PRs #719/#720/#721/#722 + F4 shipped 2026-06-16 via PR #740 + **F1 shipped 2026-06-17, advisory**) + 2 resolved-by-exemption (F7, F8) → **1 F-item remains open** (F3) + F18 + F19–F23. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
+**Roll-up:** of the original 18 F-candidates, **16 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 merged 2026-06-15 via PRs #719/#720/#721/#722 + F4 shipped 2026-06-16 via PR #740 + F1 + **F3 shipped 2026-06-17, advisory**) + 2 resolved-by-exemption (F7, F8) → **all ready-now F-items shipped; remaining open** = F18 (date-gated, post-F16-Phase-E) + F19–F23 (operator/launch-gated). Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18** (gated on F16 enforce flip); ship target 2026-07-31.
 
 ---
 

--- a/scripts/integrity-check.py
+++ b/scripts/integrity-check.py
@@ -1088,6 +1088,145 @@ def check_state_tasks_filesystem_drift(coverage: "GateCoverage | None" = None) -
     return findings
 
 
+def check_dependency_graph_cycles(coverage: "GateCoverage | None" = None) -> list[dict]:
+    """F3 (v8.x docket, Theme A): DEPENDENCY_GRAPH_CYCLE cycle-time advisory.
+
+    Builds a directed dependency graph across all features from the structured
+    edges scheduled_after.predecessor + parent_feature (edge A->B means "A is
+    scheduled after / depends on B") and flags graph-integrity problems:
+
+      1. dangling — an edge target is not an existing feature directory
+      2. self-loop — A -> A
+      3. cycle — a directed cycle A -> B -> ... -> A (deduped via canonical
+         rotation so the same cycle isn't reported from every member)
+
+    Surfaced because one dependency cycle was caught manually, post-hoc, on a
+    multi-feature roadmap. `depends_on` is intentionally EXCLUDED: in practice
+    it holds free-text prerequisites, not feature names, so treating it as an
+    edge would manufacture dangling-reference false positives.
+
+    Severity: ADVISORY only — never affects finding_count or exit code.
+    Emits Mechanism A coverage (gate DEPENDENCY_GRAPH_CYCLE) when `coverage` is
+    supplied — one candidate per feature that carries >=1 structured edge.
+
+    Full design: .claude/features/f3-dependency-graph-cycle-check/calibration-artifacts.md
+    """
+    GATE = "DEPENDENCY_GRAPH_CYCLE"
+    findings: list[dict] = []
+    if not FEATURES_DIR.exists():
+        if coverage is not None:
+            coverage.skip(GATE, "features_dir_missing")
+        return findings
+
+    nodes: set[str] = set()
+    states: dict[str, dict] = {}
+    for state_path in sorted(FEATURES_DIR.glob("*/state.json")):
+        name = state_path.parent.name
+        nodes.add(name)
+        try:
+            states[name] = json.loads(state_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            states[name] = {}
+
+    def _edges(d: dict) -> list[tuple[str, str]]:
+        """(kind, target) structured dependency edges for one feature."""
+        out: list[tuple[str, str]] = []
+        sa = d.get("scheduled_after")
+        if isinstance(sa, dict) and isinstance(sa.get("predecessor"), str) and sa["predecessor"]:
+            out.append(("scheduled_after", sa["predecessor"]))
+        elif isinstance(sa, str) and sa:
+            out.append(("scheduled_after", sa))
+        pf = d.get("parent_feature")
+        if isinstance(pf, str) and pf:
+            out.append(("parent_feature", pf))
+        return out
+
+    adj: dict[str, list[str]] = {}
+    for name in sorted(nodes):
+        edges = _edges(states.get(name, {}))
+        if not edges:
+            continue
+        # Candidate: a graph participant (has >=1 structured edge).
+        if coverage is not None:
+            coverage.candidate(GATE)
+            coverage.checked(GATE)
+        for kind, tgt in edges:
+            if tgt not in nodes:
+                findings.append({
+                    "feature": name,
+                    "severity": "ADVISORY",
+                    "code": GATE,
+                    "message": (
+                        f"{name}: {kind} references '{tgt}', which is not an "
+                        f"existing feature (dangling dependency reference)."
+                    ),
+                })
+                continue
+            if tgt == name:
+                findings.append({
+                    "feature": name,
+                    "severity": "ADVISORY",
+                    "code": GATE,
+                    "message": f"{name}: {kind} points at itself (self-dependency).",
+                })
+                continue
+            adj.setdefault(name, []).append(tgt)
+
+    # Cycle detection (iterative DFS, WHITE/GREY/BLACK) with canonical dedup.
+    WHITE, GREY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in nodes}
+    seen_cycles: set[tuple[str, ...]] = set()
+
+    def _canonical(cycle: list[str]) -> tuple[str, ...]:
+        # cycle is the node list from the back-edge target to the current node
+        # (no repeated closing node); rotate so the lexicographically smallest
+        # node leads → one canonical key per distinct cycle.
+        if not cycle:
+            return tuple()
+        i = cycle.index(min(cycle))
+        return tuple(cycle[i:] + cycle[:i])
+
+    def _dfs(start: str) -> None:
+        stack = [(start, iter(adj.get(start, [])))]
+        path = [start]
+        color[start] = GREY
+        while stack:
+            u, it = stack[-1]
+            advanced = False
+            for v in it:
+                if color.get(v) == GREY:  # back-edge → cycle
+                    idx = path.index(v)
+                    key = _canonical(path[idx:])
+                    if key not in seen_cycles:
+                        seen_cycles.add(key)
+                        findings.append({
+                            "feature": v,
+                            "severity": "ADVISORY",
+                            "code": GATE,
+                            "message": (
+                                "dependency cycle detected: "
+                                + " -> ".join(list(key) + [key[0]])
+                                + " (scheduled_after / parent_feature). Break the "
+                                "cycle — a feature cannot transitively depend on itself."
+                            ),
+                        })
+                elif color.get(v) == WHITE:
+                    color[v] = GREY
+                    path.append(v)
+                    stack.append((v, iter(adj.get(v, []))))
+                    advanced = True
+                    break
+            if not advanced:
+                color[u] = BLACK
+                stack.pop()
+                path.pop()
+
+    for n in sorted(nodes):
+        if color[n] == WHITE:
+            _dfs(n)
+    return findings
+
+
 def check_gate_coverage_zero() -> list[dict]:
     """GATE_COVERAGE_ZERO (advisory, v7.10 candidate — built 2026-06-08).
 
@@ -1471,6 +1610,7 @@ def build_snapshot(snapshot_trigger: str) -> dict:
         + check_pattern_skill_unmapped(coverage=cycle_coverage)  # v7.9.1 overlay
         + check_gate_coverage_zero()  # v7.10 candidate (built 2026-06-08, advisory)
         + check_state_tasks_filesystem_drift(coverage=cycle_coverage)  # F1 (v8.x Theme A)
+        + check_dependency_graph_cycles(coverage=cycle_coverage)  # F3 (v8.x Theme A)
     )
     all_findings = findings + advisory_findings
 

--- a/scripts/tests/test_dependency_graph_cycle.py
+++ b/scripts/tests/test_dependency_graph_cycle.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit + dispatch tests for F3 — DEPENDENCY_GRAPH_CYCLE.
+
+Cycle-time ADVISORY in `scripts/integrity-check.py`. Builds a directed
+dependency graph from scheduled_after.predecessor + parent_feature and flags
+cycles, self-loops, and dangling references. See
+`.claude/features/f3-dependency-graph-cycle-check/calibration-artifacts.md`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "integrity_check", SCRIPTS_DIR / "integrity-check.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+GATE = "DEPENDENCY_GRAPH_CYCLE"
+
+
+def _make(features_dir: Path, name: str, **fields) -> None:
+    d = features_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    content = {"feature_name": name, "current_phase": "complete"}
+    content.update(fields)
+    (d / "state.json").write_text(json.dumps(content, indent=2) + "\n")
+
+
+def _wire(monkeypatch, tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    features_dir = repo / ".claude" / "features"
+    features_dir.mkdir(parents=True)
+    (repo / "docs" / "case-studies").mkdir(parents=True)
+    monkeypatch.setattr(_mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(_mod, "FEATURES_DIR", features_dir)
+    monkeypatch.setattr(_mod, "CASE_STUDIES_DIR", repo / "docs" / "case-studies")
+    return features_dir
+
+
+def _codes(findings, feature=None):
+    return [f for f in findings
+            if f["code"] == GATE and (feature is None or f["feature"] == feature)]
+
+
+# ─── Fire: cycle / self-loop / dangling ───────────────────────────────────
+
+
+def test_two_node_cycle_fires_once(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "a", scheduled_after={"predecessor": "b"})
+    _make(fd, "b", parent_feature="a")
+    findings = _mod.check_dependency_graph_cycles()
+    cyc = [f for f in findings if "cycle detected" in f["message"]]
+    assert len(cyc) == 1, f"expected exactly one cycle finding, got {cyc}"
+    assert {f["severity"] for f in findings} == {"ADVISORY"}
+
+
+def test_three_node_cycle(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "a", scheduled_after={"predecessor": "b"})
+    _make(fd, "b", scheduled_after={"predecessor": "c"})
+    _make(fd, "c", scheduled_after={"predecessor": "a"})
+    findings = _mod.check_dependency_graph_cycles()
+    cyc = [f for f in findings if "cycle detected" in f["message"]]
+    assert len(cyc) == 1
+
+
+def test_self_loop(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "solo", parent_feature="solo")
+    findings = _mod.check_dependency_graph_cycles()
+    assert any("itself" in f["message"] for f in _codes(findings, "solo"))
+
+
+def test_dangling_reference(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "child", parent_feature="ghost-parent")
+    findings = _mod.check_dependency_graph_cycles()
+    msgs = [f["message"] for f in _codes(findings, "child")]
+    assert msgs and "dangling" in msgs[0] and "ghost-parent" in msgs[0]
+
+
+def test_string_form_scheduled_after_dangling(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "x", scheduled_after="missing-pred")  # bare-string form
+    findings = _mod.check_dependency_graph_cycles()
+    assert any("missing-pred" in f["message"] for f in _codes(findings, "x"))
+
+
+# ─── No-fire: clean graph / free-text depends_on / no edges ───────────────
+
+
+def test_clean_dag_no_findings(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "base")
+    _make(fd, "mid", parent_feature="base")
+    _make(fd, "leaf", scheduled_after={"predecessor": "mid"})
+    findings = _mod.check_dependency_graph_cycles()
+    assert _codes(findings) == []
+
+
+def test_depends_on_freetext_not_an_edge(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    # depends_on holds prose, not feature names — must NOT be parsed as edges.
+    _make(fd, "feat", depends_on=[
+        "PR #158 — six lifecycle analytics events (MERGED 2026-04-30; ready)",
+        "Existing Supabase cohort_stats table + increment RPC",
+    ])
+    findings = _mod.check_dependency_graph_cycles()
+    assert _codes(findings) == [], (
+        "depends_on free-text must not produce dangling findings"
+    )
+
+
+def test_feature_with_no_edges_not_candidate(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "lonely")
+    cov = _mod.GateCoverage(mode="cycle")
+    _mod.check_dependency_graph_cycles(coverage=cov)
+    assert GATE not in cov.gates or cov.gates[GATE]["candidates"] == 0
+
+
+# ─── Coverage + graceful degradation ──────────────────────────────────────
+
+
+def test_coverage_emission(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "base")
+    _make(fd, "mid", parent_feature="base")
+    cov = _mod.GateCoverage(mode="cycle")
+    _mod.check_dependency_graph_cycles(coverage=cov)
+    assert GATE in cov.gates
+    assert cov.gates[GATE]["candidates"] >= 1  # mid has an edge
+    assert cov.gates[GATE]["checked"] >= 1
+
+
+def test_graceful_when_features_dir_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(_mod, "REPO_ROOT", tmp_path / "repo")
+    monkeypatch.setattr(_mod, "FEATURES_DIR", tmp_path / "repo" / ".claude" / "features")
+    cov = _mod.GateCoverage(mode="cycle")
+    findings = _mod.check_dependency_graph_cycles(coverage=cov)
+    assert findings == []
+    assert cov.gates[GATE]["skip_reasons"].get("features_dir_missing") == 1
+
+
+def test_invalid_json_skipped(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "ok", parent_feature="base")
+    _make(fd, "base")
+    bad = fd / "broken"
+    bad.mkdir()
+    (bad / "state.json").write_text("{ not valid json")
+    findings = _mod.check_dependency_graph_cycles()  # must not raise
+    assert isinstance(findings, list)
+
+
+# ─── Dispatch: wired into build_snapshot() ────────────────────────────────
+
+
+def test_dispatch_via_build_snapshot(monkeypatch, tmp_path):
+    fd = _wire(monkeypatch, tmp_path)
+    _make(fd, "a", scheduled_after={"predecessor": "b"})
+    _make(fd, "b", scheduled_after={"predecessor": "a"})
+
+    def _empty_check_output(cmd, **kw):
+        return ""
+    monkeypatch.setattr(_mod.subprocess, "check_output", _empty_check_output)
+    monkeypatch.setattr(sys, "argv", ["integrity-check.py"])
+    monkeypatch.setenv("GATE_COVERAGE_LEDGER_DISABLED", "1")
+
+    snap = _mod.build_snapshot("manual")
+    codes = {f["code"] for f in snap["findings"]}
+    assert GATE in codes
+    fires = [f for f in snap["findings"] if f["code"] == GATE]
+    assert all(f["severity"] == "ADVISORY" for f in fires)


### PR DESCRIPTION
## What

F3 from the v8.x ready-now docket (RICE 14.4, Theme A) — **the last ready-now item**. Adds a **cycle-time ADVISORY** in `scripts/integrity-check.py` that builds a directed dependency graph across all features and flags graph-integrity problems.

The graph edges come from two **structured** state.json fields: `scheduled_after.predecessor` and `parent_feature` (edge `A → B` = "A scheduled after / depends on B"). It flags:

1. **dangling** — an edge target is not an existing feature
2. **self-loop** — `A → A`
3. **cycle** — a directed cycle `A → … → A` (canonical-rotation dedup → one finding per distinct cycle, not one per member)

Surfaced because one dependency cycle was caught manually, post-hoc, on a multi-feature roadmap.

## Key design call: `depends_on` is excluded

`depends_on` is **not** treated as a graph edge — in practice it holds free-text prerequisites ("PR #158 — six lifecycle analytics events…"), not feature names. Parsing it as edges would manufacture dangling-reference false positives (`smart-reminders-behavioral-learning` is the witness). Only the structured `scheduled_after.predecessor` + `parent_feature` fields form the graph.

Full calibration artifacts: `.claude/features/f3-dependency-graph-cycle-check/calibration-artifacts.md`

## Baseline at ship

**0 findings** — the current corpus has no cycles, self-loops, or dangling refs across `scheduled_after` + `parent_feature` (28 features carry ≥1 edge). candidates ≥ 1 → a *healthy* zero-firing guard-gate (GATE_COVERAGE_ZERO distinguishes this from a 0-candidate mis-wire). **0 gating findings; exit code unchanged.**

## Tests

`scripts/tests/test_dependency_graph_cycle.py` — 12 unit + dispatch tests (2-node & 3-node cycles fire once; self-loop; dangling; bare-string `scheduled_after`; clean DAG = 0; `depends_on` free-text ≠ edge; no-edge feature not a candidate; coverage emission; graceful degradation; invalid JSON skipped; `build_snapshot()` dispatch). All pass; F1 + dispatch + cycle-coverage suites still green.

## Docket

`v8-0-ready-now-workplan` + `v8-x-build-docket` F3 rows marked shipped → **all 8 ready-now v8.x F-items now shipped; 0 remain.** Remaining v8.x work is date-gated (T1 2026-08-22) or operator-gated (F18, F19–F23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)