### PR TITLE
chore(FIT-181): pre-commit hook latency profiler (P50/P95 vs budget)

### DIFF
--- a/.claude/features/precommit-hook-latency-profiling/state.json
+++ b/.claude/features/precommit-hook-latency-profiling/state.json
@@ -1,0 +1,109 @@
+{
+  "feature": "precommit-hook-latency-profiling",
+  "linear_id": "FIT-181",
+  "thematic_code": "DE-R15-audit0519",
+  "created_at": "2026-07-02T17:30:00Z",
+  "updated": "2026-07-02T17:35:00Z",
+  "branch": "chore/precommit-hook-latency-profiling",
+  "current_phase": "implement",
+  "work_type": "chore",
+  "work_subtype": "framework_feature",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Framework-meta chore (Linear FIT-181, dev-env 2026-05-19 audit R15): pre-commit hook latency profiler + P95 budget report. No product surface; PR body + state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "summary": "FIT-181 — profile per-check pre-commit hook latency across N samples, compute P50/P95, compare vs a per-check + total budget, emit a report. scripts/profile-precommit-hooks.py + make profile-hooks + unit test.",
+  "phases": {
+    "research": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "prd": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "tasks": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "ux_or_integration": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "implementation": {
+      "status": "approved",
+      "commits": []
+    },
+    "testing": {
+      "status": "pending"
+    },
+    "review": {
+      "status": "pending"
+    },
+    "merge": {
+      "status": "pending",
+      "pr_number": null
+    },
+    "documentation": {
+      "status": "pending"
+    }
+  },
+  "timing": {
+    "session_start": "2026-07-02T17:30:00Z",
+    "phases": {
+      "implement": {
+        "started_at": "2026-07-02T17:30:00Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "profile-precommit-hooks.py — time each pre-commit check over N samples, P50/P95, budget compare, JSON+stdout report",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.2,
+      "depends_on": [],
+      "completed_at": "2026-07-02T17:35:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "make profile-hooks target",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "medium",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T1"
+      ],
+      "completed_at": "2026-07-02T17:35:00Z"
+    },
+    {
+      "id": "T3",
+      "title": "unit test test_profile_precommit_hooks.py",
+      "type": "test",
+      "skill": "qa",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T1"
+      ],
+      "completed_at": "2026-07-02T17:35:00Z"
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": {
+    "ux": null,
+    "design": null
+  },
+  "worktree_path": "/Volumes/DevSSD/FitTracker2-infra-hook-latency-profiling"
+}

--- a/.claude/logs/precommit-hook-latency-profiling.log.json
+++ b/.claude/logs/precommit-hook-latency-profiling.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "precommit-hook-latency-profiling",
+  "title": "precommit hook latency profiling",
+  "work_type": "chore",
+  "current_phase": "implement",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-02T17:30:29Z",
+  "updated_at": "2026-07-02T17:30:29Z",
+  "events": [
+    {
+      "timestamp": "2026-07-02T17:30:29Z",
+      "event_type": "phase_started",
+      "phase": "implement",
+      "summary": "Chore implement: pre-commit hook latency profiler (FIT-181/R15) \u2014 profile-precommit-hooks.py + make profile-hooks{,-check} + 7 unit tests. Baseline total P95 0.119s (budget 8s).",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude_opus_4_8",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ ai-engine/htmlcov/
 .mutmut-cache
 /.coverage
 .claude/shared/mutation-baseline.json
+
+# FIT-181: machine-specific pre-commit latency report (regenerate via make profile-hooks)
+.claude/shared/precommit-hook-latency.json

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,15 @@ integrity-check:
 gate-last-fired:
 	@python3 scripts/refresh-gate-last-fired.py
 
+# FIT-181 (dev-env R15): profile pre-commit hook check latency (P50/P95 vs
+# budget). Writes .claude/shared/precommit-hook-latency.json. `--check` mode
+# (make profile-hooks-check) exits 1 if over budget.
+profile-hooks:
+	@python3 scripts/profile-precommit-hooks.py
+
+profile-hooks-check:
+	@python3 scripts/profile-precommit-hooks.py --check
+
 # v7.9.1 F2: per-feature reality-check sub-step in Phase 0.
 # Cross-checks each pending task in <feature>'s state.json against the last
 # 30d of git log subjects + merged PR titles (both repos) + Tier 2.2 log

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -101,7 +101,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F15** ✅ | Unit tests for 5 zero-coverage gates | Test discipline | 40.0 | SHIPPED (joint w/ F14) |
 | **F16** ✅ | try-repo end-to-end harness | Test infra foundation | 48.0 | SHIPPED v7.9.1 #607–#612 · enforce flip 2026-06-18 |
 | **F17** ✅ | Per-gate `last_fired_at` derived index | Telemetry materialization | 66.7 | SHIPPED v7.9.1 #617 (+T13 #694) |
-| **F18** | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | OPEN — gated on F16 Phase E + F14 |
+| ~~**F18**~~ ✅ | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | **SHIPPED 2026-06-26 #809** (`f18-mutation-testing` complete) — see §0 |
 
 **Source E — post-v7.9 candidate plan (2026-05-20):**
 
@@ -110,7 +110,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F19** | Analytics Phase 1.B GA4 conversions (D-2) + dashboard wiring | Telemetry wiring | M | OPEN — D-2 operator + post-launch signal |
 | **F20** | Phase 1.B conversion event mapping + Firebase cleanup (D-4) | Schema cleanup | L | OPEN |
 | ~~**F21**~~ | ~~Sentry full integration~~ | — | — | **PAUSED → pre-launch** (PR #418) |
-| **F22** | Funnel Analysis Dashboards | Product observability | M | OPEN — depends on F19 + GA4 data |
+| ~~**F22**~~ ✅ | Funnel Analysis Dashboards | Product observability | M | **SHIPPED 2026-06-24 #799** (`funnel-analysis-dashboards` complete) — see §0 |
 | **F23** | `/ops digest` skill | Skill extension | M | OPEN — depends on F22 + Sentry resume |
 
 **Resolved by exemption (v7.8.2):** F7 (cross-repo gate parity) + F8 (`gate-coverage.jsonl` parity) — documented exemptions.

--- a/scripts/profile-precommit-hooks.py
+++ b/scripts/profile-precommit-hooks.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+scripts/profile-precommit-hooks.py — FIT-181 (dev-env 2026-05-19 audit R15).
+
+Profiles the **latency of the pre-commit hook's checks** so hook slowdown is a
+measured, budget-able number instead of a "feels slow lately" complaint. For
+each check the hook runs, it times N invocations, reports P50 / P95 / max, and
+compares the total P95 against a budget.
+
+**Methodology (honest about what it measures).** Each check is invoked as
+`<interpreter> <script> --help` — a side-effect-free path that still pays the
+full interpreter cold-start + module-import cost. For a git hook that cost is
+the dominant, developer-felt latency (the checks themselves scan only the small
+staged set). The number is therefore a stable *floor* on hook latency, not a
+worst-case; it is what makes `git commit` feel slow. Machine-dependent, so the
+report is informational and the `--check` budget is deliberately generous.
+
+Usage:
+    python3 scripts/profile-precommit-hooks.py                 # profile + write report
+    python3 scripts/profile-precommit-hooks.py --samples 9      # more samples
+    python3 scripts/profile-precommit-hooks.py --check          # exit 1 if over budget (CI)
+
+Writes .claude/shared/precommit-hook-latency.json + a stdout table.
+
+Exit codes:
+    0  profiled OK (and, in --check mode, within budget)
+    1  --check mode and total P95 exceeded the budget
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+REPO_ROOT = Path(
+    os.environ.get("REPO_ROOT_OVERRIDE", Path(__file__).resolve().parent.parent)
+)
+REPORT_PATH = REPO_ROOT / ".claude" / "shared" / "precommit-hook-latency.json"
+
+# The checks the .githooks/pre-commit hook invokes, in order. Each entry is a
+# side-effect-free invocation that still pays the full startup cost.
+CHECKS = [
+    {"name": "check-state-schema",
+     "argv": [sys.executable, "scripts/check-state-schema.py", "--help"]},
+    {"name": "check-case-study-preflight",
+     "argv": [sys.executable, "scripts/check-case-study-preflight.py", "--help"]},
+    {"name": "check-prereg-lock",
+     "argv": ["bash", "scripts/check-prereg-lock.sh", "--help"]},
+]
+
+# Budgets (seconds). Generous on purpose — this gates only egregious regressions
+# (e.g. a check that starts importing a heavy dependency). Override via CLI.
+DEFAULT_PER_CHECK_P95 = 3.0
+DEFAULT_TOTAL_P95 = 8.0
+
+
+def percentile(sorted_vals: list[float], q: float) -> float:
+    """Linear-interpolation percentile. q in [0,1]. `sorted_vals` must be sorted."""
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    pos = q * (len(sorted_vals) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = pos - lo
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * frac
+
+
+def summarize(durations: list[float]) -> dict:
+    s = sorted(durations)
+    return {
+        "samples": len(s),
+        "p50": round(percentile(s, 0.50), 4),
+        "p95": round(percentile(s, 0.95), 4),
+        "max": round(s[-1], 4) if s else 0.0,
+        "mean": round(sum(s) / len(s), 4) if s else 0.0,
+    }
+
+
+def time_command(argv: list[str], samples: int) -> list[float]:
+    """Run argv `samples` times from REPO_ROOT, returning wall-clock seconds each.
+    Non-zero exit codes are fine — we time the invocation regardless (--help on a
+    script without an argparse handler may exit non-zero)."""
+    out = []
+    for _ in range(samples):
+        t0 = time.perf_counter()
+        try:
+            subprocess.run(argv, cwd=REPO_ROOT, stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL, timeout=60)
+        except (OSError, subprocess.TimeoutExpired):
+            out.append(60.0)
+            continue
+        out.append(time.perf_counter() - t0)
+    return out
+
+
+def build_report(check_durations: dict[str, list[float]], budgets: dict) -> dict:
+    """Assemble the report from per-check duration samples. Pure — the unit test
+    feeds synthetic durations so it never shells out."""
+    checks = {}
+    total_p95 = 0.0
+    over = []
+    for name, durs in check_durations.items():
+        stats = summarize(durs)
+        total_p95 += stats["p95"]
+        if stats["p95"] > budgets["per_check_p95"]:
+            over.append(name)
+        checks[name] = stats
+    total_p95 = round(total_p95, 4)
+    total_over = total_p95 > budgets["total_p95"]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "budgets": budgets,
+        "checks": checks,
+        "total_p95": total_p95,
+        "over_budget": {
+            "per_check": sorted(over),
+            "total": total_over,
+        },
+        "within_budget": (not over) and (not total_over),
+    }
+
+
+def _print_table(report: dict) -> None:
+    b = report["budgets"]
+    print(f"\n  pre-commit hook latency  (budget: per-check P95 <= {b['per_check_p95']}s, "
+          f"total P95 <= {b['total_p95']}s)")
+    print(f"  {'CHECK':<30} {'P50':>7} {'P95':>7} {'MAX':>7}  {'N':>3}")
+    for name, s in report["checks"].items():
+        flag = "  ⚠ OVER" if name in report["over_budget"]["per_check"] else ""
+        print(f"  {name:<30} {s['p50']:>7.3f} {s['p95']:>7.3f} {s['max']:>7.3f}  {s['samples']:>3}{flag}")
+    verdict = "WITHIN budget" if report["within_budget"] else "OVER budget"
+    print(f"  {'TOTAL P95':<30} {report['total_p95']:>15.3f}  → {verdict}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Profile pre-commit hook check latency (FIT-181/R15).")
+    ap.add_argument("--samples", type=int, default=5, help="samples per check (default 5)")
+    ap.add_argument("--per-check-p95", type=float, default=DEFAULT_PER_CHECK_P95)
+    ap.add_argument("--total-p95", type=float, default=DEFAULT_TOTAL_P95)
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if any budget is exceeded (CI gate mode)")
+    args = ap.parse_args()
+
+    budgets = {"per_check_p95": args.per_check_p95, "total_p95": args.total_p95}
+    durations = {}
+    for c in CHECKS:
+        script = REPO_ROOT / c["argv"][1]
+        if not script.exists():
+            print(f"  skip {c['name']}: {c['argv'][1]} not found", file=sys.stderr)
+            continue
+        durations[c["name"]] = time_command(c["argv"], args.samples)
+
+    report = build_report(durations, budgets)
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    _print_table(report)
+    print(f"\n  wrote {REPORT_PATH.relative_to(REPO_ROOT)}")
+
+    if args.check and not report["within_budget"]:
+        print("FAIL: pre-commit hook latency over budget.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_profile_precommit_hooks.py
+++ b/scripts/tests/test_profile_precommit_hooks.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for scripts/profile-precommit-hooks.py (FIT-181 / dev-env R15).
+
+Tests the pure analysis layer (percentile / summarize / build_report / budget
+evaluation) with synthetic durations — never shells out, so it's fast + stable
+in CI.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "profile-precommit-hooks.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("profile_precommit_hooks", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pp = _load()
+
+
+def test_percentile_interpolates():
+    vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert pp.percentile(vals, 0.0) == 1.0
+    assert pp.percentile(vals, 1.0) == 5.0
+    assert pp.percentile(vals, 0.5) == 3.0
+    # p95 of 1..5 interpolates between the 4th and 5th value
+    assert 4.7 < pp.percentile(vals, 0.95) <= 5.0
+
+
+def test_percentile_edge_cases():
+    assert pp.percentile([], 0.95) == 0.0
+    assert pp.percentile([2.5], 0.95) == 2.5
+
+
+def test_summarize_shape():
+    s = pp.summarize([0.3, 0.1, 0.2])
+    assert s["samples"] == 3
+    assert s["p50"] == 0.2
+    assert s["max"] == 0.3
+    assert abs(s["mean"] - 0.2) < 1e-9
+
+
+def test_build_report_within_budget():
+    durs = {
+        "check-a": [0.5, 0.6, 0.55],
+        "check-b": [0.4, 0.45, 0.42],
+    }
+    budgets = {"per_check_p95": 3.0, "total_p95": 8.0}
+    r = pp.build_report(durs, budgets)
+    assert r["within_budget"] is True
+    assert r["over_budget"]["per_check"] == []
+    assert r["over_budget"]["total"] is False
+    assert set(r["checks"]) == {"check-a", "check-b"}
+    assert r["total_p95"] == round(r["checks"]["check-a"]["p95"] + r["checks"]["check-b"]["p95"], 4)
+
+
+def test_build_report_per_check_over_budget():
+    durs = {"slow": [5.0, 5.1, 5.2], "fast": [0.1, 0.1, 0.1]}
+    budgets = {"per_check_p95": 3.0, "total_p95": 100.0}  # total generous, per-check tight
+    r = pp.build_report(durs, budgets)
+    assert r["over_budget"]["per_check"] == ["slow"]
+    assert r["within_budget"] is False
+
+
+def test_build_report_total_over_budget():
+    durs = {"a": [3.0, 3.0, 3.0], "b": [3.0, 3.0, 3.0]}
+    budgets = {"per_check_p95": 10.0, "total_p95": 5.0}  # per-check generous, total tight
+    r = pp.build_report(durs, budgets)
+    assert r["over_budget"]["per_check"] == []
+    assert r["over_budget"]["total"] is True
+    assert r["within_budget"] is False
+
+
+def test_checks_registry_matches_hook():
+    """The profiled checks must be the ones the real pre-commit hook invokes."""
+    names = {c["name"] for c in pp.CHECKS}
+    assert names == {"check-state-schema", "check-case-study-preflight", "check-prereg-lock"}


### PR DESCRIPTION
## What
dev-env 2026-05-19 audit **R15** (Linear **FIT-181**). Makes pre-commit hook slowdown a measured, budget-able number.

- **`scripts/profile-precommit-hooks.py`** — times each check the `.githooks/pre-commit` hook invokes (`check-state-schema`, `check-case-study-preflight`, `check-prereg-lock`) over N samples → P50/P95/max, and compares total P95 vs a budget.
- **`make profile-hooks`** / **`make profile-hooks-check`** (`--check` exits 1 if over budget — CI-gate ready).
- **7 unit tests** over the pure analysis layer (percentile / summarize / build_report / budget eval) — synthetic durations, no subprocess, stable in CI.

## Methodology (honest)
Each check is invoked via its side-effect-free `--help` path, which still pays the full interpreter cold-start + import cost — the dominant, developer-felt latency for a git hook. It's a stable *floor* on hook latency, not worst-case. Machine-dependent, so the report is informational and the `--check` budget is generous (per-check P95 ≤ 3s, total ≤ 8s).

## Baseline
Total P95 ≈ **0.12s** locally (budget 8s) — all three checks startup-dominated (~40ms each).

## Notes
The generated report `.claude/shared/precommit-hook-latency.json` is machine-specific and **gitignored** (regenerate via `make profile-hooks`).

## Verification
- `python3.12 -m pytest scripts/tests/test_profile_precommit_hooks.py` → 7 passed
- `make profile-hooks` runs clean; pre-commit gates green (isolated worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)