### PR TITLE
chore(telemetry): recover 06-12 + 06-13 adoption-history snapshots

### DIFF
--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -1331,6 +1331,120 @@
       }
     },
     {
+      "date": "2026-06-12",
+      "generated_at": "2026-06-12T06:08:36Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 105,
+        "features_post_v6": 71,
+        "features_pre_v6": 34,
+        "fully_adopted": 9,
+        "partial_adopted": 60,
+        "zero_adopted": 36,
+        "fully_adopted_post_v6": 9,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 36,
+          "overall_percent": 34.3,
+          "post_v6_present": 36,
+          "post_v6_percent": 50.7,
+          "overall_instrumented": 17,
+          "overall_derived": 19,
+          "post_v6_instrumented": 17,
+          "post_v6_derived": 19
+        },
+        "per_phase_timing": {
+          "overall_present": 69,
+          "overall_percent": 65.7,
+          "post_v6_present": 66,
+          "post_v6_percent": 93.0,
+          "overall_instrumented": 69,
+          "overall_derived": 0,
+          "post_v6_instrumented": 66,
+          "post_v6_derived": 0
+        },
+        "cache_hits": {
+          "overall_present": 29,
+          "overall_percent": 27.6,
+          "post_v6_present": 28,
+          "post_v6_percent": 39.4,
+          "overall_instrumented": 29,
+          "overall_derived": 0,
+          "post_v6_instrumented": 28,
+          "post_v6_derived": 0
+        },
+        "cu_v2": {
+          "overall_present": 25,
+          "overall_percent": 23.8,
+          "post_v6_present": 25,
+          "post_v6_percent": 35.2,
+          "overall_instrumented": 25,
+          "overall_derived": 0,
+          "post_v6_instrumented": 25,
+          "post_v6_derived": 0
+        }
+      }
+    },
+    {
+      "date": "2026-06-13",
+      "generated_at": "2026-06-13T06:07:47Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 106,
+        "features_post_v6": 72,
+        "features_pre_v6": 34,
+        "fully_adopted": 9,
+        "partial_adopted": 61,
+        "zero_adopted": 36,
+        "fully_adopted_post_v6": 9,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 36,
+          "overall_percent": 34.0,
+          "post_v6_present": 36,
+          "post_v6_percent": 50.0,
+          "overall_instrumented": 17,
+          "overall_derived": 19,
+          "post_v6_instrumented": 17,
+          "post_v6_derived": 19
+        },
+        "per_phase_timing": {
+          "overall_present": 70,
+          "overall_percent": 66.0,
+          "post_v6_present": 67,
+          "post_v6_percent": 93.1,
+          "overall_instrumented": 70,
+          "overall_derived": 0,
+          "post_v6_instrumented": 67,
+          "post_v6_derived": 0
+        },
+        "cache_hits": {
+          "overall_present": 30,
+          "overall_percent": 28.3,
+          "post_v6_present": 29,
+          "post_v6_percent": 40.3,
+          "overall_instrumented": 30,
+          "overall_derived": 0,
+          "post_v6_instrumented": 29,
+          "post_v6_derived": 0
+        },
+        "cu_v2": {
+          "overall_present": 25,
+          "overall_percent": 23.6,
+          "post_v6_present": 25,
+          "post_v6_percent": 34.7,
+          "overall_instrumented": 25,
+          "overall_derived": 0,
+          "post_v6_instrumented": 25,
+          "post_v6_derived": 0
+        }
+      }
+    },
+    {
       "date": "2026-06-14",
       "generated_at": "2026-06-14T06:08:09Z",
       "trigger": "manual",


### PR DESCRIPTION
## Summary
Fills a **2-day gap** in the `measurement-adoption-history.json` trend ledger — main jumped 2026-06-11 → 06-14, missing 06-12 and 06-13. The only copies of those snapshots lived on two stale branches (`chore/daily-cycle-snapshot-2026-06-12` no-PR + `#707` CLOSED). Union-merged by date (38 snapshots total, chronological).

Recovers the data **before** those branches are deleted as part of Batch B cleanup.

## Verification
- `make integrity-check`: **0 findings**
- snapshots[] chronological, 06-12/06-13 entries schema-valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)