### PR TITLE
docs(w40): reconcile 2 stale-open rows in v8-x build docket

### DIFF
--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -101,7 +101,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F15** ✅ | Unit tests for 5 zero-coverage gates | Test discipline | 40.0 | SHIPPED (joint w/ F14) |
 | **F16** ✅ | try-repo end-to-end harness | Test infra foundation | 48.0 | SHIPPED v7.9.1 #607–#612 · enforce flip 2026-06-18 |
 | **F17** ✅ | Per-gate `last_fired_at` derived index | Telemetry materialization | 66.7 | SHIPPED v7.9.1 #617 (+T13 #694) |
-| **F18** | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | OPEN — gated on F16 Phase E + F14 |
+| ~~**F18**~~ ✅ | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | **SHIPPED 2026-06-26 #809** (`f18-mutation-testing` complete) — see §0 |
 
 **Source E — post-v7.9 candidate plan (2026-05-20):**
 
@@ -110,7 +110,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F19** | Analytics Phase 1.B GA4 conversions (D-2) + dashboard wiring | Telemetry wiring | M | OPEN — D-2 operator + post-launch signal |
 | **F20** | Phase 1.B conversion event mapping + Firebase cleanup (D-4) | Schema cleanup | L | OPEN |
 | ~~**F21**~~ | ~~Sentry full integration~~ | — | — | **PAUSED → pre-launch** (PR #418) |
-| **F22** | Funnel Analysis Dashboards | Product observability | M | OPEN — depends on F19 + GA4 data |
+| ~~**F22**~~ ✅ | Funnel Analysis Dashboards | Product observability | M | **SHIPPED 2026-06-24 #799** (`funnel-analysis-dashboards` complete) — see §0 |
 | **F23** | `/ops digest` skill | Skill extension | M | OPEN — depends on F22 + Sentry resume |
 
 **Resolved by exemption (v7.8.2):** F7 (cross-repo gate parity) + F8 (`gate-coverage.jsonl` parity) — documented exemptions.


### PR DESCRIPTION
## W40 cross-layer stale-open audit (2026-07-01)

Ran W40 against the **entire feature DB, PRs, Linear, Notion, and all master/sub plans**. Repo = source of truth (118/121 features complete; only `3d-interactive-framework-flow-diagram`, `app-store-assets`, `orchid-v1-5` genuinely open).

**Result by layer:**
- **Feature DB / crosswalk** — clean (0 missing joins)
- **Linear** — clean (0 stale-opens; 61 backlog + 2 in-progress all legit)
- **PRs** — clean (0 stale; 1 fresh automated cron PR)
- **All plans** — 99% clean; **2 stale rows** (this PR)
- **Notion** — materially stale (legacy Backlog DB frozen since 2026-04-02; handled separately — Notion-side, not a repo change)

**This PR** strikes the only 2 repo-side stale rows — both in `v8-x-build-docket-2026-06-15.md`, already ✅ in the file's own §0 but not in the source tables:
- F18 → SHIPPED #809 · F22 → SHIPPED #799

_Note: docs-only PR — path-filtered required checks may not fire (known quirk)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)