### PR TITLE
feat(FIT-163): orphan-test scanner + weekly cron (T15, advisory)

### DIFF
--- a/.claude/features/t15-orphan-test-weekly-cron/state.json
+++ b/.claude/features/t15-orphan-test-weekly-cron/state.json
@@ -1,0 +1,71 @@
+{
+  "feature": "t15-orphan-test-weekly-cron",
+  "linear_id": "FIT-163",
+  "thematic_code": "TC-T15",
+  "created_at": "2026-07-03T07:30:00Z",
+  "updated": "2026-07-03T07:45:00Z",
+  "branch": "chore/fit163-orphan-test-cron",
+  "current_phase": "complete",
+  "work_type": "chore",
+  "work_subtype": "framework_feature",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Framework-meta dev-tooling chore (TC-T15): adds an advisory orphan-test scanner + weekly cron. No product surface; PR body + this state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "platforms_tested": {
+    "ios": false,
+    "web": false,
+    "backend": false,
+    "ai": false
+  },
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "summary": "T15 (test-coverage plan §4) — advisory orphan-test + untested-symbol scanner (scripts/scan-orphan-tests.py) + weekly GitHub Actions cron (orphan-tests-weekly.yml) + make orphan-tests. Direction 1: *Tests.swift referencing 0 production symbols (subject deleted). Direction 2: logic-bearing production types with 0 test references. Regex-based (no Swift toolchain); HISTORICAL-aware; globals + free-functions counted. 11 unit tests. Baseline: 0 orphan tests, 19 untested significant symbols.",
+  "phases": {
+    "research": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "prd": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "tasks": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "ux_or_integration": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "implementation": { "status": "complete", "commits": [] },
+    "testing": { "status": "complete" },
+    "review": { "status": "complete" },
+    "merge": { "status": "complete", "pr_number": null },
+    "documentation": { "status": "complete" }
+  },
+  "timing": {
+    "phases": {
+      "implement": { "started_at": "2026-07-03T07:30:00Z", "ended_at": "2026-07-03T07:44:00Z" },
+      "complete": { "started_at": "2026-07-03T07:45:00Z", "ended_at": "2026-07-03T07:45:00Z" }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "scripts/scan-orphan-tests.py — orphan-test + untested-symbol scanner (advisory, HISTORICAL+globals aware)",
+      "type": "infra",
+      "skill": "dev",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.3,
+      "depends_on": [],
+      "completed_at": "2026-07-03T07:44:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "scripts/tests/test_scan_orphan_tests.py (11 tests) + make orphan-tests + weekly cron workflow",
+      "type": "test",
+      "skill": "qa",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.2,
+      "depends_on": ["T1"],
+      "completed_at": "2026-07-03T07:44:00Z"
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": { "ux": null, "design": null }
+}

--- a/.claude/logs/t15-orphan-test-weekly-cron.log.json
+++ b/.claude/logs/t15-orphan-test-weekly-cron.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "t15-orphan-test-weekly-cron",
+  "title": "t15 orphan test weekly cron",
+  "work_type": "chore",
+  "current_phase": "complete",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-03T18:04:30Z",
+  "updated_at": "2026-07-03T18:04:30Z",
+  "events": [
+    {
+      "timestamp": "2026-07-03T18:04:30Z",
+      "event_type": "tier_closure",
+      "phase": "complete",
+      "summary": "FIT-163 (T15) \u2014 orphan-test scanner + weekly cron + make target + 11 unit tests shipped. Baseline: 0 orphans, 19 untested significant symbols.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "success",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/.github/workflows/orphan-tests-weekly.yml
+++ b/.github/workflows/orphan-tests-weekly.yml
@@ -1,0 +1,113 @@
+name: Orphan Tests — Weekly
+
+# FIT-163 (T15) — advisory orphan-test + untested-symbol scan.
+#
+# Read-only observability (never blocks a merge; no commit/PR). Complements:
+#   - integrity-cycle.yml (every 72h, state.json health)
+#   - framework-status-weekly.yml (Mon 05:00 UTC, adoption trend)
+# This runs Mondays 07:00 UTC (2h after framework-status, 1h after the
+# dependency audit) so the weekly cron pool doesn't collide.
+#
+# Opens an issue ONLY on an orphan-test regression (a *Tests.swift that
+# references no production symbol — its subject was renamed/deleted). The
+# untested-significant-symbol list is a coarse standing inventory, so it is
+# always written to the step summary but does NOT open a weekly issue on its
+# own (avoids recurring noise from a stable list). workflow_dispatch with
+# open_issue_always=true forces the issue open for an on-demand readout.
+#
+# Security (per github.blog injection guide): no github.event.* user input is
+# used anywhere. Step outputs we set ourselves (integer counts) are routed
+# through env: into run:/script: blocks, never interpolated directly. The only
+# direct ${{ }} usages are in if: conditions, which evaluate in GitHub's
+# expression engine, not in a shell.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      open_issue_always:
+        description: "Open the digest issue even with no orphan-test regression"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  orphan-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run orphan-test scan
+        id: scan
+        run: |
+          set -o pipefail
+          python3 scripts/scan-orphan-tests.py \
+            --output /tmp/orphan-scan.json 2>&1 | tee /tmp/orphan-scan.txt
+          orphans=$(python3 -c "import json;print(len(json.load(open('/tmp/orphan-scan.json'))['orphan_tests']))")
+          untested=$(python3 -c "import json;print(len(json.load(open('/tmp/orphan-scan.json'))['untested_significant_symbols']))")
+          echo "orphans=${orphans}" >> "$GITHUB_OUTPUT"
+          echo "untested=${untested}" >> "$GITHUB_OUTPUT"
+
+      - name: Workflow summary
+        if: always()
+        env:
+          ORPHANS: ${{ steps.scan.outputs.orphans }}
+          UNTESTED: ${{ steps.scan.outputs.untested }}
+        run: |
+          {
+            echo "## Orphan-test scan (weekly)"
+            echo ""
+            echo "- Orphan tests: **${ORPHANS}**"
+            echo "- Untested significant symbols: **${UNTESTED}**"
+            echo ""
+            echo '```'
+            cat /tmp/orphan-scan.txt 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open advisory issue on orphan-test regression
+        if: steps.scan.outputs.orphans != '0' || inputs.open_issue_always == 'true'
+        uses: actions/github-script@v9
+        env:
+          ORPHANS: ${{ steps.scan.outputs.orphans }}
+          UNTESTED: ${{ steps.scan.outputs.untested }}
+        with:
+          script: |
+            const fs = require('fs');
+            const orphans = process.env.ORPHANS;
+            const untested = process.env.UNTESTED;
+            const report = fs.readFileSync('/tmp/orphan-scan.txt', 'utf8').slice(0, 8000);
+            const today = new Date().toISOString().slice(0, 10);
+            const title = orphans !== '0'
+              ? `Orphan tests ${today}: ${orphans} test file(s) reference no production symbol`
+              : `Orphan-test digest ${today}`;
+            const body = [
+              '**Advisory** — FIT-163 (T15) weekly orphan-test scan.',
+              '',
+              `- Orphan tests: **${orphans}** (a \`*Tests.swift\` referencing no production symbol — subject likely renamed/deleted)`,
+              `- Untested significant symbols: **${untested}** (logic-bearing types no test references — coarse inventory)`,
+              '',
+              '```',
+              report,
+              '```',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['test-coverage', 'orphan-tests', 'advisory'],
+            });

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Primary target: `make tokens` — regenerates DesignTokens.swift from design-tokens/tokens.json
 # CI target: `make tokens-check` — fails if DesignTokens.swift is out of sync with tokens.json
 
-.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-multi-anchor integrity-data-lake integrity-snapshot preflight skill-preflight gen-skill-preflight schema-check documentation-debt measurement-adoption framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status figma-mirror-staleness v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force daily-checkpoint-ci ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher verify-local-idempotent-check audit-cache audit-imports doctor integrity-snapshot-rotate logs-rotate sessions-compact close-feature gate-last-fired phase-0-reality-check w9-isolation-status lint lint-ios lint-py lint-md actionlint coverage-ios coverage-py coverage-report sample-contract-fixtures check-contract-fixtures mutation-test mutation-summary
+.PHONY: tokens tokens-check ui-audit ui-audit-baseline ui-audit-drift integrity-check integrity-diff integrity-multi-anchor integrity-data-lake integrity-snapshot preflight skill-preflight gen-skill-preflight schema-check documentation-debt measurement-adoption orphan-tests framework-status advancement-report test-v7-5-pipeline runtime-smoke install-hooks pre-commit-self-test membrane-status figma-mirror-staleness v7-9-snapshot install verify-local verify-web verify-ai verify-ios verify-timing verify-framework verify-evals app-icon app-store-check validate-tier-tags figma-drift snapshot-phase refresh-pr-cache validate-existing-cites daily-checkpoint daily-checkpoint-force daily-checkpoint-ci ledger install-daily-cron uninstall-daily-cron install-devssd-watcher uninstall-devssd-watcher verify-local-idempotent-check audit-cache audit-imports doctor integrity-snapshot-rotate logs-rotate sessions-compact close-feature gate-last-fired phase-0-reality-check w9-isolation-status lint lint-ios lint-py lint-md actionlint coverage-ios coverage-py coverage-report sample-contract-fixtures check-contract-fixtures mutation-test mutation-summary
 
 # All build artifacts stay on the SSD alongside the project source.
 # Override any variable via environment or command line: make verify-ios BUILD_DIR=/other/path
@@ -421,6 +421,13 @@ schema-check:
 # Generate the baseline documentation-debt report used by the control room.
 documentation-debt:
 	python3 scripts/documentation-debt-report.py --output .claude/shared/documentation-debt.json
+
+# Orphan-test scan (FIT-163 / T15 — advisory). Flags *Tests.swift files that
+# reference no production symbol (subject deleted) + logic-bearing production
+# types with no test references. Advisory: exit 0 unless --strict. Weekly cron:
+# .github/workflows/orphan-tests-weekly.yml.
+orphan-tests:
+	python3 scripts/scan-orphan-tests.py
 
 # Tracking-drift-check (Dev-Env track, 2026-05-24): surface planning rows that
 # claim OPEN (`[ ]` / un-struck RICE row) while their evidence is already on

--- a/scripts/scan-orphan-tests.py
+++ b/scripts/scan-orphan-tests.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""FIT-163 (T15) — orphan-test + untested-symbol scanner (advisory).
+
+Two directions, both advisory (never blocks a commit; surfaced weekly via
+`.github/workflows/orphan-tests-weekly.yml`):
+
+  1. ORPHAN TEST — a `*Tests.swift` file that references ZERO production
+     symbols. Signal: its subject was renamed/deleted, or the file is pure
+     scaffolding. High-value: a test that exercises nothing still "passes".
+
+  2. UNTESTED SYMBOL — a *significant* production type (Service / Manager /
+     Store / Engine / Orchestrator / Gateway / Adapter / Coordinator /
+     ViewModel / Repository) that NO test file references. Coarser signal;
+     scoped to logic-bearing types so the list stays actionable (SwiftUI
+     Views and small value types are intentionally out of scope).
+
+Symbol extraction is regex-based (no Swift toolchain needed), matching the
+convention of the other repo scanners (check-pr-workflow-coverage.py, etc.).
+
+Usage:
+    python3 scripts/scan-orphan-tests.py            # human summary + JSON, exit 0
+    python3 scripts/scan-orphan-tests.py --json      # JSON only
+    python3 scripts/scan-orphan-tests.py --strict    # exit 1 if any finding
+    python3 scripts/scan-orphan-tests.py \
+        --prod-dir FitTracker --test-dir FitTrackerTests
+
+Exit codes: 0 = clean OR advisory (default). 1 = findings AND --strict. 2 = usage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Top-level nominal type declarations. `extension` does not declare a new type.
+_DECL_RE = re.compile(
+    r"^\s*(?:public\s+|private\s+|internal\s+|fileprivate\s+|final\s+|open\s+|"
+    r"@\w+\s+)*"
+    r"(?:class|struct|enum|protocol|actor)\s+([A-Z]\w*)",
+    re.MULTILINE,
+)
+
+# Top-level (column-0, file-scope) global bindings + free functions. A test can
+# exercise production through a global (e.g. `supabase`) or a free function
+# without ever naming a type — those references must count so the orphan check
+# doesn't false-positive. Anchored at line start with NO leading whitespace so
+# nested/member declarations (which are indented) are excluded.
+_GLOBAL_RE = re.compile(
+    r"^(?:public\s+|internal\s+|private\s+|fileprivate\s+|@\w+\s+)*"
+    r"(?:let|var|func)\s+([A-Za-z_]\w*)",
+    re.MULTILINE,
+)
+
+# Logic-bearing type-name suffixes eligible for the untested-symbol direction.
+_SIGNIFICANT_SUFFIXES = (
+    "Service", "Manager", "Store", "Engine", "Orchestrator", "Gateway",
+    "Adapter", "Coordinator", "ViewModel", "Repository", "Client", "Provider",
+    "Builder", "Parser", "Validator", "Calculator", "Resolver", "Scheduler",
+)
+
+# Generated / non-source files excluded from the production symbol set.
+_PROD_EXCLUDE_NAMES = {"DesignTokens.swift"}
+
+
+def _rel(path: Path) -> str:
+    """Repo-relative path when under REPO_ROOT; else a stable fallback (used by
+    tmp_path fixtures in the unit tests, which live outside the repo)."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _is_historical(text: str) -> bool:
+    """HISTORICAL v1 files are not in the build target — skip them."""
+    head = text[:600]
+    return "HISTORICAL —" in head or "HISTORICAL --" in head
+
+
+def extract_prod_symbols(prod_dir: Path) -> dict[str, dict]:
+    """Return {type_name: {"file": rel_path, "historical": bool}} for every
+    declared production type.
+
+    HISTORICAL v1 files are NOT excluded from the symbol universe: a HISTORICAL
+    file can still define a type a *live* test references (e.g.
+    NotificationPreferencesStore), and dropping it produces false-positive
+    orphan-test findings. Instead each symbol carries a `historical` flag so
+    the untested-symbol direction can skip superseded types (where a missing
+    test is expected, not a regression)."""
+    symbols: dict[str, dict] = {}
+    for path in sorted(prod_dir.rglob("*.swift")):
+        if path.name in _PROD_EXCLUDE_NAMES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        historical = _is_historical(text)
+        rel = _rel(path)
+        for m in _DECL_RE.finditer(text):
+            name = m.group(1)
+            # First declaration wins for path attribution; ignore re-decls.
+            symbols.setdefault(name, {"file": rel, "historical": historical})
+    return symbols
+
+
+def extract_prod_globals(prod_dir: Path) -> set[str]:
+    """Return the set of top-level global binding / free-function names."""
+    names: set[str] = set()
+    for path in sorted(prod_dir.rglob("*.swift")):
+        if path.name in _PROD_EXCLUDE_NAMES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        names.update(_GLOBAL_RE.findall(text))
+    return names
+
+
+def _word_set(text: str) -> set[str]:
+    """Identifier tokens in a source file (for fast membership tests)."""
+    return set(re.findall(r"[A-Za-z_]\w*", text))
+
+
+def scan(prod_dir: Path, test_dir: Path) -> dict:
+    prod_symbols = extract_prod_symbols(prod_dir)
+    # Orphan detection references the full production identifier universe:
+    # declared types PLUS top-level globals / free functions.
+    prod_names = set(prod_symbols) | extract_prod_globals(prod_dir)
+
+    orphan_tests: list[str] = []
+    # Track which production symbols any test references.
+    referenced: set[str] = set()
+    test_files = sorted(test_dir.rglob("*Tests.swift"))
+
+    for path in test_files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        tokens = _word_set(text)
+        hits = tokens & prod_names
+        referenced |= hits
+        if not hits:
+            orphan_tests.append(_rel(path))
+
+    # Untested significant symbols: logic-bearing types no test references.
+    # HISTORICAL (superseded) types are excluded — a missing test there is
+    # expected, not a regression.
+    untested: list[dict] = []
+    for name, meta in sorted(prod_symbols.items()):
+        if name in referenced or meta["historical"]:
+            continue
+        if name.endswith(_SIGNIFICANT_SUFFIXES):
+            untested.append({"symbol": name, "file": meta["file"]})
+
+    return {
+        "schema_version": 1,
+        "prod_symbol_count": len(prod_symbols),
+        "test_file_count": len(test_files),
+        "orphan_tests": orphan_tests,
+        "untested_significant_symbols": untested,
+        "finding_count": len(orphan_tests) + len(untested),
+    }
+
+
+def render(result: dict) -> str:
+    lines = ["Orphan-test scan (FIT-163 / T15 — advisory)", ""]
+    lines.append(
+        f"  production types: {result['prod_symbol_count']}  |  "
+        f"test files: {result['test_file_count']}"
+    )
+    lines.append("")
+    orphans = result["orphan_tests"]
+    if orphans:
+        lines.append(f"⚠ ORPHAN TESTS ({len(orphans)}) — reference no production symbol:")
+        lines.extend(f"    - {p}" for p in orphans)
+    else:
+        lines.append("✓ No orphan tests — every *Tests.swift references ≥1 production symbol.")
+    lines.append("")
+    untested = result["untested_significant_symbols"]
+    if untested:
+        lines.append(
+            f"⚠ UNTESTED SIGNIFICANT SYMBOLS ({len(untested)}) — "
+            "logic-bearing types no test references:"
+        )
+        lines.extend(f"    - {u['symbol']}  ({u['file']})" for u in untested)
+    else:
+        lines.append("✓ Every significant production type is referenced by ≥1 test.")
+    lines.append("")
+    lines.append(f"Total advisory findings: {result['finding_count']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Orphan-test + untested-symbol scanner (advisory).")
+    ap.add_argument("--prod-dir", default="FitTracker", help="Production source dir (default: FitTracker)")
+    ap.add_argument("--test-dir", default="FitTrackerTests", help="Test dir (default: FitTrackerTests)")
+    ap.add_argument("--json", action="store_true", help="Emit JSON only")
+    ap.add_argument("--strict", action="store_true", help="Exit 1 if any finding (default: advisory exit 0)")
+    ap.add_argument("--output", help="Write JSON result to this path")
+    args = ap.parse_args(argv)
+
+    prod_dir = (REPO_ROOT / args.prod_dir).resolve()
+    test_dir = (REPO_ROOT / args.test_dir).resolve()
+    if not prod_dir.is_dir():
+        print(f"error: prod dir not found: {prod_dir}", file=sys.stderr)
+        return 2
+    if not test_dir.is_dir():
+        print(f"error: test dir not found: {test_dir}", file=sys.stderr)
+        return 2
+
+    result = scan(prod_dir, test_dir)
+
+    if args.output:
+        Path(args.output).write_text(json.dumps(result, indent=2) + "\n")
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(render(result))
+
+    if args.strict and result["finding_count"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_scan_orphan_tests.py
+++ b/scripts/tests/test_scan_orphan_tests.py
@@ -1,0 +1,168 @@
+"""Unit tests for FIT-163 (T15) scripts/scan-orphan-tests.py.
+
+Uses importlib.util because the source file has a hyphen in its name and
+cannot be imported with `import scan-orphan-tests`. Fixtures build tiny Swift
+trees under tmp_path so the scanner runs against controlled input.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "scan_orphan_tests", SCRIPTS_DIR / "scan-orphan-tests.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+def _write(base: Path, rel: str, text: str) -> Path:
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return p
+
+
+@pytest.fixture
+def tree(tmp_path: Path):
+    """Return (prod_dir, test_dir) factory helpers on a fresh tmp tree."""
+    prod = tmp_path / "FitTracker"
+    tests = tmp_path / "FitTrackerTests"
+    prod.mkdir()
+    tests.mkdir()
+    return prod, tests
+
+
+# ── extraction ───────────────────────────────────────────────────────────────
+
+def test_extract_types_and_historical_flag(tree):
+    prod, _ = tree
+    _write(prod, "Services/FooService.swift", "final class FooService {}\n")
+    _write(
+        prod,
+        "Views/OldView.swift",
+        "// HISTORICAL — superseded 2026-01-01\nstruct OldView {}\n",
+    )
+    syms = mod.extract_prod_symbols(prod)
+    assert syms["FooService"]["historical"] is False
+    assert syms["OldView"]["historical"] is True
+
+
+def test_extract_globals_column0_only(tree):
+    prod, _ = tree
+    _write(
+        prod,
+        "Services/Client.swift",
+        "let supabase: X = makeIt()\n"
+        "func topLevelHelper() {}\n"
+        "struct Wrapper {\n    let nestedProp = 1\n    func member() {}\n}\n",
+    )
+    globals_ = mod.extract_prod_globals(prod)
+    assert "supabase" in globals_
+    assert "topLevelHelper" in globals_
+    # Indented (member) declarations must NOT be treated as globals.
+    assert "nestedProp" not in globals_
+    assert "member" not in globals_
+
+
+# ── orphan detection ─────────────────────────────────────────────────────────
+
+def test_test_referencing_a_type_is_not_orphan(tree):
+    prod, tests = tree
+    _write(prod, "Services/FooService.swift", "class FooService {}\n")
+    _write(tests, "FooServiceTests.swift", "@testable import FitTracker\nlet x = FooService()\n")
+    r = mod.scan(prod, tests)
+    assert r["orphan_tests"] == []
+
+
+def test_test_referencing_nothing_is_orphan(tree):
+    prod, tests = tree
+    _write(prod, "Services/FooService.swift", "class FooService {}\n")
+    _write(tests, "GhostTests.swift", "import XCTest\nfinal class GhostTests: XCTestCase {}\n")
+    r = mod.scan(prod, tests)
+    assert "FitTrackerTests/GhostTests.swift".split("/")[-1] in r["orphan_tests"][0]
+
+
+def test_test_referencing_only_a_global_is_not_orphan(tree):
+    prod, tests = tree
+    _write(prod, "Services/Client.swift", "let supabase: X = makeIt()\n")
+    _write(tests, "SupabaseClientTests.swift", "import XCTest\nXCTAssertNotNil(supabase)\n")
+    r = mod.scan(prod, tests)
+    assert r["orphan_tests"] == []
+
+
+def test_test_referencing_symbol_in_historical_file_is_not_orphan(tree):
+    prod, tests = tree
+    _write(
+        prod,
+        "Services/LegacyStore.swift",
+        "// HISTORICAL — superseded\nfinal class LegacyPreferencesStore {}\n",
+    )
+    _write(tests, "LegacyTests.swift", "let s = LegacyPreferencesStore()\n")
+    r = mod.scan(prod, tests)
+    assert r["orphan_tests"] == []
+
+
+# ── untested-symbol direction ────────────────────────────────────────────────
+
+def test_untested_significant_symbol_listed(tree):
+    prod, tests = tree
+    _write(prod, "Services/LonelyService.swift", "class LonelyService {}\n")
+    _write(prod, "Services/UsedService.swift", "class UsedService {}\n")
+    _write(tests, "UsedServiceTests.swift", "let u = UsedService()\n")
+    r = mod.scan(prod, tests)
+    names = {u["symbol"] for u in r["untested_significant_symbols"]}
+    assert "LonelyService" in names
+    assert "UsedService" not in names
+
+
+def test_untested_excludes_non_significant_and_historical(tree):
+    prod, tests = tree
+    # Non-significant name (no logic-bearing suffix) → not listed.
+    _write(prod, "Models/Widget.swift", "struct Widget {}\n")
+    # HISTORICAL significant type → excluded even though untested.
+    _write(
+        prod,
+        "Services/OldService.swift",
+        "// HISTORICAL — superseded\nclass OldService {}\n",
+    )
+    _write(tests, "AnchorTests.swift", "let w = Widget()\n")  # keep this test non-orphan
+    r = mod.scan(prod, tests)
+    names = {u["symbol"] for u in r["untested_significant_symbols"]}
+    assert "Widget" not in names
+    assert "OldService" not in names
+
+
+# ── CLI / exit codes ─────────────────────────────────────────────────────────
+
+def test_strict_exit_code_on_findings(tree, capsys):
+    prod, tests = tree
+    _write(prod, "A.swift", "class A {}\n")
+    _write(tests, "GhostTests.swift", "final class GhostTests {}\n")
+    rc = mod.main(["--prod-dir", str(prod), "--test-dir", str(tests), "--strict"])
+    assert rc == 1
+
+
+def test_advisory_exit_zero_by_default(tree):
+    prod, tests = tree
+    _write(prod, "A.swift", "class A {}\n")
+    _write(tests, "GhostTests.swift", "final class GhostTests {}\n")
+    rc = mod.main(["--prod-dir", str(prod), "--test-dir", str(tests)])
+    assert rc == 0
+
+
+def test_missing_dir_returns_usage_error(tmp_path):
+    rc = mod.main(["--prod-dir", str(tmp_path / "nope"), "--test-dir", str(tmp_path)])
+    assert rc == 2


### PR DESCRIPTION
## What

Closes **FIT-163 (T15)** — test-coverage-master-plan §4. An **advisory** orphan-test + untested-symbol scanner with a weekly cron. Never blocks a commit.

## Deliverables

- **`scripts/scan-orphan-tests.py`** — regex-based (no Swift toolchain):
  - **Orphan tests**: a `*Tests.swift` referencing **0** production symbols (its subject was renamed/deleted). HISTORICAL-file symbols + top-level globals / free-functions are counted so live tests don't false-positive.
  - **Untested symbols**: logic-bearing production types (`Service`/`Manager`/`Store`/`Engine`/… suffix) with **0** test references. HISTORICAL types excluded.
  - Advisory (exit 0); `--strict` exits 1; `--json` / `--output` modes.
- **`.github/workflows/orphan-tests-weekly.yml`** — Mondays 07:00 UTC. Opens an advisory issue **only** on an orphan-test regression; the untested list is always in the step summary (no weekly noise from a stable inventory).
- **`make orphan-tests`** + **11 unit tests** (`test_scan_orphan_tests.py`, 0.06s).

## Bug caught during development

The first cut excluded HISTORICAL files from the symbol universe → false-positive orphan (`NotificationTests` references `NotificationPreferencesStore`, which lives in a HISTORICAL-marked file a live test still uses). Fixed: HISTORICAL symbols count for orphan-detection, excluded only from the untested-symbol list. A second false-positive (`SupabaseClientTests` → the `supabase` global) drove the globals/free-function extraction.

## Baseline (on main)

534 production types, 81 test files → **0 orphan tests**, 19 untested significant symbols.

`work_type=chore` / `framework_feature` (Q2-exempt). Parent: test-coverage plan §4 T15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)