### PR TITLE
chore(FIT-200): teach unified_status the Won't-Do terminal status

### DIFF
--- a/scripts/build-item-registry.py
+++ b/scripts/build-item-registry.py
@@ -43,6 +43,13 @@ def unified_status(state: dict) -> str:
     phase = (state.get("current_phase") or "").lower()
     if phase in TERMINAL:
         return "Done"
+    # Won't-Do (terminal park / cancelled) — checked BEFORE the Blocked
+    # signals because a Won't-Do feature is also `paused: true`, and the
+    # terminal decision must win over the resumable-Blocked coarsening.
+    # Canonical marker is `wont_do: true`; the Linear mirror status
+    # (`linear_status` == Canceled) is accepted as a secondary signal.
+    if state.get("wont_do") or (state.get("linear_status") or "").lower() in ("canceled", "cancelled"):
+        return "Won't-Do"
     # Blocked signals (paused / external dependency).
     if state.get("paused") or state.get("blocked") or state.get("blocked_on"):
         return "Blocked"

--- a/scripts/tests/test_build_item_registry.py
+++ b/scripts/tests/test_build_item_registry.py
@@ -30,6 +30,24 @@ def test_unified_status_no_phase_is_backlog():
     assert bir.unified_status({}) == "Backlog"
 
 
+def test_unified_status_wont_do_marker_wins_over_paused():
+    # A parked-permanently feature is also paused; Won't-Do must win.
+    assert bir.unified_status({"current_phase": "tasks_phase", "paused": True, "wont_do": True}) == "Won't-Do"
+
+
+def test_unified_status_linear_canceled_is_wont_do():
+    assert bir.unified_status({"current_phase": "prd", "linear_status": "Canceled"}) == "Won't-Do"
+
+
+def test_unified_status_paused_without_wont_do_still_blocked():
+    # Regression guard: a normal pause (no wont_do / cancel) stays Blocked.
+    assert bir.unified_status({"current_phase": "tasks_phase", "paused": True}) == "Blocked"
+
+
+def test_unified_status_completed_wins_over_wont_do():
+    assert bir.unified_status({"current_phase": "complete", "wont_do": True}) == "Done"
+
+
 def test_collect_prs_merges_all_sources_deduped_sorted():
     state = {
         "related_prs": [10, "12", 10],


### PR DESCRIPTION
## What

`build-item-registry.py::unified_status` coarsened **every** `paused` feature to `Blocked`, with no Won't-Do case. So a permanently-parked / cancelled item could never surface as **Won't-Do** in `item-registry.json` — contradicting its Linear status.

Companion to **#870** (which sets `wont_do: true` on FIT-138). Together they let the crosswalk registry render FIT-138 as **Won't-Do** instead of Blocked.

## Change

`unified_status` gains a Won't-Do branch, checked **before** the Blocked signals (a Won't-Do feature is also `paused`, so the terminal decision must win over the resumable-Blocked coarsening):

- primary marker: `wont_do: true`
- secondary signal: `linear_status` ∈ {`Canceled`, `Cancelled`}
- `Done` (complete) still wins over Won't-Do

## Tests

+4 unit tests (marker-wins-over-paused · linear-canceled · regression guard that a plain pause stays Blocked · complete-wins). **12/12 pass** (`pytest scripts/tests/test_build_item_registry.py`).

## Merge order

Safe either way. If this merges first, the new branch is a no-op until a feature carries `wont_do`; if #870 merges first, the registry coarsens FIT-138 to Blocked until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)