### PR TITLE
fix(cron): CRON_CONTEXT=1 in daily-checkpoint plist + repoint stale SSD path (kills the +512 phantom regression)

### DIFF
--- a/infrastructure/launchd/com.fittracker.daily-integrity-checkpoint.plist.template
+++ b/infrastructure/launchd/com.fittracker.daily-integrity-checkpoint.plist.template
@@ -8,11 +8,19 @@
   if today's snapshot already exists (e.g. ran via SessionStart hook earlier),
   this fire is a no-op.
 
-  KnownIssue: BRANCH_ISOLATION_LAUNCHD_DRIFT is a v7.8.1 advisory that fires
-  when launchd plists reference repo paths that diverge from the actual
-  working directory. This template anchors to /Volumes/DevSSD/FitTracker2;
-  if the SSD ever unmounts at fire time, the script's SSD-write step skips
-  gracefully (logs warning, continues with local-only write).
+  Path: anchors to the canonical INTERNAL checkout
+  /Users/regevbarak/Developer/FitMe/FitTracker2 (the SSD is the build drive, not
+  the source, post-2026-07-05 corruption migration). The old /Volumes/DevSSD path
+  was stale template drift — the installed plist had already been repointed; this
+  template now matches. BRANCH_ISOLATION_LAUNCHD_DRIFT (v7.8.1) + the sub-fix (a)
+  path-existence health checks guard against this diverging again.
+
+  CRON_CONTEXT=1: REQUIRED. The F-LAUNCHD-DRIFT-EXTENSION phantom-finding
+  suppression (empty-PR-cache → 441 BROKEN_PR_CITATION + 71 PR_NUMBER_UNRESOLVED
+  false positives) only engages when the run is detected as cron context. launchd
+  does NOT reliably export LAUNCHD_LABEL, so we set CRON_CONTEXT=1 explicitly here;
+  without it the 06:00 cron produced a +512 phantom integrity regression
+  (observed 2026-07-14). See scripts/ensure-pr-cache-fresh.py.
 -->
 <plist version="1.0">
 <dict>
@@ -22,12 +30,12 @@
     <key>ProgramArguments</key>
     <array>
         <string>/opt/homebrew/bin/python3</string>
-        <string>/Volumes/DevSSD/FitTracker2/scripts/daily-integrity-checkpoint.py</string>
+        <string>/Users/regevbarak/Developer/FitMe/FitTracker2/scripts/daily-integrity-checkpoint.py</string>
         <string>--idempotent</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Volumes/DevSSD/FitTracker2</string>
+    <string>/Users/regevbarak/Developer/FitMe/FitTracker2</string>
 
     <key>StartCalendarInterval</key>
     <dict>
@@ -50,6 +58,8 @@
     <dict>
         <key>PATH</key>
         <string>/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin</string>
+        <key>CRON_CONTEXT</key>
+        <string>1</string>
     </dict>
 </dict>
 </plist>

--- a/scripts/daily-integrity-checkpoint.py
+++ b/scripts/daily-integrity-checkpoint.py
@@ -915,10 +915,12 @@ def regenerate_ledger_md() -> None:
 
 
 def _running_under_launchd() -> bool:
-    """True iff we're in cron context (launchd or manually-set CRON_CONTEXT)."""
-    if os.environ.get("LAUNCHD_LABEL"):
-        return True
+    """True iff we're in cron context. CRON_CONTEXT=1 (set in the launchd plist)
+    is the reliable signal — launchd does NOT dependably export LAUNCHD_LABEL, so
+    that check is a best-effort fallback only (see ensure-pr-cache-fresh.py)."""
     if os.environ.get("CRON_CONTEXT") == "1":
+        return True
+    if os.environ.get("LAUNCHD_LABEL"):
         return True
     xpc = os.environ.get("XPC_SERVICE_NAME", "")
     if xpc and "fittracker" in xpc.lower() and "daily" in xpc.lower():

--- a/scripts/ensure-pr-cache-fresh.py
+++ b/scripts/ensure-pr-cache-fresh.py
@@ -46,9 +46,13 @@ def _is_cron_context() -> bool:
     """Return True iff we're running under launchd (or another cron context).
 
     Detection signals (any one is sufficient):
-      - LAUNCHD_LABEL set (launchd sets this for every job it spawns)
-      - CRON_CONTEXT=1 (manual override / our own daily-checkpoint cron)
-      - XPC_SERVICE_NAME set + matches our daily-checkpoint label
+      - CRON_CONTEXT=1 — the PRIMARY, reliable signal. Set explicitly in the
+        launchd plist's EnvironmentVariables (infrastructure/launchd/*.template).
+        launchd does NOT reliably export LAUNCHD_LABEL to the spawned process, so
+        relying on it silently failed the 06:00 cron on 2026-07-14 and let a +512
+        empty-PR-cache phantom regression through.
+      - LAUNCHD_LABEL set (best-effort fallback — only some launchd contexts set it)
+      - XPC_SERVICE_NAME set + matches our daily-checkpoint label (fallback)
 
     Falls back to False for interactive shells; W11.b silent-pass only
     triggers in cron context, so false negatives here mean "behave as

--- a/scripts/tests/test_daily_cron_plist_template.py
+++ b/scripts/tests/test_daily_cron_plist_template.py
@@ -1,0 +1,36 @@
+"""Guard the daily-checkpoint launchd template against the 2026-07-14 regression.
+
+That day the 06:00 cron recorded a +512 phantom integrity regression (441
+BROKEN_PR_CITATION + 71 PR_NUMBER_UNRESOLVED) because the plist did not signal
+cron context — launchd doesn't reliably export LAUNCHD_LABEL, so the empty-PR-cache
+suppression (F-LAUNCHD-DRIFT-EXTENSION) never engaged. The fix sets CRON_CONTEXT=1
+in the plist. It had a second bug too: a stale /Volumes/DevSSD source path.
+"""
+import plistlib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+TEMPLATE = REPO / "infrastructure" / "launchd" / "com.fittracker.daily-integrity-checkpoint.plist.template"
+
+
+def _load():
+    return plistlib.loads(TEMPLATE.read_bytes())
+
+
+def test_template_is_valid_plist():
+    d = _load()
+    assert d["Label"] == "com.fittracker.daily-integrity-checkpoint"
+
+
+def test_cron_context_is_set():
+    # The reliable cron-context signal — without it the phantom-finding
+    # suppression silently no-ops on the 06:00 launchd fire.
+    assert _load()["EnvironmentVariables"].get("CRON_CONTEXT") == "1"
+
+
+def test_no_stale_ssd_source_path():
+    d = _load()
+    joined = " ".join(d["ProgramArguments"]) + " " + d["WorkingDirectory"]
+    assert "/Volumes/DevSSD" not in joined, "stale SSD path — source lives on internal storage"
+    assert "/Developer/FitMe/FitTracker2" in d["WorkingDirectory"]
+    assert d["ProgramArguments"][1].endswith("scripts/daily-integrity-checkpoint.py")


### PR DESCRIPTION
**Resumed to a scary SessionStart alert: `+512 integrity findings` overnight. It's a phantom** — a fresh interactive `integrity-check` shows **0 findings**. This fixes the cause so it stops recurring.

## Root cause
The 06:00 launchd cron recorded **441 `BROKEN_PR_CITATION` + 71 `PR_NUMBER_UNRESOLVED`** phantoms. The F-LAUNCHD-DRIFT-EXTENSION suppression (empty-PR-cache → skip citation checks) only engages in **detected cron context**, and it leaned on `LAUNCHD_LABEL` — which **launchd does not reliably export**. The plist signalled no cron context → the run looked interactive → normal PR-cache refresh → failed silently (no keychain) → no suppression sentinel → every citation flagged.

## Fixes
- **`*.plist.template`** — set `CRON_CONTEXT=1` (the reliable signal), and **repoint the stale `/Volumes/DevSSD` source path** to the canonical internal checkout (the installed plist was already fixed via #867; the template lagged and would re-deploy the broken path).
- **`ensure-pr-cache-fresh.py` + `daily-integrity-checkpoint.py`** — correct the wrong "launchd sets LAUNCHD_LABEL" comment; `CRON_CONTEXT` is now primary.
- **`test_daily_cron_plist_template.py`** — guards the template (valid plist + `CRON_CONTEXT=1` + no `/Volumes/DevSSD`).

## Verified
- Redeployed local plist → launchd loaded, `CRON_CONTEXT=1` present, both detectors return `True`.
- 19/19 launchd tests pass. False flag cleared (`daily-checkpoint-force` → 0 findings, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)