### PR TITLE
docs(sync): reconcile F18 shipped — 118 features, docket roll-up 17 F shipped

### DIFF
--- a/docs/FRAMEWORK-FACTS.md
+++ b/docs/FRAMEWORK-FACTS.md
@@ -2,14 +2,14 @@
 
 > **Single source of truth for "what is the framework right now."** Machine-derived; cite this from any *living* doc instead of hand-copying counts (which drift). Historical docs (case studies, dated specs/plans, audit runs, per-feature PRDs) are **point-in-time records** and intentionally keep the numbers/version of the era they were written — do **not** bump them to match this file.
 
-**Last reconciled:** 2026-06-26 (derived from `.claude/shared/gate-last-fired.json` F17 index + `.claude/features/*/state.json` + `scripts/check-state-schema.py` + `scripts/integrity-check.py`). 2026-06-26: +1 feature (`funnel-analysis-dashboards`, F22 — live GA4 funnel analysis, PR #799; no new state.json gate); F4 `FRAMEWORK_VERSION_STALE` now emitting Mechanism A coverage (31 fires). Prior reconcile 2026-06-22: +1 feature (`contract-fixture-consumer-adoption`, E-15 — no new gates; the consumer `contract:check` is a warn-only CI lint, not a state.json gate).
+**Last reconciled:** 2026-06-26 (derived from `.claude/shared/gate-last-fired.json` F17 index + `.claude/features/*/state.json` + `scripts/check-state-schema.py` + `scripts/integrity-check.py`). 2026-06-26 (later): +1 feature (`f18-mutation-testing`, F18 — warn-only mutation testing on the gate dispatchers, PR #809; no new state.json gate — a weekly CI lint + `make mutation-test`). Earlier 2026-06-26: +1 feature (`funnel-analysis-dashboards`, F22 — live GA4 funnel analysis, PR #799; no new state.json gate); F4 `FRAMEWORK_VERSION_STALE` now emitting Mechanism A coverage (31 fires). Prior reconcile 2026-06-22: +1 feature (`contract-fixture-consumer-adoption`, E-15 — no new gates; the consumer `contract:check` is a warn-only CI lint, not a state.json gate).
 
 ## Current state
 
 | Fact | Value | Source of truth |
 |---|---|---|
 | **Framework version** | **v7.10** (shipped 2026-06-10) | CLAUDE.md "v7.10" section |
-| **Features tracked** | **117** (114 complete · 3 in-flight: `3d-interactive-framework-flow-diagram`, `app-store-assets`, `orchid-v1-5`) | `.claude/features/*/state.json` |
+| **Features tracked** | **118** (115 complete · 3 in-flight: `3d-interactive-framework-flow-diagram`, `app-store-assets`, `orchid-v1-5`) | `.claude/features/*/state.json` |
 | **Instrumented gates (F17 index)** | **30** total — **18 write-time emitting + 9 cycle-time + 2 W9 hooks + 1 standalone (`FIGMA_MIRROR_STALENESS`, runs via `make figma-mirror-staleness`)** (f1 `STATE_TASKS_FILESYSTEM_DRIFT` + f3 `DEPENDENCY_GRAPH_CYCLE` advisories added 2026-06-17 #752/#753; F4 `FRAMEWORK_VERSION_STALE` now emitting since ~2026-06-21, 31 fires) | `.claude/shared/gate-last-fired.json` |
 | **Gates actively firing** | **27 of 30** (the 3 non-firing are healthy-zero — have candidates, 0 violations: `STATE_OWNER_MISSING`, `w9.auto_isolate`, `w9.concurrency`) | F17 index `total_firings > 0` |
 | **Integrity status** | **0 findings, 0 real regressions** | `make integrity-check` / `make integrity-multi-anchor` |

--- a/docs/master-plan/infra-master-plan-2026-05-12.md
+++ b/docs/master-plan/infra-master-plan-2026-05-12.md
@@ -204,15 +204,15 @@ If any criterion fails for a given gate, that gate stays advisory and re-evaluat
 | F13 | `source_commit` `workflow_dispatch` input (reverse-sync workflow) | 2026-06-15 | fitme-story #221 (`reverse-sync-fitme-story-to-ft2.yml`) |
 | F-CONTRACT (consumer) | fitme-story consumer adoption + sampling | 2026-06-22 | #790 |
 | F22 | Funnel Analysis Dashboards (live GA4, 3/5 funnels wired) | 2026-06-24 | #799 |
+| F18 | Mutation testing on dispatcher files (warn-only weekly CI; mutmut, 1,857-mutant baseline) | 2026-06-26 | #809 (`f18-mutation-testing`) |
 
 **B. Open — carried into the v8.0 build (kickoff target ~2026-06-18, after F16 enforce flip ✅ 2026-06-17):**
 
-> Reconciled 2026-06-26: 10 of the 16 prior rows (F1/F3/F4/F5/F10/F11/F12/F13/F22/F-CONTRACT-consumer) **shipped** and moved to table A. The rows below are the genuinely-remaining items.
+> Reconciled 2026-06-26: 11 of the 16 prior rows (F1/F3/F4/F5/F10/F11/F12/F13/F18/F22/F-CONTRACT-consumer) **shipped** and moved to table A. The rows below are the genuinely-remaining items.
 
 | ID | Item | Class | RICE-est | Gating |
 |---|---|---|---|---|
-| T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** |
-| F18 | Mutation testing on dispatcher files | Test infra | 13.7 | F16 Phase E ✓ + F14 ✓ — **now unblocked (top open infra item)** |
+| T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** (F18 mutation survivor data feeds calibration) |
 | F19/F20 | Analytics Phase 1.B GA4 conversions + gates (`CSV_TAXONOMY_DRIFT`, `GA4_MCP_DISCONNECTED`) | Telemetry/gates | M / L | D-2 operator (GA4 Key-event toggle, register A1) + post-launch signal |
 | F23 | `/ops digest` skill | Skill extension | M | F22 ✓ + Sentry resume (launch-gated, §C) |
 | T4 | Swift snapshot testing | iOS test infra | — | Phase A scaffold shipped (#700); build pending (in flight) |
@@ -223,7 +223,7 @@ If any criterion fails for a given gate, that gate stays advisory and re-evaluat
 
 **E. Operator decision open:** W-MISTRAL-VERCEL-FREE-TIER-BURST (API-tier choice for multi-provider HADF experiments).
 
-**Roll-up (reconciled 2026-06-26):** of the original 18 F-candidates, **16 shipped** (F1, F2, F3, F4, F5, F6, F9, F10, F11, F12, F13, F14, F15, F16, F17, F22 + the GATE_COVERAGE_ZERO meta-check) + 2 resolved-by-exemption (F7, F8) → **all ready-now F-items shipped; remaining open: F18** (now unblocked — F16 enforced 2026-06-17 + F14 shipped — top open infra item), **F19/F20** (operator-gated on GA4 Key-event toggle, register item A1), **F23** (gated on Sentry resume, §C). **F21** Sentry is paused/launch-gated (§C). Theme H (test-coverage T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **v8.0 build kickoff target ~2026-06-18 met** (F16 enforce flip ✅ 2026-06-17); ship target 2026-07-31.
+**Roll-up (reconciled 2026-06-26, post-F18):** of the original 18 F-candidates, **17 shipped** (F1, F2, F3, F4, F5, F6, F9, F10, F11, F12, F13, F14, F15, F16, F17, F18, F22 + the GATE_COVERAGE_ZERO meta-check) + 2 resolved-by-exemption (F7, F8) → **all ready-now F-items shipped; remaining open: F19/F20** (operator-gated on GA4 Key-event toggle, register item A1), **F23** (gated on Sentry resume, §C). **F21** Sentry is paused/launch-gated (§C). Theme H (test-coverage T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22 (now fed by F18 mutation-survivor data). **v8.0 build kickoff target ~2026-06-18 met** (F16 enforce flip ✅ 2026-06-17); ship target 2026-07-31.
 
 ---
 

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -49,8 +49,8 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | ~~F3~~ ✅ | `DEPENDENCY_GRAPH_CYCLE` cycle-time advisory — cycles / self-loops / dangling refs across `scheduled_after` + `parent_feature` | Cycle-time gate | 14.4 | **SHIPPED 2026-06-17** (feature `f3-dependency-graph-cycle-check`; advisory-permanent, 0 baseline findings) |
 | ~~F22~~ ✅ | Funnel Analysis Dashboards (live GA4, 3/5 funnels wired) | Product observability | M | **SHIPPED 2026-06-24** (feature `funnel-analysis-dashboards`, PR #799) |
 | ~~F-CONTRACT (consumer)~~ ✅ | fitme-story consumer adoption + sampling | Cross-repo | — | **SHIPPED 2026-06-22** (feature `contract-fixture-consumer-adoption`, PR #790) |
-| T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** |
-| F18 | Mutation testing on dispatcher files | Test infra | 13.7 | F16 Phase E ✓ + F14 ✓ — **now unblocked (top open infra item)** |
+| ~~F18~~ ✅ | Mutation testing on dispatcher files (mutmut, warn-only weekly CI, 1,857-mutant baseline) | Test infra | 13.7 | **SHIPPED 2026-06-26** (feature `f18-mutation-testing`, PR #809) |
+| T1 | `GATE_TEST_MISSING` meta-gate | Test discipline | 53.3 | F14 Phase E **2026-08-22** (fed by F18 mutation-survivor data) |
 | F23 | `/ops digest` skill | Skill extension | M | F22 ✓ + Sentry resume (launch-gated, §C) |
 | F19/F20 | Analytics Phase 1.B GA4 conversions + gates (`CSV_TAXONOMY_DRIFT`, `GA4_MCP_DISCONNECTED`) | Telemetry/gates | M / L | D-2 operator (GA4) + post-launch signal |
 | T4 | Swift snapshot testing | iOS test infra | — | Phase A scaffold shipped (#700); build pending |
@@ -59,7 +59,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 
 **D. Operator decision open:** W-MISTRAL-VERCEL-FREE-TIER-BURST (API-tier choice for multi-provider HADF experiments).
 
-**Roll-up:** of the original 18 F-candidates, **16 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 merged 2026-06-15 via PRs #719/#720/#721/#722 + F4 shipped 2026-06-16 via PR #740 + F1 + **F3 shipped 2026-06-17, advisory**) + 2 resolved-by-exemption (F7, F8) → **all ready-now F-items shipped; remaining open** = F18 (now unblocked — F16 enforced 2026-06-17 + F14 shipped) + F19/F20 (operator-gated, GA4 register A1) + F23 (Sentry-resume-gated, §C). **F22 shipped 2026-06-24 (#799); F-CONTRACT-consumer shipped 2026-06-22 (#790)** — reconciled 2026-06-26. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **F16 enforce flip DONE 2026-06-17** (try-repo-harness now a main required check) → **v8.0 build kickoff gate cleared**; ship target 2026-07-31.
+**Roll-up:** of the original 18 F-candidates, **17 shipped** (F2, F6, F9, F14, F15, F16, F17, GATE_COVERAGE_ZERO + F5, F10, F11, F12, F13 merged 2026-06-15 via PRs #719/#720/#721/#722 + F4 shipped 2026-06-16 via PR #740 + F1 + F3 shipped 2026-06-17 + **F18 shipped 2026-06-26 via PR #809**) + 2 resolved-by-exemption (F7, F8) → **all ready-now F-items shipped; remaining open** = F19/F20 (operator-gated, GA4 register A1) + F23 (Sentry-resume-gated, §C). **F22 shipped 2026-06-24 (#799); F-CONTRACT-consumer shipped 2026-06-22 (#790); F18 shipped 2026-06-26 (#809)** — reconciled 2026-06-26. Theme H (T1–T16): T3/T5/T10/T13/T14 shipped, T4 in flight, T1 gated to 2026-08-22. **F16 enforce flip DONE 2026-06-17** (try-repo-harness now a main required check) → **v8.0 build kickoff gate cleared**; ship target 2026-07-31.
 
 ---
 


### PR DESCRIPTION
## Summary
Follow-up to #808 + #809: now that **F18 mutation testing** is merged (#809), reconcile the canonical docs.

- **FRAMEWORK-FACTS**: features **117 → 118** (115 complete); +F18 note
- **infra-master-plan §3.0** + **v8-x-build-docket §0**: F18 **Open → Shipped** (#809); roll-up **16 → 17** F-candidates shipped
- Remaining open infra: **F19/F20** (GA4, operator-gated A1) + **F23** (Sentry-gated). F18 mutation-survivor data now feeds **T1 GATE_TEST_MISSING**.

Trivial counts/status reconcile only (+9/−9). Cron ledgers + the pre-existing `check-state-schema.py` working change deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)