### PR TITLE
feat(FIT-152): Swift snapshot-testing foundation (T4, record-in-CI)

### DIFF
--- a/.claude/features/t4-ios-snapshot-testing/state.json
+++ b/.claude/features/t4-ios-snapshot-testing/state.json
@@ -1,0 +1,81 @@
+{
+  "feature": "t4-ios-snapshot-testing",
+  "linear_id": "FIT-152",
+  "thematic_code": "TC-T4",
+  "created_at": "2026-07-03T18:40:00Z",
+  "updated": "2026-07-03T19:10:00Z",
+  "branch": "chore/fit152-snapshot-testing",
+  "current_phase": "implement",
+  "work_type": "chore",
+  "work_subtype": "framework_feature",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "iOS test/CI-infrastructure foundation (TC-T4): adds the swift-snapshot-testing SPM dep + harness + record-in-CI workflow. Snapshot baselines + screen coverage are follow-up tasks; PR body + this state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "platforms_tested": {
+    "ios": false,
+    "web": false,
+    "backend": false,
+    "ai": false
+  },
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "summary": "T4 (test-coverage plan §4) FOUNDATION — pointfreeco/swift-snapshot-testing SPM dep wired into FitTrackerTests + a snapshot harness (SnapshotTestSupport SNAPSHOT_MODE gate: tests SKIP by default so the required Build+Test never reddens pre-baseline) + starter design-system-component snapshots + an operator-triggered ios-snapshot-record.yml that records CI-environment baselines and uploads them as an artifact. Baselines can't be recorded locally (Xcode 26/iPhone 17 Pro local vs iPhone 15/16 CI). Verified locally: SnapshotTesting package resolves + test target compiles.",
+  "phases": {
+    "research": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "prd": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "tasks": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "ux_or_integration": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "implementation": { "status": "in_progress", "commits": [] },
+    "testing": { "status": "pending" },
+    "review": { "status": "pending" },
+    "merge": { "status": "pending", "pr_number": null },
+    "documentation": { "status": "pending" }
+  },
+  "timing": {
+    "phases": {
+      "implement": { "started_at": "2026-07-03T18:40:00Z" }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "SPM dep (swift-snapshot-testing) + SnapshotTestSupport harness + starter DS-component snapshots + ios-snapshot-record.yml (record-in-CI)",
+      "type": "infra",
+      "skill": "qa",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.4,
+      "depends_on": [],
+      "completed_at": "2026-07-03T19:05:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "Run ios-snapshot-record job → download artifact → commit CI-recorded baselines → flip harness into required test job (SNAPSHOT_MODE=verify)",
+      "type": "infra",
+      "skill": "qa",
+      "status": "pending",
+      "priority": "high",
+      "effort_days": 0.2,
+      "depends_on": ["T1"],
+      "completed_at": null
+    },
+    {
+      "id": "T3",
+      "title": "Expand snapshot coverage to the 6 v2 screens (Home/Stats/Settings/Nutrition/Training/Readiness) + 4 auth views with mock view-model/store injection",
+      "type": "test",
+      "skill": "qa",
+      "status": "pending",
+      "priority": "medium",
+      "effort_days": 0.8,
+      "depends_on": ["T2"],
+      "completed_at": null
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": { "ux": null, "design": null }
+}

--- a/.claude/logs/t4-ios-snapshot-testing.log.json
+++ b/.claude/logs/t4-ios-snapshot-testing.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "t4-ios-snapshot-testing",
+  "title": "t4 ios snapshot testing",
+  "work_type": "chore",
+  "current_phase": "implement",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-03T20:40:20Z",
+  "updated_at": "2026-07-03T20:40:20Z",
+  "events": [
+    {
+      "timestamp": "2026-07-03T20:40:20Z",
+      "event_type": "phase_started",
+      "phase": "implement",
+      "summary": "FIT-152 (T4) foundation \u2014 swift-snapshot-testing SPM dep + harness + starter DS-component snapshots + record-in-CI workflow. Verified: TEST BUILD SUCCEEDED locally (package resolves, test target compiles).",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "success",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/.github/workflows/ios-snapshot-record.yml
+++ b/.github/workflows/ios-snapshot-record.yml
@@ -1,0 +1,80 @@
+name: iOS Snapshot — Record Baselines
+
+# FIT-152 (T4) — operator-triggered baseline recorder.
+#
+# Snapshot reference PNGs must be recorded in the CI simulator environment
+# (local Xcode 26 / iPhone 17 Pro does NOT match the CI iPhone 15/16 sims), so
+# this workflow runs the snapshot tests with SNAPSHOT_MODE=record and uploads
+# the generated __Snapshots__ dirs as an artifact. The operator downloads the
+# artifact, commits the PNGs under FitTrackerTests/SnapshotTests/__Snapshots__/,
+# and flips the gate to SNAPSHOT_MODE=verify (a follow-up PR wiring these into
+# the required test job). See docs/process/snapshot-testing.md.
+#
+# workflow_dispatch only — never runs on PRs, so it can never block a merge.
+#
+# Security: no github.event.* input and no ${{ }} interpolation anywhere — the
+# simulator destination is computed inside the run: block as a shell variable.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PROJECT_PATH: FitTracker.xcodeproj
+  SCHEME: FitTracker
+
+jobs:
+  record:
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve packages
+        run: |
+          xcodebuild -resolvePackageDependencies -project "$PROJECT_PATH" -scheme "$SCHEME"
+
+      - name: Record snapshots
+        env:
+          SNAPSHOT_MODE: record
+        run: |
+          set -o pipefail
+          # Pick the same simulator family the required CI test job uses so the
+          # recorded baselines will match at verify time.
+          sim_list="$(xcrun simctl list devices available)"
+          SIM_DEST=""
+          for d in "iPhone 16 Pro" "iPhone 16" "iPhone 15 Pro" "iPhone 15" "iPhone 14"; do
+            if echo "$sim_list" | grep -qF "${d} ("; then
+              SIM_DEST="platform=iOS Simulator,name=${d}"
+              break
+            fi
+          done
+          if [ -z "$SIM_DEST" ]; then
+            fb="$(echo "$sim_list" | grep -oE 'iPhone [^(]+' | head -1 | xargs)"
+            SIM_DEST="platform=iOS Simulator,name=${fb}"
+          fi
+          echo "Selected simulator: ${SIM_DEST}"
+
+          # Record mode: swift-snapshot-testing writes the reference PNGs and
+          # (by design) reports the tests as failed on the recording run, so we
+          # tolerate a non-zero exit and rely on the uploaded artifact instead.
+          xcodebuild test \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -destination "$SIM_DEST" \
+            -only-testing:FitTrackerTests/V2ComponentSnapshotTests \
+            -parallel-testing-enabled NO \
+            CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
+            2>&1 | tee /tmp/snapshot-record.log || true
+
+      - name: Upload recorded baselines
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-baselines
+          path: |
+            **/__Snapshots__/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/FitTracker.xcodeproj/project.pbxproj
+++ b/FitTracker.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		SNAP000001000000000000002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = SNAP000002000000000000001 /* SnapshotTesting */; };
+		SNAP000001000000000000003 /* SnapshotTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = SNAP000000000000000000003 /* SnapshotTestSupport.swift */; };
+		SNAP000001000000000000004 /* V2ComponentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SNAP000000000000000000004 /* V2ComponentSnapshotTests.swift */; };
 		111A5E022F64641D006E7013 /* WatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E012F64641D006E7013 /* WatchConnectivityService.swift */; };
 		111A5E042F64641D006E7013 /* TrainingProgramStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E032F64641D006E7013 /* TrainingProgramStore.swift */; };
 		111A5E062F64641D006E7013 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A5E052F64641D006E7013 /* AppTheme.swift */; };
@@ -329,6 +332,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		SNAP000000000000000000003 /* SnapshotTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTests/SnapshotTestSupport.swift; sourceTree = "<group>"; };
+		SNAP000000000000000000004 /* V2ComponentSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTests/V2ComponentSnapshotTests.swift; sourceTree = "<group>"; };
 		111A5E012F64641D006E7013 /* WatchConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityService.swift; sourceTree = "<group>"; };
 		111A5E032F64641D006E7013 /* TrainingProgramStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingProgramStore.swift; sourceTree = "<group>"; };
 		111A5E052F64641D006E7013 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
@@ -677,6 +682,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				SNAP000001000000000000002 /* SnapshotTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -982,6 +988,8 @@
 				HA200000000000000000001 /* AnalyticsTests.swift */,
 				DA200000000000000000AT01 /* DebugSinkAdapterTests.swift */,
 				B20000010000000000000001 /* FitTrackerCoreTests.swift */,
+				SNAP000000000000000000003 /* SnapshotTestSupport.swift */,
+				SNAP000000000000000000004 /* V2ComponentSnapshotTests.swift */,
 				HA200000000000000000002 /* HomeAnalyticsTests.swift */,
 				TA200000000000000000001 /* TrainingAnalyticsTests.swift */,
 				NA200000000000000000001 /* NutritionAnalyticsTests.swift */,
@@ -1473,6 +1481,9 @@
 			dependencies = (
 				B80000010000000000000001 /* PBXTargetDependency */,
 			);
+			packageProductDependencies = (
+				SNAP000002000000000000001 /* SnapshotTesting */,
+			);
 			name = FitTrackerTests;
 			productName = FitTrackerTests;
 			productReference = B20000010000000000000002 /* FitTrackerTests.xctest */;
@@ -1528,6 +1539,7 @@
 				FC3000000000000000000001 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				GG3000000000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				SUP0000003000000000000001 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+				SNAP000003000000000000001 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			productRefGroup = A40000010000000000000003 /* Products */;
 			projectDirPath = "";
@@ -1786,6 +1798,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B10000010000000000000001 /* FitTrackerCoreTests.swift in Sources */,
+				SNAP000001000000000000003 /* SnapshotTestSupport.swift in Sources */,
+				SNAP000001000000000000004 /* V2ComponentSnapshotTests.swift in Sources */,
 				HA100000000000000000001 /* AnalyticsTests.swift in Sources */,
 				DA100000000000000000AT01 /* DebugSinkAdapterTests.swift in Sources */,
 				HA100000000000000000002 /* HomeAnalyticsTests.swift in Sources */,
@@ -2360,6 +2374,14 @@
 				minimumVersion = 2.5.1;
 			};
 		};
+		SNAP000003000000000000001 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.17.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2382,6 +2404,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = SUP0000003000000000000001 /* XCRemoteSwiftPackageReference "supabase-swift" */;
 			productName = Supabase;
+		};
+		SNAP000002000000000000001 /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = SNAP000003000000000000001 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/FitTracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FitTracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3e19959b3888f301d8ed88c18f3b496ddbce6062c1fa41420e4130f7b3694017",
+  "originHash" : "b0ec5a6ba1887a5aba532ba34fe849a32a5c0239fc7fccb0b8ea98ab6ebb2d76",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -191,6 +191,15 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
@@ -206,6 +215,24 @@
       "state" : {
         "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
         "version" : "1.36.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/FitTrackerTests/SnapshotTests/SnapshotTestSupport.swift
+++ b/FitTrackerTests/SnapshotTests/SnapshotTestSupport.swift
@@ -1,0 +1,46 @@
+// FitTrackerTests/SnapshotTests/SnapshotTestSupport.swift
+//
+// FIT-152 (T4) — Swift snapshot-testing harness support.
+//
+// Snapshot baselines are simulator-specific. Local (Xcode 26 / iPhone 17 Pro,
+// iOS 26) and CI (iPhone 15/16, iOS ~18) do NOT share a simulator, so a
+// baseline recorded locally would fail in CI. To bootstrap safely we RECORD
+// baselines in the CI environment (the `ios-snapshot-record` job runs with
+// SNAPSHOT_MODE=record and uploads the __Snapshots__ dir as an artifact), then
+// commit those CI-recorded PNGs and flip the gate to SNAPSHOT_MODE=verify.
+//
+// Until then these tests SKIP in the default `Build and Test` run (SNAPSHOT_MODE
+// unset) so they never redden the required check without baselines. See
+// .github/workflows/ios-snapshot-record.yml + docs/process/snapshot-testing.md.
+
+import Foundation
+import XCTest
+
+enum SnapshotMode {
+    /// Raw SNAPSHOT_MODE env value: nil (default) | "record" | "verify".
+    static var current: String? {
+        ProcessInfo.processInfo.environment["SNAPSHOT_MODE"]
+    }
+
+    /// True in the CI record job — captures/overwrites reference PNGs.
+    static var isRecording: Bool { current == "record" }
+
+    /// True when snapshot assertions should run at all (record OR verify).
+    static var isActive: Bool { current == "record" || current == "verify" }
+}
+
+extension XCTestCase {
+    /// Skip the calling test unless SNAPSHOT_MODE is set. Keeps snapshot tests
+    /// out of the default test run (which has no CI-matching baselines yet).
+    func requireSnapshotMode(
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws {
+        if !SnapshotMode.isActive {
+            throw XCTSkip(
+                "SNAPSHOT_MODE unset — snapshot tests run only in the "
+                + "ios-snapshot-record job (record) or once baselines are "
+                + "committed (SNAPSHOT_MODE=verify)."
+            )
+        }
+    }
+}

--- a/FitTrackerTests/SnapshotTests/V2ComponentSnapshotTests.swift
+++ b/FitTrackerTests/SnapshotTests/V2ComponentSnapshotTests.swift
@@ -1,0 +1,86 @@
+// FitTrackerTests/SnapshotTests/V2ComponentSnapshotTests.swift
+//
+// FIT-152 (T4) — snapshot-testing foundation.
+//
+// Baselines the shared design-system components that the v2 screens are built
+// from — the highest-leverage, lowest-flake starting point (self-contained,
+// no injected environment/state). Fixed-size layout + perceptual precision keep
+// the images deterministic across simulators. The 6 v2 screens + 4 auth views
+// (which require mock view-model / store injection) are the documented
+// follow-up, added once the CI-recorded baseline flow is proven (see
+// docs/process/snapshot-testing.md).
+//
+// Runs only when SNAPSHOT_MODE is set (see SnapshotTestSupport) — the default
+// `Build and Test` run skips these so it never reddens without baselines.
+
+import XCTest
+import SwiftUI
+import SnapshotTesting
+@testable import FitTracker
+
+final class V2ComponentSnapshotTests: XCTestCase {
+
+    /// Assert a fixed-size light-mode image snapshot with tolerance for
+    /// cross-OS anti-aliasing differences. Records when SNAPSHOT_MODE=record.
+    private func assertComponent<V: View>(
+        _ view: V,
+        width: CGFloat,
+        height: CGFloat,
+        named name: String = #function,
+        file: StaticString = #filePath,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        let hosted = view
+            .frame(width: width, height: height)
+            .background(Color.white)
+        assertSnapshot(
+            of: hosted,
+            as: .image(
+                precision: 0.98,
+                perceptualPrecision: 0.98,
+                layout: .fixed(width: width, height: height),
+                traits: .init(userInterfaceStyle: .light)
+            ),
+            record: SnapshotMode.isRecording,
+            file: file,
+            testName: testName,
+            line: line
+        )
+    }
+
+    func testAppProgressRing() throws {
+        try requireSnapshotMode()
+        assertComponent(
+            AppProgressRing(value: 0.6, color: AppColor.Status.warning, label: "60%"),
+            width: 80, height: 80
+        )
+    }
+
+    func testAppPickerChipSelected() throws {
+        try requireSnapshotMode()
+        assertComponent(
+            AppPickerChip(label: "Selected", isSelected: true) {},
+            width: 140, height: 56
+        )
+    }
+
+    func testAppSegmentedControl() throws {
+        try requireSnapshotMode()
+        assertComponent(
+            AppSegmentedControl(options: ["Day", "Week", "Month"], selection: .constant("Week")),
+            width: 320, height: 56
+        )
+    }
+
+    func testAppMetricColumn() throws {
+        try requireSnapshotMode()
+        assertComponent(
+            AppMetricColumn(
+                icon: "scalemass.fill", title: "WEIGHT", value: "82.5",
+                unit: "kg", target: "Goal 80 kg", tintColor: .blue
+            ),
+            width: 160, height: 140
+        )
+    }
+}


### PR DESCRIPTION
## What

Foundation slice of **FIT-152 (T4)** — test-coverage-master-plan §4. Stands up the iOS snapshot-testing harness so the v2-view drift gate can be built incrementally. **Baselines + screen coverage are explicit follow-up tasks** (feature stays at `current_phase=implement`).

## Why a foundation (not the full 10 screens)

Image snapshot baselines are **simulator-specific and local≠CI**: local is Xcode 26 / iPhone 17 Pro / iOS 26; CI dynamically picks iPhone 15/16 / iOS ~18. A baseline recorded locally would fail in CI. So this PR ships the **record-in-CI** mechanism and defers baseline capture to a CI run (per the agreed approach).

## Deliverables

- **SPM dep** `pointfreeco/swift-snapshot-testing` (1.17.x) wired into `FitTrackerTests` (`project.pbxproj` + `Package.resolved`).
- **`SnapshotTestSupport.swift`** — `SNAPSHOT_MODE` gate. Snapshot tests **SKIP by default**, so the required Build+Test job never reddens before baselines exist. `record` / `verify` activate them.
- **`V2ComponentSnapshotTests.swift`** — starter design-system-component snapshots (fixed-layout + perceptual precision for cross-OS tolerance).
- **`.github/workflows/ios-snapshot-record.yml`** — operator-triggered (`workflow_dispatch`) recorder: runs `SNAPSHOT_MODE=record` on the CI simulator + uploads `__Snapshots__` as an artifact. Never runs on PRs → can't block.

## Follow-up (tracked in state.json tasks)

- **T2**: run the record job → download artifact → commit CI baselines → flip harness into the required test job (`SNAPSHOT_MODE=verify`).
- **T3**: expand to the 6 v2 screens + 4 auth views (mock view-model/store injection).

## Verification

Locally: **TEST BUILD SUCCEEDED** — SnapshotTesting package resolves + the test target compiles against the API. In this PR's CI, the snapshot tests skip (no `SNAPSHOT_MODE`) so Build+Test stays green.

Tracks [FIT-152](https://linear.app/fitme-project/issue/FIT-152).

🤖 Generated with [Claude Code](https://claude.com/claude-code)