### PR TITLE
chore(FIT-200): backfill 29 linear_id joins + fix 10 platforms_tested anomalies

### DIFF
--- a/.claude/features/ai-engine-architecture-adaptation/state.json
+++ b/.claude/features/ai-engine-architecture-adaptation/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "ai-engine-architecture-adaptation",
+  "linear_id": "FIT-25",
   "case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/07-ai-engine-architecture.mdx",
   "created_at": "2026-04-12T21:30:00Z",

--- a/.claude/features/ai-engine-v2/state.json
+++ b/.claude/features/ai-engine-v2/state.json
@@ -10,9 +10,9 @@
     "ios": false,
     "web": false,
     "backend": false,
-    "ai": false
+    "ai": true
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "backfill-manual-2026-06-30",
   "framework_version": "v5.0",
   "agent_manifest": {
     "reads": [],

--- a/.claude/features/ai-golden-set-evals/state.json
+++ b/.claude/features/ai-golden-set-evals/state.json
@@ -1,5 +1,6 @@
 {
   "name": "ai-golden-set-evals",
+  "linear_id": "FIT-158",
   "state_owner": "ft2",
   "framework_version": "v7.10",
   "work_type": "Feature",

--- a/.claude/features/ai-recommendation-ui/state.json
+++ b/.claude/features/ai-recommendation-ui/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "ai-recommendation-ui",
+  "linear_id": "FIT-35",
   "case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
   "parent_case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
   "parent_case_study_showcase": "fitme-story/content/04-case-studies/07-ai-engine-architecture.mdx",

--- a/.claude/features/authentication/state.json
+++ b/.claude/features/authentication/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "authentication",
+  "linear_id": "FIT-6",
   "work_type": "feature",
   "case_study_type": "pre_pm_workflow_backfill",
   "backfill_note": "Shipped before 2026-04-06 PM workflow enforcement. Sub-phase statuses use pre-pm-workflow / backfilled / shipped as terminal states \u2014 not lies, just legacy vocabulary. No dedicated case study is expected; feature is captured in the collective pre-PM-workflow baseline that the post-2026-04-06 program builds on.",

--- a/.claude/features/data-integrity-framework-v7-6/state.json
+++ b/.claude/features/data-integrity-framework-v7-6/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "data-integrity-framework-v7-6",
+  "linear_id": "FIT-45",
   "case_study": "docs/case-studies/mechanical-enforcement-v7-6-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/21-mechanical-enforcement-v7-6.mdx",
   "display_name": "Data Integrity Framework v7.6 \u2014 Mechanical Enforcement",

--- a/.claude/features/data-sync/state.json
+++ b/.claude/features/data-sync/state.json
@@ -10,10 +10,10 @@
   "platforms_tested": {
     "ios": false,
     "web": false,
-    "backend": false,
+    "backend": true,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "backfill-manual-2026-06-30",
   "framework_version": "pre-v5.0",
   "agent_manifest": {
     "reads": [],

--- a/.claude/features/design-system-v2/state.json
+++ b/.claude/features/design-system-v2/state.json
@@ -8,12 +8,12 @@
   "branch": null,
   "current_phase": "complete",
   "platforms_tested": {
-    "ios": false,
+    "ios": true,
     "web": false,
     "backend": false,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "backfill-manual-2026-06-30",
   "framework_version": "pre-v5.0",
   "agent_manifest": {
     "reads": [],

--- a/.claude/features/f18-mutation-testing/state.json
+++ b/.claude/features/f18-mutation-testing/state.json
@@ -109,7 +109,12 @@
       "note": "F18 shipped: mutmut harness + summary reader + warn-only weekly CI; PR #809"
     }
   ],
-  "platforms_tested": {},
+  "platforms_tested": {
+    "ios": false,
+    "web": false,
+    "backend": false,
+    "ai": false
+  },
   "timing": {
     "phases": {
       "research": {
@@ -151,5 +156,6 @@
   "linear_id": "FIT-102",
   "thematic_codes": [
     "FW-F18"
-  ]
+  ],
+  "platforms_tested_provenance": "exempt:framework_meta"
 }

--- a/.claude/features/framework-f14-f15-dispatch-test-coverage/state.json
+++ b/.claude/features/framework-f14-f15-dispatch-test-coverage/state.json
@@ -1,5 +1,6 @@
 {
   "feature_name": "framework-f14-f15-dispatch-test-coverage",
+  "linear_id": "FIT-94",
   "display_name": "Framework F14/F15 \u2014 dispatch-test coverage push",
   "current_phase": "complete",
   "platforms_tested": {},

--- a/.claude/features/framework-v5-0-soc/state.json
+++ b/.claude/features/framework-v5-0-soc/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "framework-v5-0-soc",
+  "linear_id": "FIT-26",
   "feature_name": "framework-v5-0-soc",
   "current_phase": "complete",
   "platforms_tested": {
@@ -8,7 +9,7 @@
     "backend": false,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "exempt:framework_meta",
   "framework_version": "v5.0",
   "work_type": "Feature",
   "case_study_type": "framework_meta_retroactive",

--- a/.claude/features/framework-v7-1-integrity-cycle/state.json
+++ b/.claude/features/framework-v7-1-integrity-cycle/state.json
@@ -8,7 +8,7 @@
     "backend": false,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "exempt:framework_meta",
   "framework_version": "v7.1",
   "work_type": "Feature",
   "case_study_type": "framework_meta_retroactive",

--- a/.claude/features/framework-v7-5-data-integrity/state.json
+++ b/.claude/features/framework-v7-5-data-integrity/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "framework-v7-5-data-integrity",
+  "linear_id": "FIT-44",
   "feature_name": "framework-v7-5-data-integrity",
   "current_phase": "complete",
   "platforms_tested": {
@@ -8,7 +9,7 @@
     "backend": false,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "exempt:framework_meta",
   "framework_version": "v7.5",
   "work_type": "Feature",
   "case_study_type": "framework_meta_retroactive",

--- a/.claude/features/framework-v7-7-validity-closure/state.json
+++ b/.claude/features/framework-v7-7-validity-closure/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "framework-v7-7-validity-closure",
+  "linear_id": "FIT-49",
   "feature_name": "framework-v7-7-validity-closure",
   "display_name": "Framework v7.7 \u2014 Validity Closure",
   "case_study": "docs/case-studies/framework-v7-7-validity-closure-case-study.md",

--- a/.claude/features/framework-v7-8-branch-isolation/state.json
+++ b/.claude/features/framework-v7-8-branch-isolation/state.json
@@ -1,5 +1,6 @@
 {
   "feature_name": "framework-v7-8-branch-isolation",
+  "linear_id": "FIT-62",
   "current_phase": "complete",
   "platforms_tested": {},
   "platforms_tested_provenance": "exempt:framework_meta",

--- a/.claude/features/framework-v7-8-bridge/state.json
+++ b/.claude/features/framework-v7-8-bridge/state.json
@@ -8,7 +8,7 @@
     "backend": false,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "exempt:framework_meta",
   "framework_version": "v7.8",
   "work_type": "Feature",
   "case_study_type": "framework_meta_retroactive",

--- a/.claude/features/framework-v7-9-1-promotion/state.json
+++ b/.claude/features/framework-v7-9-1-promotion/state.json
@@ -1,5 +1,6 @@
 {
   "feature_name": "framework-v7-9-1-promotion",
+  "linear_id": "FIT-194",
   "current_phase": "complete",
   "platforms_tested": {},
   "platforms_tested_provenance": "exempt:framework_meta",

--- a/.claude/features/framework-v7-9-promotion/state.json
+++ b/.claude/features/framework-v7-9-promotion/state.json
@@ -1,5 +1,6 @@
 {
   "feature_name": "framework-v7-9-promotion",
+  "linear_id": "FIT-72",
   "current_phase": "complete",
   "platforms_tested": {},
   "platforms_tested_provenance": "exempt:framework_meta",

--- a/.claude/features/garmin-health-connection/state.json
+++ b/.claude/features/garmin-health-connection/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "garmin-health-connection",
+  "linear_id": "FIT-199",
   "name": "garmin-health-connection",
   "created": "2026-06-10T17:00:38Z",
   "created_at": "2026-06-10T17:00:38Z",

--- a/.claude/features/google-analytics/state.json
+++ b/.claude/features/google-analytics/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "google-analytics",
+  "linear_id": "FIT-7",
   "work_type": "chore",
   "case_study": "docs/case-studies/google-analytics-case-study.md",
   "parent_case_study": "docs/case-studies/six-features-roundup-case-study.md",

--- a/.claude/features/hadf-signature-expansion/state.json
+++ b/.claude/features/hadf-signature-expansion/state.json
@@ -14,7 +14,7 @@
     "backend": false,
     "ai": false
   },
-  "platforms_tested_provenance": "backfill-heuristic-low-confidence",
+  "platforms_tested_provenance": "exempt:framework_meta",
   "isolation_opt_out": false,
   "has_ui": false,
   "requires_analytics": false,

--- a/.claude/features/home-status-goal-card/state.json
+++ b/.claude/features/home-status-goal-card/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "home-status-goal-card",
+  "linear_id": "FIT-31",
   "parent_case_study": "docs/case-studies/home-today-screen-v2-case-study.md",
   "parent_case_study_showcase": "fitme-story/content/04-case-studies/18a-home-today-screen.mdx",
   "created_at": "2026-04-09T19:00:00Z",

--- a/.claude/features/home-today-screen/state.json
+++ b/.claude/features/home-today-screen/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "home-today-screen",
+  "linear_id": "FIT-27",
   "created_at": "2026-04-06T14:00:00Z",
   "updated": "2026-04-20T00:00:00Z",
   "branch": "feature/home-today-screen-v2",

--- a/.claude/features/metric-tile-deep-linking/state.json
+++ b/.claude/features/metric-tile-deep-linking/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "metric-tile-deep-linking",
+  "linear_id": "FIT-32",
   "parent_case_study": "docs/case-studies/home-today-screen-v2-case-study.md",
   "parent_case_study_showcase": "fitme-story/content/04-case-studies/18a-home-today-screen.mdx",
   "created_at": "2026-04-09T23:30:00Z",

--- a/.claude/features/nutrition-v2/state.json
+++ b/.claude/features/nutrition-v2/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "nutrition-v2",
+  "linear_id": "FIT-29",
   "case_study": "docs/case-studies/m-2-mealentrysheet-decomposition-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/19-stacked-pr-misfire.mdx",
   "created_at": "2026-04-10T12:00:00Z",

--- a/.claude/features/onboarding-v2-auth-flow/state.json
+++ b/.claude/features/onboarding-v2-auth-flow/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "onboarding-v2-auth-flow",
+  "linear_id": "FIT-36",
   "case_study": "docs/case-studies/onboarding-v2-auth-flow-v5.1-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/06-auth-flow-velocity.mdx",
   "created_at": "2026-04-15T14:00:00Z",

--- a/.claude/features/onboarding/state.json
+++ b/.claude/features/onboarding/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "onboarding",
+  "linear_id": "FIT-5",
   "case_study": "docs/case-studies/pm-workflow-showcase-onboarding.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/01-onboarding-pilot.mdx",
   "work_type": "feature",

--- a/.claude/features/readiness-score-v2/state.json
+++ b/.claude/features/readiness-score-v2/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "readiness-score-v2",
+  "linear_id": "FIT-34",
   "parent_case_study": "docs/case-studies/ai-engine-architecture-v5.1-case-study.md",
   "parent_case_study_showcase": "fitme-story/content/04-case-studies/07-ai-engine-architecture.mdx",
   "created_at": "2026-04-10T20:00:00Z",

--- a/.claude/features/settings-v2/state.json
+++ b/.claude/features/settings-v2/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "settings-v2",
+  "linear_id": "FIT-30",
   "case_study": "docs/case-studies/m-1-settings-decomposition-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/16a-settings-v2.mdx",
   "created_at": "2026-04-10T16:00:00Z",

--- a/.claude/features/settings/state.json
+++ b/.claude/features/settings/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "settings",
+  "linear_id": "FIT-13",
   "work_type": "feature",
   "case_study_type": "pre_pm_workflow_backfill",
   "backfill_note": "Shipped before 2026-04-06 PM workflow enforcement. Sub-phase statuses use pre-pm-workflow / backfilled / shipped as terminal states \u2014 not lies, just legacy vocabulary. No dedicated case study is expected; feature is captured in the collective pre-PM-workflow baseline that the post-2026-04-06 program builds on.",

--- a/.claude/features/smart-reminders-behavioral-learning/state.json
+++ b/.claude/features/smart-reminders-behavioral-learning/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "smart-reminders-behavioral-learning",
+  "linear_id": "FIT-61",
   "feature_name": "smart-reminders-behavioral-learning",
   "display_name": "Smart Reminders \u2014 Behavioral Learning Layer",
   "case_study": "docs/case-studies/smart-reminders-behavioral-learning-case-study.md",

--- a/.claude/features/smart-reminders/state.json
+++ b/.claude/features/smart-reminders/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "smart-reminders",
+  "linear_id": "FIT-42",
   "case_study": "docs/case-studies/smart-reminders-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/08a-smart-reminders.mdx",
   "created_at": "2026-04-15T17:33:00Z",

--- a/.claude/features/stats-v2/state.json
+++ b/.claude/features/stats-v2/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "stats-v2",
+  "linear_id": "FIT-33",
   "case_study": "docs/case-studies/stats-v2-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/22c-stats-v2.mdx",
   "case_study_type": "shipped",

--- a/.claude/features/t14-platform-parity-state-field/state.json
+++ b/.claude/features/t14-platform-parity-state-field/state.json
@@ -227,5 +227,12 @@
   "linear_id": "FIT-162",
   "thematic_codes": [
     "TC-T14"
-  ]
+  ],
+  "platforms_tested": {
+    "ios": false,
+    "web": false,
+    "backend": false,
+    "ai": false
+  },
+  "platforms_tested_provenance": "exempt:framework_meta"
 }

--- a/.claude/features/training-plan-v2/state.json
+++ b/.claude/features/training-plan-v2/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "training-plan-v2",
+  "linear_id": "FIT-28",
   "created_at": "2026-04-10T00:00:00Z",
   "updated": "2026-04-10T05:00:00Z",
   "branch": "feature/training-plan-v2",

--- a/.claude/features/ucc-passkey-auth/state.json
+++ b/.claude/features/ucc-passkey-auth/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "ucc-passkey-auth",
+  "linear_id": "FIT-63",
   "created_at": "2026-05-07T16:25:00Z",
   "updated": "2026-05-20T06:34:21Z",
   "branch": "feature/ucc-passkey-auth",

--- a/.claude/features/user-profile-settings/state.json
+++ b/.claude/features/user-profile-settings/state.json
@@ -1,5 +1,6 @@
 {
   "feature": "user-profile-settings",
+  "linear_id": "FIT-41",
   "case_study": "docs/case-studies/user-profile-v4.4-case-study.md",
   "case_study_showcase": "fitme-story/content/04-case-studies/04-user-profile.mdx",
   "created_at": "2026-04-13T19:00:00Z",


### PR DESCRIPTION
## Summary
Cross-layer crosswalk hygiene — advisory burndown from a full-system data-integrity + telemetry sweep (2026-06-30). **No gates added; no `current_phase` mutations.**

### `linear_id` join: 26 → 55 (+29)
Curated, collision-checked matches of feature slug → real Linear `FIT-NNN` issue. Semantic-exact only — the matcher's "conflicts" were features **already** correctly joined (confirming the logic). The remaining **66** genuinely-ambiguous / no-clean-issue features (fitme-story web, HADF phase-specific, research) are left blank **by design** rather than fabricate join keys.

### `platforms_tested` anomalies: 10 → 0
- 7 framework-meta → `exempt:framework_meta` (incl. `t14`'s missing field + `f18`'s empty `{}`)
- 3 product reclassified from `backfill-heuristic-low-confidence`: `design-system-v2`→ios, `data-sync`→backend, `ai-engine-v2`→ai (provenance `backfill-manual-2026-06-30`)

## Verification
- `make schema-check` — 121/121 pass
- `make integrity-check` — 0 findings
- No `current_phase` transitions → `FEATURE_CLOSURE_COMPLETENESS` / `PLATFORMS_TESTED` do not re-fire
- Derived ledgers (`.claude/shared/*`) intentionally excluded (regenerate downstream; `.claude/shared/*` is a Mode-B infra glob)

🤖 Generated with [Claude Code](https://claude.com/claude-code)