### PR TITLE
chore(ledger): 2026-06-21 daily digest — measurement-adoption + doc-debt snapshot

### DIFF
--- a/.claude/shared/documentation-debt.json
+++ b/.claude/shared/documentation-debt.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-20T21:39:04Z",
+  "updated": "2026-06-21T06:12:25Z",
   "description": "Baseline documentation-debt report for case-study structure, state linkage, and integrity-cycle readiness.",
   "summary": {
     "case_studies_scanned": 113,
@@ -54,9 +54,9 @@
       ]
     },
     "pr_citation_exempt": {
-      "present": 26,
-      "missing": 87,
-      "percent": 23.0,
+      "present": 27,
+      "missing": 86,
+      "percent": 23.9,
       "examples": [
         "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
         "docs/case-studies/ai-golden-set-evals-case-study.md",

--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "description": "Append-only daily snapshots of Tier 1.1 measurement adoption. Dedup by date \u2014 at most one snapshot per day. Mirrors the documentation-debt history pattern; enables Tier 1.1 trend analysis after 3+ daily snapshots accumulate.",
+  "description": "Append-only daily snapshots of Tier 1.1 measurement adoption. Dedup by date — at most one snapshot per day. Mirrors the documentation-debt history pattern; enables Tier 1.1 trend analysis after 3+ daily snapshots accumulate.",
   "snapshots": [
     {
       "date": "2026-04-25",
@@ -1785,7 +1785,64 @@
           "post_v6_derived": 0
         }
       }
+    },
+    {
+      "date": "2026-06-21",
+      "generated_at": "2026-06-21T06:12:25Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 115,
+        "features_post_v6": 81,
+        "features_pre_v6": 34,
+        "fully_adopted": 9,
+        "partial_adopted": 70,
+        "zero_adopted": 36,
+        "fully_adopted_post_v6": 9,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 37,
+          "overall_percent": 32.2,
+          "post_v6_present": 37,
+          "post_v6_percent": 45.7,
+          "overall_instrumented": 18,
+          "overall_derived": 19,
+          "post_v6_instrumented": 18,
+          "post_v6_derived": 19
+        },
+        "per_phase_timing": {
+          "overall_present": 79,
+          "overall_percent": 68.7,
+          "post_v6_present": 76,
+          "post_v6_percent": 93.8,
+          "overall_instrumented": 79,
+          "overall_derived": 0,
+          "post_v6_instrumented": 76,
+          "post_v6_derived": 0
+        },
+        "cache_hits": {
+          "overall_present": 31,
+          "overall_percent": 27.0,
+          "post_v6_present": 30,
+          "post_v6_percent": 37.0,
+          "overall_instrumented": 31,
+          "overall_derived": 0,
+          "post_v6_instrumented": 30,
+          "post_v6_derived": 0
+        },
+        "cu_v2": {
+          "overall_present": 26,
+          "overall_percent": 22.6,
+          "post_v6_present": 26,
+          "post_v6_percent": 32.1,
+          "overall_instrumented": 26,
+          "overall_derived": 0,
+          "post_v6_instrumented": 26,
+          "post_v6_derived": 0
+        }
+      }
     }
   ],
-  "updated": "2026-06-20T21:39:04Z"
+  "updated": "2026-06-21T06:12:25Z"
 }

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-06-20T21:39:20Z",
+  "updated": "2026-06-21T06:12:25Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {
@@ -67,818 +67,114 @@
     "roadmap-stress-test-2026-05-07"
   ],
   "partial_adopted_features": [
-    {
-      "feature": "3d-interactive-framework-flow-diagram",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "adaptive-intelligence-next-pass",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ai-golden-set-evals",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ai-user-feedback-loop",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "analytics-observability",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "android-token-pipeline",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "auth-polish-v2",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "code-connect-automation",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "cross-repo-state-sync-impl",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "dev-env-r11-r13-r14-r17-r18-batch",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "exercise-search-filter",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f-deployed-url-probe-ft2",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f-launchd-drift-extension",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f-launchd-drift-extension-sub-a",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f-phase-e-adoption-freeze-discipline",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f1-state-tasks-filesystem-drift",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f11-reverse-sync-historical-exempt",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f12-actionlint-gate",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f16-try-repo-harness",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f17-last-fired-at-index",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f2-phase-0-reality-check",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f3-dependency-graph-cycle-check",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "f4-framework-version-stale",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "figma-design-architecture",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "fitme-story-design-system-p2-cleanup",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "fitme-story-ds-p2-deferred",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "fitme-story-ds-p2-final-sweep",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "fitme-story-dual-audience-redesign",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "fitme-story-public-enhancements",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "fitme-story-website-design-system",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "foundation-models-tier3",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "framework-f14-f15-dispatch-test-coverage",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "framework-honesty-fixes-2026-05-01",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "framework-measurement-v6",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "framework-story-site",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "framework-v7-8-branch-isolation",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "framework-v7-9-1-promotion",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "framework-v7-9-promotion",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "framework-w30-w31-w32-durable-fixes",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "garmin-health-connection",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "hadf-infrastructure",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "hadf-phase2-cloud-fingerprinting",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "hadf-phase2bis-replication",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "hadf-phase3a-sensing",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "hadf-signature-expansion",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "import-training-plan",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ios-code-connect",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ios-ui-audit-p1-burndown",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ios-ui-audit-p1-drift-cleanup",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "onboarding-v2-retroactive",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "orchid-v1-5",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "r9-track-b-coverage-aggregator",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "readiness-aware-training-alert",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "smart-reminders-behavioral-learning",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "stats-v2",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "t13-last-failed-at-index",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "t14-platform-parity-state-field",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "t3-signinservice-passkey-tests",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "t5-mock-protocol-drift",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "training-program-customization",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "trend-alerts-hrv",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ucc-passkey-auth",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ucc-passkey-auth-audit-log-redis-fix",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "ucc-passkey-auth-security-hardening",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "ucc-sign-in-figma-mapping",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "ui-audit-baseline-burndown",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "ui-ux-final-sweep-2026-05-12",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "unified-control-center",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      }
-    },
-    {
-      "feature": "v8-f10-f5-schema-vocab",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    },
-    {
-      "feature": "w9-drift-triggered-auto-isolation",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      }
-    }
+    {"feature":"3d-interactive-framework-flow-diagram","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"adaptive-intelligence-next-pass","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"ai-golden-set-evals","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"ai-user-feedback-loop","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"analytics-observability","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"android-token-pipeline","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"auth-polish-v2","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"code-connect-automation","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"cross-repo-state-sync-impl","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"dev-env-r11-r13-r14-r17-r18-batch","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"exercise-search-filter","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f-deployed-url-probe-ft2","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f-launchd-drift-extension","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f-launchd-drift-extension-sub-a","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f-phase-e-adoption-freeze-discipline","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f1-state-tasks-filesystem-drift","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f11-reverse-sync-historical-exempt","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f12-actionlint-gate","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f16-try-repo-harness","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f17-last-fired-at-index","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f2-phase-0-reality-check","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f3-dependency-graph-cycle-check","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"f4-framework-version-stale","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"figma-design-architecture","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"fitme-story-design-system-p2-cleanup","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"fitme-story-ds-p2-deferred","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"fitme-story-ds-p2-final-sweep","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"fitme-story-dual-audience-redesign","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"fitme-story-public-enhancements","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"fitme-story-website-design-system","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"foundation-models-tier3","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"framework-f14-f15-dispatch-test-coverage","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"framework-honesty-fixes-2026-05-01","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"framework-measurement-v6","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"framework-story-site","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"framework-v7-8-branch-isolation","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"framework-v7-9-1-promotion","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"framework-v7-9-promotion","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"framework-w30-w31-w32-durable-fixes","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"garmin-health-connection","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"hadf-infrastructure","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"hadf-phase2-cloud-fingerprinting","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"hadf-phase2bis-replication","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"hadf-phase3a-sensing","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"hadf-signature-expansion","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"import-training-plan","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"ios-code-connect","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"ios-ui-audit-p1-burndown","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"ios-ui-audit-p1-drift-cleanup","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"onboarding-v2-retroactive","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"orchid-v1-5","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"r9-track-b-coverage-aggregator","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"readiness-aware-training-alert","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"smart-reminders-behavioral-learning","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"stats-v2","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"t13-last-failed-at-index","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"t14-platform-parity-state-field","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"t3-signinservice-passkey-tests","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"t5-mock-protocol-drift","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"training-program-customization","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"trend-alerts-hrv","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"ucc-passkey-auth","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"ucc-passkey-auth-audit-log-redis-fix","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"ucc-passkey-auth-security-hardening","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"ucc-sign-in-figma-mapping","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":true}},
+    {"feature":"ui-audit-baseline-burndown","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"ui-ux-final-sweep-2026-05-12","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":true,"cu_v2":false}},
+    {"feature":"unified-control-center","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":true,"cu_v2":true}},
+    {"feature":"v8-f10-f5-schema-vocab","adoption":{"timing_wall_time":false,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}},
+    {"feature":"w9-drift-triggered-auto-isolation","adoption":{"timing_wall_time":true,"per_phase_timing":true,"cache_hits":false,"cu_v2":false}}
   ],
   "zero_adopted_features": [
-    {
-      "feature": "adaptive-intelligence",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "ai-cohort-intelligence",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "ai-engine-architecture-adaptation",
-      "created": "2026-04-12",
-      "post_v6": false
-    },
-    {
-      "feature": "ai-engine-v2",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "ai-recommendation-ui",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "android-design-system",
-      "created": "2026-04-04",
-      "post_v6": false
-    },
-    {
-      "feature": "app-store-assets",
-      "created": "2026-04-12",
-      "post_v6": false
-    },
-    {
-      "feature": "authentication",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "data-sync",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "design-system-v2",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "development-dashboard",
-      "created": "2026-04-02",
-      "post_v6": false
-    },
-    {
-      "feature": "dispatch-intelligence-v5.2",
-      "created": "2026-04-16",
-      "post_v6": true
-    },
-    {
-      "feature": "framework-v5-0-soc",
-      "created": "2026-04-14",
-      "post_v6": false
-    },
-    {
-      "feature": "framework-v7-1-integrity-cycle",
-      "created": "2026-04-21",
-      "post_v6": true
-    },
-    {
-      "feature": "framework-v7-5-data-integrity",
-      "created": "2026-04-24",
-      "post_v6": true
-    },
-    {
-      "feature": "framework-v7-8-bridge",
-      "created": "2026-05-04",
-      "post_v6": true
-    },
-    {
-      "feature": "gdpr-compliance",
-      "created": "2026-04-04",
-      "post_v6": false
-    },
-    {
-      "feature": "google-analytics",
-      "created": "2026-04-02",
-      "post_v6": false
-    },
-    {
-      "feature": "home-status-goal-card",
-      "created": "2026-04-09",
-      "post_v6": false
-    },
-    {
-      "feature": "home-today-screen",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "marketing-website",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "metric-tile-deep-linking",
-      "created": "2026-04-09",
-      "post_v6": false
-    },
-    {
-      "feature": "nutrition-logging",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "nutrition-v2",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "onboarding",
-      "created": "2026-04-05",
-      "post_v6": false
-    },
-    {
-      "feature": "onboarding-v2-auth-flow",
-      "created": "2026-04-15",
-      "post_v6": false
-    },
-    {
-      "feature": "parallel-write-safety-v5.2",
-      "created": "2026-04-16",
-      "post_v6": true
-    },
-    {
-      "feature": "readiness-score-v2",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "recovery-biometrics",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "settings",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "settings-v2",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "smart-reminders",
-      "created": "2026-04-15",
-      "post_v6": false
-    },
-    {
-      "feature": "stats-progress-hub",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "training-plan-v2",
-      "created": "2026-04-10",
-      "post_v6": false
-    },
-    {
-      "feature": "training-tracking",
-      "created": "2026-04-06",
-      "post_v6": false
-    },
-    {
-      "feature": "user-profile-settings",
-      "created": "2026-04-13",
-      "post_v6": false
-    }
+    {"feature":"adaptive-intelligence","created":"2026-04-10","post_v6":false},
+    {"feature":"ai-cohort-intelligence","created":"2026-04-06","post_v6":false},
+    {"feature":"ai-engine-architecture-adaptation","created":"2026-04-12","post_v6":false},
+    {"feature":"ai-engine-v2","created":"2026-04-10","post_v6":false},
+    {"feature":"ai-recommendation-ui","created":"2026-04-10","post_v6":false},
+    {"feature":"android-design-system","created":"2026-04-04","post_v6":false},
+    {"feature":"app-store-assets","created":"2026-04-12","post_v6":false},
+    {"feature":"authentication","created":"2026-04-06","post_v6":false},
+    {"feature":"data-sync","created":"2026-04-06","post_v6":false},
+    {"feature":"design-system-v2","created":"2026-04-06","post_v6":false},
+    {"feature":"development-dashboard","created":"2026-04-02","post_v6":false},
+    {"feature":"dispatch-intelligence-v5.2","created":"2026-04-16","post_v6":true},
+    {"feature":"framework-v5-0-soc","created":"2026-04-14","post_v6":false},
+    {"feature":"framework-v7-1-integrity-cycle","created":"2026-04-21","post_v6":true},
+    {"feature":"framework-v7-5-data-integrity","created":"2026-04-24","post_v6":true},
+    {"feature":"framework-v7-8-bridge","created":"2026-05-04","post_v6":true},
+    {"feature":"gdpr-compliance","created":"2026-04-04","post_v6":false},
+    {"feature":"google-analytics","created":"2026-04-02","post_v6":false},
+    {"feature":"home-status-goal-card","created":"2026-04-09","post_v6":false},
+    {"feature":"home-today-screen","created":"2026-04-06","post_v6":false},
+    {"feature":"marketing-website","created":"2026-04-06","post_v6":false},
+    {"feature":"metric-tile-deep-linking","created":"2026-04-09","post_v6":false},
+    {"feature":"nutrition-logging","created":"2026-04-06","post_v6":false},
+    {"feature":"nutrition-v2","created":"2026-04-10","post_v6":false},
+    {"feature":"onboarding","created":"2026-04-05","post_v6":false},
+    {"feature":"onboarding-v2-auth-flow","created":"2026-04-15","post_v6":false},
+    {"feature":"parallel-write-safety-v5.2","created":"2026-04-16","post_v6":true},
+    {"feature":"readiness-score-v2","created":"2026-04-10","post_v6":false},
+    {"feature":"recovery-biometrics","created":"2026-04-06","post_v6":false},
+    {"feature":"settings","created":"2026-04-06","post_v6":false},
+    {"feature":"settings-v2","created":"2026-04-10","post_v6":false},
+    {"feature":"smart-reminders","created":"2026-04-15","post_v6":false},
+    {"feature":"stats-progress-hub","created":"2026-04-06","post_v6":false},
+    {"feature":"training-plan-v2","created":"2026-04-10","post_v6":false},
+    {"feature":"training-tracking","created":"2026-04-06","post_v6":false},
+    {"feature":"user-profile-settings","created":"2026-04-13","post_v6":false}
   ],
   "features": [
     {
@@ -886,18 +182,8 @@
       "created": "2026-05-11",
       "post_v6": true,
       "current_phase": "tasks_phase",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -906,18 +192,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -926,18 +202,8 @@
       "created": "2026-06-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -946,18 +212,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -966,18 +222,8 @@
       "created": "2026-04-12",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -986,18 +232,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1006,18 +242,8 @@
       "created": "2026-06-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1026,18 +252,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1046,18 +262,8 @@
       "created": "2026-06-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1066,18 +272,8 @@
       "created": "2026-05-13",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1086,18 +282,8 @@
       "created": "2026-04-04",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1106,18 +292,8 @@
       "created": "2026-06-17",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1126,18 +302,8 @@
       "created": "2026-04-12",
       "post_v6": false,
       "current_phase": "implementation",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1146,18 +312,8 @@
       "created": "2026-05-22",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -1166,18 +322,8 @@
       "created": "2026-04-27",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1186,18 +332,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1206,18 +342,8 @@
       "created": "2026-05-07",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -1226,18 +352,8 @@
       "created": "2026-04-28",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -1246,18 +362,8 @@
       "created": "2026-05-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1266,18 +372,8 @@
       "created": "2026-05-11",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1286,18 +382,8 @@
       "created": "2026-04-25",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -1306,18 +392,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1326,18 +402,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1346,18 +412,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1366,18 +422,8 @@
       "created": "2026-04-02",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1386,18 +432,8 @@
       "created": "2026-04-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1406,18 +442,8 @@
       "created": "2026-06-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1426,18 +452,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1446,18 +462,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1466,18 +472,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1486,18 +482,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1506,18 +492,8 @@
       "created": "2026-06-17",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1526,18 +502,8 @@
       "created": "2026-06-15",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1546,18 +512,8 @@
       "created": "2026-06-15",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1566,18 +522,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1586,18 +532,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1606,18 +542,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1626,18 +552,8 @@
       "created": "2026-06-17",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1646,18 +562,8 @@
       "created": "2026-06-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1666,18 +572,8 @@
       "created": "2026-06-17",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1686,18 +582,8 @@
       "created": "2026-05-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1706,18 +592,8 @@
       "created": "2026-05-12",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1726,18 +602,8 @@
       "created": "2026-05-12",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1746,18 +612,8 @@
       "created": "2026-06-09",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1766,18 +622,8 @@
       "created": "2026-05-08",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1786,18 +632,8 @@
       "created": "2026-05-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1806,18 +642,8 @@
       "created": "2026-06-15",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1826,18 +652,8 @@
       "created": "2026-05-22",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1846,18 +662,8 @@
       "created": "2026-05-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1866,18 +672,8 @@
       "created": "2026-04-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1886,18 +682,8 @@
       "created": "2026-04-19",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -1906,18 +692,8 @@
       "created": "2026-04-14",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1926,18 +702,8 @@
       "created": "2026-04-21",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1946,18 +712,8 @@
       "created": "2026-04-24",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -1966,18 +722,8 @@
       "created": "2026-04-27",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -1986,18 +732,8 @@
       "created": "2026-04-30",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2006,18 +742,8 @@
       "created": "2026-05-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2026,18 +752,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2046,18 +762,8 @@
       "created": "2026-05-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2066,18 +772,8 @@
       "created": "2026-06-05",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2086,18 +782,8 @@
       "created": "2026-06-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2106,18 +792,8 @@
       "created": "2026-04-04",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2126,18 +802,8 @@
       "created": "2026-04-02",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2146,18 +812,8 @@
       "created": "2026-04-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2166,18 +822,8 @@
       "created": "2026-04-29",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2186,18 +832,8 @@
       "created": "2026-05-12",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2206,18 +842,8 @@
       "created": "2026-06-05",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2226,18 +852,8 @@
       "created": "2026-06-05",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2246,18 +862,8 @@
       "created": "2026-04-09",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2266,18 +872,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2286,18 +882,8 @@
       "created": "2026-04-11",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2306,18 +892,8 @@
       "created": "2026-05-09",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2326,18 +902,8 @@
       "created": "2026-05-11",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2346,18 +912,8 @@
       "created": "2026-05-12",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2366,18 +922,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2386,18 +932,8 @@
       "created": "2026-04-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -2406,18 +942,8 @@
       "created": "2026-05-22",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -2426,18 +952,8 @@
       "created": "2026-04-09",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2446,18 +962,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2466,18 +972,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2486,18 +982,8 @@
       "created": "2026-04-05",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2506,18 +992,8 @@
       "created": "2026-04-15",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2526,18 +1002,8 @@
       "created": "2026-04-09",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2546,18 +1012,8 @@
       "created": "2026-05-03",
       "post_v6": true,
       "current_phase": "implementation",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2566,18 +1022,8 @@
       "created": "2026-04-16",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2586,18 +1032,8 @@
       "created": "2026-05-07",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -2606,18 +1042,8 @@
       "created": "2026-06-04",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2626,18 +1052,8 @@
       "created": "2026-06-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2646,18 +1062,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2666,18 +1072,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2686,18 +1082,8 @@
       "created": "2026-05-07",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": true,
       "any_adopted": true
     },
@@ -2706,18 +1092,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2726,18 +1102,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2746,18 +1112,8 @@
       "created": "2026-04-15",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2766,18 +1122,8 @@
       "created": "2026-04-29",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2786,18 +1132,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2806,18 +1142,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2826,18 +1152,8 @@
       "created": "2026-06-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2845,19 +1161,9 @@
       "feature": "t14-platform-parity-state-field",
       "created": "2026-06-04",
       "post_v6": true,
-      "current_phase": "implementation",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "current_phase": "complete",
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2866,18 +1172,8 @@
       "created": "2026-06-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2886,18 +1182,8 @@
       "created": "2026-06-10",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2906,18 +1192,8 @@
       "created": "2026-04-10",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2926,18 +1202,8 @@
       "created": "2026-06-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2946,18 +1212,8 @@
       "created": "2026-04-06",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -2966,18 +1222,8 @@
       "created": "2026-06-01",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -2986,18 +1232,8 @@
       "created": "2026-05-07",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3006,18 +1242,8 @@
       "created": "2026-05-17",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3026,18 +1252,8 @@
       "created": "2026-05-19",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3046,18 +1262,8 @@
       "created": "2026-05-17",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3066,18 +1272,8 @@
       "created": "2026-04-21",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3086,18 +1282,8 @@
       "created": "2026-05-12",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "instrumented",
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": true,"cu_v2": false},
+      "provenance": {"timing_wall_time": "instrumented","per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3106,18 +1292,8 @@
       "created": "2026-04-26",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": true,
-        "cu_v2": true
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": "instrumented",
-        "cu_v2": "instrumented"
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": true,"cu_v2": true},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": "instrumented","cu_v2": "instrumented"},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3126,18 +1302,8 @@
       "created": "2026-04-13",
       "post_v6": false,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": false,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": null,
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": false,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": null,"cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": false
     },
@@ -3146,18 +1312,8 @@
       "created": "2026-06-15",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": false,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": null,
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": false,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": null,"per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     },
@@ -3166,18 +1322,8 @@
       "created": "2026-06-06",
       "post_v6": true,
       "current_phase": "complete",
-      "adoption": {
-        "timing_wall_time": true,
-        "per_phase_timing": true,
-        "cache_hits": false,
-        "cu_v2": false
-      },
-      "provenance": {
-        "timing_wall_time": "derived",
-        "per_phase_timing": "instrumented",
-        "cache_hits": null,
-        "cu_v2": null
-      },
+      "adoption": {"timing_wall_time": true,"per_phase_timing": true,"cache_hits": false,"cu_v2": false},
+      "provenance": {"timing_wall_time": "derived","per_phase_timing": "instrumented","cache_hits": null,"cu_v2": null},
       "fully_adopted": false,
       "any_adopted": true
     }


### PR DESCRIPTION
## Daily ecosystem sync — 2026-06-21 (09:00 IDT)

Automated snapshot of the three telemetry ledgers generated by `make documentation-debt` and `make measurement-adoption`.

### What changed
- `.claude/shared/documentation-debt.json` — baseline refreshed at 2026-06-21T06:12:25Z
- `.claude/shared/measurement-adoption.json` — snapshot at 2026-06-21T06:12:25Z
- `.claude/shared/measurement-adoption-history.json` — new snapshot appended (42 total, 2026-04-25 → 2026-06-21)

### Key numbers
| Metric | Value |
|---|---|
| Features total | 115 |
| Post-v6 features | 81 |
| Fully adopted | 9/81 (11.1% post-v6) |
| Partial adopted | 70 |
| Zero adopted | 36 |
| Doc-debt open items | 1 (LOW — kill_criteria_resolution 52.2%) |
| Integrity findings | 0 |

### Notable (today)
- T14 `PLATFORMS_TESTED` gate promoted advisory → **enforced** today via PR #781

> Auto-generated by daily 09:00 IDT digest routine. Direct push to main blocked by branch protection; changes routed to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEzdiy3hgGimhB8ctPoJzU)_