### PR TITLE
docs(3d-universe): record Phase 4 operator decisions (2026-06-18)

### DIFF
--- a/.claude/features/3d-interactive-framework-flow-diagram/state.json
+++ b/.claude/features/3d-interactive-framework-flow-diagram/state.json
@@ -375,5 +375,46 @@
   "updated_at": "2026-06-07T00:00:00Z",
   "state_owner_sync_origin": "fitme-story-reverse",
   "isolation_opt_out": true,
-  "isolation_opt_out_reason": "Feature is state_owner=fitme-story (reverse-synced into FT2). Its FT2-side planning artifacts (prd/tasks/state) are updated across multiple framework PRs rather than a single feature/* branch, so BRANCH_ISOLATION_HISTORICAL fires by construction. Silenced per the documented path; the authoritative fitme-story copy should carry the same flag to survive reverse-sync (2026-06-10 self-test)."
+  "isolation_opt_out_reason": "Feature is state_owner=fitme-story (reverse-synced into FT2). Its FT2-side planning artifacts (prd/tasks/state) are updated across multiple framework PRs rather than a single feature/* branch, so BRANCH_ISOLATION_HISTORICAL fires by construction. Silenced per the documented path; the authoritative fitme-story copy should carry the same flag to survive reverse-sync (2026-06-10 self-test).",
+  "phase_4_decisions": {
+    "decided_at": "2026-06-18",
+    "decided_by": "operator",
+    "decisions": [
+      {
+        "id": "D1-hero-assets",
+        "decision": "defer_procedural_only",
+        "detail": "Ship procedural-only scene; 6 hero glTF pieces deferred to post-launch polish (not on critical path)."
+      },
+      {
+        "id": "D2-scrub-control",
+        "decision": "custom_lightweight",
+        "detail": "Build custom Controls.tsx (pause + arrow-key scrub + 4x slow + replay + keyboard a11y). Theatre.js v9 NOT adopted."
+      },
+      {
+        "id": "D3-hadf-path",
+        "decision": "path_1_act_iii_chambers",
+        "detail": "Render HADF Phase 3a sensing as new chambers inside Act III Architecture (aggregator half already shipped #203)."
+      },
+      {
+        "id": "D6-relaunch",
+        "decision": "keep_404_until_rive_and_polish",
+        "detail": "Stay 404 until the Rive reduced-motion fallback (T-rive-tier-2) is authored AND a full polish pass lands. T-rive-tier-2 is now the single re-launch blocker."
+      },
+      {
+        "id": "D4-playwright",
+        "decision": "recommended_approve_pending_confirm",
+        "detail": "Operator default rec: approve ~200MB Playwright install for AC-10/AC-11/mobile e2e. Awaiting explicit confirm."
+      },
+      {
+        "id": "D5-lighthouse",
+        "decision": "keep_warn_until_post_relaunch",
+        "detail": "Keep lighthouse warn @0.8; flip to enforce >=0.95 after re-launch + 1-2wk calibration."
+      }
+    ],
+    "now_buildable_no_assets": [
+      "T-scrub-pause-timedilation",
+      "T-hadf-sensing-layer-hooks (scene consumer, path 1)"
+    ],
+    "relaunch_blocker": "T-rive-tier-2 (.riv asset) + full polish pass"
+  }
 }

--- a/.claude/features/3d-interactive-framework-flow-diagram/tasks.md
+++ b/.claude/features/3d-interactive-framework-flow-diagram/tasks.md
@@ -29,13 +29,17 @@
 | T-comprehension-panel | ✅ shipped | fitme-story #200 |
 | T-hadf-sensing-layer-hooks (aggregator half) | ✅ shipped (path-agnostic) | fitme-story #203 |
 | T-lighthouse-perf URL list | ✅ shipped | fitme-story #204 |
-| T-hero-gate-machinery, T-hero-telemetry-instruments, T-hero-signature-props (×4) | 🔒 gated | visual-direction lock + Blender authoring decision |
-| T-scrub-pause-timedilation | 🔒 gated | Theatre.js v9 compatibility OR alternative path |
-| T-rive-tier-2 | 🔒 gated | operator Rive asset |
+| T-hero-gate-machinery, T-hero-telemetry-instruments, T-hero-signature-props (×4) | ⏸️ deferred (D1) | post-launch polish — procedural scene ships without them |
+| T-scrub-pause-timedilation | 🟡 unblocked (D2) | custom lightweight Controls.tsx (Theatre.js NOT adopted); in progress |
+| T-rive-tier-2 | 🔴 re-launch blocker (D6) | operator Rive `.riv` asset — single gate to un-404 `/framework/universe` |
 | T-poster-tier-3 | 🔒 gated | operator hero PNG/WebP capture |
-| T-hadf-sensing-layer-hooks (scene consumer half) | 🔒 gated | operator path 1 (Act III chambers) vs path 2 (new sub-Act) decision |
-| T-playwright-ac10, T-playwright-ac11, T-mobile-60fps | 🔒 gated | Playwright browser binary install approval (~200 MB) |
-| T-lighthouse-perf assertion promotion | 🔒 gated | calibration window (currently `warn` @ minScore 0.8; AC-16 target ≥0.95) |
+| T-hadf-sensing-layer-hooks (scene consumer half) | 🟡 unblocked (D3) | **path 1 — Act III chambers** (aggregator half shipped #203); in progress |
+| T-playwright-ac10, T-playwright-ac11, T-mobile-60fps | 🔒 gated | Playwright browser binary install approval (~200 MB) — D4 rec: approve |
+| T-lighthouse-perf assertion promotion | 🔒 gated (D5) | keep `warn` @0.8 until re-launch + 1–2wk calibration, then flip ≥0.95 |
+
+### Phase 4 operator decisions (2026-06-18)
+
+Recorded in `state.json::phase_4_decisions`. **D1** hero assets → defer (procedural-only). **D2** scrub → custom lightweight. **D3** HADF → path 1 (Act III chambers). **D6** re-launch → keep 404 until Rive + full polish (⇒ `T-rive-tier-2` is the single re-launch blocker). **D4** Playwright → rec approve (pending confirm). **D5** lighthouse → keep warn until post-relaunch calibration. Now-buildable with no assets: `T-scrub-pause-timedilation` + `T-hadf-sensing-layer-hooks` (scene consumer, path 1).
 
 ### Production status (2026-06-06)
 


### PR DESCRIPTION
Persists the 6 Phase-4 decisions to `state.json::phase_4_decisions` + tasks.md status table. D1 defer hero glTF · D2 custom scrub · D3 HADF path-1 (Act III chambers) · D6 keep-404-until-Rive (⇒ T-rive-tier-2 sole re-launch blocker) · D4 rec-approve Playwright · D5 keep lighthouse warn. Unblocks two code-only tasks (custom scrub + HADF scene-consumer) being built in fitme-story next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)