### PR TITLE
feat(FIT-183): FT2 daily-checkpoint probe for cross-repo state-sync health (R17)

### DIFF
--- a/.claude/features/r17-state-sync-health-endpoint/state.json
+++ b/.claude/features/r17-state-sync-health-endpoint/state.json
@@ -1,0 +1,75 @@
+{
+  "feature": "r17-state-sync-health-endpoint",
+  "linear_id": "FIT-183",
+  "thematic_code": "DE-R17",
+  "created_at": "2026-07-04T05:00:00Z",
+  "updated": "2026-07-04T05:30:00Z",
+  "branch": "chore/fit183-state-sync-probe",
+  "current_phase": "complete",
+  "work_type": "chore",
+  "work_subtype": "framework_feature",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Cross-repo dev-env observability infra (DE-R17, parent FIT-166 Tier 3): fitme-story health endpoint + FT2 daily-checkpoint probe. No product surface; PR bodies + this state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "platforms_tested": {
+    "ios": false,
+    "web": false,
+    "backend": false,
+    "ai": false
+  },
+  "platforms_tested_provenance": "exempt:framework_meta",
+  "summary": "R17 (dev-env plan / FIT-166 Tier 3) — cross-repo state-sync read-only health endpoint. fitme-story GET /api/control-room/state-sync-health reports FT2-mirror freshness ({last_sync_ts, ft2_state_count, gate_coverage_lines, age_minutes, healthy, reason}; 200 fresh / 503 stale; public, not proxy-gated). FT2 daily-integrity-checkpoint.py gains an N4 best-effort probe that alerts on stale (>6h) and no-ops gracefully on unreachable/not-deployed. fitme-story: pure computeSyncHealth + 7 tests. FT2: probe + 4 tests.",
+  "cross_repo_code_pr": "fitme-story#258",
+  "pr_citation_exempt": [
+    { "pr_number": 258, "reason": "Endpoint code lives in fitme-story (cross-repo); this FT2 PR ships the daily-checkpoint probe + tracking." }
+  ],
+  "phases": {
+    "research": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "prd": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "tasks": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "ux_or_integration": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "implementation": { "status": "complete", "commits": [] },
+    "testing": { "status": "complete" },
+    "review": { "status": "complete" },
+    "merge": { "status": "complete", "pr_number": null },
+    "documentation": { "status": "complete" }
+  },
+  "timing": {
+    "phases": {
+      "implement": { "started_at": "2026-07-04T05:00:00Z", "ended_at": "2026-07-04T05:28:00Z" },
+      "complete": { "started_at": "2026-07-04T05:30:00Z", "ended_at": "2026-07-04T05:30:00Z" }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "fitme-story GET /api/control-room/state-sync-health + pure computeSyncHealth + 7 tests (PR #258)",
+      "type": "infra",
+      "skill": "dev",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.3,
+      "depends_on": [],
+      "completed_at": "2026-07-04T05:20:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "FT2 daily-integrity-checkpoint.py N4 best-effort probe (alert on stale >6h) + 4 tests",
+      "type": "infra",
+      "skill": "dev",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.2,
+      "depends_on": ["T1"],
+      "completed_at": "2026-07-04T05:28:00Z"
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": { "ux": null, "design": null }
+}

--- a/.claude/logs/r17-state-sync-health-endpoint.log.json
+++ b/.claude/logs/r17-state-sync-health-endpoint.log.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "feature": "r17-state-sync-health-endpoint",
+  "title": "r17 state sync health endpoint",
+  "work_type": "chore",
+  "current_phase": "complete",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-04T05:08:09Z",
+  "updated_at": "2026-07-04T05:08:09Z",
+  "events": [
+    {
+      "timestamp": "2026-07-04T05:08:09Z",
+      "event_type": "tier_closure",
+      "phase": "complete",
+      "summary": "FIT-183 (R17) \u2014 cross-repo state-sync health endpoint (fitme-story #258) + FT2 daily-checkpoint N4 probe. 7 web tests + 4 python tests. FT2 probe verified: graceful 404/unreachable handling (endpoint pre-deploy).",
+      "artifacts": [
+        "fitme-story#258"
+      ],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "success",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/scripts/daily-integrity-checkpoint.py
+++ b/scripts/daily-integrity-checkpoint.py
@@ -606,6 +606,41 @@ def pr_babysit(repos: tuple[str, ...] = ("Regevba/FitTracker2", "Regevba/fitme-s
     return result
 
 
+STATE_SYNC_HEALTH_URL = os.environ.get(
+    "FT2_STATE_SYNC_HEALTH_URL",
+    "https://fitme-story.vercel.app/api/control-room/state-sync-health",
+)
+
+
+def state_sync_health_probe(url: str = STATE_SYNC_HEALTH_URL, timeout: int = 8) -> dict:
+    """N4 (FIT-183 / R17) — probe the fitme-story cross-repo state-sync health
+    endpoint. Returns a dict describing the outcome; NEVER raises.
+
+    The endpoint returns 200 + healthy=true when the FT2→fitme-story mirror is
+    fresh (<6h), or 503 + a reason (`stale` / `empty_mirror` / …) when not. A
+    network error / 404 (endpoint not yet deployed) is reported as
+    reachable=False — best-effort, so a transient outage never fails the daily
+    checkpoint.
+    """
+    import urllib.error
+    import urllib.request
+
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed https URL
+            body = json.loads(resp.read().decode("utf-8"))
+            return {"reachable": True, "http_status": resp.status, **body}
+    except urllib.error.HTTPError as e:
+        # 503 (stale/broken) still carries a JSON body with the reason.
+        try:
+            body = json.loads(e.read().decode("utf-8"))
+        except Exception:  # noqa: BLE001
+            body = {}
+        return {"reachable": True, "http_status": e.code, **body}
+    except Exception as e:  # noqa: BLE001 — best-effort; any failure = unreachable
+        return {"reachable": False, "error": f"{type(e).__name__}: {e}"}
+
+
 def upcoming_followups(today: dt.date, lookahead_days: int = FOLLOWUP_LOOKAHEAD_DAYS) -> list[dict]:
     """Parse must-have-cadence-followups.md and return rows whose date is within lookahead_days.
 
@@ -1001,6 +1036,26 @@ def _run_pipeline(today: str, local_dir: Path, ssd_dir: Path, args, log) -> None
                     log(f"    #{p['number']} ({p['updated_hours_ago']}h idle): {p['title']}")
                 if len(prs) > 3:
                     log(f"    ... +{len(prs) - 3} more")
+
+    # N4 (FIT-183 / R17) — cross-repo state-sync freshness probe
+    sync = state_sync_health_probe()
+    if not sync.get("reachable"):
+        log(f"\n🔗 State-sync health: endpoint unreachable ({sync.get('error', 'unknown')}) "
+            "— best-effort, ignoring (transient network).")
+    elif "healthy" not in sync:
+        # Reachable but no valid health body (e.g. 404 before the route
+        # deploys, or an unexpected response) — best-effort, not an alert.
+        log(f"\n🔗 State-sync health: endpoint returned http {sync.get('http_status')} "
+            "without a health body — best-effort, ignoring (route not deployed yet?).")
+    elif sync.get("healthy"):
+        age = sync.get("age_minutes")
+        log(f"\n🔗 State-sync health: OK (mirror {age}m old, "
+            f"{sync.get('ft2_state_count')} states, {sync.get('gate_coverage_lines')} gate-cov lines).")
+    else:
+        age = sync.get("age_minutes")
+        log(f"\n⚠ STATE-SYNC STALE: reason={sync.get('reason')} age={age}m "
+            f"(threshold 360m) — the fitme-story FT2 mirror has gone stale. "
+            f"Check scripts/sync-from-fittracker2.ts / the pre-build sync.")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_state_sync_health_probe.py
+++ b/scripts/tests/test_state_sync_health_probe.py
@@ -1,0 +1,81 @@
+"""FIT-183 (R17) — tests for daily-integrity-checkpoint.py::state_sync_health_probe.
+
+The probe is best-effort I/O — it must NEVER raise, and it must correctly
+classify 200/503/404/network-error responses. urllib is mocked; no network.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "daily_checkpoint", SCRIPTS_DIR / "daily-integrity-checkpoint.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_healthy_200():
+    body = json.dumps({"healthy": True, "reason": "ok", "age_minutes": 30,
+                       "ft2_state_count": 113, "gate_coverage_lines": 4024}).encode()
+    with patch("urllib.request.urlopen", return_value=_FakeResp(body, 200)):
+        r = mod.state_sync_health_probe(url="https://example.test/health")
+    assert r["reachable"] is True
+    assert r["http_status"] == 200
+    assert r["healthy"] is True
+    assert r["age_minutes"] == 30
+
+
+def test_stale_503_carries_reason_body():
+    body = json.dumps({"healthy": False, "reason": "stale", "age_minutes": 500}).encode()
+    err = urllib.error.HTTPError("u", 503, "Service Unavailable", {}, io.BytesIO(body))
+    with patch("urllib.request.urlopen", side_effect=err):
+        r = mod.state_sync_health_probe(url="https://example.test/health")
+    assert r["reachable"] is True
+    assert r["http_status"] == 503
+    assert r["healthy"] is False
+    assert r["reason"] == "stale"
+
+
+def test_404_not_deployed_has_no_health_key():
+    err = urllib.error.HTTPError("u", 404, "Not Found", {}, io.BytesIO(b"not json"))
+    with patch("urllib.request.urlopen", side_effect=err):
+        r = mod.state_sync_health_probe(url="https://example.test/health")
+    assert r["reachable"] is True
+    assert r["http_status"] == 404
+    assert "healthy" not in r  # render treats this as best-effort, not an alert
+
+
+def test_network_error_is_unreachable_not_raised():
+    with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+        r = mod.state_sync_health_probe(url="https://example.test/health")
+    assert r["reachable"] is False
+    assert "error" in r
+    assert "OSError" in r["error"]


### PR DESCRIPTION
## What

Closes the **FT2 side of FIT-183 (R17)** — parent FIT-166 Tier 3. The health **endpoint** ships in **fitme-story PR #258**; this PR adds the daily-checkpoint **probe** that consumes it (the "probed by FT2 daily checkpoint + alert if age > 6h" half of the spec).

## Deliverables

- **`scripts/daily-integrity-checkpoint.py`** — N4 `state_sync_health_probe()`: GETs the fitme-story `/api/control-room/state-sync-health` endpoint (env-overridable `FT2_STATE_SYNC_HEALTH_URL`), **never raises**. Rendered in the daily checkpoint output alongside the N2/N3 babysit sections:
  - **OK** when the mirror is <6h old,
  - **⚠ STATE-SYNC STALE** alert on a 503 + reason (`stale` / `empty_mirror`),
  - **best-effort no-op** on unreachable (network) or a 404 (route not deployed yet) — so a transient outage or pre-deploy state never fires a false alarm or fails the checkpoint.
- **`scripts/tests/test_state_sync_health_probe.py`** — 4 tests (200-healthy / 503-stale-with-body / 404-no-health-key / network-error), urllib mocked, no network.

## Verification

Probed the live (pre-deploy) endpoint → `{reachable: true, http_status: 404}` → correctly rendered as best-effort (not a false STALE alarm). 4/4 unit tests pass. Staged `check-state-schema.py` passes.

Cross-repo: `pr_citation_exempt` for fitme-story #258. Tracks [FIT-183](https://linear.app/fitme-project/issue/FIT-183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)