### PR TITLE
chore(state): backfill tasks[] on 5 f1-flagged complete features

### DIFF
--- a/.claude/features/case-study-presentation/state.json
+++ b/.claude/features/case-study-presentation/state.json
@@ -12,7 +12,12 @@
     "shared_writes": []
   },
   "current_phase": "complete",
-  "platforms_tested": {"ios": false, "web": true, "backend": false, "ai": false},
+  "platforms_tested": {
+    "ios": false,
+    "web": true,
+    "backend": false,
+    "ai": false
+  },
   "platforms_tested_provenance": "backfill-heuristic-2026-06-07",
   "status": "complete",
   "created_at": "2026-04-28T04:00:00Z",
@@ -210,5 +215,15 @@
   "_meta": {
     "deprecation_warnings": []
   },
-  "state_owner": "ft2"
+  "state_owner": "ft2",
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "Visual-aid catalog + Alt-A/B templates + state.json (docs case-study presentation)",
+      "status": "done",
+      "pr_number": 146,
+      "provenance": "backfill-from-merge-pr-2026-06-17",
+      "completed_at": "2026-04-28T22:00:00Z"
+    }
+  ]
 }

--- a/.claude/features/fitme-story-design-system-p2-cleanup/state.json
+++ b/.claude/features/fitme-story-design-system-p2-cleanup/state.json
@@ -1,7 +1,12 @@
 {
   "feature_name": "fitme-story-design-system-p2-cleanup",
   "current_phase": "complete",
-  "platforms_tested": {"ios": true, "web": true, "backend": false, "ai": false},
+  "platforms_tested": {
+    "ios": true,
+    "web": true,
+    "backend": false,
+    "ai": false
+  },
   "platforms_tested_provenance": "backfill-heuristic-2026-06-07",
   "created_at": "2026-05-10T18:13:57Z",
   "updated_at": "2026-05-10T18:51:19Z",
@@ -143,7 +148,16 @@
       "kill_criteria_resolution": "Not_yet_triggered. Operator visual spot-check pending post-deploy (PR #84 lists this as a checkbox). Migrations were mechanical (Card / Stat / ExternalLink / .divider-row) so confidence in no-regression is high; but visual regression IS the kill criterion if discovered."
     }
   },
-  "tasks": [],
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "P2 design-system audit cleanup \u2014 Card\u00d75 + Stat\u00d71 + ExternalLink + divider class (fitme-story)",
+      "status": "done",
+      "pr_number": 84,
+      "provenance": "backfill-from-merge-pr-2026-06-17",
+      "completed_at": "2026-05-10T18:45:11Z"
+    }
+  ],
   "figma_node_ids": {},
   "figma_build_status": "tokens_published_2026-05-10",
   "pre_merge_review": {

--- a/.claude/features/ios-ui-audit-p1-burndown/state.json
+++ b/.claude/features/ios-ui-audit-p1-burndown/state.json
@@ -1,7 +1,12 @@
 {
   "feature_name": "ios-ui-audit-p1-burndown",
   "current_phase": "complete",
-  "platforms_tested": {"ios": true, "web": true, "backend": false, "ai": false},
+  "platforms_tested": {
+    "ios": true,
+    "web": true,
+    "backend": false,
+    "ai": false
+  },
   "platforms_tested_provenance": "backfill-heuristic-2026-06-07",
   "created_at": "2026-05-11T03:09:17Z",
   "updated_at": "2026-05-11T07:26:45Z",
@@ -165,7 +170,16 @@
       "kill_criteria_resolution": "not_triggered_no_visual_regression_post_spot_check (operator iOS simulator spot-check per PR cleared with zero visual drift; all token substitutions are pixel-identical)"
     }
   },
-  "tasks": [],
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "iOS UI P1 burndown \u2014 3 AppText tokens + 23 font subs + 5 a11y labels + widened audit window",
+      "status": "done",
+      "pr_number": 294,
+      "provenance": "backfill-from-merge-pr-2026-06-17",
+      "completed_at": "2026-05-11T07:24:37Z"
+    }
+  ],
   "figma_node_ids": {},
   "figma_build_status": null,
   "pre_merge_review": {

--- a/.claude/features/smart-reminders-behavioral-learning/state.json
+++ b/.claude/features/smart-reminders-behavioral-learning/state.json
@@ -156,5 +156,15 @@
   ],
   "notes": "Brainstorm session 2026-04-30 locked OQ-1..OQ-5: (1) v1 scope = SR-17 data layer + SR-18 timing automation; (2) Bayesian update with static-default fire-time prior, no count-threshold cliff; (3) hybrid architecture - server cohort prior via existing Supabase cohort_stats + on-device per-user posterior + new backend writer hook + retention extension; (4) single global 'Smart timing' toggle in Settings -> Notifications (on by default) PLUS per-type 'Why this time?' affordance reusing AIIntelligenceSheet pattern; (5) success metric = aggregate tap-through lift >= +5 pp at p < 0.05 with per-type kill at -3 pp; readout window 14 +/- 4 days flexible per-user, plus post-population aggregation later for stable per-segment baselines. Constraint surfaced during brainstorm: only 3 of 6 ReminderTypes are personalisable (Nutrition Gap, Training Day, Rest Day); HealthKit/Account/Engagement keep static defaults due to lifetime caps. Approach A/B/C sequencing pick still open at session pause; design sections + spec doc + writing-plans not yet done. Resume by reading research/open-questions.md 'Decisions locked 2026-04-30' section.",
   "known_followups": [],
-  "state_owner": "ft2"
+  "state_owner": "ft2",
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "Behavioral learning PR 1 \u2014 iOS data layer + toggle-off (backend deferred)",
+      "status": "done",
+      "pr_number": 190,
+      "provenance": "backfill-from-merge-pr-2026-06-17",
+      "completed_at": "2026-05-04T06:58:43Z"
+    }
+  ]
 }

--- a/.claude/features/trend-alerts-hrv/state.json
+++ b/.claude/features/trend-alerts-hrv/state.json
@@ -43,7 +43,16 @@
     "trigger_windows_distinct": "C2 fires at the user's learned training time-of-day. C4 fires on a daily morning evaluation (~08:00 local fallback, learnable from app-open patterns later) regardless of training schedule.",
     "conflict_risk": "AIInsightCard + AIIntelligenceSheet edited by C2 are likely targets for C4 too. Phase 0 mitigation: defer C4's in-app surface to a follow-on commit if C2 ships first; otherwise C4 lands the patterns and C2 rebases on top."
   },
-  "tasks": [],
+  "tasks": [
+    {
+      "id": "T1",
+      "description": "Trend-alerts HRV \u2014 PRD + Tasks + implementation (shipped)",
+      "status": "done",
+      "pr_number": 564,
+      "provenance": "backfill-from-merge-pr-2026-06-17",
+      "completed_at": "2026-06-01T14:13:53Z"
+    }
+  ],
   "phases": {
     "research": {
       "started_at": "2026-06-01T08:30:00Z",


### PR DESCRIPTION
## Summary
The new `STATE_TASKS_FILESYSTEM_DRIFT` (f1) advisory flagged 5 shipped features (v7.7–v7.9) with empty `tasks[]` — they predate the tasks-ledger discipline. Each gets **one honest summary task reconstructed from its real merge PR**, tagged `provenance: backfill-from-merge-pr-2026-06-17` (post-hoc, not fabricated granular detail).

| Feature | Merge PR |
|---|---|
| case-study-presentation | #146 |
| fitme-story-design-system-p2-cleanup | #84 (fitme-story) |
| ios-ui-audit-p1-burndown | #294 |
| smart-reminders-behavioral-learning | #190 |
| trend-alerts-hrv | #564 |

## Verification
- `make integrity-check`: **0 findings**; f1 `STATE_TASKS_FILESYSTEM_DRIFT` advisories **5→0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)