### PR TITLE
chore(F4): promote FRAMEWORK_VERSION_STALE advisory→enforced (Phase D)

### DIFF
--- a/scripts/check-state-schema.py
+++ b/scripts/check-state-schema.py
@@ -178,7 +178,13 @@ _FRAMEWORK_VERSION_RE = re.compile(r"^(pre-)?v\d+\.\d+(\.\d+)?$")
 # advisory→enforced flip independent of any sibling gate (mirrors
 # PLATFORMS_TESTED_ADVISORY_MODE). Phase A artifacts:
 # .claude/features/f4-framework-version-stale/calibration-artifacts.md
-FRAMEWORK_VERSION_STALE_ADVISORY_MODE = True
+# PROMOTED advisory->enforced 2026-07-05 (Phase D): 18-day window (2026-06-17
+# first_seen -> 07-05); 382 candidates / 35 checked (not mis-wired); canonical
+# v7.10 resolves cleanly from FRAMEWORK-FACTS.md; 0 false positives (gate fires
+# only on phase transitions, so the 95 sub-v7.10 complete/frozen features are
+# stale-by-design and never trip it). Reversible: flip back to True on
+# chore/f4-rollback. Phase E validate 7d -> ~2026-07-12.
+FRAMEWORK_VERSION_STALE_ADVISORY_MODE = False
 
 # AN-1B.1 (analytics-master-plan §8.2, Theme C / F19): CSV_TAXONOMY_DRIFT.
 # Commit-level gate — fires when AnalyticsProvider.swift is staged and an

--- a/scripts/tests/test_framework_version_stale.py
+++ b/scripts/tests/test_framework_version_stale.py
@@ -107,12 +107,16 @@ def _run(state, monkeypatch, *, committed=None, canonical="v7.10",
 
 
 def test_fires_on_stale_with_transition(monkeypatch):
+    # Enforced since the 2026-07-05 Phase D promotion: a stale version + phase
+    # transition now yields a blocking (advisory=False) finding by default.
+    # The advisory-mode path is covered by test_advisory_finding_is_not_an_error.
+    monkeypatch.setattr(_mod, "FRAMEWORK_VERSION_STALE_ADVISORY_MODE", False)
     findings, stats = _run(_base_state(framework_version="v7.5"), monkeypatch,
                            committed=None)  # None HEAD => transition
     assert len(findings) == 1
     f = findings[0]
     assert f["code"] == GATE
-    assert f["advisory"] is True
+    assert f["advisory"] is False
     assert f["recorded"] == "v7.5"
     assert f["canonical"] == "v7.10"
     assert stats["checked"] == 1


### PR DESCRIPTION
Flips `FRAMEWORK_VERSION_STALE_ADVISORY_MODE` True→False after the 18-day calibration window (first_seen 2026-06-17 → 07-05).

## Kill criteria — all clear (per `.claude/features/f4-framework-version-stale/calibration-artifacts.md`)
| Criterion | Result |
|---|---|
| ≥14d advisory coverage | ✅ 18 days |
| Not mis-wired (candidates > 0) | ✅ 382 candidates / 35 checked |
| Canonical resolution reliable | ✅ v7.10 resolves from FRAMEWORK-FACTS.md |
| 0 false positives | ✅ gate fires only on phase transitions; the 95 sub-v7.10 complete/frozen features are stale-by-design and never trip it |
| Reversible | ✅ single-line flip on `chore/f4-rollback` |

## Consequence
Once enforced, the next phase-advance of `3d-interactive-framework-flow-diagram` (v7.9.1) or `app-store-assets` (v5.0) will be **blocked** until they bump `framework_version` to v7.10 or add `framework_version_stale_exempt` — correct behavior.

## Tests
`test_fires_on_stale_with_transition` updated to assert the now-default enforced (advisory=False) finding; advisory-mode path still covered by `test_advisory_finding_is_not_an_error`. **60/60** schema + try-repo tests pass; integrity-check green.

Phase E validate 7d → ~2026-07-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)