### PR TITLE
docs(framework): reconcile canonical versions.json to v7.10 + v8.x

### DIFF
--- a/docs/framework/versions.json
+++ b/docs/framework/versions.json
@@ -1,39 +1,37 @@
 {
   "schema_version": "1.0.0",
   "generated_by": "manual seed 2026-05-28; future generator: fitme-story/scripts/sync-from-fittracker2.ts (Phase 4 of feature 3d-interactive-framework-flow-diagram)",
-  "last_reconciled": "2026-05-28",
-  "reconciled_by": "v7.9 → v7.9.1 PRD reconciliation pass for feature 3d-interactive-framework-flow-diagram",
+  "last_reconciled": "2026-06-17",
+  "reconciled_by": "v7.10 + v8.x ready-now batch reconciliation (F16 advisory→enforced 2026-06-17; F4/F1/F3 gates shipped) — FT2 PR #764",
   "current": {
-    "version": "v7.9",
-    "shipped_at": "2026-05-21",
-    "status": "phase_e_calibration",
-    "phase_e_started": "2026-05-21",
-    "phase_e_ends": "2026-06-04",
-    "case_study_path": "docs/case-studies/framework-v7-9-promotion-case-study.md",
-    "pr_number": 417
+    "version": "v7.10",
+    "shipped_at": "2026-06-10",
+    "status": "shipped",
+    "case_study_path": "docs/case-studies/framework-v7-9-1-promotion-case-study.md",
+    "note": "GATE_COVERAGE_ZERO observability hardening + field-rename silent-pass closure + T10 AI golden-set evals. v8.x build window is open (kickoff gate cleared by F16 enforce flip 2026-06-17)."
   },
   "next": {
-    "version": "v7.9.1",
-    "status": "in_flight",
-    "candidates": [
-      "F-AUTH-LATENCY-SERVER-METRIC",
-      "F-CONTRACT-FIXTURE-SAMPLING",
-      "F-DEPLOYED-URL-PROBE",
-      "F-LAUNCHD-DRIFT-EXTENSION"
+    "version": "v8.0",
+    "status": "build_window_open",
+    "shipped_ready_now": [
+      "F4 FRAMEWORK_VERSION_STALE (write-time advisory, #740, 2026-06-16)",
+      "F1 STATE_TASKS_FILESYSTEM_DRIFT (cycle-time advisory-permanent, #752, 2026-06-17)",
+      "F3 DEPENDENCY_GRAPH_CYCLE (cycle-time advisory-permanent, #753, 2026-06-17)",
+      "F16 try-repo harness advisory→enforced (#764, 2026-06-17 — added to main required status checks)"
     ],
-    "expected_ship_window": "2026-06-04 → 2026-06-18",
-    "v8_window_opens": "2026-06-18"
+    "open_remaining": ["T1 GATE_TEST_MISSING (2026-08-22)", "F18 mutation testing (post-F16-Phase-E)", "F19–F23 (operator/launch-gated)"],
+    "ship_target": "2026-07-31"
   },
   "stats": {
-    "write_time_gates": 17,
+    "write_time_gates": 18,
     "cycle_time_gates": 16,
-    "advisory_gates": 3,
+    "advisory_gates": 5,
+    "instrumented_gates_total": 28,
     "mechanisms": ["A", "B", "C", "D", "E", "F"],
     "lifecycle_phases": 10,
     "data_quality_tiers": 3,
-    "active_features_with_phase": 4,
-    "complete_features": 60,
-    "_note": "Gate counts are approximate as of last_reconciled; reconcile via `make integrity-check` for live numbers. Active/complete counts derive from .claude/features/*/state.json — see also .claude/shared/measurement-adoption.json."
+    "features_tracked": 113,
+    "_note": "Counts as of 2026-06-17 reconcile; FT2 docs/FRAMEWORK-FACTS.md is the canonical machine-derived source (defer to it for live numbers). instrumented_gates_total = 18 write-time + 7 cycle-time emitting + 2 W9 hooks + 1 (F4 not yet emitting) per the F17 gate-last-fired index."
   },
   "timeline": [
     { "version": "v5.0", "ship_date": null, "label": "Skill-on-demand Separation of Concerns", "status": "shipped", "note": "Pre-PM-workflow tracking; ship date approximate." },
@@ -53,7 +51,9 @@
     { "version": "v7.8.5", "ship_date": "2026-05-13", "label": "Observability Layer (Observed Patterns Catalog + W9)", "status": "shipped", "pr_numbers": [328, 341] },
     { "version": "v7.8.6", "ship_date": "2026-05-15", "label": "Cadence Batch (preflight + integrity-diff + W1)", "status": "shipped", "pr_numbers": [363, 365, 366] },
     { "version": "v7.9", "ship_date": "2026-05-21", "label": "Promotion Release (3 advisory gates flipped to enforced)", "status": "shipped", "pr_number": 417, "case_study_path": "docs/case-studies/framework-v7-9-promotion-case-study.md" },
-    { "version": "v7.9.1", "ship_date": null, "label": "In flight — 4 candidates", "status": "in_flight" }
+    { "version": "v7.9.1", "ship_date": "2026-06-04", "label": "Build Window (8 ships / 14 PRs, 0 new enforcement gates) — F16 try-repo harness + F17 last_fired index + F2 reality-check", "status": "shipped", "case_study_path": "docs/case-studies/framework-v7-9-1-promotion-case-study.md" },
+    { "version": "v7.10", "ship_date": "2026-06-10", "label": "GATE_COVERAGE_ZERO observability + field-rename closure + T10 AI golden-set evals", "status": "shipped", "pr_numbers": [689, 687, 688, 691] },
+    { "version": "v8.x (ready-now batch)", "ship_date": "2026-06-17", "label": "v8.x docket — F4 FRAMEWORK_VERSION_STALE + F1 STATE_TASKS_FILESYSTEM_DRIFT + F3 DEPENDENCY_GRAPH_CYCLE advisory gates; F16 try-repo harness advisory→enforced", "status": "build_window_open", "pr_numbers": [740, 752, 753, 764] }
   ],
   "gates_flipped_at_v7_9": [
     "BRANCH_ISOLATION_VIOLATION Mode B (infra commit-level)",
@@ -109,7 +109,7 @@
     "fitme-story /glossary — version chip on glossary terms"
   ],
   "source_of_truth_pointers": {
-    "version_history": "FT2:CLAUDE.md — Framework version sections (v7.5 → v7.9)",
+    "version_history": "FT2:CLAUDE.md — Framework version sections (v7.5 → v7.10); FT2:docs/FRAMEWORK-FACTS.md for canonical current-state counts",
     "gate_definitions": "FT2:scripts/check-state-schema.py + FT2:scripts/integrity-check.py",
     "observed_patterns": "FT2:.claude/integrity/observed-patterns.md",
     "feature_roster": "FT2:.claude/features/*/state.json",
@@ -117,7 +117,7 @@
     "gate_telemetry": "FT2:.claude/logs/gate-coverage.jsonl",
     "case_studies": "FT2:docs/case-studies/*.md",
     "lifecycle_event_catalog": "FT2:docs/architecture/feature-lifecycle-event-catalog.md",
-    "dev_guide": "FT2:docs/architecture/dev-guide-v1-to-v7-7.md (filename retained for ref-stability; content tracks v7.9)"
+    "dev_guide": "FT2:docs/architecture/dev-guide-v1-to-v7-7.md (filename retained for ref-stability; content tracks v7.10 + v8.x ready-now batch)"
   },
   "update_protocol": {
     "when": "Every framework version ship (v7.9.1, v8.0, v9.0, …) MUST update this file in the same PR that lands the version.",


### PR DESCRIPTION
`docs/framework/versions.json` is the **canonical version-timeline data source** that fitme-story mirrors verbatim (`sync-from-fittracker2.ts` → `src/data/framework/versions.json`), feeding the `/framework/dev-guide` timeline, `/control-room` gate-count pill, `/glossary` version chip, and the 3D Framework Universe. It was stale at v7.9.

- `current` → **v7.10** (2026-06-10); `next` → **v8.0 build window open** (F4/F1/F3 shipped + F16 enforced)
- `stats` → 18 write-time gates, **28 instrumented total**, 113 features tracked
- `timeline[]` → v7.9.1 marked shipped (was `in_flight`) + appended **v7.10** + **v8.x ready-now** entries
- source-of-truth pointers → v7.10; defer counts to FRAMEWORK-FACTS

**Companion to fitme-story [PR #234](https://github.com/Regevba/fitme-story/pull/234)** (hand-authored site prose: glossary 25→28 gates, framework-page timeline, EvolutionStrip v8.x entry). This is the data-driven half; #234 is the prose half. The dev-guide + README half already landed via #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)