### PR TITLE
feat(checkpoint): record integrity-sweep verdict daily + fix ~-approximate-date cadence parser

### DIFF
--- a/scripts/daily-integrity-checkpoint.py
+++ b/scripts/daily-integrity-checkpoint.py
@@ -781,6 +781,30 @@ def state_sync_health_probe(url: str = STATE_SYNC_HEALTH_URL, timeout: int = 8) 
         return {"reachable": False, "error": f"{type(e).__name__}: {e}"}
 
 
+def run_integrity_sweep() -> dict:
+    """Run the codified cross-layer sweep (scripts/integrity-telemetry-sweep.py)
+    and return its verdict so the daily ledger RECORDS the per-layer health over
+    time. Uses --no-refresh (the 6 make targets already ran above, so ledgers are
+    fresh). Best-effort: an absent script (e.g. before its PR merges) or any error
+    yields {"overall": "SKIPPED"} — it must never crash the checkpoint.
+    """
+    sweep = REPO_ROOT / "scripts" / "integrity-telemetry-sweep.py"
+    if not sweep.exists():
+        return {"overall": "SKIPPED", "reason": "sweep script not present yet"}
+    try:
+        p = subprocess.run(
+            ["python3", str(sweep), "--no-refresh", "--json"],
+            capture_output=True, text=True, timeout=180, check=False,
+        )
+        data = json.loads(p.stdout or "{}")
+        return {
+            "overall": data.get("overall", "UNKNOWN"),
+            "layers": {row["layer"]: row["status"] for row in data.get("layers", [])},
+        }
+    except Exception as e:  # noqa: BLE001 — best-effort; never crash the checkpoint
+        return {"overall": "SKIPPED", "reason": f"{type(e).__name__}: {e}"}
+
+
 def upcoming_followups(today: dt.date, lookahead_days: int = FOLLOWUP_LOOKAHEAD_DAYS) -> list[dict]:
     """Parse must-have-cadence-followups.md and return rows whose date is within lookahead_days.
 
@@ -793,9 +817,13 @@ def upcoming_followups(today: dt.date, lookahead_days: int = FOLLOWUP_LOOKAHEAD_
     import re
     rows = []
     for line in FOLLOWUPS_FILE.read_text().splitlines():
-        if not line.startswith("| ") or not "**20" in line:
+        if not line.startswith("| ") or "**" not in line:
             continue
-        m = re.search(r"\| ([A-Z]\d+) \| \*\*(\d{4}-\d{2}-\d{2})\*\* \| (.+?) \|", line)
+        # Accept both firm dates `**2026-07-23**` and approximate dates
+        # `**~2026-07-23**` (a leading `~` means "around this date"). Struck-through
+        # rows (`| ~~B16~~ | ~~2026-…~~ |`) still fail the `| Bxx | **date**` anchor
+        # since their id/date cells use `~~…~~`, not `**…**`.
+        m = re.search(r"\| ([A-Z]\d+) \| \*\*~?\s*(\d{4}-\d{2}-\d{2})\*\* \| (.+?) \|", line)
         if not m:
             continue
         try:
@@ -1080,6 +1108,9 @@ def _run_pipeline(today: str, local_dir: Path, ssd_dir: Path, args, log) -> None
         prev_row.get("metrics") if prev_row else None, metrics
     )
 
+    # Cross-layer sweep verdict, recorded into the ledger for over-time tracking.
+    sweep = run_integrity_sweep()
+
     row = {
         "date": today,
         "generated_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -1093,6 +1124,7 @@ def _run_pipeline(today: str, local_dir: Path, ssd_dir: Path, args, log) -> None
         "metrics": metrics,
         "regression": regression,
         "deltas_vs_prev": deltas,
+        "integrity_sweep": sweep,
         "snapshot_local": str(local_dir),
         "snapshot_local_ok": local_ok,
         "snapshot_ssd": str(ssd_dir),
@@ -1203,6 +1235,19 @@ def _run_pipeline(today: str, local_dir: Path, ssd_dir: Path, args, log) -> None
         log(f"\n⚠ STATE-SYNC STALE: reason={sync.get('reason')} age={age}m "
             f"(threshold 360m) — the fitme-story FT2 mirror has gone stale. "
             f"Check scripts/sync-from-fittracker2.ts / the pre-build sync.")
+
+    # Cross-layer sweep verdict (recorded in the ledger row above).
+    sw_overall = sweep.get("overall", "?")
+    if sw_overall == "PASS":
+        log("\n🩺 Integrity sweep: PASS — all layers green.")
+    elif sw_overall == "WARN":
+        warn_layers = [k for k, v in sweep.get("layers", {}).items() if v == "WARN"]
+        log(f"\n🩺 Integrity sweep: WARN — {', '.join(warn_layers)}. Run `make integrity-sweep`.")
+    elif sw_overall == "FAIL":
+        fail_layers = [k for k, v in sweep.get("layers", {}).items() if v == "FAIL"]
+        log(f"\n🚨 Integrity sweep: FAIL — {', '.join(fail_layers)}. Run `make integrity-sweep`.")
+    else:
+        log(f"\n🩺 Integrity sweep: {sw_overall} ({sweep.get('reason', 'n/a')}).")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_upcoming_followups.py
+++ b/scripts/tests/test_upcoming_followups.py
@@ -1,0 +1,66 @@
+"""Regression tests for daily-integrity-checkpoint upcoming_followups parser.
+
+Covers the 2026-07-13 fix: `**~YYYY-MM-DD**` approximate dates must surface,
+firm `**YYYY-MM-DD**` dates keep working, struck-through `~~Bxx~~` rows stay
+excluded, and out-of-window rows are dropped.
+"""
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "dc", REPO / "scripts" / "daily-integrity-checkpoint.py"
+)
+dc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dc)
+
+TODAY = dt.date(2026, 7, 13)
+
+
+def _run(tmp_path, body, monkeypatch, lookahead=14):
+    f = tmp_path / "followups.md"
+    f.write_text(body)
+    monkeypatch.setattr(dc, "FOLLOWUPS_FILE", f)
+    return {r["id"]: r for r in dc.upcoming_followups(TODAY, lookahead_days=lookahead)}
+
+
+def test_firm_date_surfaces(tmp_path, monkeypatch):
+    body = "| B1 | **2026-07-20** | do a thing | operator | src |\n"
+    rows = _run(tmp_path, body, monkeypatch)
+    assert "B1" in rows and rows["B1"]["days_away"] == 7
+
+
+def test_approximate_date_surfaces(tmp_path, monkeypatch):
+    # The bug: `**~2026-07-23**` was skipped by the `**20` prefilter + digit-anchored regex.
+    body = "| B17 | **~2026-07-23** | schema-diff review | operator | src |\n"
+    rows = _run(tmp_path, body, monkeypatch)
+    assert "B17" in rows and rows["B17"]["days_away"] == 10
+
+
+def test_struck_through_excluded(tmp_path, monkeypatch):
+    # Struck rows use ~~id~~ / ~~date~~ and often bold **EXECUTED 2026-07-13** text —
+    # must NOT match (the id/date cells aren't `| Bxx | **date**`).
+    body = "| ~~B16~~ | ~~2026-07-13~~ | ~~review~~ **EXECUTED 2026-07-13** done | operator | src |\n"
+    rows = _run(tmp_path, body, monkeypatch)
+    assert rows == {}
+
+
+def test_out_of_window_dropped(tmp_path, monkeypatch):
+    body = (
+        "| B19 | **2026-08-10** | soak verdict | operator | src |\n"
+        "| B20 | **~2026-10-11** | rotate PAT | operator | src |\n"
+    )
+    rows = _run(tmp_path, body, monkeypatch)
+    assert rows == {}  # both > 14 days away
+
+
+def test_mixed_block(tmp_path, monkeypatch):
+    body = (
+        "| ~~B16~~ | ~~2026-07-13~~ | ~~done~~ | operator | src |\n"
+        "| B17 | **~2026-07-23** | review | operator | src |\n"
+        "| B18 | **ASAP (blocks B19)** | provision PAT | operator | src |\n"
+        "| B19 | **2026-08-10** | verdict | operator | src |\n"
+    )
+    rows = _run(tmp_path, body, monkeypatch)
+    assert set(rows) == {"B17"}  # B16 struck, B18 no date, B19 out of window


### PR DESCRIPTION
Two follow-ups to the codified sweep (#888), both on `daily-integrity-checkpoint.py`.

## 1. Record the sweep verdict over time
The daily checkpoint now runs `integrity-telemetry-sweep.py --no-refresh --json` and **stores the per-layer verdict in the ledger row** (`row["integrity_sweep"] = {overall, layers}`), so cross-layer health is tracked historically — not just shown once. A `🩺 PASS` / `⚠ WARN` / `🚨 FAIL` summary prints at the end.

Best-effort by design: if the sweep script isn't on main yet (before #888 merges) or errors, it records `{"overall": "SKIPPED"}` and **never crashes the checkpoint**. Verified both paths (real `PASS` verdict with the script present; graceful `SKIPPED` when absent).

## 2. Fix the `~`-approximate-date cadence parser
`upcoming_followups()` silently dropped `**~YYYY-MM-DD**` dates (the `**20` prefilter + digit-anchored regex), so B17's `~2026-07-23` never surfaced in the daily "upcoming follow-ups" readout. Now `\*\*~?\s*(\d{4}-\d{2}-\d{2})\*\*` matches both firm and approximate dates; struck-through `~~Bxx~~` rows (including ones with bold `**EXECUTED 2026-…**` text) stay excluded via the `| Bxx | **date**` anchor.

`scripts/tests/test_upcoming_followups.py` locks it in — 5 cases (firm, approximate, struck-excluded, out-of-window, mixed).

## Independent of #888
Safe to merge in either order — the sweep integration activates once #888 lands the script; until then it's a graceful SKIP. **21 existing checkpoint tests + 5 new parser tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)