### PR TITLE
chore(digest): append 2026-07-04 cycle snapshots from daily digest run

### DIFF
--- a/.claude/shared/measurement-adoption-history.json
+++ b/.claude/shared/measurement-adoption-history.json
@@ -2412,6 +2412,63 @@
           "post_v6_derived": 0
         }
       }
+    },
+    {
+      "date": "2026-07-04",
+      "generated_at": "2026-07-04T06:05:03Z",
+      "trigger": "manual",
+      "summary": {
+        "features_total": 130,
+        "features_post_v6": 96,
+        "features_pre_v6": 34,
+        "fully_adopted": 9,
+        "partial_adopted": 83,
+        "zero_adopted": 38,
+        "fully_adopted_post_v6": 9,
+        "tier_1_1_status": "partial"
+      },
+      "dimension_coverage": {
+        "timing_wall_time": {
+          "overall_present": 37,
+          "overall_percent": 28.5,
+          "post_v6_present": 37,
+          "post_v6_percent": 38.5,
+          "overall_instrumented": 18,
+          "overall_derived": 19,
+          "post_v6_instrumented": 18,
+          "post_v6_derived": 19
+        },
+        "per_phase_timing": {
+          "overall_present": 92,
+          "overall_percent": 70.8,
+          "post_v6_present": 89,
+          "post_v6_percent": 92.7,
+          "overall_instrumented": 92,
+          "overall_derived": 0,
+          "post_v6_instrumented": 89,
+          "post_v6_derived": 0
+        },
+        "cache_hits": {
+          "overall_present": 34,
+          "overall_percent": 26.2,
+          "post_v6_present": 33,
+          "post_v6_percent": 34.4,
+          "overall_instrumented": 34,
+          "overall_derived": 0,
+          "post_v6_instrumented": 33,
+          "post_v6_derived": 0
+        },
+        "cu_v2": {
+          "overall_present": 27,
+          "overall_percent": 20.8,
+          "post_v6_present": 27,
+          "post_v6_percent": 28.1,
+          "overall_instrumented": 27,
+          "overall_derived": 0,
+          "post_v6_instrumented": 27,
+          "post_v6_derived": 0
+        }
+      }
     }
   ],
   "updated": "2026-07-03T06:05:17Z"

--- a/.claude/shared/measurement-adoption.json
+++ b/.claude/shared/measurement-adoption.json
@@ -1,44 +1,44 @@
 {
   "version": "1.0",
-  "updated": "2026-07-03T06:05:17Z",
+  "updated": "2026-07-04T06:05:03Z",
   "v6_ship_date": "2026-04-16",
   "description": "Gemini audit Tier 1.1 adoption inventory. Counts which features have v6.0 measurement fields (timing.total_wall_time_minutes, per-phase timing, cache_hits, CU v2) in their state.json.",
   "summary": {
-    "features_total": 125,
-    "features_post_v6": 91,
+    "features_total": 130,
+    "features_post_v6": 96,
     "features_pre_v6": 34,
     "fully_adopted": 9,
-    "partial_adopted": 80,
-    "zero_adopted": 36,
+    "partial_adopted": 83,
+    "zero_adopted": 38,
     "fully_adopted_post_v6": 9,
     "tier_1_1_status": "partial"
   },
   "dimension_coverage": {
     "timing_wall_time": {
       "overall_present": 37,
-      "overall_percent": 29.6,
+      "overall_percent": 28.5,
       "post_v6_present": 37,
-      "post_v6_percent": 40.7,
+      "post_v6_percent": 38.5,
       "overall_instrumented": 18,
       "overall_derived": 19,
       "post_v6_instrumented": 18,
       "post_v6_derived": 19
     },
     "per_phase_timing": {
-      "overall_present": 89,
-      "overall_percent": 71.2,
-      "post_v6_present": 86,
-      "post_v6_percent": 94.5,
-      "overall_instrumented": 89,
+      "overall_present": 92,
+      "overall_percent": 70.8,
+      "post_v6_present": 89,
+      "post_v6_percent": 92.7,
+      "overall_instrumented": 92,
       "overall_derived": 0,
-      "post_v6_instrumented": 86,
+      "post_v6_instrumented": 89,
       "post_v6_derived": 0
     },
     "cache_hits": {
       "overall_present": 34,
-      "overall_percent": 27.2,
+      "overall_percent": 26.2,
       "post_v6_present": 33,
-      "post_v6_percent": 36.3,
+      "post_v6_percent": 34.4,
       "overall_instrumented": 34,
       "overall_derived": 0,
       "post_v6_instrumented": 33,
@@ -46,9 +46,9 @@
     },
     "cu_v2": {
       "overall_present": 27,
-      "overall_percent": 21.6,
+      "overall_percent": 20.8,
       "post_v6_present": 27,
-      "post_v6_percent": 29.7,
+      "post_v6_percent": 28.1,
       "overall_instrumented": 27,
       "overall_derived": 0,
       "post_v6_instrumented": 27,
@@ -590,6 +590,15 @@
       }
     },
     {
+      "feature": "r17-state-sync-health-endpoint",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      }
+    },
+    {
       "feature": "r9-track-b-coverage-aggregator",
       "adoption": {
         "timing_wall_time": true,
@@ -644,6 +653,15 @@
       }
     },
     {
+      "feature": "t15-orphan-test-weekly-cron",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      }
+    },
+    {
       "feature": "t16-gate-test-tier-annotation",
       "adoption": {
         "timing_wall_time": false,
@@ -663,6 +681,15 @@
     },
     {
       "feature": "t5-mock-protocol-drift",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      }
+    },
+    {
+      "feature": "t7-web-critical-route-smoke-tests",
       "adoption": {
         "timing_wall_time": false,
         "per_phase_timing": true,
@@ -953,6 +980,16 @@
       "feature": "stats-progress-hub",
       "created": "2026-04-06",
       "post_v6": false
+    },
+    {
+      "feature": "t4-ios-snapshot-testing",
+      "created": "2026-07-03",
+      "post_v6": true
+    },
+    {
+      "feature": "t9-backend-chaos-tests",
+      "created": "2026-07-04",
+      "post_v6": true
     },
     {
       "feature": "training-plan-v2",
@@ -2832,6 +2869,26 @@
       "any_adopted": true
     },
     {
+      "feature": "r17-state-sync-health-endpoint",
+      "created": "2026-07-04",
+      "post_v6": true,
+      "current_phase": "complete",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      },
+      "provenance": {
+        "timing_wall_time": null,
+        "per_phase_timing": "instrumented",
+        "cache_hits": null,
+        "cu_v2": null
+      },
+      "fully_adopted": false,
+      "any_adopted": true
+    },
+    {
       "feature": "r9-track-b-coverage-aggregator",
       "created": "2026-06-04",
       "post_v6": true,
@@ -3092,6 +3149,26 @@
       "any_adopted": true
     },
     {
+      "feature": "t15-orphan-test-weekly-cron",
+      "created": "2026-07-03",
+      "post_v6": true,
+      "current_phase": "complete",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      },
+      "provenance": {
+        "timing_wall_time": null,
+        "per_phase_timing": "instrumented",
+        "cache_hits": null,
+        "cu_v2": null
+      },
+      "fully_adopted": false,
+      "any_adopted": true
+    },
+    {
       "feature": "t16-gate-test-tier-annotation",
       "created": "2026-07-02",
       "post_v6": true,
@@ -3132,8 +3209,48 @@
       "any_adopted": true
     },
     {
+      "feature": "t4-ios-snapshot-testing",
+      "created": "2026-07-03",
+      "post_v6": true,
+      "current_phase": "implement",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": false,
+        "cache_hits": false,
+        "cu_v2": false
+      },
+      "provenance": {
+        "timing_wall_time": null,
+        "per_phase_timing": null,
+        "cache_hits": null,
+        "cu_v2": null
+      },
+      "fully_adopted": false,
+      "any_adopted": false
+    },
+    {
       "feature": "t5-mock-protocol-drift",
       "created": "2026-06-10",
+      "post_v6": true,
+      "current_phase": "complete",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": true,
+        "cache_hits": false,
+        "cu_v2": false
+      },
+      "provenance": {
+        "timing_wall_time": null,
+        "per_phase_timing": "instrumented",
+        "cache_hits": null,
+        "cu_v2": null
+      },
+      "fully_adopted": false,
+      "any_adopted": true
+    },
+    {
+      "feature": "t7-web-critical-route-smoke-tests",
+      "created": "2026-07-03",
       "post_v6": true,
       "current_phase": "complete",
       "adoption": {
@@ -3170,6 +3287,26 @@
       },
       "fully_adopted": false,
       "any_adopted": true
+    },
+    {
+      "feature": "t9-backend-chaos-tests",
+      "created": "2026-07-04",
+      "post_v6": true,
+      "current_phase": "implement",
+      "adoption": {
+        "timing_wall_time": false,
+        "per_phase_timing": false,
+        "cache_hits": false,
+        "cu_v2": false
+      },
+      "provenance": {
+        "timing_wall_time": null,
+        "per_phase_timing": null,
+        "cache_hits": null,
+        "cu_v2": null
+      },
+      "fully_adopted": false,
+      "any_adopted": false
     },
     {
       "feature": "training-plan-v2",


### PR DESCRIPTION
## Summary

- `make measurement-adoption` → appended 2026-07-04 snapshot to `measurement-adoption-history.json`; refreshed `measurement-adoption.json` (130 features, 9/96 fully adopted post-v6)
- `make documentation-debt` → refreshed `documentation-debt.json` (1 open advisory item — 54 pre-v7.9 case studies missing `kill_criteria_resolution`)
- `make integrity-check` → 0 findings + 8 BRANCH_ISOLATION_HISTORICAL advisories (all recurring/known)

These are the standard append-only telemetry ledgers updated by the daily scheduled digest run (09:00 IDT, 2026-07-04). No logic changes.

## What changed

| File | Change |
|---|---|
| `.claude/shared/measurement-adoption-history.json` | +1 daily snapshot (2026-07-04, manual trigger) |
| `.claude/shared/measurement-adoption.json` | Refreshed full report (130 features, 96 post-v6) |
| `.claude/shared/documentation-debt.json` | Refreshed debt ledger |

## Digest highlights

- **10 commits to main** across both repos in last 24h (T4 snapshots, T9 chaos tests, T15 orphan scanner, R17 state-sync health probe)
- **Adoption metric dilution detected**: 9 new post-v6 features entered denominator July 1–4 with no backfill — `cache_hits` 39.3%→34.4%, `cu_v2` 32.1%→28.1%. Soak-window discipline applies.
- **PR #845** (integrity snapshot W37 fallback) needs merge to close the 72.5h overdue gap.
- `orchid-v1-5` has no `linear_id` — assign FIT-NNN before next phase advance.

_Generated by the FitMe daily scheduled digest (09:00 IDT)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9vtGBPdUHJC8bkwWc3LWq)_