### PR TITLE
chore(FIT-155): FT2 state closure for T7 web critical-route smoke tests

### DIFF
--- a/.claude/features/t7-web-critical-route-smoke-tests/state.json
+++ b/.claude/features/t7-web-critical-route-smoke-tests/state.json
@@ -1,0 +1,63 @@
+{
+  "feature": "t7-web-critical-route-smoke-tests",
+  "linear_id": "FIT-155",
+  "thematic_code": "TC-T7",
+  "created_at": "2026-07-03T06:45:00Z",
+  "updated": "2026-07-03T07:12:00Z",
+  "branch": "chore/fit155-ft2-state-closure",
+  "current_phase": "complete",
+  "work_type": "chore",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Test-coverage chore (TC-T7 / test-coverage-master-plan §4 T7): adds a Playwright critical-route smoke over 5 fitme-story routes. No product surface; fitme-story PR #257 body + this state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "platforms_tested": {
+    "ios": false,
+    "web": true,
+    "backend": false,
+    "ai": false
+  },
+  "platforms_tested_provenance": "authored",
+  "summary": "T7 (test-coverage plan §4) — Playwright critical-route smoke over 5 highest-value fitme-story routes (/, /case-studies, /control-room/framework, /control-room/analytics, /api/auth/authenticate/options). Closes the '27 routes, zero E2E' gap. webServer sets DASHBOARD_PUBLIC=true for dashboard render; API route asserts proxy-passthrough reachability. Shipped in fitme-story PR #257; verified locally 5 passed via real build+start.",
+  "cross_repo_code_pr": "fitme-story#257",
+  "pr_citation_exempt": [
+    { "pr_number": 257, "reason": "Code + tests live in fitme-story (cross-repo); FT2 state.json tracks the test-coverage-plan item only." }
+  ],
+  "phases": {
+    "research": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "prd": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "tasks": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "ux_or_integration": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "implementation": { "status": "complete", "commits": [] },
+    "testing": { "status": "complete" },
+    "review": { "status": "complete" },
+    "merge": { "status": "complete", "pr_number": null },
+    "documentation": { "status": "complete" }
+  },
+  "timing": {
+    "phases": {
+      "implement": { "started_at": "2026-07-03T06:45:00Z", "ended_at": "2026-07-03T07:05:00Z" },
+      "complete": { "started_at": "2026-07-03T07:12:00Z", "ended_at": "2026-07-03T07:12:00Z" }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "5-route Playwright smoke spec (e2e/routes/critical-routes.smoke.spec.ts) + DASHBOARD_PUBLIC webServer env",
+      "type": "test",
+      "skill": "qa",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.3,
+      "depends_on": [],
+      "completed_at": "2026-07-03T07:05:00Z"
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": { "ux": null, "design": null }
+}

--- a/.claude/logs/t7-web-critical-route-smoke-tests.log.json
+++ b/.claude/logs/t7-web-critical-route-smoke-tests.log.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "feature": "t7-web-critical-route-smoke-tests",
+  "title": "t7 web critical route smoke tests",
+  "work_type": "chore",
+  "current_phase": "complete",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-03T07:09:54Z",
+  "updated_at": "2026-07-03T07:09:54Z",
+  "events": [
+    {
+      "timestamp": "2026-07-03T07:09:54Z",
+      "event_type": "tier_closure",
+      "phase": "complete",
+      "summary": "FIT-155 (T7) closure \u2014 shipped via fitme-story PR #257; 5-route Playwright smoke, verified 5 passed via real build+start. FT2 state reconciled to complete.",
+      "artifacts": [
+        "fitme-story#257"
+      ],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "success",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}


### PR DESCRIPTION
## What

FT2 test-coverage-plan tracking entry for **FIT-155 (T7)**. The Playwright smoke shipped in **fitme-story PR #257** — this adds the FT2 `.claude/features/` state so the daily checkpoint + crosswalk see the completed item (matching the t3/t5/t8 sibling test-coverage entries).

## The shipped work (fitme-story #257)

5-route critical smoke: `/`, `/case-studies`, `/control-room/framework`, `/control-room/analytics`, `/api/auth/authenticate/options`. Verified locally **5 passed** via the real build+start path. Closes the "27 routes, zero E2E" gap.

## State

`work_type=chore` · `case_study_type=no_case_study_required` · `platforms_tested.web=true` · cross-repo `pr_citation_exempt` for #257. Staged `check-state-schema.py` passes. Parent: test-coverage-master-plan §4 T7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)