### PR TITLE
test(FIT-157): EncryptionService concurrency + payload chaos tests (T9 foundation)

### DIFF
--- a/.claude/features/t9-backend-chaos-tests/state.json
+++ b/.claude/features/t9-backend-chaos-tests/state.json
@@ -1,0 +1,80 @@
+{
+  "feature": "t9-backend-chaos-tests",
+  "linear_id": "FIT-157",
+  "thematic_code": "TC-T9",
+  "created_at": "2026-07-04T05:45:00Z",
+  "updated": "2026-07-04T06:05:00Z",
+  "branch": "chore/fit157-encryption-rotation-tests",
+  "current_phase": "implement",
+  "work_type": "chore",
+  "schema_version": 1,
+  "state_owner": "ft2",
+  "framework_version": "v7.10",
+  "has_ui": false,
+  "requires_analytics": false,
+  "case_study_type": "no_case_study_required",
+  "case_study_exempt_reason": "Adversarial backend test-coverage (TC-T9): adds chaos/edge tests to existing test files. No product surface; PR body + this state.json are the provenance record.",
+  "isolation_opt_out": false,
+  "platforms_tested": {
+    "ios": true,
+    "web": false,
+    "backend": false,
+    "ai": false
+  },
+  "platforms_tested_provenance": "authored",
+  "summary": "T9 (test-coverage plan §4) FOUNDATION — adversarial backend chaos/edge tests. First slice: 3 EncryptionService chaos tests on the session-context path (concurrent round-trips / actor serialization, ~2MB large-payload round-trip, 50-payload no-cross-contamination). NOTE: the biometric-gated rotateKeys path is untestable on the CI simulator (LAError -7 no enrolled authenticator) — deferred to T2 pending biometry-enrolled CI or a prod test seam. Remaining bullet areas (sync reconciliation, GDPR cascade, network-churn auth) are T3 follow-ups. Test-only, no prod change.",
+  "phases": {
+    "research": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "prd": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "tasks": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "ux_or_integration": { "status": "skipped", "skip_reason": "work_type:chore" },
+    "implementation": { "status": "in_progress", "commits": [] },
+    "testing": { "status": "pending" },
+    "review": { "status": "pending" },
+    "merge": { "status": "pending", "pr_number": null },
+    "documentation": { "status": "pending" }
+  },
+  "timing": {
+    "phases": {
+      "implement": { "started_at": "2026-07-04T05:45:00Z" }
+    }
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "EncryptionService session-context chaos tests (3): concurrency, large-payload, no-cross-contamination",
+      "type": "test",
+      "skill": "qa",
+      "status": "complete",
+      "priority": "high",
+      "effort_days": 0.3,
+      "depends_on": [],
+      "completed_at": "2026-07-04T06:00:00Z"
+    },
+    {
+      "id": "T2",
+      "title": "Key-rotation chaos tests (rotateKeys) — needs biometry-enrolled CI simulator or a prod test seam for authenticatedContext()",
+      "type": "test",
+      "skill": "qa",
+      "status": "pending",
+      "priority": "medium",
+      "effort_days": 0.5,
+      "depends_on": [],
+      "completed_at": null
+    },
+    {
+      "id": "T3",
+      "title": "GDPR cascade (CloudKit+Supabase) + network-churn auth recovery chaos tests",
+      "type": "test",
+      "skill": "qa",
+      "status": "pending",
+      "priority": "medium",
+      "effort_days": 0.7,
+      "depends_on": [],
+      "completed_at": null
+    }
+  ],
+  "transitions": [],
+  "figma_node_ids": {},
+  "pre_merge_review": { "ux": null, "design": null }
+}

--- a/.claude/logs/t9-backend-chaos-tests.log.json
+++ b/.claude/logs/t9-backend-chaos-tests.log.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "feature": "t9-backend-chaos-tests",
+  "title": "t9 backend chaos tests",
+  "work_type": "chore",
+  "current_phase": "implement",
+  "framework_version": "v7.10",
+  "started_at": "2026-07-04T05:47:33Z",
+  "updated_at": "2026-07-04T05:47:33Z",
+  "events": [
+    {
+      "timestamp": "2026-07-04T05:47:33Z",
+      "event_type": "phase_started",
+      "phase": "implement",
+      "summary": "FIT-157 (T9) foundation \u2014 3 EncryptionService session-context chaos tests (concurrency/large-payload/no-cross-contamination). Verified TEST SUCCEEDED on simulator. Discovered rotateKeys is biometry-gated (untestable on CI sim) \u2192 deferred to T2.",
+      "artifacts": [],
+      "metrics": {},
+      "actor": "human_or_agent",
+      "status": "success",
+      "recording_mode": "contemporaneous"
+    }
+  ]
+}

--- a/FitTrackerTests/EncryptionServiceTests.swift
+++ b/FitTrackerTests/EncryptionServiceTests.swift
@@ -136,4 +136,67 @@ final class EncryptionServiceTests: XCTestCase {
         let decrypted = try await EncryptionService.shared.decryptRaw(blob)
         XCTAssertEqual(decrypted, plaintext)
     }
+
+    // MARK: - Concurrency + payload chaos (FIT-157 / T9 — adversarial edge cases)
+    //
+    // These exercise the session-context encrypt/decrypt path (the path the app
+    // uses at runtime) under load / large data / high cardinality. The
+    // biometric-gated `rotateKeys` path is NOT covered here: it calls
+    // `authenticatedContext()`, which requires an enrolled authenticator the CI
+    // simulator does not have (LAError -7 "No identities are enrolled"). Testing
+    // rotation needs either a biometry-enrolled CI simulator or a prod-code test
+    // seam — tracked as a follow-up (state.json task T2/T3), not attempted here.
+
+    func testEncrypt_concurrentRoundTrips_allSucceed() async throws {
+        // The EncryptionService actor must serialize concurrent crypto ops
+        // without data races or cross-talk. Fire many parallel encrypt→decrypt
+        // round-trips and assert every one preserves its own bytes.
+        let enc = EncryptionService.shared
+        let count = 32
+
+        try await withThrowingTaskGroup(of: Bool.self) { group in
+            for i in 0..<count {
+                group.addTask {
+                    let payload = "concurrent-\(i)-\(String(repeating: "x", count: i))".data(using: .utf8)!
+                    let blob = try await enc.encryptRaw(payload)
+                    let back = try await enc.decryptRaw(blob)
+                    return back == payload
+                }
+            }
+            var ok = 0
+            for try await result in group where result { ok += 1 }
+            XCTAssertEqual(ok, count, "Every concurrent round-trip must preserve its own bytes")
+        }
+    }
+
+    func testEncrypt_largePayload_roundTripsLosslessly() async throws {
+        // ~2 MB of random bytes must survive the double-seal (AES-GCM → ChaCha20)
+        // container round-trip exactly — guards against buffer/length bugs on the
+        // large end (a full day of health data is far smaller, but the ceiling
+        // must hold).
+        let enc = EncryptionService.shared
+        var big = Data(count: 2 * 1024 * 1024)
+        big.withUnsafeMutableBytes { _ = SecRandomCopyBytes(kSecRandomDefault, $0.count, $0.baseAddress!) }
+
+        let blob = try await enc.encryptRaw(big)
+        let back = try await enc.decryptRaw(blob)
+        XCTAssertEqual(back, big, "Large payload must round-trip byte-for-byte")
+        XCTAssertGreaterThan(blob.count, big.count, "Container must add header + auth overhead")
+    }
+
+    func testEncrypt_manyDistinctPayloads_noCrossContamination() async throws {
+        // Encrypt many distinct plaintexts, then decrypt each blob and assert it
+        // maps back to its OWN plaintext — a blob must never decrypt to another
+        // record's data (IV/key reuse or container-mixup regression guard).
+        let enc = EncryptionService.shared
+        let payloads = (0..<50).map { "record-\($0)-value-\($0 * 7)".data(using: .utf8)! }
+
+        var blobs: [Data] = []
+        for p in payloads { blobs.append(try await enc.encryptRaw(p)) }
+
+        for (idx, blob) in blobs.enumerated() {
+            let back = try await enc.decryptRaw(blob)
+            XCTAssertEqual(back, payloads[idx], "Blob \(idx) must decrypt to its own plaintext")
+        }
+    }
 }


### PR DESCRIPTION
## What

First slice of **FIT-157 (T9)** — test-coverage-master-plan §4 (backend chaos/edge). Adds 3 adversarial tests to the existing `EncryptionServiceTests` (test-only, no production change).

| Test | Guards |
|---|---|
| `concurrentRoundTrips_allSucceed` | 32 parallel encrypt→decrypt via `TaskGroup` — the actor serializes crypto ops with no data race / cross-talk |
| `largePayload_roundTripsLosslessly` | ~2 MB random data survives the double-seal (AES-GCM → ChaCha20) container byte-for-byte |
| `manyDistinctPayloads_noCrossContamination` | 50 distinct payloads each decrypt to their **own** plaintext — IV/key-reuse + container-mixup regression guard |

## Verification

**TEST SUCCEEDED** on iPhone 17 Pro simulator — **3/3 pass** (verified locally via `xcodebuild test -only-testing`).

## Scoping note (honest boundary)

I initially targeted the **key-rotation** chaos tests, but `rotateKeys` calls `authenticatedContext()` which requires an enrolled authenticator the CI simulator doesn't have (`LAError -7 "No identities are enrolled"`) — the existing suite passes only because it uses the session-context path. Rotation is untestable on the CI simulator without a biometry-enrolled runner or a prod-code test seam (high-risk, out of scope). So I pivoted to the session-context chaos surface that actually runs green.

**Follow-ups (state.json T2/T3):** key-rotation (needs biometry-enrolled CI), multi-device sync reconciliation, GDPR cascade, network-churn auth. Feature stays at `current_phase=implement`.

Tracks [FIT-157](https://linear.app/fitme-project/issue/FIT-157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)