### PR TITLE
feat(AN-1B.2): GA4_MCP_DISCONNECTED advisory-only connectivity gate (FIT-146)

### DIFF
--- a/.claude/features/an-1b2-ga4-mcp-disconnected/design-notes.md
+++ b/.claude/features/an-1b2-ga4-mcp-disconnected/design-notes.md
@@ -1,0 +1,43 @@
+# AN-1B.2 — `GA4_MCP_DISCONNECTED` — Design Notes
+
+> v8.x docket **F20** (Theme C). Tracked: Linear **FIT-146**, thematic code
+> **AN-1B.2**. Spec: [analytics-master-plan §8.3](../../../docs/master-plan/analytics-master-plan-2026-05-13.md).
+> Convention: [`docs/process/cross-layer-item-naming-convention.md`](../../../docs/process/cross-layer-item-naming-convention.md).
+
+## What it does
+
+Commit-level connectivity **advisory**. When a commit stages analytics-affecting
+code (`FitTracker/Services/Analytics/*`, `fitme-story/src/lib/control-room/analytics.ts`,
+or `docs/product/analytics-taxonomy.csv`) and GA4 MCP is **not reachable via env**
+— `GA4_PROPERTY_ID` set **and** `GOOGLE_APPLICATION_CREDENTIALS` pointing at an
+existing file — it prints a `[ADVISORY] GA4_MCP_DISCONNECTED` line to stderr.
+
+## Advisory-only by design (no calibration ladder)
+
+Unlike AN-1B.1, this gate has **no advisory→enforced flip**. Per §8.3 it is
+*"advisory only — never blocks commits, even when promoted. The gate exists to
+surface drift, not to gate analytics work behind operator GA4 setup."* It always
+routes to stderr, never to `errors[]`. Therefore there is **no promotion criteria,
+no 14-day window, and no cadence-ledger entry** — nothing to flip.
+
+## Operator dependency (expected pre-launch state)
+
+Pre-launch the GA4 env is typically unset, so the advisory is **expected** to fire
+on analytics commits until the operator wires GA4 (register item A1 + set the two
+env vars). That is the intended signal — it reminds whoever touches analytics code
+that GA4 ingest isn't connected yet. It is not a blocker and not a bug.
+
+## Implementation
+
+- `check_ga4_mcp_connectivity(staged_files, *, coverage, repo_root)` in
+  [`scripts/check-state-schema.py`](../../../scripts/check-state-schema.py).
+- Path match via `_matches_any_glob` against `ANALYTICS_AFFECTING_GLOBS`.
+- Mechanism A coverage: `candidate` always; `skip("no_analytics_files_staged")`
+  when not relevant; `checked` when a connectivity check runs.
+- Commit-level dispatch in `main()` (staged mode), after CSV_TAXONOMY_DRIFT.
+- Tests: [`scripts/tests/test_ga4_mcp_disconnected.py`](../../../scripts/tests/test_ga4_mcp_disconnected.py) — 6 (skip / disconnected / csv-affecting / connected / creds-missing / always-advisory).
+
+## Reversibility
+
+Remove the dispatch block in `main()` (or early-return the function). <2 min.
+No flag — advisory-only means there's nothing to demote.

--- a/.claude/features/an-1b2-ga4-mcp-disconnected/state.json
+++ b/.claude/features/an-1b2-ga4-mcp-disconnected/state.json
@@ -1,0 +1,28 @@
+{
+  "feature": "an-1b2-ga4-mcp-disconnected",
+  "current_phase": "implementation",
+  "work_type": "Feature",
+  "work_subtype": "framework_feature",
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "schema_version": 1,
+  "linear_id": "FIT-146",
+  "thematic_codes": ["AN-1B.2"],
+  "created_at": "2026-06-29T17:20:00Z",
+  "platforms_tested": {},
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "case_study_type": "no_case_study_required",
+  "case_study_type_reason": "Framework-meta connectivity advisory (advisory-only, never blocks; no enforced flip / no calibration window). Tracked at docket level (analytics-master-plan §8.3, AN-1B.2 / F20) + design-notes.md; sibling pattern f4/an-1b1.",
+  "timing": {
+    "phases": {
+      "implementation": { "started_at": "2026-06-29T17:20:00Z" }
+    }
+  },
+  "tasks": [
+    { "id": "T1", "status": "complete", "title": "check_ga4_mcp_connectivity() in check-state-schema.py (advisory-only) + coverage" },
+    { "id": "T2", "status": "complete", "title": "commit-level dispatch in main() (always stderr, never errors[])" },
+    { "id": "T3", "status": "complete", "title": "scripts/tests/test_ga4_mcp_disconnected.py (6 tests)" },
+    { "id": "T4", "status": "complete", "title": ".githooks/pre-commit header bump" },
+    { "id": "T5", "status": "complete", "title": "design-notes.md" }
+  ]
+}

--- a/.claude/logs/an-1b2-ga4-mcp-disconnected.log.json
+++ b/.claude/logs/an-1b2-ga4-mcp-disconnected.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "an-1b2-ga4-mcp-disconnected",
+  "title": "an 1b2 ga4 mcp disconnected",
+  "work_type": "Feature",
+  "current_phase": "implementation",
+  "framework_version": "v7.10",
+  "started_at": "2026-06-29T16:51:44Z",
+  "updated_at": "2026-06-29T16:51:44Z",
+  "events": [
+    {
+      "timestamp": "2026-06-29T16:51:44Z",
+      "event_type": "phase_started",
+      "phase": "implementation",
+      "summary": "AN-1B.2 GA4_MCP_DISCONNECTED advisory-only connectivity gate + 6 tests",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude",
+      "status": "complete",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -76,6 +76,11 @@
 #         docs/product/analytics-taxonomy.csv. Exempt via state.json
 #         csv_taxonomy_exempt: [{constant, reason}]. Flip
 #         CSV_TAXONOMY_DRIFT_ADVISORY_MODE to enforce.
+#       - GA4_MCP_DISCONNECTED (AN-1B.2, write-time, ADVISORY-ONLY by design —
+#         never blocks): commit-level — fires when analytics-affecting code is
+#         staged and GA4 MCP is unreachable via env (GA4_PROPERTY_ID set +
+#         GOOGLE_APPLICATION_CREDENTIALS file exists). Surfaces drift; expected
+#         pre-launch until the operator wires GA4.
 #     Cycle-time advisories (non-pre-commit) live in scripts/integrity-check.py:
 #     T17 BranchIsolationHistorical, T18 BranchIsolationLaunchdDrift, T19
 #     FeatureClosureCompleteness mirror. See .claude/integrity/README.md.

--- a/scripts/check-state-schema.py
+++ b/scripts/check-state-schema.py
@@ -190,6 +190,19 @@ CSV_TAXONOMY_DRIFT_ADVISORY_MODE = True
 ANALYTICS_PROVIDER_PATH = "FitTracker/Services/Analytics/AnalyticsProvider.swift"
 ANALYTICS_TAXONOMY_CSV = "docs/product/analytics-taxonomy.csv"
 
+# AN-1B.2 (analytics-master-plan §8.3, Theme C / F20): GA4_MCP_DISCONNECTED.
+# Commit-level connectivity advisory — fires when analytics-affecting code is
+# staged and GA4 MCP is not reachable via env (GA4_PROPERTY_ID set +
+# GOOGLE_APPLICATION_CREDENTIALS file exists). ADVISORY-ONLY BY DESIGN: never
+# blocks a commit, even "promoted" — it surfaces drift, it does not gate
+# analytics work behind operator GA4 setup. Pre-launch the GA4 env is typically
+# unset, so this advisory is expected until the operator wires GA4 (register A1).
+ANALYTICS_AFFECTING_GLOBS = (
+    "FitTracker/Services/Analytics/*",
+    "fitme-story/src/lib/control-room/analytics.ts",
+    ANALYTICS_TAXONOMY_CSV,
+)
+
 # Canonical-version override (tests + operator escape hatch). When unset, the
 # resolver parses docs/FRAMEWORK-FACTS.md — the declared machine-derived SoT.
 _FRAMEWORK_VERSION_CANONICAL_OVERRIDE = os.environ.get(
@@ -1955,6 +1968,61 @@ def check_csv_taxonomy_drift(
     return findings
 
 
+def check_ga4_mcp_connectivity(
+    staged_files: list[str], *, coverage: GateCoverage | None = None,
+    repo_root: Path | None = None,
+) -> list[dict]:
+    """AN-1B.2 (analytics-master-plan §8.3): GA4_MCP_DISCONNECTED.
+
+    Commit-level. Fires when analytics-affecting code is staged and GA4 MCP
+    is not reachable via env (GA4_PROPERTY_ID set + GOOGLE_APPLICATION_CREDENTIALS
+    points at an existing file). ADVISORY-ONLY by design — surfaces drift, never
+    blocks (even when "promoted"). Pre-launch the env is typically unset, so the
+    advisory is expected until the operator wires GA4.
+    """
+    repo_root = repo_root or REPO_ROOT
+    findings: list[dict] = []
+    GATE = "GA4_MCP_DISCONNECTED"
+    if coverage is not None:
+        coverage.candidate(GATE)
+
+    affecting = [f for f in staged_files
+                 if _matches_any_glob(f, ANALYTICS_AFFECTING_GLOBS)]
+    if not affecting:
+        if coverage is not None:
+            coverage.skip(GATE, "no_analytics_files_staged")
+        return findings
+
+    if coverage is not None:
+        coverage.checked(GATE)
+
+    prop = os.environ.get("GA4_PROPERTY_ID")
+    creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    creds_ok = bool(creds) and Path(creds).is_file()
+    if prop and creds_ok:
+        return findings  # connected — healthy, no finding
+
+    reasons: list[str] = []
+    if not prop:
+        reasons.append("GA4_PROPERTY_ID unset")
+    if not creds:
+        reasons.append("GOOGLE_APPLICATION_CREDENTIALS unset")
+    elif not creds_ok:
+        reasons.append(f"GOOGLE_APPLICATION_CREDENTIALS file missing ({creds})")
+    findings.append({
+        "code": GATE,
+        "advisory": True,  # advisory-only by design — never blocks
+        "reasons": reasons,
+        "staged_sample": affecting[:5],
+        "remediation": (
+            "GA4 MCP not reachable: " + "; ".join(reasons) + ". Expected "
+            "pre-launch until the operator wires GA4 (set GA4_PROPERTY_ID + "
+            "GOOGLE_APPLICATION_CREDENTIALS). Advisory only — does not block."
+        ),
+    })
+    return findings
+
+
 def main() -> int:
     args = sys.argv[1:]
     if args == ["--staged"]:
@@ -2034,6 +2102,15 @@ def main() -> int:
                 all_errors.append(
                     f"COMMIT-LEVEL: [{finding['code']}] {finding['remediation']}"
                 )
+
+        # AN-1B.2 (analytics-master-plan §8.3): GA4_MCP_DISCONNECTED — commit-level.
+        # Advisory-only by design: prints to stderr, NEVER added to errors[].
+        for finding in check_ga4_mcp_connectivity(all_staged, coverage=coverage):
+            print(
+                f"[ADVISORY] {finding['code']}\n"
+                f"  {finding['remediation']}",
+                file=sys.stderr,
+            )
 
     # Persist the coverage ledger. Failure to write must not affect the
     # exit code — Mechanism A is advisory in v7.8; the gate verdict is

--- a/scripts/tests/test_ga4_mcp_disconnected.py
+++ b/scripts/tests/test_ga4_mcp_disconnected.py
@@ -1,0 +1,59 @@
+"""Tests for GA4_MCP_DISCONNECTED (AN-1B.2, analytics-master-plan §8.3)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MOD = Path(__file__).resolve().parent.parent / "check-state-schema.py"
+_spec = importlib.util.spec_from_file_location("check_state_schema", _MOD)
+css = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(css)
+
+ANALYTICS_FILE = css.ANALYTICS_PROVIDER_PATH
+
+
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("GA4_PROPERTY_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+
+def test_skip_when_no_analytics_files(monkeypatch):
+    _clear_env(monkeypatch)
+    assert css.check_ga4_mcp_connectivity(["scripts/foo.py", "docs/x.md"]) == []
+
+
+def test_disconnected_fires_advisory_when_env_unset(monkeypatch):
+    _clear_env(monkeypatch)
+    f = css.check_ga4_mcp_connectivity([ANALYTICS_FILE])
+    assert len(f) == 1
+    assert f[0]["code"] == "GA4_MCP_DISCONNECTED"
+    assert f[0]["advisory"] is True  # advisory-only by design
+    assert "GA4_PROPERTY_ID unset" in f[0]["reasons"]
+
+
+def test_taxonomy_csv_is_analytics_affecting(monkeypatch):
+    _clear_env(monkeypatch)
+    assert len(css.check_ga4_mcp_connectivity([css.ANALYTICS_TAXONOMY_CSV])) == 1
+
+
+def test_connected_no_finding(monkeypatch, tmp_path):
+    creds = tmp_path / "sa.json"
+    creds.write_text("{}")
+    monkeypatch.setenv("GA4_PROPERTY_ID", "properties/123456")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(creds))
+    assert css.check_ga4_mcp_connectivity([ANALYTICS_FILE]) == []
+
+
+def test_creds_file_missing_fires(monkeypatch):
+    monkeypatch.setenv("GA4_PROPERTY_ID", "properties/123456")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/sa.json")
+    f = css.check_ga4_mcp_connectivity([ANALYTICS_FILE])
+    assert len(f) == 1
+    assert any("file missing" in r for r in f[0]["reasons"])
+
+
+def test_never_blocks_advisory_always_true(monkeypatch):
+    _clear_env(monkeypatch)
+    f = css.check_ga4_mcp_connectivity([ANALYTICS_FILE])
+    # advisory must always be True — the gate never routes to errors[]
+    assert f and f[0]["advisory"] is True


### PR DESCRIPTION
## What (AN-1B.2 / FIT-146 / v8 docket F20)
Completes analytics **Phase 1.B** (analytics-master-plan §8.3). Commit-level: when analytics-affecting code is staged (`Analytics/*`, `control-room/analytics.ts`, taxonomy CSV) and GA4 MCP is unreachable via env (`GA4_PROPERTY_ID` + `GOOGLE_APPLICATION_CREDENTIALS` file), prints `[ADVISORY] GA4_MCP_DISCONNECTED`.

- `check_ga4_mcp_connectivity()` + Mechanism A coverage + commit-level dispatch.
- **Advisory-only by design** (per §8.3): always stderr, **never** `errors[]` — surfaces drift, doesn't gate analytics work behind operator GA4 setup. **No advisory→enforced flip → no calibration window/cadence entry.**
- **6 tests** (+ 7 CSV + 24 schema = 37 pass). pre-commit header bumped. `design-notes.md`.
- Feature under FW-NAMING convention (FIT-146, AN-1B.2, schema_version 1).

Pre-launch the GA4 env is typically unset, so the advisory is the **expected** signal until the operator wires GA4 (register A1). With #822 (AN-1B.1), **Phase 1.B is now complete**. No Makefile/Swift touched → fast CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)