### PR TITLE
feat(FW-NAMING): cross-layer item naming convention + crosswalk registry (FIT-200)

### DIFF
--- a/.claude/shared/item-registry.json
+++ b/.claude/shared/item-registry.json
@@ -1,0 +1,1394 @@
+{
+  "schema_version": 1,
+  "generated_note": "derived from .claude/features/*/state.json \u2014 do not hand-edit; run `make crosswalk`",
+  "items": [
+    {
+      "slug": "3d-interactive-framework-flow-diagram",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "In Progress",
+      "current_phase": "tasks_phase",
+      "work_type": "Feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "adaptive-intelligence",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
+      "prs": [
+        78
+      ]
+    },
+    {
+      "slug": "adaptive-intelligence-next-pass",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/adaptive-intelligence-next-pass-case-study.md",
+      "prs": [
+        576
+      ]
+    },
+    {
+      "slug": "ai-cohort-intelligence",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/six-features-roundup-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "ai-engine-architecture-adaptation",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "ai-engine-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": null,
+      "prs": [
+        78
+      ]
+    },
+    {
+      "slug": "ai-golden-set-evals",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/ai-golden-set-evals-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "ai-recommendation-ui",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
+      "prs": [
+        78
+      ]
+    },
+    {
+      "slug": "ai-user-feedback-loop",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/ai-user-feedback-loop-case-study.md",
+      "prs": [
+        572
+      ]
+    },
+    {
+      "slug": "analytics-observability",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/analytics-observability-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "android-design-system",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/android-design-system-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "android-token-pipeline",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Enhancement",
+      "case_study": "docs/case-studies/android-token-pipeline-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "app-store-assets",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Blocked",
+      "current_phase": "implementation",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "audit-1-corrections",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "auth-polish-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/auth-polish-v2-case-study.md",
+      "prs": [
+        163
+      ]
+    },
+    {
+      "slug": "authentication",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "case-study-comparison-table",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "case-study-presentation",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/case-study-presentation-refactor-case-study.md",
+      "prs": [
+        146
+      ]
+    },
+    {
+      "slug": "code-connect-automation",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "contract-fixture-consumer-adoption",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/contract-fixture-consumer-adoption-case-study.md",
+      "prs": [
+        790
+      ]
+    },
+    {
+      "slug": "cross-repo-state-sync-impl",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/cross-repo-state-sync-impl-case-study.md",
+      "prs": [
+        298,
+        299,
+        300,
+        301,
+        302,
+        303,
+        304
+      ]
+    },
+    {
+      "slug": "data-integrity-framework-v7-6",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "framework",
+      "case_study": "docs/case-studies/mechanical-enforcement-v7-6-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "data-sync",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "design-system-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "dev-env-r11-r13-r14-r17-r18-batch",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Chore",
+      "case_study": "docs/case-studies/dev-env-r11-r13-r14-r17-r18-batch-case-study.md",
+      "prs": [
+        627
+      ]
+    },
+    {
+      "slug": "development-dashboard",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/six-features-roundup-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "dispatch-intelligence-v5.2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/v5.1-v5.2-framework-evolution-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "exercise-search-filter",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/exercise-search-filter-case-study.md",
+      "prs": [
+        573
+      ]
+    },
+    {
+      "slug": "f-deployed-url-probe-ft2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f-deployed-url-probe-ft2-case-study.md",
+      "prs": [
+        628
+      ]
+    },
+    {
+      "slug": "f-launchd-drift-extension",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f-launchd-drift-extension-case-study.md",
+      "prs": [
+        621
+      ]
+    },
+    {
+      "slug": "f-launchd-drift-extension-sub-a",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f-launchd-drift-extension-sub-a-case-study.md",
+      "prs": [
+        623
+      ]
+    },
+    {
+      "slug": "f-phase-e-adoption-freeze-discipline",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f-phase-e-adoption-freeze-discipline-case-study.md",
+      "prs": [
+        625
+      ]
+    },
+    {
+      "slug": "f1-state-tasks-filesystem-drift",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": null,
+      "prs": [
+        752
+      ]
+    },
+    {
+      "slug": "f11-reverse-sync-historical-exempt",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Chore",
+      "case_study": null,
+      "prs": [
+        722
+      ]
+    },
+    {
+      "slug": "f12-actionlint-gate",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Chore",
+      "case_study": null,
+      "prs": [
+        719
+      ]
+    },
+    {
+      "slug": "f16-try-repo-harness",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f16-try-repo-harness-case-study.md",
+      "prs": [
+        606,
+        607,
+        608,
+        610,
+        611,
+        612
+      ]
+    },
+    {
+      "slug": "f17-last-fired-at-index",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f17-last-fired-at-index-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "f18-mutation-testing",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/f18-mutation-testing-case-study.md",
+      "prs": [
+        809
+      ]
+    },
+    {
+      "slug": "f2-phase-0-reality-check",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/f2-phase-0-reality-check-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "f3-dependency-graph-cycle-check",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": null,
+      "prs": [
+        753
+      ]
+    },
+    {
+      "slug": "f4-framework-version-stale",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": null,
+      "prs": [
+        740
+      ]
+    },
+    {
+      "slug": "figma-design-architecture",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/figma-design-architecture-case-study.md",
+      "prs": [
+        767
+      ]
+    },
+    {
+      "slug": "fitme-story-design-system-p2-cleanup",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/fitme-story-design-system-p2-cleanup-case-study.md",
+      "prs": [
+        84
+      ]
+    },
+    {
+      "slug": "fitme-story-ds-p2-deferred",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/fitme-story-ds-p2-deferred-case-study.md",
+      "prs": [
+        93
+      ]
+    },
+    {
+      "slug": "fitme-story-ds-p2-final-sweep",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/fitme-story-ds-p2-final-sweep-case-study.md",
+      "prs": [
+        95
+      ]
+    },
+    {
+      "slug": "fitme-story-dual-audience-redesign",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/fitme-story-dual-audience-redesign-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "fitme-story-public-enhancements",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/fitme-story-public-enhancements-case-study.md",
+      "prs": [
+        59,
+        61,
+        62,
+        63,
+        65,
+        66,
+        67,
+        70,
+        71,
+        75,
+        134,
+        258,
+        260,
+        261
+      ]
+    },
+    {
+      "slug": "fitme-story-website-design-system",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/fitme-story-website-design-system-case-study.md",
+      "prs": [
+        287
+      ]
+    },
+    {
+      "slug": "foundation-models-tier3",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/foundation-models-tier3-case-study.md",
+      "prs": [
+        724,
+        725
+      ]
+    },
+    {
+      "slug": "framework-f14-f15-dispatch-test-coverage",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/framework-f14-f15-dispatch-test-coverage-case-study.md",
+      "prs": [
+        451
+      ]
+    },
+    {
+      "slug": "framework-honesty-fixes-2026-05-01",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/framework-honesty-fixes-2026-05-01-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "framework-measurement-v6",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/framework-measurement-v6-case-study.md",
+      "prs": [
+        81
+      ]
+    },
+    {
+      "slug": "framework-story-site",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/framework-story-site-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "framework-v5-0-soc",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/soc-v5-framework-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "framework-v7-1-integrity-cycle",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/integrity-cycle-v7.1-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "framework-v7-5-data-integrity",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/data-integrity-framework-v7.5-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "framework-v7-7-validity-closure",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "framework",
+      "case_study": "docs/case-studies/framework-v7-7-validity-closure-case-study.md",
+      "prs": [
+        144
+      ]
+    },
+    {
+      "slug": "framework-v7-8-branch-isolation",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/framework-v7-8-branch-isolation-case-study.md",
+      "prs": [
+        244
+      ]
+    },
+    {
+      "slug": "framework-v7-8-bridge",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/framework-v7-8-bridge-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "framework-v7-9-1-promotion",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/framework-v7-9-1-promotion-case-study.md",
+      "prs": [
+        629,
+        630
+      ]
+    },
+    {
+      "slug": "framework-v7-9-promotion",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/framework-v7-9-promotion-case-study.md",
+      "prs": [
+        413,
+        415,
+        416,
+        417
+      ]
+    },
+    {
+      "slug": "framework-w30-w31-w32-durable-fixes",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Chore",
+      "case_study": "docs/case-studies/framework-w30-w31-w32-durable-fixes-case-study.md",
+      "prs": [
+        637
+      ]
+    },
+    {
+      "slug": "funnel-analysis-dashboards",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/funnel-analysis-dashboards-case-study.md",
+      "prs": [
+        799
+      ]
+    },
+    {
+      "slug": "garmin-health-connection",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/garmin-health-connection-case-study.md",
+      "prs": [
+        705
+      ]
+    },
+    {
+      "slug": "gdpr-compliance",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/gdpr-compliance-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "google-analytics",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/google-analytics-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "hadf-infrastructure",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/hadf-hardware-aware-dispatch-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "hadf-phase2-cloud-fingerprinting",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/hadf-phase2-cloud-fingerprinting-case-study.md",
+      "prs": [
+        170,
+        264
+      ]
+    },
+    {
+      "slug": "hadf-phase2bis-replication",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/hadf-phase2bis-cross-sub-exp-synthesis-case-study.md",
+      "prs": [
+        306,
+        313,
+        316,
+        490,
+        506,
+        507,
+        520,
+        530,
+        533,
+        534,
+        536,
+        539,
+        542,
+        543,
+        583
+      ]
+    },
+    {
+      "slug": "hadf-phase3a-sensing",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/hadf-phase3a-sensing-case-study.md",
+      "prs": [
+        635,
+        644
+      ]
+    },
+    {
+      "slug": "hadf-signature-expansion",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/hadf-signature-expansion-case-study.md",
+      "prs": [
+        644
+      ]
+    },
+    {
+      "slug": "home-status-goal-card",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": [
+        65
+      ]
+    },
+    {
+      "slug": "home-today-screen",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/home-today-screen-v2-case-study.md",
+      "prs": [
+        61
+      ]
+    },
+    {
+      "slug": "import-training-plan",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/import-training-plan-case-study.md",
+      "prs": [
+        234
+      ]
+    },
+    {
+      "slug": "ios-code-connect",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "ios-ui-audit-p1-burndown",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ios-ui-audit-p1-burndown-case-study.md",
+      "prs": [
+        294
+      ]
+    },
+    {
+      "slug": "ios-ui-audit-p1-drift-cleanup",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ios-ui-audit-p1-drift-cleanup-case-study.md",
+      "prs": [
+        307
+      ]
+    },
+    {
+      "slug": "marketing-website",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "meta-analysis-audit",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/meta-analysis-full-system-audit-v7.0-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "meta-analysis-refresh-phase-1",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": null,
+      "prs": [
+        445
+      ]
+    },
+    {
+      "slug": "metric-tile-deep-linking",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": null,
+      "prs": [
+        67
+      ]
+    },
+    {
+      "slug": "nutrition-logging",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "nutrition-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/m-2-mealentrysheet-decomposition-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "onboarding",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/pm-workflow-showcase-onboarding.md",
+      "prs": [
+        59
+      ]
+    },
+    {
+      "slug": "onboarding-v2-auth-flow",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/onboarding-v2-auth-flow-v5.1-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "onboarding-v2-retroactive",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/onboarding-v2-retroactive-case-study.md",
+      "prs": [
+        63
+      ]
+    },
+    {
+      "slug": "orchid-v1-5",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Blocked",
+      "current_phase": "implementation",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/orchid-v1-5-additive-units-case-study.md",
+      "prs": [
+        179,
+        180,
+        182,
+        183,
+        184
+      ]
+    },
+    {
+      "slug": "parallel-write-safety-v5.2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/parallel-write-safety-v5.2-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "push-notifications",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/push-notifications-v2-case-study.md",
+      "prs": [
+        239
+      ]
+    },
+    {
+      "slug": "r9-track-b-coverage-aggregator",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Chore",
+      "case_study": "docs/case-studies/r9-track-b-coverage-aggregator-case-study.md",
+      "prs": [
+        626
+      ]
+    },
+    {
+      "slug": "readiness-aware-training-alert",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/readiness-aware-training-alert-case-study.md",
+      "prs": [
+        560
+      ]
+    },
+    {
+      "slug": "readiness-score-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": null,
+      "prs": [
+        78
+      ]
+    },
+    {
+      "slug": "recovery-biometrics",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "roadmap-stress-test-2026-05-07",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/roadmap-stress-test-2026-05-07-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "settings",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "settings-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/m-1-settings-decomposition-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "smart-reminders",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/smart-reminders-case-study.md",
+      "prs": [
+        98
+      ]
+    },
+    {
+      "slug": "smart-reminders-behavioral-learning",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/smart-reminders-behavioral-learning-case-study.md",
+      "prs": [
+        190
+      ]
+    },
+    {
+      "slug": "stats-progress-hub",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "stats-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/stats-v2-case-study.md",
+      "prs": [
+        164
+      ]
+    },
+    {
+      "slug": "t13-last-failed-at-index",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/t13-last-failed-at-index-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "t14-platform-parity-state-field",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/t14-platform-parity-state-field-case-study.md",
+      "prs": [
+        662,
+        781
+      ]
+    },
+    {
+      "slug": "t3-signinservice-passkey-tests",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/t3-signinservice-passkey-tests-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "t5-mock-protocol-drift",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Feature",
+      "case_study": "docs/case-studies/t5-mock-protocol-drift-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "training-plan-v2",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/training-plan-v2-case-study.md",
+      "prs": [
+        74
+      ]
+    },
+    {
+      "slug": "training-program-customization",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/training-program-customization-case-study.md",
+      "prs": [
+        574
+      ]
+    },
+    {
+      "slug": "training-tracking",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": null,
+      "prs": []
+    },
+    {
+      "slug": "trend-alerts-hrv",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/trend-alerts-hrv-case-study.md",
+      "prs": [
+        564
+      ]
+    },
+    {
+      "slug": "ucc-passkey-auth",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/ucc-passkey-auth-case-study.md",
+      "prs": [
+        248
+      ]
+    },
+    {
+      "slug": "ucc-passkey-auth-audit-log-redis-fix",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ucc-passkey-auth-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "ucc-passkey-auth-security-hardening",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ucc-passkey-auth-security-hardening-case-study.md",
+      "prs": [
+        127,
+        410,
+        411,
+        412
+      ]
+    },
+    {
+      "slug": "ucc-sign-in-figma-mapping",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ucc-passkey-auth-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "ui-audit-baseline-burndown",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "chore",
+      "case_study": "docs/case-studies/ui-audit-baseline-burndown.md",
+      "prs": [
+        139
+      ]
+    },
+    {
+      "slug": "ui-ux-final-sweep-2026-05-12",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "enhancement",
+      "case_study": "docs/case-studies/ui-ux-final-sweep-2026-05-12-case-study.md",
+      "prs": [
+        311
+      ]
+    },
+    {
+      "slug": "unified-control-center",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": {
+        "started_at": "2026-04-26T05:30:00Z",
+        "log_path": ".claude/logs/unified-control-center.log.json",
+        "case_study_path": "docs/case-studies/unified-control-center-case-study.md",
+        "monitored_from_day_one": true
+      },
+      "prs": [
+        21,
+        22,
+        230
+      ]
+    },
+    {
+      "slug": "user-profile-settings",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/user-profile-v4.4-case-study.md",
+      "prs": []
+    },
+    {
+      "slug": "v8-f10-f5-schema-vocab",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "Chore",
+      "case_study": null,
+      "prs": [
+        720
+      ]
+    },
+    {
+      "slug": "w9-drift-triggered-auto-isolation",
+      "linear_id": null,
+      "thematic_codes": [],
+      "status": "Done",
+      "current_phase": "complete",
+      "work_type": "feature",
+      "case_study": "docs/case-studies/w9-drift-triggered-auto-isolation-case-study.md",
+      "prs": [
+        646,
+        648,
+        649
+      ]
+    }
+  ],
+  "coverage": {
+    "total": 118,
+    "with_linear_id": 0,
+    "missing_linear_id": 118,
+    "with_thematic_codes": 0
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -903,6 +903,14 @@ node_modules:
 refresh-pr-cache:
 	python3 scripts/refresh-pr-cache.py
 
+# FIT-200: cross-layer item crosswalk registry (slug <-> linear_id <-> thematic codes).
+# Builds .claude/shared/item-registry.json + prints an advisory for features
+# missing their linear_id join. Spec: docs/process/cross-layer-item-naming-convention.md
+#   make crosswalk          # build + report
+#   make crosswalk CHECK=1  # report only, no write
+crosswalk:
+	@python3 scripts/build-item-registry.py $(if $(CHECK),--check,)
+
 validate-existing-cites: refresh-pr-cache
 	@echo "Validating PR cites in all docs/case-studies/*.md against unified cache…"
 	@python3 scripts/check-case-study-preflight.py docs/case-studies/*.md

--- a/docs/process/cross-layer-item-naming-convention.md
+++ b/docs/process/cross-layer-item-naming-convention.md
@@ -1,0 +1,147 @@
+# Cross-Layer Item Naming Convention
+
+> **Status:** active (established 2026-06-29, FIT-200 / `cross-layer-item-naming-convention`).
+> **Why:** before this, the same logical item had different identifiers in every
+> layer (feature slug ≠ `FIT-NNN` ≠ thematic code), thematic codes **collided**
+> (two different "R14"s — dev-env SBOM vs integrity-check parallelization), and
+> there was no mechanical join, so ~12 shipped items sat stale-open in Linear
+> (2026-06-29 reconciliation). This convention gives every trackable item **one
+> canonical key, one tracking key, and a namespaced label** that repeat
+> identically across Linear, Notion, `docs/product/backlog.md`, the master plan,
+> and every sub-plan.
+
+---
+
+## 1. The three identifiers (every item carries all three)
+
+| Role | Identifier | Where it lives | Example |
+|---|---|---|---|
+| **Canonical key** (source of truth) | **feature slug** (kebab-case) | `.claude/features/<slug>/` directory name | `f4-framework-version-stale` |
+| **Tracking key** (cross-tool) | **`FIT-NNN`** | `state.json.linear_id` ← → Linear issue id | `FIT-96` |
+| **Thematic label** (grouping/sort) | **`SCHEME-CODE`** | `state.json.thematic_codes[]` + Linear/Notion/plan titles | `FW-F4` |
+
+**Rule of precedence:** the **slug is canonical** (repo is source of truth per
+CLAUDE.md). `FIT-NNN` is the pointer that makes repo ↔ Linear a *mechanical*
+join. Thematic codes are labels for grouping and human reference — **never** the
+primary key (that is what allowed the collisions).
+
+A feature with no Linear issue yet still has a slug; a Linear issue with no
+feature dir yet (pure backlog) still gets a slug **reserved** in its title so the
+join is ready the moment work starts.
+
+---
+
+## 2. Scheme prefixes (kills the collision class)
+
+Thematic codes are **always** prefixed by their scheme. Bare `F4` / `T14` / `R14`
+are no longer valid identifiers anywhere.
+
+| Prefix | Scheme | Source | Example codes |
+|---|---|---|---|
+| **`FW-`** | Framework infrastructure & gates | infra-master-plan F-candidates | `FW-F4`, `FW-F16`, `FW-F22` |
+| **`TC-`** | Test coverage (Theme H) | test-coverage-master-plan | `TC-T14`, `TC-T3`, `TC-T1` |
+| **`DE-`** | Dev-env upgrade plan | 2026-05-19 dev-env audit (R1–R24) | `DE-R14`, `DE-R18` |
+| **`HADF-`** | HADF program | HADF plans (B14.x/B15.x/C16.x/Phase-3a) | `HADF-B15.22a`, `HADF-3A-T4` |
+| **`AN-`** | Analytics-observability | analytics sub-plan (Phase 1.B.x) | `AN-1B.1`, `AN-1B.2` |
+| **`PROD-`** | Product features (app/site) | product backlog | `PROD-app-store-assets` |
+| **`SEC-`** | Security hardening | GitHub-security tiers | `SEC-tier-a` |
+| **`AUDIT-`** | External audits | audit substrate | `AUDIT-hadf-2` |
+
+> **The collision this fixes:** Linear's `R14` ("make integrity-check
+> parallelization", `DE-R14`) vs the 2026-05-24 dev-env plan's `R14` ("SBOM
+> workflow", shipped in `dev-env-r11-r13-r14-r17-r18-batch`). Under this scheme
+> the SBOM item is **not** `DE-R14` — the 05-24 plan items are a *separate*
+> shipped batch and keep their own historical labels; the live `DE-` scheme is
+> the Linear R1–R24 plan only. New work never reuses a number across schemes.
+
+**Forward-only.** Existing shipped case studies / dated plans keep their bare
+historical codes (point-in-time records). New rows + reconciled live rows use
+prefixed codes.
+
+---
+
+## 3. Shared status vocabulary ("Done" means the same everywhere)
+
+Every layer maps its native states onto this single enum. The repo
+`state.json.current_phase` is the **authoritative status source**; Linear/Notion/
+backlog mirror it.
+
+| Unified status | `state.json.current_phase` | Linear status | Backlog / plan marker |
+|---|---|---|---|
+| **Done** | `complete` | Done | ✅ SHIPPED / DONE |
+| **In Progress** | any non-terminal phase with a feature dir (`implementation`, `tasks_phase`, `ux`, `test`, `review`, `merge`, `docs`, …) | In Progress | 🟡 in flight |
+| **Blocked** | non-terminal + `paused`/`blocked`/`isolation_opt_out` reason or external dependency | Blocked (or In Progress + note) | ⛔ blocked (reason) |
+| **Planned** | feature dir exists at `research`/`prd`/`tasks` OR reserved slug, work not started | Backlog | 🗓️ planned / Now-Next-Later |
+| **Backlog** | no feature dir yet (Linear-only) | Backlog | backlog row |
+| **Won't-Do** | n/a (`case_study_type: no_case_study_required` + reason, or external block) | Canceled | 🚫 won't-do (reason) |
+
+---
+
+## 4. Title format (identical string in every layer)
+
+```
+[SCHEME-CODE] <short name> (<slug>)
+```
+
+- **Linear issue title:** `FW-F4 — framework_version auto-update (f4-framework-version-stale)`
+- **Backlog / master-plan / sub-plan row:** same `[SCHEME-CODE] <name>` + cite the slug
+- **Notion row:** same; link the Linear `FIT-NNN` and the slug
+
+This means a single grep for the slug, the `FIT-NNN`, or the `SCHEME-CODE` finds
+the item in **every** layer.
+
+---
+
+## 5. The crosswalk registry (the join table)
+
+`make crosswalk` runs [`scripts/build-item-registry.py`](../../scripts/build-item-registry.py),
+which reads every `.claude/features/<slug>/state.json` and emits
+[`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json):
+
+```json
+{
+  "schema_version": 1,
+  "generated_note": "derived from .claude/features/*/state.json — do not hand-edit",
+  "items": [
+    {
+      "slug": "f4-framework-version-stale",
+      "linear_id": "FIT-96",
+      "thematic_codes": ["FW-F4"],
+      "status": "Done",
+      "current_phase": "complete",
+      "case_study": "...",
+      "prs": [740]
+    }
+  ],
+  "coverage": { "total": 118, "with_linear_id": 71, "missing_linear_id": 47 }
+}
+```
+
+Notion, backlog, and the plans cite items **by slug + `FIT-NNN`**; the registry
+is the authority that ties them together. Regenerate after any reconcile.
+
+---
+
+## 6. Enforcement (advisory, forward-only)
+
+- `state.json` gains two **optional** fields: `linear_id` (string `FIT-NNN`) and
+  `thematic_codes` (array of `SCHEME-CODE` strings).
+- `make crosswalk` prints an **advisory** list of features missing `linear_id`
+  (the join gap). It **never blocks a commit** at introduction.
+- Promotion path: once the backfill lands and the missing-join count is stable
+  near zero, a `LINEAR_ID_MISSING` cycle-time advisory (then enforced gate) can
+  be added through the standard 14-day calibration ladder. Not before.
+
+---
+
+## 7. Operating rules
+
+1. **New item →** create the Linear issue with the `[SCHEME-CODE] name (slug)`
+   title, reserve the slug, and (when work starts) write `linear_id` +
+   `thematic_codes` into `state.json`.
+2. **Reconcile →** run `make crosswalk`; for any Done feature, ensure its Linear
+   issue + Notion row + backlog row read **Done**, and its `state.json` carries
+   `linear_id`.
+3. **Never reuse a bare number across schemes.** Always prefix.
+4. **Repo wins.** If Linear/Notion/backlog disagree with `state.json`, the
+   repo is right; fix the mirror (this is the 2026-06-29 stale-open lesson).

--- a/scripts/build-item-registry.py
+++ b/scripts/build-item-registry.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+build-item-registry.py — the cross-layer crosswalk generator (FIT-200).
+
+Reads every `.claude/features/<slug>/state.json` and emits
+`.claude/shared/item-registry.json`: the single join table that ties the
+canonical key (feature slug) to the tracking key (`linear_id` = FIT-NNN),
+the thematic labels (`thematic_codes`, scheme-prefixed), a unified status,
+and the merged-PR set.
+
+Also prints an ADVISORY list of features missing `linear_id` (the join
+gap). Advisory only — never exits non-zero for a missing join.
+
+Convention spec: docs/process/cross-layer-item-naming-convention.md
+
+Usage:
+  python3 scripts/build-item-registry.py            # write + report
+  python3 scripts/build-item-registry.py --check    # report only, no write
+  python3 scripts/build-item-registry.py --quiet
+
+Exit codes:
+  0 — success
+  2 — features dir not found
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FEATURES_DIR = REPO_ROOT / ".claude" / "features"
+REGISTRY = REPO_ROOT / ".claude" / "shared" / "item-registry.json"
+SCHEMA_VERSION = 1
+
+# state.json current_phase -> unified status (see convention §3).
+TERMINAL = {"complete"}
+PLANNING = {"research", "prd", "tasks", "discovery"}
+
+
+def unified_status(state: dict) -> str:
+    phase = (state.get("current_phase") or "").lower()
+    if phase in TERMINAL:
+        return "Done"
+    # Blocked signals (paused / external dependency).
+    if state.get("paused") or state.get("blocked") or state.get("blocked_on"):
+        return "Blocked"
+    rn = state.get("resume_notes")
+    if isinstance(rn, (list, str)) and rn and "paused" in json.dumps(rn).lower():
+        return "Blocked"
+    if not phase:
+        return "Backlog"
+    if phase in PLANNING:
+        return "Planned"
+    return "In Progress"
+
+
+def collect_prs(state: dict) -> list[int]:
+    prs: set[int] = set()
+    for n in state.get("related_prs") or []:
+        if isinstance(n, int):
+            prs.add(n)
+        elif isinstance(n, str) and n.isdigit():
+            prs.add(int(n))
+    phases = state.get("phases")
+    if isinstance(phases, dict):
+        merge = phases.get("merge")
+        if isinstance(merge, dict) and isinstance(merge.get("pr_number"), int):
+            prs.add(merge["pr_number"])
+    for t in state.get("tasks") or []:
+        if isinstance(t, dict) and isinstance(t.get("pr_number"), int):
+            prs.add(t["pr_number"])
+    return sorted(prs)
+
+
+def build() -> dict:
+    items = []
+    for sj in sorted(FEATURES_DIR.glob("*/state.json")):
+        slug = sj.parent.name
+        try:
+            state = json.loads(sj.read_text())
+        except (OSError, json.JSONDecodeError):
+            items.append({"slug": slug, "error": "unreadable state.json"})
+            continue
+        items.append({
+            "slug": slug,
+            "linear_id": state.get("linear_id"),
+            "thematic_codes": state.get("thematic_codes") or [],
+            "status": unified_status(state),
+            "current_phase": state.get("current_phase"),
+            "work_type": state.get("work_type"),
+            "case_study": state.get("case_study") or state.get("case_study_showcase"),
+            "prs": collect_prs(state),
+        })
+    total = len(items)
+    with_id = sum(1 for it in items if it.get("linear_id"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_note": "derived from .claude/features/*/state.json — do not hand-edit; run `make crosswalk`",
+        "items": items,
+        "coverage": {
+            "total": total,
+            "with_linear_id": with_id,
+            "missing_linear_id": total - with_id,
+            "with_thematic_codes": sum(1 for it in items if it.get("thematic_codes")),
+        },
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--check", action="store_true", help="report only; do not write registry")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not FEATURES_DIR.is_dir():
+        print(f"build-item-registry: features dir not found: {FEATURES_DIR}", file=sys.stderr)
+        return 2
+
+    reg = build()
+    if not args.check:
+        REGISTRY.write_text(json.dumps(reg, indent=2) + "\n")
+
+    cov = reg["coverage"]
+    if not args.quiet:
+        where = "(check-only, not written)" if args.check else f"→ {REGISTRY.relative_to(REPO_ROOT)}"
+        print(f"item-registry: {cov['total']} features {where}")
+        print(f"  linear_id join: {cov['with_linear_id']}/{cov['total']} "
+              f"({cov['missing_linear_id']} missing) · "
+              f"thematic_codes: {cov['with_thematic_codes']}/{cov['total']}")
+        missing = [it["slug"] for it in reg["items"] if not it.get("linear_id")]
+        if missing:
+            print(f"\n  ⚠ ADVISORY — {len(missing)} feature(s) missing linear_id join "
+                  f"(add `linear_id` to state.json):")
+            for slug in missing[:40]:
+                print(f"      - {slug}")
+            if len(missing) > 40:
+                print(f"      … and {len(missing) - 40} more")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_build_item_registry.py
+++ b/scripts/tests/test_build_item_registry.py
@@ -1,0 +1,68 @@
+"""Tests for scripts/build-item-registry.py (FIT-200 crosswalk generator)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MOD = Path(__file__).resolve().parent.parent / "build-item-registry.py"
+_spec = importlib.util.spec_from_file_location("build_item_registry", _MOD)
+bir = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bir)
+
+
+def test_unified_status_complete_is_done():
+    assert bir.unified_status({"current_phase": "complete"}) == "Done"
+
+
+def test_unified_status_inflight_is_in_progress():
+    assert bir.unified_status({"current_phase": "implementation"}) == "In Progress"
+
+
+def test_unified_status_planning():
+    assert bir.unified_status({"current_phase": "prd"}) == "Planned"
+
+
+def test_unified_status_blocked_signal():
+    assert bir.unified_status({"current_phase": "implementation", "blocked_on": "x"}) == "Blocked"
+
+
+def test_unified_status_no_phase_is_backlog():
+    assert bir.unified_status({}) == "Backlog"
+
+
+def test_collect_prs_merges_all_sources_deduped_sorted():
+    state = {
+        "related_prs": [10, "12", 10],
+        "phases": {"merge": {"pr_number": 11}},
+        "tasks": [{"pr_number": 12}, {"pr_number": 13}, {"status": "done"}],
+    }
+    assert bir.collect_prs(state) == [10, 11, 12, 13]
+
+
+def test_collect_prs_empty():
+    assert bir.collect_prs({}) == []
+
+
+def test_build_shape_and_coverage(tmp_path, monkeypatch):
+    import json
+    feats = tmp_path / ".claude" / "features"
+    (feats / "alpha").mkdir(parents=True)
+    (feats / "beta").mkdir(parents=True)
+    (feats / "alpha" / "state.json").write_text(json.dumps({
+        "current_phase": "complete", "linear_id": "FIT-1",
+        "thematic_codes": ["FW-F4"], "related_prs": [5],
+    }))
+    (feats / "beta" / "state.json").write_text(json.dumps({
+        "current_phase": "implementation",  # no linear_id → missing join
+    }))
+    monkeypatch.setattr(bir, "FEATURES_DIR", feats)
+    reg = bir.build()
+    assert reg["coverage"]["total"] == 2
+    assert reg["coverage"]["with_linear_id"] == 1
+    assert reg["coverage"]["missing_linear_id"] == 1
+    by = {it["slug"]: it for it in reg["items"]}
+    assert by["alpha"]["status"] == "Done"
+    assert by["alpha"]["linear_id"] == "FIT-1"
+    assert by["alpha"]["prs"] == [5]
+    assert by["beta"]["status"] == "In Progress"
+    assert by["beta"]["linear_id"] is None


### PR DESCRIPTION
## What

One cohesive tracking spine across **Linear, Notion, backlog, master plan, and all sub-plans** so items are traceable end-to-end. Closes the root cause of the 2026-06-29 stale-open audit (no shared key + colliding thematic codes).

## Convention (per FIT-200 decisions)
- **Canonical key = feature slug** (`.claude/features/<slug>/`) — repo is SoT.
- **Tracking key = `FIT-NNN`** in `state.json.linear_id` — mechanical repo↔Linear join.
- **Scheme-prefixed thematic codes**: `FW-` / `TC-` / `DE-` / `HADF-` / `AN-` / `PROD-` — permanently kills the R14/R17/R18 collision.
- **Generated crosswalk**: `make crosswalk` → `.claude/shared/item-registry.json` + **advisory** for features missing the `linear_id` join (forward-only, non-blocking).
- **Shared status vocabulary** so "Done" means the same everywhere.

## Files
- `docs/process/cross-layer-item-naming-convention.md` — the spec
- `scripts/build-item-registry.py` + `make crosswalk` — the generator
- `scripts/tests/test_build_item_registry.py` — 8 tests (pass)
- `.claude/shared/item-registry.json` — baseline (118 features, 0 joined → advisory baseline)

## Next (separate passes)
1. **Reconcile**: backfill `linear_id` + `thematic_codes`, mark all verified-shipped items Done (Linear/Notion/backlog).
2. Then real open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)