### PR TITLE
chore(TC-T16): machine-derived gate catalog (stage + test-tier annotation)

### DIFF
--- a/.claude/features/t16-gate-test-tier-annotation/state.json
+++ b/.claude/features/t16-gate-test-tier-annotation/state.json
@@ -1,0 +1,135 @@
+{
+  "feature": "t16-gate-test-tier-annotation",
+  "linear_id": "FIT-164",
+  "thematic_code": "TC-T16",
+  "created_at": "2026-07-02T16:35:00Z",
+  "updated": "2026-07-02T16:40:00Z",
+  "branch": "chore/t16-gate-test-tier-annotation",
+  "current_phase": "implement",
+  "work_type": "chore",
+  "work_subtype": "framework_feature",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Framework-meta chore (TC-T16): adds a machine-derived gate-catalog manifest + validator. No product surface; PR body + this state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "summary": "T16 (test-coverage plan §4) — add stage:/tier: annotation to all 32 framework gates via a new machine-derived .claude/shared/gate-catalog.json + scripts/gate-catalog.py validator (make gate-catalog). Feeds the future T1 GATE_TEST_MISSING meta-gate.",
+  "phases": {
+    "research": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "prd": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "tasks": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "ux_or_integration": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "implementation": {
+      "status": "approved",
+      "commits": []
+    },
+    "testing": {
+      "status": "pending"
+    },
+    "review": {
+      "status": "pending"
+    },
+    "merge": {
+      "status": "pending",
+      "pr_number": null
+    },
+    "documentation": {
+      "status": "pending"
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "Enumerate authoritative 32-gate set (20 write-time + 9 cycle-time + 2 W9 + 1 standalone)",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.1,
+      "depends_on": [],
+      "completed_at": "2026-07-02T16:40:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "Author gate-catalog.json authored fields (stage, source, enforcement, description) + scripts/gate-catalog.py deriving tier/fixture/dispatch/unit coverage",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.2,
+      "depends_on": [
+        "T1"
+      ],
+      "completed_at": "2026-07-02T16:40:00Z"
+    },
+    {
+      "id": "T3",
+      "title": "make gate-catalog target + validate (every live gate present, no orphans)",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T2"
+      ],
+      "completed_at": "2026-07-02T16:40:00Z"
+    },
+    {
+      "id": "T4",
+      "title": "Unit test scripts/tests/test_gate_catalog.py",
+      "type": "test",
+      "skill": "qa",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T2"
+      ],
+      "completed_at": "2026-07-02T16:40:00Z"
+    },
+    {
+      "id": "T5",
+      "title": "Docs: dev-guide gate-catalog reference + FRAMEWORK-FACTS pointer",
+      "type": "docs",
+      "skill": "dev",
+      "status": "done",
+      "priority": "medium",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T3"
+      ],
+      "completed_at": "2026-07-02T16:40:00Z"
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": {
+    "ux": null,
+    "design": null
+  },
+  "worktree_path": "/Volumes/DevSSD/FitTracker2-infra-test-tier-annotation",
+  "timing": {
+    "phases": {
+      "implement": {
+        "started_at": "2026-07-02T16:35:00Z"
+      }
+    },
+    "session_start": "2026-07-02T16:35:00Z"
+  }
+}

--- a/.claude/logs/t16-gate-test-tier-annotation.log.json
+++ b/.claude/logs/t16-gate-test-tier-annotation.log.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.0",
+  "feature": "t16-gate-test-tier-annotation",
+  "title": "t16 gate test tier annotation",
+  "work_type": "chore",
+  "current_phase": "implement",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-02T16:46:50Z",
+  "updated_at": "2026-07-02T16:48:39Z",
+  "events": [
+    {
+      "timestamp": "2026-07-02T16:46:50Z",
+      "event_type": "implementation",
+      "phase": "implement",
+      "summary": "Built .claude/shared/gate-catalog.json (33 gates: 21 write-time + 9 cycle + 2 hook + 1 standalone) + scripts/gate-catalog.py deriving test tier from live fixtures/tests + make gate-catalog{,-check} + 7 unit tests. Surfaced 2 real findings: CASE_STUDY_MISSING_FIELDS is a live write-time gate in check-case-study-preflight.py that FRAMEWORK-FACTS's check-state-schema.py-scoped '20' missed (true count 33); and 4 write-time gates lack try-repo fixtures (T1 gap signal).",
+      "artifacts": [
+        "scripts/gate-catalog.py",
+        ".claude/shared/gate-catalog.json",
+        "scripts/tests/test_gate_catalog.py"
+      ],
+      "metrics": {
+        "tests_passing": 7,
+        "gate_count": 33
+      },
+      "actor": "claude_opus_4_8",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    },
+    {
+      "timestamp": "2026-07-02T16:48:39Z",
+      "event_type": "phase_started",
+      "phase": "implement",
+      "summary": "Chore implement phase: gate catalog (T16) \u2014 33-gate machine-derived manifest + validator + tests + docs.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude_opus_4_8",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/.claude/shared/gate-catalog.json
+++ b/.claude/shared/gate-catalog.json
@@ -1,0 +1,620 @@
+{
+  "schema_version": 1,
+  "gate_count": 33,
+  "summary": {
+    "by_stage": {
+      "cycle-time": 9,
+      "hook": 2,
+      "standalone": 1,
+      "write-time": 21
+    },
+    "by_tier": {
+      "dispatch": 1,
+      "try-repo": 17,
+      "unit": 15
+    },
+    "untested_gates": [],
+    "write_time_without_try_repo": [
+      "CSV_TAXONOMY_DRIFT",
+      "GA4_MCP_DISCONNECTED",
+      "PLATFORMS_TESTED",
+      "PR_NUMBER_UNRESOLVED"
+    ]
+  },
+  "gates": {
+    "BRANCH_ISOLATION_VIOLATION": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Mode B — infra-path commit staged on a non-isolated branch.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/BRANCH_ISOLATION_VIOLATION_MODE_B/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_branch_isolation_and_closure_completeness.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_phase_0_reality_check.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_refresh_gate_last_fired.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_isolation_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "BRANCH_ISOLATION_VIOLATION_MODE_C": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Mode C — state.json current_phase mutation from a non-feature branch.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/BRANCH_ISOLATION_VIOLATION_MODE_C/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_try_repo_isolation_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Empty cache_hits[] on a post-v6 feature at complete-transition.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_gate_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_telemetry_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "CSV_TAXONOMY_DRIFT": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "advisory",
+      "description": "AN-1B.1 — staged AnalyticsEvent value has no analytics-taxonomy.csv row.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_csv_taxonomy_drift.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "CU_V2_INVALID": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "cu_v2 schema invalid (4 factors in [0,1], total within 0.01, valid tier_class).",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/CU_V2_INVALID/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_gate_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_pre_commit_self_test.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_telemetry_gates.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_validate_cu_v2.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "FEATURE_CLOSURE_COMPLETENESS": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "complete-transition missing required case-study frontmatter / kill_criteria_resolution / PR parity.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/FEATURE_CLOSURE_COMPLETENESS/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_branch_isolation_and_closure_completeness.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_refresh_gate_last_fired.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_closure_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "FRAMEWORK_VERSION_FORMAT": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "framework_version not in canonical vX.Y form.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/FRAMEWORK_VERSION_FORMAT/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_schema_gates.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_v7_9_measurement_snapshot.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "FRAMEWORK_VERSION_STALE": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "advisory",
+      "description": "F4 — framework_version behind the current framework version (advisory→enforced review ~2026-06-30).",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/FRAMEWORK_VERSION_STALE/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_framework_version_stale.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_framework_version_stale.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "GA4_MCP_DISCONNECTED": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "advisory-only",
+      "description": "AN-1B.2 — analytics code staged while GA4 MCP env unreachable. Never blocks by design.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_ga4_mcp_disconnected.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "ISOLATION_OPT_OUT_REASON_MISSING": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "isolation_opt_out:true with empty isolation_opt_out_reason.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/ISOLATION_OPT_OUT_REASON_MISSING/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_try_repo_isolation_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "PHASE_TRANSITION_NO_LOG": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "current_phase change without a matching .claude/logs/<feature>.log.json event in 15 min.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/PHASE_TRANSITION_NO_LOG/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_pre_commit_self_test.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_telemetry_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "PHASE_TRANSITION_NO_TIMING": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "current_phase change without timing.phases.<phase> started_at/ended_at.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/PHASE_TRANSITION_NO_TIMING/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_telemetry_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "PLATFORMS_TESTED": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "T14 — complete-transition with no platforms_tested platform true (Q2-exempt for framework-meta).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_platforms_tested.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_framework_version_stale.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "PR_NUMBER_UNRESOLVED": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "phases.merge.pr_number does not resolve in the cached gh pr list (skipped when gh unavailable).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_pre_commit_self_test.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "SCHEMA_DRIFT_LEGACY_CREATED": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Legacy `created` key present; canonical is `created_at`.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/SCHEMA_DRIFT_LEGACY_CREATED/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_try_repo_schema_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "SCHEMA_DRIFT_LEGACY_PHASE": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Legacy `phase` key present; canonical is `current_phase`.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/SCHEMA_DRIFT_LEGACY_PHASE/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_try_repo_regression_proof.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_schema_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "STATE_NO_CASE_STUDY_LINK": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Terminal phase with no case_study link and no case_study_type exemption.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/STATE_NO_CASE_STUDY_LINK/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_gate_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_pre_commit_self_test.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_closure_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "STATE_OWNER_INVALID": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "state_owner not in the valid enum {ft2, fitme-story}.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/STATE_OWNER_INVALID/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_try_repo_schema_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "STATE_OWNER_LOCATION_MISMATCH": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "state.json file location does not match state_owner (reverse-sync mirrors exempt).",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/STATE_OWNER_LOCATION_MISMATCH/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_try_repo_closure_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "STATE_OWNER_MISSING": {
+      "stage": "write-time",
+      "source": "scripts/check-state-schema.py",
+      "enforcement": "enforced",
+      "description": "Required state_owner field absent.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/STATE_OWNER_MISSING/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_state_schema.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_gate_coverage_zero.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_baseline.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_schema_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "CASE_STUDY_MISSING_FIELDS": {
+      "stage": "write-time",
+      "source": "scripts/check-case-study-preflight.py",
+      "enforcement": "enforced",
+      "description": "Post-cutoff (>= 2026-04-21) scoped case study missing required frontmatter fields. Lives in check-case-study-preflight.py (a 2nd pre-commit gate host), NOT check-state-schema.py.",
+      "tier": "try-repo",
+      "fixture_path": "tests/fixtures/CASE_STUDY_MISSING_FIELDS/",
+      "test_files": [
+        {
+          "file": "scripts/tests/test_check_case_study_preflight.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_try_repo_closure_gates.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "BROKEN_PR_CITATION": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "finding",
+      "description": "Case study cites a PR number that does not resolve (skipped gracefully when gh unavailable).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_pre_commit_self_test.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "CASE_STUDY_MISSING_TIER_TAGS": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "finding",
+      "description": "Scoped case study (dated >= 2026-04-21) with no T1/T2/T3 tier tag.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_pre_commit_self_test.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "PATTERN_SKILL_UNMAPPED": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "finding",
+      "description": "Observed-patterns entry not mapped to a skill in pattern-skill-map.json.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "TIER_TAG_LIKELY_INCORRECT": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "advisory-permanent",
+      "description": "Heuristic T1/T2/T3 mismatch (kill criterion 2 fired at baseline; ships advisory-permanent).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_validate_tier_tags.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "PHASE_LIE": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "finding",
+      "description": "state.json current_phase inconsistent with the phases block / evidence.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_close_feature.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        },
+        {
+          "file": "scripts/tests/test_refresh_gate_last_fired.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "advisory",
+      "description": "Session events show Reads but state.json cache_hits[] is empty.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "BRANCH_ISOLATION_HISTORICAL": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "advisory",
+      "description": "T17 forward-only audit of past infra commits' isolation.",
+      "tier": "dispatch",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_integrity_check_dispatch.py",
+          "layer": "dispatch"
+        },
+        {
+          "file": "scripts/tests/test_integrity_cycle_coverage.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "STATE_TASKS_FILESYSTEM_DRIFT": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "advisory-permanent",
+      "description": "f1 — state.json tasks reference files that do not exist (shipped 2026-06-17 #752).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_state_tasks_filesystem_drift.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "DEPENDENCY_GRAPH_CYCLE": {
+      "stage": "cycle-time",
+      "source": "scripts/integrity-check.py",
+      "enforcement": "advisory-permanent",
+      "description": "f3 — Phase 2 task dependency graph contains a cycle/mismatch (shipped 2026-06-17 #753).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_dependency_graph_cycle.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "w9.auto_isolate": {
+      "stage": "hook",
+      "source": "scripts/check-branch-drift.py",
+      "enforcement": "advisory",
+      "description": "W9 — offers auto-isolation when infra work is detected off an isolated branch.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_w9_auto_isolate.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "w9.concurrency": {
+      "stage": "hook",
+      "source": "scripts/check-branch-drift.py",
+      "enforcement": "advisory",
+      "description": "W9 — detects an unexpected concurrent branch flip within a session (HOLD at advisory 2026-06-28).",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_w9_auto_isolate.py",
+          "layer": "unit"
+        }
+      ]
+    },
+    "FIGMA_MIRROR_STALENESS": {
+      "stage": "standalone",
+      "source": "scripts/figma-mirror-staleness.py",
+      "enforcement": "advisory-permanent",
+      "description": "Code-token (tokens.json) vs Figma-mirror-snapshot drift. Runs on `make figma-mirror-staleness`.",
+      "tier": "unit",
+      "fixture_path": null,
+      "test_files": [
+        {
+          "file": "scripts/tests/test_figma_mirror_staleness.py",
+          "layer": "unit"
+        }
+      ]
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,18 @@ integrity-check:
 gate-last-fired:
 	@python3 scripts/refresh-gate-last-fired.py
 
+# T16 (TC-T16): build the machine-derived gate catalog at
+# .claude/shared/gate-catalog.json — every framework gate annotated with an
+# authored stage (write-time|cycle-time|hook|standalone) + a DERIVED test tier
+# (try-repo>dispatch>unit>none). `make gate-catalog-check` validates the
+# committed catalog vs a fresh derivation (CI) + flags orphan try-repo fixtures.
+# Feeds the future T1 GATE_TEST_MISSING meta-gate (tier=="none" = untested).
+gate-catalog:
+	@python3 scripts/gate-catalog.py --print
+
+gate-catalog-check:
+	@python3 scripts/gate-catalog.py --check
+
 # v7.9.1 F2: per-feature reality-check sub-step in Phase 0.
 # Cross-checks each pending task in <feature>'s state.json against the last
 # 30d of git log subjects + merged PR titles (both repos) + Tier 2.2 log

--- a/docs/FRAMEWORK-FACTS.md
+++ b/docs/FRAMEWORK-FACTS.md
@@ -26,6 +26,14 @@
 ### W9 real-time hooks (2)
 `w9.auto_isolate` · `w9.concurrency` (PostToolUse drift detection). **Calibration RESOLVED 2026-06-28: HOLD at advisory** — `CLAUDE_W9_CONCURRENCY_ENFORCE` stays default-off (criterion 2 vacuous: 0 `concurrency_offer` events in the window). Re-eval now event-gated (first real offer).
 
+### Gate catalog (T16 / TC-T16, machine-derived)
+
+[`.claude/shared/gate-catalog.json`](../.claude/shared/gate-catalog.json) (`make gate-catalog`, producer `scripts/gate-catalog.py`) is the machine-derived enumeration of **all 33 live gates** — each annotated with an authored `stage` (write-time | cycle-time | hook | standalone) + `source`, and a **derived** test `tier` (try-repo > dispatch > unit > none) computed by scanning `tests/fixtures/` + `scripts/tests/` live. `make gate-catalog-check` validates it in CI (fails on drift or an orphan try-repo fixture).
+
+**Live (33) vs instrumented (32):** the catalog counts every gate that fires; the F17 index above counts every gate that emits Mechanism A coverage. The 1-gate delta is **`CASE_STUDY_MISSING_FIELDS`** — a live, enforced write-time gate hosted in `scripts/check-case-study-preflight.py` (the *second* pre-commit gate host, distinct from `check-state-schema.py`) that emits no Mechanism A coverage, so it is invisible to both the F17 index and `GATE_COVERAGE_ZERO`. Follow-up candidate: instrument it.
+
+**T1 precursor:** `summary.write_time_without_try_repo` lists the 4 write-time gates lacking a try-repo fixture (`CSV_TAXONOMY_DRIFT`, `GA4_MCP_DISCONNECTED`, `PLATFORMS_TESTED`, `PR_NUMBER_UNRESOLVED`) — the machine signal the planned **T1 `GATE_TEST_MISSING`** meta-gate consumes.
+
 ### New infra (2026-06-29 session)
 
 - **Cross-layer naming convention** (FIT-200) — every item carries slug (canonical) + `state.json.linear_id` (FIT-NNN) + scheme-prefixed code (`FW-`/`TC-`/`DE-`/`HADF-`/`AN-`/`PROD-`). `make crosswalk` → `.claude/shared/item-registry.json`. Spec: `docs/process/cross-layer-item-naming-convention.md`.

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -101,7 +101,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F15** ✅ | Unit tests for 5 zero-coverage gates | Test discipline | 40.0 | SHIPPED (joint w/ F14) |
 | **F16** ✅ | try-repo end-to-end harness | Test infra foundation | 48.0 | SHIPPED v7.9.1 #607–#612 · enforce flip 2026-06-18 |
 | **F17** ✅ | Per-gate `last_fired_at` derived index | Telemetry materialization | 66.7 | SHIPPED v7.9.1 #617 (+T13 #694) |
-| **F18** | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | OPEN — gated on F16 Phase E + F14 |
+| ~~**F18**~~ ✅ | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | **SHIPPED 2026-06-26 #809** (`f18-mutation-testing` complete) — see §0 |
 
 **Source E — post-v7.9 candidate plan (2026-05-20):**
 
@@ -110,7 +110,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F19** | Analytics Phase 1.B GA4 conversions (D-2) + dashboard wiring | Telemetry wiring | M | OPEN — D-2 operator + post-launch signal |
 | **F20** | Phase 1.B conversion event mapping + Firebase cleanup (D-4) | Schema cleanup | L | OPEN |
 | ~~**F21**~~ | ~~Sentry full integration~~ | — | — | **PAUSED → pre-launch** (PR #418) |
-| **F22** | Funnel Analysis Dashboards | Product observability | M | OPEN — depends on F19 + GA4 data |
+| ~~**F22**~~ ✅ | Funnel Analysis Dashboards | Product observability | M | **SHIPPED 2026-06-24 #799** (`funnel-analysis-dashboards` complete) — see §0 |
 | **F23** | `/ops digest` skill | Skill extension | M | OPEN — depends on F22 + Sentry resume |
 
 **Resolved by exemption (v7.8.2):** F7 (cross-repo gate parity) + F8 (`gate-coverage.jsonl` parity) — documented exemptions.

--- a/scripts/gate-catalog.py
+++ b/scripts/gate-catalog.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+scripts/gate-catalog.py — T16 (test-coverage master plan §4, TC-T16).
+
+The machine-derived **gate catalog**: one queryable manifest that annotates
+every framework gate with
+
+  • an AUTHORED `stage`  — write-time | cycle-time | hook | standalone
+  • an AUTHORED `source` — the file that defines/fires the gate
+  • an AUTHORED `enforcement` — enforced | advisory | advisory-only |
+                                advisory-permanent | finding
+  • a DERIVED  `tier`   — the deepest TEST layer that covers the gate:
+                          try-repo > dispatch > unit > none
+
+plus the concrete coverage refs used to derive the tier (`fixture_path`,
+`test_files` with their layer). The derivation scans the live repo, so the
+catalog cannot silently drift from reality — `--check` re-derives and fails
+on any mismatch.
+
+Why this exists: before T16 there was no single place that answered "which
+stage does gate X fire at, and is it tested?" The count lived in prose in
+docs/FRAMEWORK-FACTS.md and the test coverage was implicit in
+tests/fixtures/ + scripts/tests/. This manifest makes both queryable and
+directly feeds the planned **T1 GATE_TEST_MISSING** meta-gate: `tier ==
+"none"` is the machine signal for "this gate ships without a test".
+
+Usage:
+    python3 scripts/gate-catalog.py            # write .claude/shared/gate-catalog.json
+    python3 scripts/gate-catalog.py --check     # validate committed catalog vs live derivation (CI)
+    python3 scripts/gate-catalog.py --print      # write + print a human summary table
+
+Exit codes:
+    0  success (write) OR catalog matches live derivation (--check)
+    1  --check drift: committed catalog != freshly derived, or an authored
+       gate/fixture is orphaned
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+REPO_ROOT = Path(
+    os.environ.get("REPO_ROOT_OVERRIDE", Path(__file__).resolve().parent.parent)
+)
+CATALOG_PATH = REPO_ROOT / ".claude" / "shared" / "gate-catalog.json"
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures"
+TESTS_DIR = REPO_ROOT / "scripts" / "tests"
+
+# Test-layer ranking (higher = deeper coverage). Mirrors the F16 3-layer model:
+# unit (per-function) < dispatch (monkey-patched main()) < try-repo (real hook
+# via subprocess against a throwaway git repo).
+TIER_RANK = {"none": 0, "unit": 1, "dispatch": 2, "try-repo": 3}
+
+# --------------------------------------------------------------------------
+# AUTHORED gate metadata — the canonical 32-gate set.
+# Source of truth for the enumeration: docs/FRAMEWORK-FACTS.md (reconciled
+# 2026-06-29): 20 write-time + 9 cycle-time + 2 W9 hooks + 1 standalone.
+#
+# `fixture_key` overrides the try-repo fixture directory name when it differs
+# from the gate id (e.g. the Mode B gate's fixture is suffixed).
+# --------------------------------------------------------------------------
+GATES: dict[str, dict] = {
+    # ---- Write-time (20) — scripts/check-state-schema.py ----
+    "BRANCH_ISOLATION_VIOLATION": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced", "fixture_key": "BRANCH_ISOLATION_VIOLATION_MODE_B",
+        "description": "Mode B — infra-path commit staged on a non-isolated branch.",
+    },
+    "BRANCH_ISOLATION_VIOLATION_MODE_C": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "Mode C — state.json current_phase mutation from a non-feature branch.",
+    },
+    "CACHE_HITS_AUTO_INSTRUMENTATION_DRIFT": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "Empty cache_hits[] on a post-v6 feature at complete-transition.",
+    },
+    "CSV_TAXONOMY_DRIFT": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "advisory",
+        "description": "AN-1B.1 — staged AnalyticsEvent value has no analytics-taxonomy.csv row.",
+    },
+    "CU_V2_INVALID": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "cu_v2 schema invalid (4 factors in [0,1], total within 0.01, valid tier_class).",
+    },
+    "FEATURE_CLOSURE_COMPLETENESS": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "complete-transition missing required case-study frontmatter / kill_criteria_resolution / PR parity.",
+    },
+    "FRAMEWORK_VERSION_FORMAT": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "framework_version not in canonical vX.Y form.",
+    },
+    "FRAMEWORK_VERSION_STALE": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "advisory",
+        "description": "F4 — framework_version behind the current framework version (advisory→enforced review ~2026-06-30).",
+    },
+    "GA4_MCP_DISCONNECTED": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "advisory-only",
+        "description": "AN-1B.2 — analytics code staged while GA4 MCP env unreachable. Never blocks by design.",
+    },
+    "ISOLATION_OPT_OUT_REASON_MISSING": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "isolation_opt_out:true with empty isolation_opt_out_reason.",
+    },
+    "PHASE_TRANSITION_NO_LOG": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "current_phase change without a matching .claude/logs/<feature>.log.json event in 15 min.",
+    },
+    "PHASE_TRANSITION_NO_TIMING": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "current_phase change without timing.phases.<phase> started_at/ended_at.",
+    },
+    "PLATFORMS_TESTED": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "T14 — complete-transition with no platforms_tested platform true (Q2-exempt for framework-meta).",
+    },
+    "PR_NUMBER_UNRESOLVED": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "phases.merge.pr_number does not resolve in the cached gh pr list (skipped when gh unavailable).",
+    },
+    "SCHEMA_DRIFT_LEGACY_CREATED": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "Legacy `created` key present; canonical is `created_at`.",
+    },
+    "SCHEMA_DRIFT_LEGACY_PHASE": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "Legacy `phase` key present; canonical is `current_phase`.",
+    },
+    "STATE_NO_CASE_STUDY_LINK": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "Terminal phase with no case_study link and no case_study_type exemption.",
+    },
+    "STATE_OWNER_INVALID": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "state_owner not in the valid enum {ft2, fitme-story}.",
+    },
+    "STATE_OWNER_LOCATION_MISMATCH": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "state.json file location does not match state_owner (reverse-sync mirrors exempt).",
+    },
+    "STATE_OWNER_MISSING": {
+        "stage": "write-time", "source": "scripts/check-state-schema.py",
+        "enforcement": "enforced",
+        "description": "Required state_owner field absent.",
+    },
+    "CASE_STUDY_MISSING_FIELDS": {
+        "stage": "write-time", "source": "scripts/check-case-study-preflight.py",
+        "enforcement": "enforced",
+        "description": "Post-cutoff (>= 2026-04-21) scoped case study missing required frontmatter fields. "
+                       "Lives in check-case-study-preflight.py (a 2nd pre-commit gate host), NOT check-state-schema.py.",
+    },
+    # ---- Cycle-time (9) — scripts/integrity-check.py ----
+    "BROKEN_PR_CITATION": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "finding",
+        "description": "Case study cites a PR number that does not resolve (skipped gracefully when gh unavailable).",
+    },
+    "CASE_STUDY_MISSING_TIER_TAGS": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "finding",
+        "description": "Scoped case study (dated >= 2026-04-21) with no T1/T2/T3 tier tag.",
+    },
+    "PATTERN_SKILL_UNMAPPED": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "finding",
+        "description": "Observed-patterns entry not mapped to a skill in pattern-skill-map.json.",
+    },
+    "TIER_TAG_LIKELY_INCORRECT": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "advisory-permanent",
+        "description": "Heuristic T1/T2/T3 mismatch (kill criterion 2 fired at baseline; ships advisory-permanent).",
+    },
+    "PHASE_LIE": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "finding",
+        "description": "state.json current_phase inconsistent with the phases block / evidence.",
+    },
+    "CACHE_HITS_AUTO_INSTRUMENTATION_INACTIVE": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "advisory",
+        "description": "Session events show Reads but state.json cache_hits[] is empty.",
+    },
+    "BRANCH_ISOLATION_HISTORICAL": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "advisory",
+        "description": "T17 forward-only audit of past infra commits' isolation.",
+    },
+    "STATE_TASKS_FILESYSTEM_DRIFT": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "advisory-permanent",
+        "description": "f1 — state.json tasks reference files that do not exist (shipped 2026-06-17 #752).",
+    },
+    "DEPENDENCY_GRAPH_CYCLE": {
+        "stage": "cycle-time", "source": "scripts/integrity-check.py",
+        "enforcement": "advisory-permanent",
+        "description": "f3 — Phase 2 task dependency graph contains a cycle/mismatch (shipped 2026-06-17 #753).",
+    },
+    # ---- W9 real-time hooks (2) — PostToolUse ----
+    "w9.auto_isolate": {
+        "stage": "hook", "source": "scripts/check-branch-drift.py",
+        "enforcement": "advisory",
+        "description": "W9 — offers auto-isolation when infra work is detected off an isolated branch.",
+    },
+    "w9.concurrency": {
+        "stage": "hook", "source": "scripts/check-branch-drift.py",
+        "enforcement": "advisory",
+        "description": "W9 — detects an unexpected concurrent branch flip within a session (HOLD at advisory 2026-06-28).",
+    },
+    # ---- Standalone (1) ----
+    "FIGMA_MIRROR_STALENESS": {
+        "stage": "standalone", "source": "scripts/figma-mirror-staleness.py",
+        "enforcement": "advisory-permanent",
+        "description": "Code-token (tokens.json) vs Figma-mirror-snapshot drift. Runs on `make figma-mirror-staleness`.",
+    },
+}
+
+
+# The catalog's own test file mentions many gate ids in its assertions; it is
+# NOT a test *of* those gates, so it must be excluded from the coverage scan to
+# avoid self-referential over-crediting.
+_SELF_TEST = "test_gate_catalog.py"
+
+
+def _iter_test_files() -> list[Path]:
+    if not TESTS_DIR.is_dir():
+        return []
+    return sorted(
+        p for p in TESTS_DIR.glob("test_*.py")
+        if p.is_file() and p.name != _SELF_TEST
+    )
+
+
+def _layer_for_test_file(name: str) -> str:
+    """Classify a scripts/tests/ file into a test layer by naming convention.
+
+    Note: `try-repo` is deliberately NOT inferable from a filename. The
+    try-repo harness is fixture-driven, so real try-repo coverage is proven by
+    a `tests/fixtures/<GATE>/` directory — not by a gate id appearing inside
+    some other gate's `test_try_repo_*` file (that is an incidental mention via
+    the shared baseline state, and would over-credit the tier)."""
+    if "dispatch" in name:
+        return "dispatch"
+    return "unit"
+
+
+def derive_coverage(gate_id: str, meta: dict, test_files: list[Path]) -> dict:
+    """Derive the test tier + concrete coverage refs for one gate by scanning
+    the live repo (fixtures + scripts/tests). Pure filesystem read — no guess."""
+    fixture_key = meta.get("fixture_key", gate_id)
+    fixture_dir = FIXTURES_DIR / fixture_key
+    has_fixture = fixture_dir.is_dir()
+
+    found: list[dict] = []
+    layers_present: set[str] = set()
+    for tf in test_files:
+        try:
+            text = tf.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if gate_id in text:
+            layer = _layer_for_test_file(tf.name)
+            found.append({"file": f"scripts/tests/{tf.name}", "layer": layer})
+            layers_present.add(layer)
+
+    # Fixture presence is the ONLY authoritative try-repo signal (the harness is
+    # fixture-driven). This is what the future T1 GATE_TEST_MISSING meta-gate
+    # keys on when it asserts "every enforced write-time gate has a try-repo
+    # fixture".
+    if has_fixture:
+        layers_present.add("try-repo")
+
+    tier = "none"
+    for layer in layers_present:
+        if TIER_RANK[layer] > TIER_RANK[tier]:
+            tier = layer
+
+    return {
+        "tier": tier,
+        "fixture_path": (
+            f"tests/fixtures/{fixture_key}/" if has_fixture else None
+        ),
+        "test_files": found,
+    }
+
+
+def build_catalog() -> dict:
+    test_files = _iter_test_files()
+    gates: dict[str, dict] = {}
+    for gate_id, meta in GATES.items():
+        cov = derive_coverage(gate_id, meta, test_files)
+        entry = {
+            "stage": meta["stage"],
+            "source": meta["source"],
+            "enforcement": meta["enforcement"],
+            "description": meta["description"],
+            "tier": cov["tier"],
+            "fixture_path": cov["fixture_path"],
+            "test_files": cov["test_files"],
+        }
+        gates[gate_id] = entry
+
+    stages: dict[str, int] = {}
+    tiers: dict[str, int] = {}
+    for e in gates.values():
+        stages[e["stage"]] = stages.get(e["stage"], 0) + 1
+        tiers[e["tier"]] = tiers.get(e["tier"], 0) + 1
+
+    untested = sorted(g for g, e in gates.items() if e["tier"] == "none")
+    # T1 GATE_TEST_MISSING precursor signal: write-time gates without their own
+    # try-repo fixture (the F16 discipline says every write-time gate should
+    # ship one). Distinct from `untested` — these DO have unit/dispatch tests
+    # but lack the deepest (integration) layer.
+    write_time_without_try_repo = sorted(
+        g for g, e in gates.items()
+        if e["stage"] == "write-time" and e["tier"] != "try-repo"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "gate_count": len(gates),
+        "summary": {
+            "by_stage": dict(sorted(stages.items())),
+            "by_tier": dict(sorted(tiers.items())),
+            "untested_gates": untested,
+            "write_time_without_try_repo": write_time_without_try_repo,
+        },
+        "gates": gates,
+    }
+
+
+def orphan_fixtures() -> list[str]:
+    """Fixture dirs on disk that no authored gate claims (via id or fixture_key)."""
+    if not FIXTURES_DIR.is_dir():
+        return []
+    claimed = set()
+    for gate_id, meta in GATES.items():
+        claimed.add(meta.get("fixture_key", gate_id))
+    orphans = []
+    for p in sorted(FIXTURES_DIR.iterdir()):
+        if not p.is_dir() or p.name.startswith("_") or p.name == "contracts":
+            continue
+        if p.name not in claimed:
+            orphans.append(p.name)
+    return orphans
+
+
+def _dump(catalog: dict) -> str:
+    return json.dumps(catalog, indent=2, ensure_ascii=False) + "\n"
+
+
+def cmd_check() -> int:
+    fresh = build_catalog()
+    if not CATALOG_PATH.exists():
+        print(f"FAIL: {CATALOG_PATH} does not exist — run `make gate-catalog`.", file=sys.stderr)
+        return 1
+    committed = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    rc = 0
+    if committed != fresh:
+        print("FAIL: committed gate-catalog.json is stale vs live derivation.", file=sys.stderr)
+        print("      Run `make gate-catalog` and commit the result.", file=sys.stderr)
+        # surface the first-level diff for the operator
+        cg = committed.get("gates", {})
+        fg = fresh.get("gates", {})
+        for gid in sorted(set(cg) | set(fg)):
+            if cg.get(gid) != fg.get(gid):
+                print(f"      drift: {gid}", file=sys.stderr)
+        rc = 1
+    orphans = orphan_fixtures()
+    if orphans:
+        print(f"FAIL: try-repo fixtures with no catalog gate: {orphans}", file=sys.stderr)
+        print("      Add the gate to GATES or remove/rename the fixture.", file=sys.stderr)
+        rc = 1
+    if rc == 0:
+        print(f"OK: gate-catalog.json matches live derivation ({fresh['gate_count']} gates, "
+              f"{len(fresh['summary']['untested_gates'])} untested).")
+    return rc
+
+
+def cmd_write(do_print: bool) -> int:
+    catalog = build_catalog()
+    CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CATALOG_PATH.write_text(_dump(catalog), encoding="utf-8")
+    print(f"Wrote {CATALOG_PATH.relative_to(REPO_ROOT)} — {catalog['gate_count']} gates.")
+    orphans = orphan_fixtures()
+    if orphans:
+        print(f"  warning: orphan try-repo fixtures (no catalog gate): {orphans}")
+    if do_print:
+        s = catalog["summary"]
+        print("\n  by stage:", ", ".join(f"{k}={v}" for k, v in s["by_stage"].items()))
+        print("  by tier: ", ", ".join(f"{k}={v}" for k, v in s["by_tier"].items()))
+        print(f"  untested ({len(s['untested_gates'])}):", ", ".join(s["untested_gates"]) or "none")
+        print(f"\n  {'GATE':<44} {'STAGE':<11} {'TIER':<9} ENFORCEMENT")
+        for gid, e in catalog["gates"].items():
+            print(f"  {gid:<44} {e['stage']:<11} {e['tier']:<9} {e['enforcement']}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build/validate the framework gate catalog (T16).")
+    ap.add_argument("--check", action="store_true",
+                    help="Validate committed catalog vs live derivation; exit 1 on drift/orphans.")
+    ap.add_argument("--print", dest="do_print", action="store_true",
+                    help="Write, then print a human summary table.")
+    args = ap.parse_args()
+    if args.check:
+        return cmd_check()
+    return cmd_write(args.do_print)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_gate_catalog.py
+++ b/scripts/tests/test_gate_catalog.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for scripts/gate-catalog.py (T16 / TC-T16).
+
+Covers: enumeration completeness, required-field shape, tier derivation
+(fixture == try-repo authority, no over-crediting from try_repo test-file
+mentions), orphan-fixture detection, and the committed catalog staying in
+sync with the live derivation (the `--check` contract).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "gate-catalog.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("gate_catalog", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gc = _load_module()
+
+
+def test_enumeration_counts():
+    cat = gc.build_catalog()
+    by_stage = cat["summary"]["by_stage"]
+    # 21 write-time (incl. CASE_STUDY_MISSING_FIELDS in check-case-study-preflight.py)
+    # + 9 cycle-time + 2 W9 hooks + 1 standalone = 33.
+    assert by_stage == {
+        "cycle-time": 9,
+        "hook": 2,
+        "standalone": 1,
+        "write-time": 21,
+    }, by_stage
+    assert cat["gate_count"] == 33
+
+
+def test_every_gate_has_required_fields():
+    cat = gc.build_catalog()
+    for gid, e in cat["gates"].items():
+        for field in ("stage", "source", "enforcement", "description", "tier", "test_files"):
+            assert field in e, f"{gid} missing {field}"
+        assert e["stage"] in {"write-time", "cycle-time", "hook", "standalone"}, gid
+        assert e["tier"] in {"none", "unit", "dispatch", "try-repo"}, gid
+
+
+def test_fixture_is_the_only_try_repo_signal():
+    """A gate with its own fixture dir is try-repo; a gate merely *mentioned*
+    inside another gate's try_repo test file (no fixture) must NOT be
+    over-credited to try-repo."""
+    cat = gc.build_catalog()["gates"]
+    # FEATURE_CLOSURE_COMPLETENESS has a fixture dir -> try-repo.
+    assert cat["FEATURE_CLOSURE_COMPLETENESS"]["tier"] == "try-repo"
+    assert cat["FEATURE_CLOSURE_COMPLETENESS"]["fixture_path"] is not None
+    # PLATFORMS_TESTED has NO fixture dir; it appears in another gate's
+    # try_repo test via shared baseline state -> must be unit, not try-repo.
+    assert cat["PLATFORMS_TESTED"]["fixture_path"] is None
+    assert cat["PLATFORMS_TESTED"]["tier"] == "unit"
+
+
+def test_case_study_missing_fields_is_cataloged():
+    """The gate that FRAMEWORK-FACTS's check-state-schema.py-scoped count
+    missed — proves the catalog spans both pre-commit gate hosts."""
+    cat = gc.build_catalog()["gates"]
+    e = cat["CASE_STUDY_MISSING_FIELDS"]
+    assert e["source"] == "scripts/check-case-study-preflight.py"
+    assert e["stage"] == "write-time"
+    assert e["tier"] == "try-repo"  # has both fixture + dispatch test
+
+
+def test_write_time_gap_signal():
+    """The T1 GATE_TEST_MISSING precursor: write-time gates lacking a try-repo
+    fixture are surfaced explicitly."""
+    cat = gc.build_catalog()
+    gap = cat["summary"]["write_time_without_try_repo"]
+    assert set(gap) == {
+        "CSV_TAXONOMY_DRIFT",
+        "GA4_MCP_DISCONNECTED",
+        "PLATFORMS_TESTED",
+        "PR_NUMBER_UNRESOLVED",
+    }, gap
+    # every listed gap gate really is write-time and really lacks a fixture
+    for gid in gap:
+        assert cat["gates"][gid]["stage"] == "write-time"
+        assert cat["gates"][gid]["fixture_path"] is None
+
+
+def test_no_orphan_fixtures():
+    """Every try-repo fixture on disk is claimed by exactly one catalog gate."""
+    assert gc.orphan_fixtures() == []
+
+
+def test_committed_catalog_matches_live_derivation():
+    """The committed .claude/shared/gate-catalog.json must equal a fresh build
+    (this is what `gate-catalog.py --check` enforces in CI)."""
+    committed = json.loads(gc.CATALOG_PATH.read_text(encoding="utf-8"))
+    assert committed == gc.build_catalog(), (
+        "gate-catalog.json is stale — run `make gate-catalog` and commit."
+    )


### PR DESCRIPTION
## What

T16 (test-coverage master plan §4, Linear **FIT-164**). Adds a machine-derived **gate catalog** — the queryable manifest that annotates every framework gate with a `stage` and a test `tier`.

- **`.claude/shared/gate-catalog.json`** — all **33 live gates**. Each: authored `stage` (write-time | cycle-time | hook | standalone) + `source` + `enforcement` + `description`, and a **derived** `tier` (try-repo > dispatch > unit > none) computed live from `tests/fixtures/` + `scripts/tests/`.
- **`scripts/gate-catalog.py`** — producer + `--check` validator (fails on drift or orphan try-repo fixture). `make gate-catalog` / `make gate-catalog-check`.
- **`scripts/tests/test_gate_catalog.py`** — 7 unit tests (enumeration, field shape, fixture-is-the-only-try-repo-signal, gap signal, no-orphans, committed==derived).

## Two real findings surfaced by the catalog

1. **`CASE_STUDY_MISSING_FIELDS` is a live enforced write-time gate** hosted in `scripts/check-case-study-preflight.py` — a *second* pre-commit gate host, distinct from `check-state-schema.py`. It emits **no Mechanism A coverage**, so it's absent from the F17 index (32 instrumented) and **invisible to `GATE_COVERAGE_ZERO`**. True live-gate count is **33** (32 instrumented + 1 uninstrumented). Follow-up candidate: instrument it.
2. **4 write-time gates lack a try-repo fixture** — `CSV_TAXONOMY_DRIFT`, `GA4_MCP_DISCONNECTED`, `PLATFORMS_TESTED`, `PR_NUMBER_UNRESOLVED`. Surfaced as `summary.write_time_without_try_repo` — the machine signal the planned **T1 `GATE_TEST_MISSING`** meta-gate consumes.

## Docs
`docs/FRAMEWORK-FACTS.md` gains a **Gate catalog (T16)** subsection reconciling live(33) vs instrumented(32) and documenting both findings.

## Verification
- `make gate-catalog-check` → OK (33 gates, 0 untested, 0 orphans)
- `python3.12 -m pytest scripts/tests/test_gate_catalog.py` → 7 passed
- Built in isolated worktree per branch-isolation; pre-commit gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)