### PR TITLE
chore(FW-NAMING): backfill linear_id on 23 features → crosswalk join 23/118 (FIT-200)

### DIFF
--- a/.claude/features/3d-interactive-framework-flow-diagram/state.json
+++ b/.claude/features/3d-interactive-framework-flow-diagram/state.json
@@ -417,5 +417,6 @@
     ],
     "relaunch_blocker": "T-rive-tier-2 (.riv asset) + full polish pass"
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-138"
 }

--- a/.claude/features/analytics-observability/state.json
+++ b/.claude/features/analytics-observability/state.json
@@ -636,5 +636,6 @@
   },
   "platforms_tested_provenance": "authored",
   "updated_at": "2026-06-09T17:55:00Z",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-139"
 }

--- a/.claude/features/app-store-assets/state.json
+++ b/.claude/features/app-store-assets/state.json
@@ -294,5 +294,6 @@
     "deprecation_warnings": []
   },
   "state_owner": "ft2",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-134"
 }

--- a/.claude/features/f1-state-tasks-filesystem-drift/state.json
+++ b/.claude/features/f1-state-tasks-filesystem-drift/state.json
@@ -138,5 +138,9 @@
   ],
   "case_study_type": "no_case_study_required",
   "case_study_type_reason": "Framework-meta advisory gate; tracked at docket level (v8-x-build-docket-2026-06-15.md Theme A/C), not via standalone case study (matches f11/f12 sibling closure).",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-95",
+  "thematic_codes": [
+    "FW-F1"
+  ]
 }

--- a/.claude/features/f11-reverse-sync-historical-exempt/state.json
+++ b/.claude/features/f11-reverse-sync-historical-exempt/state.json
@@ -134,5 +134,9 @@
   "case_study_exempt_reason": "Mechanical framework_feature chore (gate/enum/exemption); thin change per the six-features-roundup principle \u2014 no dedicated narrative warranted.",
   "isolation_opt_out": true,
   "isolation_opt_out_reason": "Bundled post-merge closure of 3 co-shipped framework_feature chores (PRs #719/#720/#722) in one reconciliation PR 2026-06-15.",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-98",
+  "thematic_codes": [
+    "FW-F11"
+  ]
 }

--- a/.claude/features/f12-actionlint-gate/state.json
+++ b/.claude/features/f12-actionlint-gate/state.json
@@ -134,5 +134,9 @@
   "case_study_exempt_reason": "Mechanical framework_feature chore (gate/enum/exemption); thin change per the six-features-roundup principle \u2014 no dedicated narrative warranted.",
   "isolation_opt_out": true,
   "isolation_opt_out_reason": "Bundled post-merge closure of 3 co-shipped framework_feature chores (PRs #719/#720/#722) in one reconciliation PR 2026-06-15.",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-103",
+  "thematic_codes": [
+    "FW-F12"
+  ]
 }

--- a/.claude/features/f16-try-repo-harness/state.json
+++ b/.claude/features/f16-try-repo-harness/state.json
@@ -186,5 +186,9 @@
     "total_wall_time_minutes": 200.0,
     "total_wall_time_minutes_provenance": "backfill-derived-from-phase-durations-2026-06-10"
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-88",
+  "thematic_codes": [
+    "FW-F16"
+  ]
 }

--- a/.claude/features/f17-last-fired-at-index/state.json
+++ b/.claude/features/f17-last-fired-at-index/state.json
@@ -123,5 +123,9 @@
     "total_wall_time_minutes": 40.0,
     "total_wall_time_minutes_provenance": "backfill-derived-from-phase-durations-2026-06-10"
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-89",
+  "thematic_codes": [
+    "FW-F17"
+  ]
 }

--- a/.claude/features/f18-mutation-testing/state.json
+++ b/.claude/features/f18-mutation-testing/state.json
@@ -147,5 +147,9 @@
       "type": "adapted"
     }
   ],
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-102",
+  "thematic_codes": [
+    "FW-F18"
+  ]
 }

--- a/.claude/features/f2-phase-0-reality-check/state.json
+++ b/.claude/features/f2-phase-0-reality-check/state.json
@@ -105,5 +105,9 @@
     "total_wall_time_minutes": 25.0,
     "total_wall_time_minutes_provenance": "backfill-derived-from-phase-durations-2026-06-10"
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-90",
+  "thematic_codes": [
+    "FW-F2"
+  ]
 }

--- a/.claude/features/f3-dependency-graph-cycle-check/state.json
+++ b/.claude/features/f3-dependency-graph-cycle-check/state.json
@@ -147,5 +147,9 @@
   ],
   "case_study_type": "no_case_study_required",
   "case_study_type_reason": "Framework-meta advisory gate; tracked at docket level (v8-x-build-docket-2026-06-15.md Theme A/C), not via standalone case study (matches f11/f12 sibling closure).",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-105",
+  "thematic_codes": [
+    "FW-F3"
+  ]
 }

--- a/.claude/features/f4-framework-version-stale/state.json
+++ b/.claude/features/f4-framework-version-stale/state.json
@@ -164,5 +164,9 @@
   ],
   "case_study_type": "no_case_study_required",
   "case_study_type_reason": "Framework-meta advisory gate; tracked at docket level (v8-x-build-docket-2026-06-15.md Theme A/C), not via standalone case study (matches f11/f12 sibling closure).",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-96",
+  "thematic_codes": [
+    "FW-F4"
+  ]
 }

--- a/.claude/features/foundation-models-tier3/state.json
+++ b/.claude/features/foundation-models-tier3/state.json
@@ -427,5 +427,6 @@
   "merge_commit_sha": "ee5d5bfe0b1f362fc238fe4031c4ca5c251c99d1",
   "merged_at": "2026-06-15T19:45:44Z",
   "feature_branch_merged": "feature/foundation-models-tier3",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-198"
 }

--- a/.claude/features/framework-v7-8-bridge/state.json
+++ b/.claude/features/framework-v7-8-bridge/state.json
@@ -68,5 +68,6 @@
     }
   },
   "state_owner": "ft2",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-60"
 }

--- a/.claude/features/import-training-plan/state.json
+++ b/.claude/features/import-training-plan/state.json
@@ -760,5 +760,6 @@
     }
   ],
   "updated_at": "2026-05-12T07:30:00Z",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-24"
 }

--- a/.claude/features/push-notifications/state.json
+++ b/.claude/features/push-notifications/state.json
@@ -563,5 +563,6 @@
     }
   },
   "state_owner": "ft2",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-23"
 }

--- a/.claude/features/t13-last-failed-at-index/state.json
+++ b/.claude/features/t13-last-failed-at-index/state.json
@@ -140,5 +140,9 @@
       "ended_at": "2026-06-10T07:17:22Z"
     }
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-161",
+  "thematic_codes": [
+    "TC-T13"
+  ]
 }

--- a/.claude/features/t14-platform-parity-state-field/state.json
+++ b/.claude/features/t14-platform-parity-state-field/state.json
@@ -223,5 +223,9 @@
       "reason": "Feature CLOSED via close-feature.py on chore/t14-platform-parity-state-field-post-merge-closure. Closes the testing\u2192complete drift-pattern documented across 5+ instances by automating the post-merge audit trail."
     }
   ],
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-162",
+  "thematic_codes": [
+    "TC-T14"
+  ]
 }

--- a/.claude/features/t3-signinservice-passkey-tests/state.json
+++ b/.claude/features/t3-signinservice-passkey-tests/state.json
@@ -140,5 +140,9 @@
       "ended_at": "2026-06-10T07:24:01Z"
     }
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-151",
+  "thematic_codes": [
+    "TC-T3"
+  ]
 }

--- a/.claude/features/t5-mock-protocol-drift/state.json
+++ b/.claude/features/t5-mock-protocol-drift/state.json
@@ -134,5 +134,9 @@
       "ended_at": "2026-06-10T14:56:25Z"
     }
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-153",
+  "thematic_codes": [
+    "TC-T5"
+  ]
 }

--- a/.claude/features/ucc-passkey-auth-security-hardening/state.json
+++ b/.claude/features/ucc-passkey-auth-security-hardening/state.json
@@ -751,5 +751,6 @@
       "note": "B12 T+7d kill-criteria evaluation: PROMOTE verdict. K1 (lockout false-positive rate) NOT FIRED \u2014 0 lockout events of any kind in 7d window. K2 (latency overhead) instrumentation invalid \u2014 audit-log duration_ms measures end-to-end WebAuthn ceremony, not server-side function time the +5ms threshold was sized for; v7.9.1 candidate F-AUTH-LATENCY-SERVER-METRIC queued. K3 (allowlist_unset) NOT FIRED \u2014 0 events. K4 (operator lockout > 5min) NOT FIRED \u2014 4 successful sign-ins across window. Primary metric unauthorized_operator_registration_attempts_succeeded = 0. Operator unaffected throughout window. Full evidence in case study \u00a74 + \u00a799."
     }
   ],
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-192"
 }

--- a/.claude/features/unified-control-center/state.json
+++ b/.claude/features/unified-control-center/state.json
@@ -1167,5 +1167,6 @@
   },
   "case_study_showcase": "fitme-story/content/04-case-studies/23a-unified-control-center.mdx",
   "state_owner": "ft2",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-58"
 }

--- a/.claude/features/v8-f10-f5-schema-vocab/state.json
+++ b/.claude/features/v8-f10-f5-schema-vocab/state.json
@@ -133,5 +133,9 @@
   "case_study_exempt_reason": "Mechanical framework_feature chore (gate/enum/exemption); thin change per the six-features-roundup principle \u2014 no dedicated narrative warranted.",
   "isolation_opt_out": true,
   "isolation_opt_out_reason": "Bundled post-merge closure of 3 co-shipped framework_feature chores (PRs #719/#720/#722) in one reconciliation PR 2026-06-15.",
-  "schema_version": 1
+  "schema_version": 1,
+  "linear_id": "FIT-99",
+  "thematic_codes": [
+    "FW-F10"
+  ]
 }

--- a/.claude/shared/item-registry.json
+++ b/.claude/shared/item-registry.json
@@ -4,7 +4,7 @@
   "items": [
     {
       "slug": "3d-interactive-framework-flow-diagram",
-      "linear_id": null,
+      "linear_id": "FIT-138",
       "thematic_codes": [],
       "status": "In Progress",
       "current_phase": "tasks_phase",
@@ -104,7 +104,7 @@
     },
     {
       "slug": "analytics-observability",
-      "linear_id": null,
+      "linear_id": "FIT-139",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -134,7 +134,7 @@
     },
     {
       "slug": "app-store-assets",
-      "linear_id": null,
+      "linear_id": "FIT-134",
       "thematic_codes": [],
       "status": "Blocked",
       "current_phase": "implementation",
@@ -360,8 +360,10 @@
     },
     {
       "slug": "f1-state-tasks-filesystem-drift",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-95",
+      "thematic_codes": [
+        "FW-F1"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -372,8 +374,10 @@
     },
     {
       "slug": "f11-reverse-sync-historical-exempt",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-98",
+      "thematic_codes": [
+        "FW-F11"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Chore",
@@ -384,8 +388,10 @@
     },
     {
       "slug": "f12-actionlint-gate",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-103",
+      "thematic_codes": [
+        "FW-F12"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Chore",
@@ -396,8 +402,10 @@
     },
     {
       "slug": "f16-try-repo-harness",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-88",
+      "thematic_codes": [
+        "FW-F16"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -413,8 +421,10 @@
     },
     {
       "slug": "f17-last-fired-at-index",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-89",
+      "thematic_codes": [
+        "FW-F17"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -423,8 +433,10 @@
     },
     {
       "slug": "f18-mutation-testing",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-102",
+      "thematic_codes": [
+        "FW-F18"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "chore",
@@ -435,8 +447,10 @@
     },
     {
       "slug": "f2-phase-0-reality-check",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-90",
+      "thematic_codes": [
+        "FW-F2"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -445,8 +459,10 @@
     },
     {
       "slug": "f3-dependency-graph-cycle-check",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-105",
+      "thematic_codes": [
+        "FW-F3"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -457,8 +473,10 @@
     },
     {
       "slug": "f4-framework-version-stale",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-96",
+      "thematic_codes": [
+        "FW-F4"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -564,7 +582,7 @@
     },
     {
       "slug": "foundation-models-tier3",
-      "linear_id": null,
+      "linear_id": "FIT-198",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -675,7 +693,7 @@
     },
     {
       "slug": "framework-v7-8-bridge",
-      "linear_id": null,
+      "linear_id": "FIT-60",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -867,7 +885,7 @@
     },
     {
       "slug": "import-training-plan",
-      "linear_id": null,
+      "linear_id": "FIT-24",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -1037,7 +1055,7 @@
     },
     {
       "slug": "push-notifications",
-      "linear_id": null,
+      "linear_id": "FIT-23",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -1171,8 +1189,10 @@
     },
     {
       "slug": "t13-last-failed-at-index",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-161",
+      "thematic_codes": [
+        "TC-T13"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -1181,8 +1201,10 @@
     },
     {
       "slug": "t14-platform-parity-state-field",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-162",
+      "thematic_codes": [
+        "TC-T14"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -1194,8 +1216,10 @@
     },
     {
       "slug": "t3-signinservice-passkey-tests",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-151",
+      "thematic_codes": [
+        "TC-T3"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -1204,8 +1228,10 @@
     },
     {
       "slug": "t5-mock-protocol-drift",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-153",
+      "thematic_codes": [
+        "TC-T5"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Feature",
@@ -1282,7 +1308,7 @@
     },
     {
       "slug": "ucc-passkey-auth-security-hardening",
-      "linear_id": null,
+      "linear_id": "FIT-192",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -1331,7 +1357,7 @@
     },
     {
       "slug": "unified-control-center",
-      "linear_id": null,
+      "linear_id": "FIT-58",
       "thematic_codes": [],
       "status": "Done",
       "current_phase": "complete",
@@ -1360,8 +1386,10 @@
     },
     {
       "slug": "v8-f10-f5-schema-vocab",
-      "linear_id": null,
-      "thematic_codes": [],
+      "linear_id": "FIT-99",
+      "thematic_codes": [
+        "FW-F10"
+      ],
       "status": "Done",
       "current_phase": "complete",
       "work_type": "Chore",
@@ -1387,8 +1415,8 @@
   ],
   "coverage": {
     "total": 118,
-    "with_linear_id": 0,
-    "missing_linear_id": 118,
-    "with_thematic_codes": 0
+    "with_linear_id": 23,
+    "missing_linear_id": 95,
+    "with_thematic_codes": 14
   }
 }


### PR DESCRIPTION
## What
Seeds the cross-layer crosswalk join (slug ↔ `FIT-NNN`) on **23 high-confidence features** + regenerates `item-registry.json`. Follows the convention (#817) + builds on DE-R18 schema_version (#819).

- 23 features get `linear_id` (+ `thematic_codes` on the 14 code-prefixed ones: `FW-F4`, `TC-T14`, …)
- Crosswalk join: **0/118 → 23/118**; the other 95 stay on the advisory + forward-rule (new features get `linear_id` at creation)
- Excluded a collision mis-match (`r9-track-b-coverage-aggregator` ≠ dev-env `FIT-175`)
- integrity 0; all 23 state.json pass pre-commit gates

**Effect:** `make crosswalk` now mechanically surfaces slug↔Linear drift for these features — the stale-open pattern (R8/T6/…) gets caught automatically instead of by hand.

Only `state.json` + `item-registry.json` changed (no Makefile/Swift → fast CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)