### PR TITLE
fix: FIT-210 scheduler wiring to v2 store + D-3 screen-view residuals

### DIFF
--- a/FitTracker/FitTrackerApp.swift
+++ b/FitTracker/FitTrackerApp.swift
@@ -153,6 +153,9 @@ struct FitTrackerApp: App {
                     // lifetime of the app.
                     reminderNotificationDelegate.setAnalytics(analytics)
                     ReminderScheduler.shared.analytics = analytics
+                    // FIT-210: let the live scheduler honor the v2 settings
+                    // screen's master/per-type toggles + configurable daily cap.
+                    ReminderScheduler.shared.reminderPreferences = reminderPreferences
 
                     // C1 first slice (L207): register smart-reminders as a
                     // consumer of the v2 notification platform. Idempotent.

--- a/FitTracker/Services/Analytics/AnalyticsScreenModifier.swift
+++ b/FitTracker/Services/Analytics/AnalyticsScreenModifier.swift
@@ -6,18 +6,22 @@ import SwiftUI
 
 struct AnalyticsScreenModifier: ViewModifier {
     let screenName: String
+    let screenClass: String?
     @EnvironmentObject private var analytics: AnalyticsService
 
     func body(content: Content) -> some View {
         content
             .onAppear {
-                analytics.logScreenView(screenName)
+                // D-3: pass a screen_class so GA4 stops reporting the generic
+                // "SwiftUIView" for every screen. Defaults to the screen name,
+                // which is a more useful class key for a SwiftUI app.
+                analytics.logScreenView(screenName, screenClass: screenClass ?? screenName)
             }
     }
 }
 
 extension View {
-    func analyticsScreen(_ name: String) -> some View {
-        modifier(AnalyticsScreenModifier(screenName: name))
+    func analyticsScreen(_ name: String, screenClass: String? = nil) -> some View {
+        modifier(AnalyticsScreenModifier(screenName: name, screenClass: screenClass))
     }
 }

--- a/FitTracker/Services/Reminders/ReminderScheduler.swift
+++ b/FitTracker/Services/Reminders/ReminderScheduler.swift
@@ -28,6 +28,13 @@ final class ReminderScheduler: ObservableObject {
     // analytics), instrumentation no-ops without affecting scheduling.
     weak var analytics: AnalyticsService?
 
+    // ── User preferences (v2) ────────────────────────────
+    // FIT-210: set by FitTrackerApp at launch to the app-level v2
+    // ReminderPreferencesStore. When nil (test harnesses without the store),
+    // user preferences don't gate — the per-type/lifetime caps + gateway still
+    // apply. Weak to avoid a retain cycle (the app owns the @StateObject).
+    weak var reminderPreferences: ReminderPreferencesStore?
+
     // ── Init ─────────────────────────────────────────────
 
     private init() {}
@@ -60,6 +67,21 @@ final class ReminderScheduler: ObservableObject {
         body: String,
         delayMinutes: Int = 0
     ) async {
+        // 0. User preferences (v2 settings screen — FIT-210): master switch +
+        //    per-type toggle + the user-configurable daily cap. `isEnabled(for:)`
+        //    maps 1:1 onto ReminderType (master AND per-type must be on).
+        //    Gates BEFORE the internal caps so a user opt-out short-circuits.
+        if let prefs = reminderPreferences {
+            guard prefs.isEnabled(for: type) else {
+                analytics?.logReminderSuppressed(type: type.rawValue, reason: "user_disabled")
+                return
+            }
+            guard todaySendCount() < prefs.dailyCap else {
+                analytics?.logReminderSuppressed(type: type.rawValue, reason: "user_daily_cap")
+                return
+            }
+        }
+
         // 1. Per-type daily cap (resets at midnight via key naming)
         guard !dailyCapReached(for: type) else {
             analytics?.logReminderSuppressed(type: type.rawValue, reason: "per_type_daily_cap")

--- a/FitTracker/Views/RootTabView.swift
+++ b/FitTracker/Views/RootTabView.swift
@@ -201,7 +201,7 @@ struct RootTabView: View {
     private func tabContent(_ tab: AppTab) -> some View {
         switch tab {
         case .main:      MainScreenView(selectedTab: $selectedTab, statsMetric: $pendingStatsMetric)
-        case .training:  TrainingPlanView().analyticsScreen(AnalyticsScreen.trainingPlan)
+        case .training:  TrainingPlanView()  // D-3: self-applies .analyticsScreen inside (was double-firing here)
         case .nutrition: NutritionView().analyticsScreen(AnalyticsScreen.nutrition)
         case .stats:     StatsView(initialMetric: pendingStatsMetric)
                             .analyticsScreen(AnalyticsScreen.stats)

--- a/FitTrackerTests/AnalyticsTests.swift
+++ b/FitTrackerTests/AnalyticsTests.swift
@@ -142,14 +142,20 @@ final class AnalyticsTests: XCTestCase {
 
     @MainActor
     func testScreenViewTracking() {
+        // D-3: all 5 main tabs are tracked via .analyticsScreen(...) (Training now
+        // fires exactly once — the RootTabView double-application was removed).
         analyticsService.logScreenView(AnalyticsScreen.home)
         analyticsService.logScreenView(AnalyticsScreen.trainingPlan)
         analyticsService.logScreenView(AnalyticsScreen.nutrition)
+        analyticsService.logScreenView(AnalyticsScreen.stats)
+        analyticsService.logScreenView(AnalyticsScreen.settings)
 
-        XCTAssertEqual(mockAdapter.capturedScreens.count, 3)
+        XCTAssertEqual(mockAdapter.capturedScreens.count, 5)
         XCTAssertEqual(mockAdapter.capturedScreens[0], AnalyticsScreen.home)
         XCTAssertEqual(mockAdapter.capturedScreens[1], AnalyticsScreen.trainingPlan)
         XCTAssertEqual(mockAdapter.capturedScreens[2], AnalyticsScreen.nutrition)
+        XCTAssertEqual(mockAdapter.capturedScreens[3], AnalyticsScreen.stats)
+        XCTAssertEqual(mockAdapter.capturedScreens[4], AnalyticsScreen.settings)
     }
 
     // MARK: - Consent Gating Tests

--- a/FitTrackerTests/ReminderAnalyticsTests.swift
+++ b/FitTrackerTests/ReminderAnalyticsTests.swift
@@ -30,6 +30,12 @@ final class ReminderAnalyticsTests: XCTestCase {
 
     override func tearDown() {
         ReminderScheduler.shared.analytics = nil
+        ReminderScheduler.shared.reminderPreferences = nil
+        // Clear any ft.reminder.* keys my preference-gating tests persisted.
+        let defaults = UserDefaults.standard
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("ft.reminder.") {
+            defaults.removeObject(forKey: key)
+        }
         mock = nil
         service = nil
         super.tearDown()
@@ -100,6 +106,53 @@ final class ReminderAnalyticsTests: XCTestCase {
 
         XCTAssertTrue(mock.capturedEvents.isEmpty,
                       "All reminder events must be gated by consent; none should fire when denied")
+    }
+
+    // MARK: - FIT-210: v2 preference gating in scheduleIfAllowed
+
+    func testScheduleIfAllowed_masterOff_suppressesWithUserDisabled() async {
+        let store = ReminderPreferencesStore()
+        store.masterEnabled = false
+        ReminderScheduler.shared.analytics = service
+        ReminderScheduler.shared.reminderPreferences = store
+
+        await ReminderScheduler.shared.scheduleIfAllowed(type: .trainingDay, body: "x")
+
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderSuppressed }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?["reason"] as? String, "user_disabled")
+        XCTAssertFalse(store.masterEnabled)  // keep `store` alive past the await (weak ref)
+    }
+
+    func testScheduleIfAllowed_perTypeOff_suppressesWithUserDisabled() async {
+        let store = ReminderPreferencesStore()
+        store.masterEnabled = true
+        store.trainingDayEnabled = false   // this type off; others on
+        ReminderScheduler.shared.analytics = service
+        ReminderScheduler.shared.reminderPreferences = store
+
+        await ReminderScheduler.shared.scheduleIfAllowed(type: .trainingDay, body: "x")
+
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderSuppressed }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?["reason"] as? String, "user_disabled")
+        XCTAssertFalse(store.trainingDayEnabled)  // keep `store` alive past the await (weak ref)
+    }
+
+    func testScheduleIfAllowed_userDailyCapZero_suppressesWithUserDailyCap() async {
+        let store = ReminderPreferencesStore()
+        store.masterEnabled = true
+        store.trainingDayEnabled = true
+        store.dailyCap = 0                 // user set the cap to zero
+        ReminderScheduler.shared.analytics = service
+        ReminderScheduler.shared.reminderPreferences = store
+
+        await ReminderScheduler.shared.scheduleIfAllowed(type: .trainingDay, body: "x")
+
+        let events = mock.capturedEvents.filter { $0.name == AnalyticsEvent.reminderSuppressed }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.parameters?["reason"] as? String, "user_daily_cap")
+        XCTAssertEqual(store.dailyCap, 0)  // keep `store` alive past the await (weak ref)
     }
 
     // MARK: - ReminderScheduler — cancel paths


### PR DESCRIPTION
Two small iOS residuals surfaced when FIT-210's settings screen and D-3 were reconciled Done (both had shipped, but with a gap). **Local `xcodebuild build` → BUILD SUCCEEDED.**

## FIT-210 — live scheduler now honors the v2 store
The v2 `NotificationsSettingsScreen` writes master/per-type toggles + a configurable daily cap to `ReminderPreferencesStore`, but `ReminderScheduler.scheduleIfAllowed` never read them — so beyond the master switch, user preferences didn't gate dispatch. `scheduleIfAllowed` now gates on the v2 store **before** the internal caps:
- `prefs.isEnabled(for: type)` — maps 1:1 onto `ReminderType` (master AND per-type) → suppress `user_disabled`.
- `todaySendCount() < prefs.dailyCap` — the user's configurable global cap → suppress `user_daily_cap`.

Store is injected at launch (`FitTrackerApp`) next to `ReminderScheduler.shared.analytics`; when unset (tests) preferences don't gate — matching the existing weak-optional no-op pattern. 3 new tests (master-off / per-type-off / dailyCap=0) assert the suppressed reason.

## D-3 — screen-view residuals
- **Training fired `screen_view` twice** per appearance (both `RootTabView`'s tab dispatch and `TrainingPlanView`'s own `.analyticsScreen`). Removed the container-level one so Training self-applies once, like Home.
- `AnalyticsScreenModifier` called the 1-arg `logScreenView`, so GA4 reported the generic `"SwiftUIView"` `screen_class` for every screen. It now passes a `screen_class` (defaulting to the screen name), with an optional override param.
- `AnalyticsTests.testScreenViewTracking` extended to all 5 main tabs.

## Verification
- Local `xcodebuild build` (generic/iOS) — **BUILD SUCCEEDED** (the only earlier failure was a missing local Firebase secret, unrelated to the diff).
- Tests match existing `ReminderAnalyticsTests` / `AnalyticsTests` patterns; CI runs the XCTest suite.

Scope note: both were flagged as separate concerns during the 2026-07-09 reconciliation; the parent tickets (FIT-210 screen, FIT-209/D-3 tracking) stay Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)