### PR TITLE
docs(FW-NAMING): apply naming convention to all master/sub plans + 2026-06-29 reconcile

### DIFF
--- a/docs/master-plan/analytics-master-plan-2026-05-13.md
+++ b/docs/master-plan/analytics-master-plan-2026-05-13.md
@@ -1,5 +1,14 @@
 # Analytics Observability — Master Plan (Sub-doc of Infra Master Plan)
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `AN-` (analytics-observability).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 **Status (reconciled 2026-06-26):** Feature `analytics-observability` is **COMPLETE** — Phase 1.A (hygiene), Phase 2 (live debugger), Phase 3 (dashboards) + most D-tasks all shipped (state.json `current_phase=complete`). **Phase 1.B gates NOT shipped** — `CSV_TAXONOMY_DRIFT` + `GA4_MCP_DISCONNECTED` (= infra docket F19/F20) are not yet implemented and remain **blocked on the operator GA4 action** (register item A1: mark `workout_complete` + `nutrition_meal_logged` as GA4 Key events; task D-2 `deferred`) + post-launch signal. Downstream **F22 Funnel Analysis Dashboards shipped separately** 2026-06-24 (PR #799, feature `funnel-analysis-dashboards`, live GA4 3/5 funnels).
 **Created:** 2026-05-13
 **Parent:** [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) §3.6.X

--- a/docs/master-plan/data-integrity-and-rollback-2026-05-14.md
+++ b/docs/master-plan/data-integrity-and-rollback-2026-05-14.md
@@ -1,5 +1,14 @@
 # FitMe Continuous Data Integrity & Rollback Plan — 2026-05-14
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `FW-` (data-integrity is framework infra).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** CURRENT · Opened 2026-05-14 as a sub-doc of [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md)
 > **Scope:** The continuous-observability layer that sits *between* the existing 4 enforcement checkpoints (write-time / cycle-time / per-PR / weekly cron), and the platform-baseline rollback mechanism that restores known-good state when integrity degrades.
 > **Purpose:** Answer two questions the infra master plan does NOT answer:

--- a/docs/master-plan/dev-env-master-plan-2026-05-24.md
+++ b/docs/master-plan/dev-env-master-plan-2026-05-24.md
@@ -1,5 +1,14 @@
 # FitMe Dev-Env Stability & Scale Master Plan — 2026-05-24
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `DE-` (dev-env upgrade plan).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** CURRENT · Opened 2026-05-24 as a sub-doc of [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md)
 > **Source audit:** [`docs/research/2026-05-19-dev-env-audit-stability-and-scale.md`](../research/2026-05-19-dev-env-audit-stability-and-scale.md) (655 lines, 24 ranked recommendations, 4 tiers)
 > **Scope:** The development environment for both repos (FT2 iOS + ai-engine + dashboard + website; fitme-story Next.js + control room), plus the v7.8.6 framework substrate, multi-agent harness, and supporting CI/observability infra. Drives lint/test/coverage/security/backup hardening across 24 R-items grouped in 4 tiers.

--- a/docs/master-plan/infra-master-plan-2026-05-12.md
+++ b/docs/master-plan/infra-master-plan-2026-05-12.md
@@ -1,5 +1,14 @@
 # FitMe Infra Master Plan & Roadmap — 2026-05-12
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `FW-` (framework infrastructure & gates).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** CURRENT · Opened 2026-05-12 (one day after v7.8.3 cross-repo state-sync shipped)
 > **Scope:** Framework infrastructure only — write-time gates, cycle-time checks, branch-isolation tooling, cross-repo sync, measurement infrastructure, and the HADF/ORCHID research substrate that depends on it. Product features tracked separately in [`master-plan-2026-04-15.md`](master-plan-2026-04-15.md) + [`master-backlog-roadmap.md`](master-backlog-roadmap.md).
 > **Purpose:** Single forward-looking source of truth for framework v7.9 promotion, v8.x candidate ranking, HADF Phase 2-bis pre-launch dependencies, and the measurement / promotion calendar through Q3 2026.

--- a/docs/master-plan/master-backlog-roadmap.md
+++ b/docs/master-plan/master-backlog-roadmap.md
@@ -1,5 +1,14 @@
 # FitTracker2 — Master Backlog & Roadmap (RICE Prioritized)
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `PROD-` (product roadmap).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 ## Context
 Complete project roadmap with 18 tasks across 6 phases. Prioritized using the RICE framework (Reach × Impact × Confidence / Effort). Each phase completion is a **gateway** — no coding for the next phase begins until the current phase is approved.
 

--- a/docs/master-plan/master-plan-2026-04-15.md
+++ b/docs/master-plan/master-plan-2026-04-15.md
@@ -1,5 +1,14 @@
 # FitMe Master Plan — 2026-04-15
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses all schemes (cross-cutting).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** CURRENT · Last updated 2026-06-26. **Framework is at v7.10** (shipped 2026-06-10). v7.9 promotion (2026-05-21) Phase E soak exited cleanly 2026-06-04; v7.9.1 build window (8 ships) closed 2026-06-04; v7.10 (gate-coverage observability + field-rename closure) shipped 2026-06-10. **For canonical current-state counts (version, features, gates) always defer to [`../FRAMEWORK-FACTS.md`](../FRAMEWORK-FACTS.md)** — the per-version mechanism counts in the banner below are accurate records of each era, not current state.
 
 > **v7.10 + v7.9.1 (SHIPPED 2026-06-04 → 2026-06-10):** v7.9.1 single-day build window (no new enforcement gates — respected Phase E discipline): F16 try-repo harness, F17 `last_fired_at` index, F2 Phase-0 reality-check, F-LAUNCHD-DRIFT-EXTENSION, F-DEPLOYED-URL-PROBE substrate, dev-env lint batch, observed-patterns W29–W32. v7.10 (2026-06-10): `GATE_COVERAGE_ZERO` meta-check extension + cycle-time coverage emission + field-rename silent-pass closure (pattern #24). **Post-v7.10 calibration ladder:** F16 enforced 2026-06-17 (1d early), `PLATFORMS_TESTED`/T14 enforced 2026-06-21, F4 `FRAMEWORK_VERSION_STALE` advisory→enforced review ~2026-06-30, W9 re-eval 2026-06-28, R9 Track-B coverage read 2026-07-04. **v8.0 build:** 16 of 18 F-candidates shipped; remaining open F18 (mutation testing, unblocked) + F19/F20 (GA4, operator-gated) + F23 (`/ops digest`, Sentry-gated); ship target 2026-07-31. See [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) §3.0 + [`v8-x-build-docket-2026-06-15.md`](v8-x-build-docket-2026-06-15.md) for the reconciled docket.

--- a/docs/master-plan/post-v7-9-candidate-plan-2026-05-20.md
+++ b/docs/master-plan/post-v7-9-candidate-plan-2026-05-20.md
@@ -1,5 +1,14 @@
 # Post-v7.9 Candidate Plan — Drafted 2026-05-20 (Eve of Promotion)
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `FW-` (framework candidates).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** ✅ LARGELY EXECUTED (refreshed 2026-06-07) · v7.9 promoted 2026-05-21, Phase E exited cleanly 2026-06-04, v7.9.1 build window shipped 2026-06-04. Most E-series candidates here have shipped — notably **E-14 F-LAUNCHD-DRIFT-EXTENSION** (all 3 sub-fixes, v7.9.1 #621–#624). Current forward reality lives in the [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md) 2026-06-07 status banner; remaining infra tails + the calibration ladder (F16 06-18 / W9 ~06-28 [reset from 06-20 by the 06-14 session-id-keying fix] / t14 06-21 → v7.10) are tracked there + in [`.claude/shared/v7-9-1-candidates.md`](../../.claude/shared/v7-9-1-candidates.md).
 > **Drafted:** 2026-05-20 (operator + Claude session)
 > **Resume from:** historical — read the infra-master-plan banner first for current reality, then this doc for the original candidate detail.

--- a/docs/master-plan/test-coverage-master-plan-2026-05-13.md
+++ b/docs/master-plan/test-coverage-master-plan-2026-05-13.md
@@ -1,5 +1,14 @@
 # FitMe Cross-Layer Test Coverage Master Plan — 2026-05-13
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `TC-` (test coverage / Theme H).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** CURRENT · Opened 2026-05-13 as a sub-doc of [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md)
 > **Scope:** Test discipline across every system layer — iOS, web (fitme-story), framework (Python gates), backend (Supabase/CloudKit/auth), AI, analytics. Forward-looking calibration of where tests exist, where they've drifted, and where they're missing.
 > **Purpose:** Answer the question the infra master plan does NOT answer: "are all current tests in spec across all layers?" The infra plan covers Theme G — Test discipline for the framework layer only (F14–F18 + F19/F20 from analytics-observability). This sub-doc widens the scope to iOS + web + backend + AI + analytics and proposes a per-layer T-series candidate docket.

--- a/docs/master-plan/ui-ux-master-plan-2026-05-24.md
+++ b/docs/master-plan/ui-ux-master-plan-2026-05-24.md
@@ -1,5 +1,14 @@
 # FitMe UI/UX Master Plan — 2026-05-24
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses `PROD-` (product UI/UX).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > **Status:** CURRENT · Opened 2026-05-24 as the 5th sub-doc of [`infra-master-plan-2026-05-12.md`](infra-master-plan-2026-05-12.md). Platform-comprehensive revision 2026-05-24 expanded scope from "iOS + website" to "iOS + website + Android" (token + adaptation layer; Android app code not yet implemented) and reconciled 3 drift items + added missing `user-profile-settings` row.
 > **Scope:** All UI/UX work across all platforms — iOS (FitTracker2), website (fitme-story), and Android (tokens + adaptation docs, no native app surface yet). Features, enhancements, and chores. Includes both shipped state and in-flight queue. Cross-references parent features (e.g., v2 alignment series under `design-system-v2`; UCC sub-features under `unified-control-center`; Android token pipeline under `android-design-system`).
 > **Purpose:** Codify the surface-level UI/UX work that was previously distributed across `.claude/features/*/state.json`, `docs/product/backlog.md` rows, and memory entries. Single source of truth for "what UI/UX is shipped, in-flight, queued, or implicit." Mirrors backlog rows; lets operators answer "what should I work on next on the UI surface" without reading 60+ state.json files.

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -1,9 +1,20 @@
 # FitMe — Complete Backlog
 
+> **Item-tracking convention (FIT-200, est. 2026-06-29):** items here are tracked under the
+> [cross-layer naming convention](../process/cross-layer-item-naming-convention.md) — **slug** (canonical) + **`FIT-NNN`**
+> (`state.json.linear_id`) + **scheme-prefixed code**: this plan uses all schemes (cross-cutting).
+> Status vocabulary (all layers): **Backlog → Planned → In Progress → Blocked → Done → Won't-Do**.
+> Live per-item status: [`.claude/shared/item-registry.json`](../../.claude/shared/item-registry.json)
+> (`make crosswalk`) + the Linear "Fitme project" board. Repo (`state.json.current_phase`) is
+> the source of truth; this doc is a planning view. Bare thematic codes (`F4`/`T14`/`R14`) are
+> retired in favor of prefixed codes to prevent the cross-scheme collisions reconciled 2026-06-29.
+
 > Compiled from: README, CHANGELOG, feature-memory, gap-review, resume-handoff, master plan, PRD gaps, session work.  
 > Last updated: 2026-05-24 (Phase E day 4, second pass — sub-plan codification batch: dev-env + UI/UX sub-plans codified under infra master plan (4th + 5th sub-docs); UI/UX Track + Dev-Env Stability & Scale Track subsections added below; 5 drift / reconciliation items closed (UX-R1 state.json closure + UX-R2 case-study link verification + UX-R3 design-rules.md new + UX-R4 orbital pm-flow case study new + UX-R5 Failure Recognition filed Aspirational); R6 reconciled `[~]` → `[x]` after fs ground-truth re-check; UX-UU1/UU2/C5 verified already shipped (cadence ledger drift). Earlier this session: D-PLAN-1 backlog backfill (rows #101-#115 covering ~30 PRs since 2026-05-21) + dev-guide v7.9 readability pass DEFERRED to follow-up via isolated worktree. Phase E telemetry healthy 0+0; baseline preserved across all edits. **v7.9 PROMOTION SHIPPED** 2026-05-21 via PR #417 `ea53ff4` — 3 advisory gates → enforced via single-flag flip; Phase E validation 2026-05-21 → 2026-06-04; framework reaches **37 mechanical gates + 5 advisories**; v7.8.6 Cadence Batch shipped 2026-05-15; v7.8.5 Observability Layer shipped 2026-05-13; Sentry integration paused → pre-launch trigger)
 >
 > **Reconciled 2026-06-26:** Framework is now at **v7.10** (shipped 2026-06-10; v7.9.1 build window closed 2026-06-04). Live state: **117 tracked features, 114 complete** (3 in-flight: `3d-interactive-framework-flow-diagram`, `app-store-assets`, `orchid-v1-5`). The "37 mechanical gates" count above is the v7.9-era record — for canonical current counts defer to [`docs/FRAMEWORK-FACTS.md`](../FRAMEWORK-FACTS.md). v8.0 docket: 16 of 18 F-candidates shipped; remaining open F18/F19/F20/F23 (see [infra §3.0](../master-plan/infra-master-plan-2026-05-12.md)). Section rows below remain accurate (no shipped-but-open false positives found in the 2026-06-26 sync).
+>
+> **Reconciled 2026-06-29:** **118 features** (115 complete; same 3 in-flight). Cross-layer **naming convention established** (FIT-200 — slug + `FIT-NNN` + scheme-prefixed code `FW-/TC-/DE-/HADF-/AN-/PROD-`; see banner above + [`docs/process/cross-layer-item-naming-convention.md`](../process/cross-layer-item-naming-convention.md)). **Linear stale-open reconcile:** 11 verified-shipped items marked Done (FIT-94/95/161/153/151/195/196/129/73/191/133), FIT-66 → In Progress (UCC cutover, operator-gated), FIT-132 (Code Connect, Pro-plan) + FIT-128 (dup) → Canceled; FIT-198 (foundation-models-tier3) closed. F18 (#809) + F22 (#799) shipped — v8.0 docket open is now **F19/F20/F23** + open T-series/DE-/AN- items. **External audits OVERDUE, NOT done** (FIT-125/126/87) → redefinition tracked under **FIT-201 `AUDIT-PROGRAM`** (separate task).
 
 ---
 


### PR DESCRIPTION
## What
Source-sync pass so **all master + sub plans conform to the FIT-200 cross-layer naming convention** (companion to #817).

- **Convention-conformance banner** added to backlog + 9 living plans (master, infra, test-coverage, data-integrity, dev-env, analytics, ui-ux, post-v7-9-candidate, master-backlog-roadmap). Each declares its **scheme prefix** (`FW-`/`TC-`/`DE-`/`AN-`/`PROD-`), the shared **status vocabulary** (Backlog→Planned→In Progress→Blocked→Done→Won't-Do), and points to the `item-registry.json` crosswalk. Bare thematic codes retired (kills the R14/R17/R18 collision).
- **backlog.md 2026-06-29 reconcile note**: 118 features; Linear stale-open fixes (11 Done + FIT-66 In Progress + FIT-132/128 Canceled); external audits **OVERDUE/NOT-done** → FIT-201 `AUDIT-PROGRAM`.

## Source-sync status (this reconcile)
- ✅ Linear — 14 items reconciled
- ✅ Notion Roadmap — convention + reconcile note posted
- ✅ Plans + backlog — this PR
- ⏳ Convention infra (#817) — merging

Docs-only; no Makefile/Swift touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)