### PR TITLE
chore(FIT-185): weekly digest A5 — silent-gate candidates enrichment

### DIFF
--- a/.claude/features/weekly-digest-silent-gate-enrichment/state.json
+++ b/.claude/features/weekly-digest-silent-gate-enrichment/state.json
@@ -1,0 +1,109 @@
+{
+  "feature": "weekly-digest-silent-gate-enrichment",
+  "linear_id": "FIT-185",
+  "thematic_code": "DE-R19-audit0519",
+  "created_at": "2026-07-02T17:55:00Z",
+  "updated": "2026-07-02T18:05:00Z",
+  "branch": "chore/weekly-digest-silent-gate-enrichment",
+  "current_phase": "implement",
+  "work_type": "chore",
+  "work_subtype": "framework_feature",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Framework-meta chore (Linear FIT-185, dev-env 2026-05-19 audit R19): weekly digest enrichment — top-3 silent-gate candidates. No product surface; PR body + state.json are provenance.",
+  "isolation_opt_out": false,
+  "summary": "FIT-185 — extend scripts/weekly-trend-scan.py + weekly digest with an A5 section: top-N silent-gate candidates (candidates>0 but checked==0 over the window), surfacing calibration risk before promotion. Reads .claude/logs/gate-coverage.jsonl (Mechanism A).",
+  "phases": {
+    "research": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "prd": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "tasks": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "ux_or_integration": {
+      "status": "skipped",
+      "skip_reason": "work_type:chore"
+    },
+    "implementation": {
+      "status": "approved",
+      "commits": []
+    },
+    "testing": {
+      "status": "pending"
+    },
+    "review": {
+      "status": "pending"
+    },
+    "merge": {
+      "status": "pending",
+      "pr_number": null
+    },
+    "documentation": {
+      "status": "pending"
+    }
+  },
+  "timing": {
+    "session_start": "2026-07-02T17:55:00Z",
+    "phases": {
+      "implement": {
+        "started_at": "2026-07-02T17:55:00Z"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "silent_gate_candidates() in weekly-trend-scan.py — read gate-coverage.jsonl over window, rank gates with candidates>0 & checked==0, top-N",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.2,
+      "depends_on": [],
+      "completed_at": "2026-07-02T18:05:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "A5 digest section + JSON payload field + regression-issue trigger wiring",
+      "type": "infra",
+      "skill": "dev",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T1"
+      ],
+      "completed_at": "2026-07-02T18:05:00Z"
+    },
+    {
+      "id": "T3",
+      "title": "unit test test_weekly_silent_gate_enrichment.py",
+      "type": "test",
+      "skill": "qa",
+      "status": "done",
+      "priority": "high",
+      "effort_days": 0.1,
+      "depends_on": [
+        "T1"
+      ],
+      "completed_at": "2026-07-02T18:05:00Z"
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": {
+    "ux": null,
+    "design": null
+  },
+  "worktree_path": "/Volumes/DevSSD/FitTracker2-infra-silent-gate-enrichment"
+}

--- a/.claude/logs/weekly-digest-silent-gate-enrichment.log.json
+++ b/.claude/logs/weekly-digest-silent-gate-enrichment.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "weekly-digest-silent-gate-enrichment",
+  "title": "weekly digest silent gate enrichment",
+  "work_type": "chore",
+  "current_phase": "implement",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-02T18:17:54Z",
+  "updated_at": "2026-07-02T18:17:54Z",
+  "events": [
+    {
+      "timestamp": "2026-07-02T18:17:54Z",
+      "event_type": "phase_started",
+      "phase": "implement",
+      "summary": "Chore implement: A5 silent-gate enrichment in weekly-trend-scan.py \u2014 compute_silent_gate_candidates() from F17 index + digest section + JSON + 5 tests. Informational (zero-firing often healthy).",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "claude_opus_4_8",
+      "status": "recorded",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/docs/master-plan/v8-x-build-docket-2026-06-15.md
+++ b/docs/master-plan/v8-x-build-docket-2026-06-15.md
@@ -101,7 +101,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F15** ✅ | Unit tests for 5 zero-coverage gates | Test discipline | 40.0 | SHIPPED (joint w/ F14) |
 | **F16** ✅ | try-repo end-to-end harness | Test infra foundation | 48.0 | SHIPPED v7.9.1 #607–#612 · enforce flip 2026-06-18 |
 | **F17** ✅ | Per-gate `last_fired_at` derived index | Telemetry materialization | 66.7 | SHIPPED v7.9.1 #617 (+T13 #694) |
-| **F18** | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | OPEN — gated on F16 Phase E + F14 |
+| ~~**F18**~~ ✅ | Nightly mutation testing on dispatcher files | Mutation testing | 13.7 | **SHIPPED 2026-06-26 #809** (`f18-mutation-testing` complete) — see §0 |
 
 **Source E — post-v7.9 candidate plan (2026-05-20):**
 
@@ -110,7 +110,7 @@ Cross-referenced to merged PRs + session memory. Framework is at **v7.10** (ship
 | **F19** | Analytics Phase 1.B GA4 conversions (D-2) + dashboard wiring | Telemetry wiring | M | OPEN — D-2 operator + post-launch signal |
 | **F20** | Phase 1.B conversion event mapping + Firebase cleanup (D-4) | Schema cleanup | L | OPEN |
 | ~~**F21**~~ | ~~Sentry full integration~~ | — | — | **PAUSED → pre-launch** (PR #418) |
-| **F22** | Funnel Analysis Dashboards | Product observability | M | OPEN — depends on F19 + GA4 data |
+| ~~**F22**~~ ✅ | Funnel Analysis Dashboards | Product observability | M | **SHIPPED 2026-06-24 #799** (`funnel-analysis-dashboards` complete) — see §0 |
 | **F23** | `/ops digest` skill | Skill extension | M | OPEN — depends on F22 + Sentry resume |
 
 **Resolved by exemption (v7.8.2):** F7 (cross-repo gate parity) + F8 (`gate-coverage.jsonl` parity) — documented exemptions.

--- a/scripts/tests/test_weekly_silent_gate_enrichment.py
+++ b/scripts/tests/test_weekly_silent_gate_enrichment.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for the A5 silent-gate enrichment in scripts/weekly-trend-scan.py
+(FIT-185 / dev-env R19). Pure — feeds a synthetic F17 index, no filesystem.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "weekly-trend-scan.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("weekly_trend_scan", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+wts = _load()
+
+
+def _idx(gates: dict) -> dict:
+    return {"gates": gates}
+
+
+def test_flags_candidates_with_zero_firings():
+    idx = _idx({
+        "SILENT_A": {"total_candidates": 100, "total_firings": 0, "total_skips": 100},
+        "HEALTHY": {"total_candidates": 500, "total_firings": 12, "total_skips": 488},
+    })
+    out = wts.compute_silent_gate_candidates(idx, top_n=3)
+    names = [r["gate"] for r in out]
+    assert names == ["SILENT_A"]  # HEALTHY has firings>0, excluded
+    assert out[0]["candidates"] == 100
+    assert out[0]["skips"] == 100
+
+
+def test_excludes_zero_candidate_gates():
+    """A gate with no candidates at all is NOT a silent-gate candidate (it's the
+    separate 0-candidate mis-wire class handled by GATE_COVERAGE_ZERO)."""
+    idx = _idx({"NEVER_REACHED": {"total_candidates": 0, "total_firings": 0, "total_skips": 0}})
+    assert wts.compute_silent_gate_candidates(idx) == []
+
+
+def test_ranked_by_candidate_volume_and_truncated():
+    idx = _idx({
+        "LOUD": {"total_candidates": 900, "total_firings": 0, "total_skips": 900},
+        "MID": {"total_candidates": 50, "total_firings": 0, "total_skips": 50},
+        "QUIET": {"total_candidates": 5, "total_firings": 0, "total_skips": 5},
+        "EXTRA": {"total_candidates": 1, "total_firings": 0, "total_skips": 1},
+    })
+    out = wts.compute_silent_gate_candidates(idx, top_n=3)
+    assert [r["gate"] for r in out] == ["LOUD", "MID", "QUIET"]  # top_n=3, sorted desc
+
+
+def test_empty_or_malformed_index():
+    assert wts.compute_silent_gate_candidates({}, 3) == []
+    assert wts.compute_silent_gate_candidates({"gates": "not-a-dict"}, 3) == []
+    # a non-dict gate entry is skipped, not crashed on
+    assert wts.compute_silent_gate_candidates({"gates": {"X": None}}, 3) == []
+
+
+def test_top_n_zero_returns_empty():
+    idx = _idx({"S": {"total_candidates": 10, "total_firings": 0, "total_skips": 10}})
+    assert wts.compute_silent_gate_candidates(idx, top_n=0) == []

--- a/scripts/weekly-trend-scan.py
+++ b/scripts/weekly-trend-scan.py
@@ -85,6 +85,47 @@ def _gates_from_index(index_path: Path) -> set[str]:
     return {g for g in gates} if isinstance(gates, dict) else set()
 
 
+def compute_silent_gate_candidates(index: dict, top_n: int = 3) -> list[dict]:
+    """(A5, R19) Rank "silent-gate candidates" from the F17 gate-last-fired
+    index: gates that reached >=1 candidate but whose check has NEVER fired
+    (``total_firings == 0``, where firings = sum of the ledger's ``checked``
+    field). Ordered by candidate volume (loudest-but-silent first), truncated
+    to ``top_n``.
+
+    Interpretation is deliberately *informational*, not a regression: a
+    zero-firing gate is often healthy — it simply never found a violation (e.g.
+    ``STATE_OWNER_MISSING``: many candidates, all compliant). The value is
+    pre-promotion calibration attention: if a gate is about to flip
+    advisory->enforced but has never once fired, an operator should eyeball
+    whether that is healthy-zero or a mis-wire that never reaches its finding
+    branch. Reads the *committed* F17 index, so it is CI-available (the raw
+    gate-coverage ledger is gitignored / absent on runners).
+    """
+    gates = index.get("gates", {})
+    if not isinstance(gates, dict):
+        return []
+    out = []
+    for name, e in gates.items():
+        if not isinstance(e, dict):
+            continue
+        cands = e.get("total_candidates", 0) or 0
+        firings = e.get("total_firings", 0) or 0
+        if cands > 0 and firings == 0:
+            out.append({
+                "gate": name,
+                "candidates": cands,
+                "skips": e.get("total_skips", 0) or 0,
+                "last_checked_at": e.get("last_checked_at"),
+            })
+    out.sort(key=lambda r: r["candidates"], reverse=True)
+    return out[: max(0, top_n)]
+
+
+def silent_gate_candidates(top_n: int = 3, index_path: Path = GATE_LAST_FIRED) -> list[dict]:
+    """Load the committed F17 index and compute the A5 silent-gate list."""
+    return compute_silent_gate_candidates(load_json(index_path), top_n)
+
+
 def _gates_from_ledger(ledger_path: Path) -> set[str]:
     """Distinct gate names from the raw (gitignored) gate-coverage ledger.
 
@@ -230,6 +271,8 @@ def main() -> int:
 
     deltas, a4_regression = dim_deltas()
 
+    a5_silent = silent_gate_candidates()
+
     append_weekly_row(cur_gates, append=not args.no_append)
 
     payload = {
@@ -239,6 +282,8 @@ def main() -> int:
         "a2_gates_missing": ",".join(missing),
         "a4_dim_regression": "true" if a4_regression else "false",
         "a4_dim_deltas": deltas,
+        "a5_silent_count": len(a5_silent),
+        "a5_silent_gates": ",".join(r["gate"] for r in a5_silent),
     }
     write_github_outputs(payload)
 
@@ -254,6 +299,10 @@ def main() -> int:
             "a4": {
                 "regression": a4_regression,
                 "deltas": deltas,
+            },
+            "a5": {
+                "silent_gate_candidates": a5_silent,
+                "note": "informational — zero-firing may be healthy (never violated); verify healthy-zero vs mis-wire before promotion",
             },
         }, indent=2))
         return 0
@@ -285,6 +334,18 @@ def main() -> int:
     lines.append("")
     if a4_regression:
         lines.append("⚠ At least one dimension regressed; opens digest issue per workflow regression rule.")
+    lines.append("")
+    lines.append(f"**A5 — Silent-gate candidates** (top {len(a5_silent)}; informational, not a regression):")
+    if a5_silent:
+        lines.append("")
+        lines.append("Gates with candidates but zero firings — verify healthy-zero vs mis-wire before any promotion:")
+        lines.append("")
+        lines.append("| Gate | Candidates | Skips | Last checked |")
+        lines.append("|---|---|---|---|")
+        for r in a5_silent:
+            lines.append(f"| `{r['gate']}` | {r['candidates']} | {r['skips']} | {r['last_checked_at'] or '—'} |")
+    else:
+        lines.append(" none — every gate with candidates has fired at least once.")
     print("\n".join(lines))
     return 0
 


### PR DESCRIPTION
## What
dev-env 2026-05-19 audit **R19** (Linear **FIT-185**). Extends `scripts/weekly-trend-scan.py` with an **A5 section — silent-gate candidates**: top-N gates that reached candidates but whose check has **never fired** (`total_firings==0`), ranked by candidate volume.

- Reads the committed **F17 `gate-last-fired.json` index** (CI-available; the raw `gate-coverage.jsonl` is gitignored/absent on runners).
- Surfaced in the markdown digest **and** `--json`. The weekly workflow already tees the script's stdout into the digest issue, so **no workflow YAML change** is needed.
- 5 unit tests over the pure ranking logic (`compute_silent_gate_candidates`).

## Deliberately informational
A zero-firing gate is **often healthy** (never violated — e.g. `STATE_OWNER_MISSING`: 3777 candidates, all compliant). A5 does **not** trigger a regression issue. Its value is *pre-promotion calibration attention*: if a gate is about to flip advisory→enforced but has never once fired, an operator should verify healthy-zero vs a mis-wire that never reaches its finding branch. (Complements `GATE_COVERAGE_ZERO`'s 0-*candidate* mis-wire detector — this is the 0-*firing* class.)

## Current output (top 3)
`STATE_OWNER_MISSING` (3777 cand), `w9.auto_isolate` (67), `w9.concurrency` (21) — all known healthy-zero.

## Verification
- `python3.12 -m pytest scripts/tests/test_weekly_silent_gate_enrichment.py` → 5 passed
- A2/A4 sections intact (regression-checked); pre-commit gates green (isolated worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)